### PR TITLE
test: Mock HuggingFace tokenizer

### DIFF
--- a/aiperf/tests/conftest.py
+++ b/aiperf/tests/conftest.py
@@ -46,3 +46,40 @@ def mock_communication(mock_zmq_communication: MagicMock) -> MagicMock:  # noqa:
         An MagicMock configured to behave like ZMQCommunication
     """
     return mock_zmq_communication
+
+
+@pytest.fixture
+def mock_hf_tokenizer() -> Generator[MagicMock, None, None]:
+    """Mock Hugging Face tokenizer to avoid HTTP requests during testing.
+
+    This fixture patches AutoTokenizer.from_pretrained and provides a realistic
+    mock tokenizer that can encode, decode, and handle special tokens.
+
+    Usage in tests:
+        def test_something(mock_hf_tokenizer):
+            tokenizer = Tokenizer.from_pretrained("any-model-name")
+            # tokenizer is now mocked and won't make HTTP requests
+    """
+    # Create a mock tokenizer with realistic behavior
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.bos_token_id = 1
+
+    def mock_call(text, **kwargs):
+        base_tokens = list(range(10, 10 + len(text.split())))
+        return {"input_ids": base_tokens}
+
+    def mock_encode(text, **kwargs):
+        return mock_call(text, **kwargs)["input_ids"]
+
+    def mock_decode(token_ids, **kwargs):
+        return " ".join([str(t) for t in token_ids])
+
+    mock_tokenizer.side_effect = mock_call
+    mock_tokenizer.encode = mock_encode
+    mock_tokenizer.decode = mock_decode
+
+    with patch(
+        "aiperf.common.tokenizer.AutoTokenizer.from_pretrained",
+        return_value=mock_tokenizer,
+    ):
+        yield mock_tokenizer

--- a/aiperf/tests/test_prompt_generator.py
+++ b/aiperf/tests/test_prompt_generator.py
@@ -11,11 +11,11 @@ from aiperf.services.dataset.generator.prompt import PromptGenerator
 
 
 class TestPromptGenerator:
-    def test_synthetic_prompt_default(self):
+    def test_synthetic_prompt_default(self, mock_hf_tokenizer):
         tokenizer = Tokenizer.from_pretrained("gpt2")
         _ = PromptGenerator.create_synthetic_prompt(tokenizer)
 
-    def test_synthetic_prompt_zero_token(self):
+    def test_synthetic_prompt_zero_token(self, mock_hf_tokenizer):
         tokenizer = Tokenizer.from_pretrained("gpt2")
         prompt = PromptGenerator.create_synthetic_prompt(
             tokenizer=tokenizer,
@@ -26,7 +26,7 @@ class TestPromptGenerator:
         assert prompt == ""
         assert len(tokenizer.encode(prompt)) == 0
 
-    def test_synthetic_prompt_nonzero_tokens(self):
+    def test_synthetic_prompt_nonzero_tokens(self, mock_hf_tokenizer):
         prompt_tokens = 123
         tokenizer = Tokenizer.from_pretrained("gpt2")
         prompt = PromptGenerator.create_synthetic_prompt(
@@ -44,7 +44,9 @@ class TestPromptGenerator:
             (16, pytest.raises(GeneratorConfigurationError)),
         ],
     )
-    def test_generate_prompt_with_token_reuse(self, test_num_tokens, context):
+    def test_generate_prompt_with_token_reuse(
+        self, test_num_tokens, context, mock_hf_tokenizer
+    ):
         tokenizer = Tokenizer.from_pretrained("gpt2")
         with context:
             _ = PromptGenerator._generate_prompt_with_token_reuse(


### PR DESCRIPTION
Create and use mocked HF tokenizer for all the tests that use tokenizer to prevent making actual HTTP requests to huggingface during the unit test.