### PR TITLE
fix: Fix console print test error

### DIFF
--- a/aiperf/common/data_exporter/__init__.py
+++ b/aiperf/common/data_exporter/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+__all__ = ["ConsoleExporter"]
+from aiperf.common.data_exporter.console_exporter import ConsoleExporter

--- a/aiperf/common/data_exporter/console_exporter.py
+++ b/aiperf/common/data_exporter/console_exporter.py
@@ -14,17 +14,17 @@ class ConsoleExporter:
     STAT_COLUMN_KEYS = ["avg", "min", "max", "p99", "p90", "p75"]
 
     def __init__(self, endpoint_config: EndPointConfig) -> None:
-        self.console = Console()
         self.endpoint_type = endpoint_config.type
         self.streaming = endpoint_config.streaming
 
-    def export(self, records: list[Record]) -> None:
+    def export(self, records: list[Record], **kwargs) -> None:
+        console = Console(**kwargs)
         table = Table(title=self._get_title())
         table.add_column("Metric", justify="right", style="cyan")
         for key in self.STAT_COLUMN_KEYS:
             table.add_column(key, justify="right", style="green")
         self._construct_table(table, records)
-        self.console.print(table)
+        console.print(table)
 
     def _construct_table(self, table: Table, records: list[Record]) -> None:
         for record in records:

--- a/aiperf/tests/data_exporters/test_console_exporter.py
+++ b/aiperf/tests/data_exporters/test_console_exporter.py
@@ -62,10 +62,10 @@ def sample_records():
 
 class TestConsoleExporter:
     def test_export_prints_expected_table(
-        self, endpoint_config, sample_records, mocker, capsys
+        self, endpoint_config, sample_records, capsys
     ):
         exporter = ConsoleExporter(endpoint_config)
-        exporter.export(sample_records)
+        exporter.export(sample_records, width=100)  # fixed width for consistent output
         captured = capsys.readouterr()
         output = captured.out
         assert "NVIDIA AIPerf | LLM Metrics" in output


### PR DESCRIPTION
- Removed unused mocker fixture from test_export_prints_expected_table.

- The test was failing due to line-wrapping in the captured console output which is caused by long metric names.
Fixed by setting a fixed console width (width=100) when calling export() to ensure consistent, single-line output during testing.

- Added __init__.py.