### PR TITLE
fix: prevent deadlocks in mock sleep by relinquishing time slice

### DIFF
--- a/aiperf/tests/base_test_service.py
+++ b/aiperf/tests/base_test_service.py
@@ -15,7 +15,7 @@ from aiperf.common.config import ServiceConfig, UserConfig
 from aiperf.common.enums import CommunicationBackend, ServiceRunType, ServiceState
 from aiperf.common.service.base_service import BaseService
 from aiperf.services import SystemController
-from aiperf.tests.utils.async_test_utils import async_fixture, async_noop
+from aiperf.tests.utils.async_test_utils import async_fixture
 
 real_sleep = (
     asyncio.sleep


### PR DESCRIPTION
This PR updates the `no_sleep` fixture to avoid blocking the event loop by yielding control back to other tasks instead of a complete no-op.

- Save the real `asyncio.sleep` at import time for in-fixture use  
- Replace the old `async_noop` patch with a `fast_sleep` that does `await real_sleep(0)`  
- Monkey-patch `asyncio.sleep` to the new `fast_sleep` in the `no_sleep` fixture

