### PR TITLE
refactor: simplify ConcurrencyStrategy using semaphore

### DIFF
--- a/aiperf/common/exceptions.py
+++ b/aiperf/common/exceptions.py
@@ -26,6 +26,18 @@ class CommunicationError(AIPerfError):
     """Generic communication error."""
 
 
+class InitializationError(AIPerfError):
+    """Exception raised when something fails to initialize."""
+
+
+class InvalidStateError(AIPerfError):
+    """Exception raised when something is in an invalid state."""
+
+
+class ShutdownError(AIPerfError):
+    """Exception raised when a service encounters an error while shutting down."""
+
+
 class ProxyError(AIPerfError):
     """Exception raised when a proxy encounters an error."""
 

--- a/aiperf/common/hooks.py
+++ b/aiperf/common/hooks.py
@@ -23,8 +23,8 @@ import contextlib
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
-from enum import Enum
 
+from aiperf.common.enums import CaseInsensitiveStrEnum
 from aiperf.common.exceptions import AIPerfError, AIPerfMultiError, UnsupportedHookError
 
 ################################################################################
@@ -32,10 +32,10 @@ from aiperf.common.exceptions import AIPerfError, AIPerfMultiError, UnsupportedH
 ################################################################################
 
 
-class AIPerfHook(Enum):
+class AIPerfHook(CaseInsensitiveStrEnum):
     """Enum for the various AIPerf hooks.
 
-    Note: If you add a new hook, you must also add it to the @supports_hooks
+    NOTE: If you add a new hook, you must also add it to the @supports_hooks
     decorator of the class you wish to use the hook in.
     """
 
@@ -51,8 +51,16 @@ class AIPerfHook(Enum):
     AIPERF_TASK = "__aiperf_task__"
 
 
-HookType = AIPerfHook | str
-"""Type alias for valid hook types. This is a union of the AIPerfHook enum and any user-defined custom strings."""
+class AIPerfTaskHook(CaseInsensitiveStrEnum):
+    """Enum for the various AIPerf task hooks."""
+
+    AIPERF_TASK = "__aiperf_task__"
+    AIPERF_AUTO_TASK = "__aiperf_auto_task__"
+    AIPERF_AUTO_TASK_INTERVAL = "__aiperf_auto_task_interval__"
+
+
+HookType = AIPerfHook | AIPerfTaskHook | str
+"""Type alias for valid hook types. This is a union of the AIPerfHook enum, the AIPerfTaskHook enum, and any user-defined custom strings."""
 
 
 AIPERF_HOOK_TYPE = "__aiperf_hook_type__"

--- a/aiperf/common/messages.py
+++ b/aiperf/common/messages.py
@@ -276,10 +276,6 @@ class CreditDropMessage(BaseServiceMessage):
 
     message_type: Literal[MessageType.CREDIT_DROP] = MessageType.CREDIT_DROP
 
-    amount: int = Field(
-        ...,
-        description="Amount of credits that have been dropped",
-    )
     conversation_id: str | None = Field(
         default=None, description="The ID of the conversation, if applicable."
     )
@@ -296,11 +292,6 @@ class CreditReturnMessage(BaseServiceMessage):
     """
 
     message_type: Literal[MessageType.CREDIT_RETURN] = MessageType.CREDIT_RETURN
-
-    amount: int = Field(
-        ...,
-        description="Amount of credits being returned",
-    )
 
 
 class ErrorMessage(Message):

--- a/aiperf/common/service/base_component_service.py
+++ b/aiperf/common/service/base_component_service.py
@@ -3,7 +3,6 @@
 import asyncio
 from collections.abc import Awaitable, Callable
 
-from aiperf.common.comms.client_enums import ClientType, PubClientType, SubClientType
 from aiperf.common.config import ServiceConfig
 from aiperf.common.enums import CommandType, ServiceState, Topic
 from aiperf.common.hooks import AIPerfHook, aiperf_task, on_run, on_set_state
@@ -39,19 +38,6 @@ class BaseComponentService(BaseService):
         self._command_callbacks: dict[
             CommandType, Callable[[CommandMessage], Awaitable[None]]
         ] = {}
-
-    @property
-    def required_clients(self) -> list[ClientType]:
-        """The communication clients required by the service.
-
-        The component services subscribe to controller messages and publish
-        component messages.
-        """
-        return [
-            *(super().required_clients or []),
-            PubClientType.COMPONENT,
-            SubClientType.CONTROLLER,
-        ]
 
     @on_run
     async def _on_run(self) -> None:

--- a/aiperf/common/service/base_controller_service.py
+++ b/aiperf/common/service/base_controller_service.py
@@ -3,7 +3,6 @@
 
 from pydantic import BaseModel
 
-from aiperf.common.comms.client_enums import ClientType, PubClientType, SubClientType
 from aiperf.common.config import ServiceConfig
 from aiperf.common.enums import CommandType, ServiceType
 from aiperf.common.hooks import on_run
@@ -28,19 +27,6 @@ class BaseControllerService(BaseService):
         self, service_config: ServiceConfig, service_id: str | None = None
     ) -> None:
         super().__init__(service_config=service_config, service_id=service_id)
-
-    @property
-    def required_clients(self) -> list[ClientType]:
-        """The communication clients required by the service.
-
-        The controller service subscribes to controller messages and publishes
-        to components.
-        """
-        return [
-            *(super().required_clients or []),
-            PubClientType.CONTROLLER,
-            SubClientType.COMPONENT,
-        ]
 
     @on_run
     async def _on_run(self) -> None:

--- a/aiperf/common/service/base_service.py
+++ b/aiperf/common/service/base_service.py
@@ -12,7 +12,6 @@ from aiperf.common.enums import ServiceState, ServiceType
 from aiperf.common.exceptions import (
     AIPerfError,
     CommunicationError,
-    CommunicationErrorReason,
     ServiceError,
 )
 from aiperf.common.factories import CommunicationFactory
@@ -81,7 +80,6 @@ class BaseService(BaseServiceInterface, ABC, AIPerfTaskMixin):
         """
         if not self._comms:
             raise CommunicationError(
-                CommunicationErrorReason.INITIALIZATION_ERROR,
                 "Communication channels are not initialized",
             )
         return self._comms

--- a/aiperf/common/service/base_service_interface.py
+++ b/aiperf/common/service/base_service_interface.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractmethod
 
-from aiperf.common.comms.client_enums import ClientType
 from aiperf.common.enums import ServiceState, ServiceType
 from aiperf.common.messages import Message
 
@@ -14,16 +13,6 @@ class BaseServiceInterface(ABC):
     methods are required to be implemented by derived classes, while others are
     meant to be implemented by the base class.
     """
-
-    @property
-    @abstractmethod
-    def required_clients(self) -> list[ClientType]:
-        """The communication clients required by the service. If nothing is returned,
-        the service will be responsible for creating its own clients.
-
-        This property should be implemented by derived classes to specify the
-        communication clients that the service requires."""
-        pass
 
     @property
     @abstractmethod

--- a/aiperf/services/system_controller/system_controller.py
+++ b/aiperf/services/system_controller/system_controller.py
@@ -18,7 +18,6 @@ from aiperf.common.enums import (
 )
 from aiperf.common.exceptions import (
     CommunicationError,
-    CommunicationErrorReason,
     ConfigError,
 )
 from aiperf.common.factories import ServiceFactory
@@ -138,7 +137,6 @@ class SystemController(SignalHandlerMixin, BaseControllerService):
             except Exception as e:
                 self.logger.error("Failed to subscribe to topic %s: %s", topic, e)
                 raise CommunicationError(
-                    CommunicationErrorReason.SUBSCRIBE_ERROR,
                     f"Failed to subscribe to topic {topic}: {e}",
                 ) from e
 
@@ -417,7 +415,6 @@ class SystemController(SignalHandlerMixin, BaseControllerService):
         if not self._comms:
             self.logger.error("Cannot send command: Communication is not initialized")
             raise CommunicationError(
-                CommunicationErrorReason.INITIALIZATION_ERROR,
                 "Communication channels are not initialized",
             )
 
@@ -438,7 +435,6 @@ class SystemController(SignalHandlerMixin, BaseControllerService):
         except Exception as e:
             self.logger.error("Exception publishing command: %s", e)
             raise CommunicationError(
-                CommunicationErrorReason.PUBLISH_ERROR,
                 f"Failed to publish command: {e}",
             ) from e
 

--- a/aiperf/services/timing_manager/concurrency_strategy.py
+++ b/aiperf/services/timing_manager/concurrency_strategy.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import logging
 import os
 import time
 
 from aiperf.common.constants import NANOS_PER_SECOND
-from aiperf.common.hooks import AIPerfLifecycleMixin, aiperf_auto_task
 from aiperf.common.messages import CreditReturnMessage
+from aiperf.common.mixins import AsyncTaskManagerMixin
 from aiperf.services.timing_manager.config import TimingManagerConfig
 from aiperf.services.timing_manager.credit_issuing_strategy import (
     CreditIssuingStrategy,
@@ -15,7 +16,7 @@ from aiperf.services.timing_manager.credit_issuing_strategy import (
 )
 
 
-class ConcurrencyStrategy(CreditIssuingStrategy, AIPerfLifecycleMixin):
+class ConcurrencyStrategy(CreditIssuingStrategy, AsyncTaskManagerMixin):
     """
     Class for concurrency credit issuing strategy.
     """
@@ -24,118 +25,105 @@ class ConcurrencyStrategy(CreditIssuingStrategy, AIPerfLifecycleMixin):
         self, config: TimingManagerConfig, credit_manager: CreditManagerProtocol
     ):
         super().__init__(config=config, credit_manager=credit_manager)
-        self._credit_lock = asyncio.Lock()
 
         self._total_credits = int(os.getenv("AIPERF_TOTAL_REQUESTS", 1000))
-        self._credits_available = min(
+        self._concurrency = min(
             self._total_credits, int(os.getenv("AIPERF_CONCURRENCY", 10))
         )
 
         self._sent_credits = 0
         self._completed_credits = 0
-        self._credit_event = asyncio.Event()
-        self.start_time_ns = time.time_ns()
+        self.start_time_ns = 0
+        self._semaphore = asyncio.Semaphore(value=self._concurrency)
 
-    async def initialize(self) -> None:
-        pass
-
-    async def start(self) -> None:
-        await self.run_and_wait_for_start()
-        self.execute_async(self._issue_credit_drops())
-
-    async def stop(self) -> None:
-        await super().stop()
-        await self.shutdown()
-
-    async def _issue_credit_drops(self) -> None:
-        """Issue credit drops to workers."""
-        self.logger.debug("Issuing credit drops to workers")
-
-        await asyncio.sleep(3)
-
-        self.start_time_ns = time.time_ns()
-
-        self.execute_async(
-            self.credit_manager.publish_progress(
-                self.start_time_ns, self._total_credits, self._completed_credits
-            )
+        self.logger.info(
+            "TM: Concurrency Strategy initialized with total_credits=%s, concurrency=%s",
+            self._total_credits,
+            self._concurrency,
         )
 
-        self.logger.info("TM: Issuing credit drops")
-        while True:
-            try:
-                if not self._credits_available:
-                    self.logger.debug("Waiting for credit event")
-                    self._credit_event.clear()
-                    await self._credit_event.wait()
-                    self.logger.debug("Credit event received")
-                    continue
+    async def start(self) -> None:
+        self.start_time_ns = time.time_ns()
+        self.execute_async(self._progress_report_loop())
+        self.execute_async(self._credit_drop_loop())
 
-                self.logger.debug(
-                    "Issuing credit drop %s of %s",
-                    self._sent_credits + 1,
-                    self._total_credits,
+    async def _credit_drop_loop(self) -> None:
+        """Issue credit drops to workers."""
+
+        await asyncio.sleep(1.5)  # TODO: HACK: Wait for the system to be ready
+
+        self.logger.info(
+            "TM: Issuing credit drops %s total credits, %s concurrency",
+            self._total_credits,
+            self._concurrency,
+        )
+
+        while self._sent_credits < self._total_credits:
+            await self._semaphore.acquire()
+            self.execute_async(
+                self.credit_manager.drop_credit(
+                    # TODO: Allow concurrency to be used with trace datasets
+                    conversation_id=None,
+                    credit_drop_ns=None,
                 )
+            )
+            self._sent_credits += 1
 
-                credits_left = self._total_credits - self._sent_credits
-                for _ in range(min(self._credits_available, credits_left)):
-                    self.execute_async(
-                        self.credit_manager.drop_credit(
-                            # TODO: Do we need to pass conversation_id?
-                            amount=1,
-                            conversation_id=None,
-                            credit_drop_ns=None,
-                        )
-                    )
-                    self._sent_credits += 1
-                    self._credits_available -= 1
-
-                if self._sent_credits >= self._total_credits:
-                    self.logger.debug("All credits sent, stopping credit drop task")
-                    break
-
-            except asyncio.CancelledError:
-                self.logger.debug("Credit drop task cancelled")
-                break
-            except Exception as e:
-                self.logger.error("Exception issuing credit drop: %s", e)
-                await asyncio.sleep(0.1)
+        self.logger.info("TM: All credits sent, stopping credit drop loop")
 
     async def on_credit_return(self, message: CreditReturnMessage) -> None:
         """Process a credit return message."""
 
-        self.logger.debug("Processing credit return: %s", message)
-        async with self._credit_lock:
-            self._credits_available += message.amount
-            self._completed_credits += message.amount
+        self._semaphore.release()
+        self._completed_credits += 1
 
-        self.logger.debug(
-            "Processing credit return: %s (completed credits: %s of %s) (%.2f requests/s)",
-            message.amount,
-            self._completed_credits,
-            self._total_credits,
-            self._completed_credits
-            / (time.time_ns() - self.start_time_ns)
-            * NANOS_PER_SECOND,
-        )
+        if self.logger.isEnabledFor(logging.DEBUG):
+            per_sec = (
+                self._completed_credits
+                / ((time.time_ns() - self.start_time_ns) / NANOS_PER_SECOND)
+                if (time.time_ns() - self.start_time_ns) > 0
+                else 0
+            )
+            self.logger.debug(
+                "Processing credit return: (completed credits: %s of %s) (%.2f requests/s)",
+                self._completed_credits,
+                self._total_credits,
+                per_sec,
+            )
 
         if self._completed_credits >= self._total_credits:
-            self.logger.debug(
-                "All credits completed, stopping credit drop task after %.2f seconds (%.2f requests/s)",
-                (time.time_ns() - self.start_time_ns) / NANOS_PER_SECOND,
-                self._total_credits
-                / ((time.time_ns() - self.start_time_ns) / NANOS_PER_SECOND),
-            )
-
             self.execute_async(self.credit_manager.publish_credits_complete(False))
 
-        self._credit_event.set()
+            if self.logger.isEnabledFor(logging.DEBUG):
+                per_sec = (
+                    self._completed_credits
+                    / ((time.time_ns() - self.start_time_ns) / NANOS_PER_SECOND)
+                    if (time.time_ns() - self.start_time_ns) > 0
+                    else 0
+                )
+                self.logger.debug(
+                    "All credits completed, stopping credit drop task after %.2f seconds (%.2f requests/s)",
+                    (time.time_ns() - self.start_time_ns) / NANOS_PER_SECOND,
+                    per_sec,
+                )
 
-    @aiperf_auto_task(interval=1)
-    async def _report_progress_task(self) -> None:
-        """Report the progress."""
-        self.execute_async(
-            self.credit_manager.publish_progress(
-                self.start_time_ns, self._total_credits, self._completed_credits
-            )
-        )
+    async def _progress_report_loop(self) -> None:
+        """Report the progress at a fixed interval."""
+        while True:
+            try:
+                await self.credit_manager.publish_progress(
+                    self.start_time_ns, self._total_credits, self._completed_credits
+                )
+            except asyncio.CancelledError:
+                self.logger.debug("TM: Progress reporting loop cancelled")
+                break
+            except Exception as e:
+                self.logger.error("TM: Error publishing progress: %s", e)
+
+            if self._completed_credits >= self._total_credits:
+                self.logger.debug(
+                    "TM: All credits completed, stopping progress reporting loop"
+                )
+                break
+
+            await asyncio.sleep(1)  # TODO: Make this configurable

--- a/aiperf/services/timing_manager/credit_issuing_strategy.py
+++ b/aiperf/services/timing_manager/credit_issuing_strategy.py
@@ -19,7 +19,6 @@ class CreditManagerProtocol(Protocol):
 
     async def drop_credit(
         self,
-        amount: int = 1,
         conversation_id: str | None = None,
         credit_drop_ns: int | None = None,
     ) -> None:
@@ -49,10 +48,6 @@ class CreditIssuingStrategy(AsyncTaskManagerMixin, ABC):
         self.logger = logging.getLogger(__class__.__name__)
         self.config = config
         self.credit_manager = credit_manager
-
-    @abstractmethod
-    async def initialize(self) -> None:
-        pass
 
     @abstractmethod
     async def start(self) -> None:

--- a/aiperf/services/timing_manager/fixed_schedule_strategy.py
+++ b/aiperf/services/timing_manager/fixed_schedule_strategy.py
@@ -7,8 +7,11 @@ from collections import defaultdict
 
 from aiperf.common.constants import NANOS_PER_SECOND
 from aiperf.common.exceptions import InvalidStateError
-from aiperf.common.messages import CreditDropMessage, DatasetTimingResponse
-from aiperf.services.timing_manager.credit_issuing_strategy import CreditIssuingStrategy
+from aiperf.services.timing_manager.config import TimingManagerConfig
+from aiperf.services.timing_manager.credit_issuing_strategy import (
+    CreditIssuingStrategy,
+    CreditManagerProtocol,
+)
 
 
 class FixedScheduleStrategy(CreditIssuingStrategy):
@@ -16,16 +19,15 @@ class FixedScheduleStrategy(CreditIssuingStrategy):
     Class for fixed schedule credit issuing strategy.
     """
 
-    def __init__(self, config, credit_drop_function):
-        super().__init__(config, credit_drop_function)
+    def __init__(
+        self,
+        config: TimingManagerConfig,
+        credit_manager: CreditManagerProtocol,
+        schedule: list[tuple[int, str]],
+    ):
+        super().__init__(config=config, credit_manager=credit_manager)
 
-        self._schedule: list[tuple[int, str]] = []
-
-    async def initialize(self) -> None:
-        pass
-
-    async def _get_dataset_timing(self, message: DatasetTimingResponse) -> None:
-        self._schedule = message.timing_data
+        self._schedule: list[tuple[int, str]] = schedule
 
     async def start(self) -> None:
         if not self._schedule:
@@ -49,13 +51,9 @@ class FixedScheduleStrategy(CreditIssuingStrategy):
 
             for _, conversation_id in timestamp_groups[unique_timestamp]:
                 self.execute_async(
-                    self.credit_drop_client.push(
-                        CreditDropMessage(
-                            service_id=self.service_id,
-                            amount=1,
-                            conversation_id=conversation_id,
-                            credit_drop_ns=time.time_ns(),
-                        ),
+                    self.credit_manager.drop_credit(
+                        conversation_id=conversation_id,
+                        credit_drop_ns=None,  # we already waited for the timestamp
                     )
                 )
 

--- a/aiperf/services/timing_manager/rate_strategy.py
+++ b/aiperf/services/timing_manager/rate_strategy.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from aiperf.services.timing_manager.credit_issuing_strategy import CreditIssuingStrategy
+from aiperf.services.timing_manager.config import TimingManagerConfig
+from aiperf.services.timing_manager.credit_issuing_strategy import (
+    CreditIssuingStrategy,
+    CreditManagerProtocol,
+)
 
 
 class RateStrategy(CreditIssuingStrategy):
@@ -9,11 +13,10 @@ class RateStrategy(CreditIssuingStrategy):
     Class for rate credit issuing strategy.
     """
 
-    def __init__(self, config, credit_drop_function):
-        raise NotImplementedError()
-
-    async def initialize(self) -> None:
-        raise NotImplementedError()
+    def __init__(
+        self, config: TimingManagerConfig, credit_manager: CreditManagerProtocol
+    ):
+        super().__init__(config=config, credit_manager=credit_manager)
 
     async def start(self) -> None:
-        raise NotImplementedError()
+        pass

--- a/aiperf/services/worker/worker.py
+++ b/aiperf/services/worker/worker.py
@@ -3,7 +3,6 @@
 import asyncio
 import sys
 
-from aiperf.common.comms.client_enums import ClientType, PullClientType, PushClientType
 from aiperf.common.config import ServiceConfig
 from aiperf.common.enums import ServiceType, Topic
 from aiperf.common.hooks import on_cleanup, on_init, on_run, on_start, on_stop
@@ -27,15 +26,6 @@ class Worker(BaseService):
     def service_type(self) -> ServiceType:
         """The type of service."""
         return ServiceType.WORKER
-
-    @property
-    def required_clients(self) -> list[ClientType]:
-        """The communication clients required by the service."""
-        return [
-            *(super().required_clients or []),
-            PullClientType.CREDIT_DROP,
-            PushClientType.CREDIT_RETURN,
-        ]
 
     @on_init
     async def _initialize(self) -> None:
@@ -82,7 +72,6 @@ class Worker(BaseService):
             topic=Topic.CREDIT_RETURN,
             message=CreditReturnMessage(
                 service_id=self.service_id,
-                amount=1,
             ),
         )
 

--- a/aiperf/tests/services/test_timing_manager.py
+++ b/aiperf/tests/services/test_timing_manager.py
@@ -72,7 +72,7 @@ class TestTimingManager(BaseTestComponentService):
         )
 
         # Mock the open function when called with that specific path
-        mock_file = io.StringIO(mock_file_content)
+        mock_file = io.StringIO(str(mock_timing_data))
 
         # Use patch to replace the built-in open function
         with patch("builtins.open", return_value=mock_file):
@@ -119,7 +119,7 @@ class TestTimingManager(BaseTestComponentService):
             pushed_messages.append((topic, message))
 
             # Create and process a return message
-            return_message = CreditReturnMessage(service_id="test-consumer", amount=1)
+            return_message = CreditReturnMessage(service_id="test-consumer")
             await service._on_credit_return(return_message)
 
         # 6. Mock necessary functions
@@ -143,6 +143,5 @@ class TestTimingManager(BaseTestComponentService):
             for topic, message in pushed_messages:
                 assert topic == Topic.CREDIT_DROP
                 assert message.service_id == service.service_id
-                assert message.amount == 1
                 # You could also verify the timestamp corresponds to the schedule
                 # if the implementation preserves that information

--- a/aiperf/tests/timing_manager/conftest.py
+++ b/aiperf/tests/timing_manager/conftest.py
@@ -1,0 +1,42 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from aiperf.services.timing_manager.config import TimingManagerConfig
+
+
+class MockCreditManager:
+    """Mock implementation of CreditManagerProtocol for testing."""
+
+    def __init__(self):
+        self.dropped_credits = []
+        self.progress_calls = []
+        self.credits_complete_calls = []
+
+    async def drop_credit(self, conversation_id=None, credit_drop_ns=None):
+        """Mock drop_credit method."""
+        self.dropped_credits.append(
+            {"conversation_id": conversation_id, "credit_drop_ns": credit_drop_ns}
+        )
+
+    async def publish_progress(self, start_time_ns, total, completed):
+        """Mock publish_progress method."""
+        self.progress_calls.append(
+            {"start_time_ns": start_time_ns, "total": total, "completed": completed}
+        )
+
+    async def publish_credits_complete(self, cancelled):
+        """Mock publish_credits_complete method."""
+        self.credits_complete_calls.append({"cancelled": cancelled})
+
+
+@pytest.fixture
+def mock_credit_manager():
+    """Fixture providing a mock credit manager."""
+    return MockCreditManager()
+
+
+@pytest.fixture
+def config():
+    """Fixture providing a TimingManagerConfig instance."""
+    return TimingManagerConfig()

--- a/aiperf/tests/timing_manager/test_concurrency_strategy.py
+++ b/aiperf/tests/timing_manager/test_concurrency_strategy.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Comprehensive unit tests for the ConcurrencyStrategy class.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aiperf.common.constants import NANOS_PER_SECOND
+from aiperf.common.messages import CreditReturnMessage
+from aiperf.services.timing_manager.concurrency_strategy import ConcurrencyStrategy
+from aiperf.tests.utils.async_test_utils import MockSemaphore
+
+
+def seconds_to_ns(seconds: float) -> int:
+    """Convert seconds to nanoseconds."""
+    return int(seconds * NANOS_PER_SECOND)
+
+
+@pytest.mark.asyncio
+class TestConcurrencyStrategy:
+    """Tests for the ConcurrencyStrategy class."""
+
+    @patch("time.time_ns")
+    async def test_start_sets_start_time_and_launches_tasks(
+        self, mock_time_ns, config, mock_credit_manager
+    ):
+        """Test that start() sets start time and launches background tasks."""
+        mock_time_ns.return_value = seconds_to_ns(1)
+
+        strategy = ConcurrencyStrategy(config, mock_credit_manager)
+
+        # Mock the background task methods to prevent actual execution
+        strategy._progress_report_loop = AsyncMock()
+        strategy._credit_drop_loop = AsyncMock()
+
+        await strategy.start()
+
+        assert strategy.start_time_ns == seconds_to_ns(1)
+        # Verify tasks were created (we can't easily verify they were started without more complex mocking)
+        assert len(strategy.tasks) == 2
+
+    async def test_credit_drop_loop_sends_all_credits(
+        self, config, mock_credit_manager
+    ):
+        """Test that credit drop loop sends all credits respecting concurrency."""
+
+        strategy = ConcurrencyStrategy(config, mock_credit_manager)
+        strategy._total_credits = 3
+        strategy._concurrency = 2
+
+        # Mock the semaphore to avoid deadlock
+        strategy._semaphore = MockSemaphore()
+
+        # Run the credit drop loop
+        await strategy._credit_drop_loop()
+
+        # Wait for the pending tasks to complete before checking the results
+        await asyncio.gather(*strategy.tasks)
+
+        # Verify all credits were sent
+        assert strategy._sent_credits == 3
+        assert strategy._semaphore.acquire_count == 3
+        assert len(mock_credit_manager.dropped_credits) == 3
+
+    async def test_credit_drop_loop_with_zero_credits(
+        self, config, mock_credit_manager
+    ):
+        """Test credit drop loop behavior with zero total credits."""
+        strategy = ConcurrencyStrategy(config, mock_credit_manager)
+        strategy._total_credits = 0
+        strategy._concurrency = 10
+
+        await strategy._credit_drop_loop()
+
+        # Wait for the pending tasks to complete before checking the results
+        await asyncio.gather(*strategy.tasks)
+
+        assert strategy._sent_credits == 0
+        assert len(mock_credit_manager.dropped_credits) == 0
+
+    @patch("time.time_ns")
+    async def test_on_credit_return_basic_functionality(
+        self, mock_time_ns, config, mock_credit_manager
+    ):
+        """Test basic credit return processing."""
+        mock_time_ns.return_value = seconds_to_ns(2)
+
+        strategy = ConcurrencyStrategy(config, mock_credit_manager)
+        strategy.start_time_ns = seconds_to_ns(1)
+        strategy._semaphore = MockSemaphore()
+
+        message = CreditReturnMessage(service_id="test-service")
+
+        await strategy.on_credit_return(message)
+
+        # Wait for the pending tasks to complete before checking the results
+        await asyncio.gather(*strategy.tasks)
+
+        assert strategy._completed_credits == 1
+        assert strategy._semaphore.release_count == 1
+
+    @patch("time.time_ns")
+    async def test_on_credit_return_triggers_credits_complete(
+        self, mock_time_ns, config, mock_credit_manager
+    ):
+        """Test that credit return triggers credits complete when all credits are returned."""
+        mock_time_ns.return_value = seconds_to_ns(2)
+
+        strategy = ConcurrencyStrategy(config, mock_credit_manager)
+        strategy._total_credits = 2
+        strategy._concurrency = 1
+        strategy._semaphore = MockSemaphore()
+
+        strategy.start_time_ns = seconds_to_ns(1)
+        strategy._completed_credits = 1  # One credit already completed
+
+        message = CreditReturnMessage(service_id="test-service")
+
+        await strategy.on_credit_return(message)
+
+        # Wait for the pending tasks to complete before checking the results
+        await asyncio.gather(*strategy.tasks)
+
+        assert strategy._completed_credits == 2
+        assert len(mock_credit_manager.credits_complete_calls) == 1
+        assert strategy._semaphore.release_count == 1
+        assert mock_credit_manager.credits_complete_calls[0]["cancelled"] is False
+
+    @patch("time.time_ns")
+    async def test_full_credit_lifecycle(
+        self, mock_time_ns, config, mock_credit_manager
+    ):
+        """Test a complete credit lifecycle from start to finish."""
+        mock_time_ns.return_value = seconds_to_ns(1)
+
+        strategy = ConcurrencyStrategy(config, mock_credit_manager)
+        strategy._total_credits = 2
+        strategy._concurrency = 1
+        strategy._semaphore = MockSemaphore()
+
+        # Mock the background loops to prevent them from running indefinitely
+        strategy._progress_report_loop = AsyncMock()
+        strategy._credit_drop_loop = AsyncMock()
+
+        # Start the strategy
+        await strategy.start()
+
+        # Simulate credit returns
+        message1 = CreditReturnMessage(service_id="test-service")
+        message2 = CreditReturnMessage(service_id="test-service")
+
+        await strategy.on_credit_return(message1)
+        await strategy.on_credit_return(message2)
+
+        # Wait for the pending tasks to complete before checking the results
+        await asyncio.gather(*strategy.tasks)
+
+        # Verify final state
+        assert strategy._completed_credits == 2
+        assert len(mock_credit_manager.credits_complete_calls) == 1
+        assert mock_credit_manager.credits_complete_calls[0]["cancelled"] is False
+
+    async def test_credit_drop_and_return_flow(self, config, mock_credit_manager):
+        """Test coordinated credit drop and return flow without deadlocks."""
+        strategy = ConcurrencyStrategy(config, mock_credit_manager)
+        strategy._total_credits = 3
+        strategy._concurrency = 2
+        strategy._semaphore = MockSemaphore()
+
+        # Run credit drop loop
+        await strategy._credit_drop_loop()
+
+        # Wait for the pending tasks to complete before checking the results
+        await asyncio.gather(*strategy.tasks)
+
+        # Verify credits were sent
+        assert strategy._sent_credits == 3
+        assert strategy._semaphore.acquire_count == 3
+        assert len(mock_credit_manager.dropped_credits) == 3
+
+        # Simulate credit returns
+        message1 = CreditReturnMessage(service_id="test-service")
+        message2 = CreditReturnMessage(service_id="test-service")
+        message3 = CreditReturnMessage(service_id="test-service")
+
+        await strategy.on_credit_return(message1)
+        await strategy.on_credit_return(message2)
+        await strategy.on_credit_return(message3)
+
+        # Wait for the pending tasks to complete before checking the results
+        await asyncio.gather(*strategy.tasks)
+
+        # Verify credits were returned
+        assert strategy._completed_credits == 3
+        assert strategy._semaphore.release_count == 3
+        assert len(mock_credit_manager.credits_complete_calls) == 1

--- a/aiperf/tests/utils/async_test_utils.py
+++ b/aiperf/tests/utils/async_test_utils.py
@@ -4,6 +4,7 @@
 Utilities for testing asynchronous code.
 """
 
+import asyncio
 import contextlib
 from collections.abc import AsyncIterator
 from typing import Any, TypeVar, cast
@@ -43,3 +44,18 @@ async def async_fixture(fixture: T) -> T:
 
     # Otherwise return the fixture as is
     return fixture
+
+
+class MockSemaphore(asyncio.Semaphore):
+    """Simple semaphore mock that allows for testing of concurrency."""
+
+    def __init__(self):
+        self.acquire_count = 0
+        self.release_count = 0
+
+    async def acquire(self):
+        self.acquire_count += 1
+        return True
+
+    def release(self):
+        self.release_count += 1


### PR DESCRIPTION
### Notes
- Simplified the `ConcurrencyStrategy`
- Removed the `amount` field from the credit messages
- Added unit tests and Mocks for `CreditManagerProtocol` and `Semaphores`
- Adjustments/Fixes to the code to at least get the unit tests running while the other PRs are in review

### How to test:
```python
pytest aiperf/tests/timing_manager/test_concurrency_strategy.py
```

---

### Concurrency and Credit Issuing Strategy Refactor:
* Refactored `ConcurrencyStrategy` in `timing_manager/concurrency_strategy.py` to use `AsyncTaskManagerMixin` instead of `AIPerfLifecycleMixin`, replaced the credit lock with a semaphore for concurrency management, and streamlined credit drop and progress reporting loops. [[1]](diffhunk://#diff-d5b354b78fe50d4c3f0e4b6e656cce70d4c07f4f3723a2fc7f1cb8fb14301f62R5-R19) [[2]](diffhunk://#diff-d5b354b78fe50d4c3f0e4b6e656cce70d4c07f4f3723a2fc7f1cb8fb14301f62L27-R129)
* Simplified `FixedScheduleStrategy` in `timing_manager/fixed_schedule_strategy.py` by removing dataset timing response handling and directly using a predefined schedule for credit drops. [[1]](diffhunk://#diff-c860473233fd2bad79209ce7b92c3feee232fe39eb4d1866ad49cf37e1deb2fcL10-R30) [[2]](diffhunk://#diff-c860473233fd2bad79209ce7b92c3feee232fe39eb4d1866ad49cf37e1deb2fcL52-R56)

### Removal of Code:
* Removed the `amount` field from `CreditDropMessage` and `CreditReturnMessage` classes in `aiperf/common/messages.py`, as it is no longer needed in the refactored credit issuing logic. [[1]](diffhunk://#diff-456115a96d923a89a566e411114119f7fcce46f1907549b2fc47ba61b003742aL279-L282) [[2]](diffhunk://#diff-456115a96d923a89a566e411114119f7fcce46f1907549b2fc47ba61b003742aL300-L304)
* Removed the `initialize` method from `CreditIssuingStrategy` and related subclasses, as initialization is now handled differently. [[1]](diffhunk://#diff-440e777d5281ed3f5ae087992e56e8ddf7170028ff07aa72681339fea600d9c9L53-L56) [[2]](diffhunk://#diff-c860473233fd2bad79209ce7b92c3feee232fe39eb4d1866ad49cf37e1deb2fcL10-R30)