### PR TITLE
fix: Fix errors in Request Throughput metric

### DIFF
--- a/aiperf/services/records_manager/metrics/types/request_throughput_metric.py
+++ b/aiperf/services/records_manager/metrics/types/request_throughput_metric.py
@@ -1,0 +1,54 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+from aiperf.common.constants import NANOS_PER_SECOND
+from aiperf.common.enums import MetricTimeType, MetricType
+from aiperf.common.record_models import ParsedResponseRecord
+from aiperf.services.records_manager.metrics.base_metric import BaseMetric
+
+
+class RequestThroughputMetric(BaseMetric):
+    """
+    Post Processor for calculating Request throughput metrics from records.
+    """
+
+    tag = "request_throughput"
+    unit = MetricTimeType.SECONDS
+    larger_is_better = True
+    header = "Request Throughput"
+    type = MetricType.METRIC_OF_BOTH
+    streaming_only = False
+
+    def __init__(self):
+        self.total_requests: int = 0
+        self.metric: float = 0.0
+
+    def update_value(
+        self,
+        record: ParsedResponseRecord | None = None,
+        metrics: dict[str, "BaseMetric"] | None = None,
+    ) -> None:
+        if record:
+            self._check_record(record)
+            self.total_requests += 1
+
+        if metrics:
+            benchmark_duration = metrics["benchmark_duration"].values()
+            self.metric = self.total_requests / (benchmark_duration / NANOS_PER_SECOND)
+
+    def values(self) -> float:
+        """
+        Returns the Request Throughput metric.
+        """
+        return self.metric
+
+    def _check_record(self, record: ParsedResponseRecord) -> None:
+        """
+        Checks if the record is valid.
+
+        Raises:
+            ValueError: If the record is None or is invalid.
+        """
+        if not record:
+            raise ValueError("Record must have a valid request.")
+        if not record.valid:
+            raise ValueError("Invalid Record.")

--- a/aiperf/services/records_manager/post_processors/metric_summary.py
+++ b/aiperf/services/records_manager/post_processors/metric_summary.py
@@ -43,7 +43,8 @@ class MetricSummary:
             for metric in self._metrics:
                 if metric.type == MetricType.METRIC_OF_METRICS:
                     metric.update_value(metrics={m.tag: m for m in self._metrics})
-                elif metric.type == MetricType.METRIC_OF_BOTH:
+            for metric in self._metrics:
+                if metric.type == MetricType.METRIC_OF_BOTH:
                     metric.update_value(
                         record=record, metrics={m.tag: m for m in self._metrics}
                     )
@@ -55,7 +56,8 @@ class MetricSummary:
         for metric in self._metrics:
             if metric.type == MetricType.METRIC_OF_METRICS:
                 metric.update_value(metrics={m.tag: m for m in self._metrics})
-            elif metric.type == MetricType.METRIC_OF_BOTH:
+        for metric in self._metrics:
+            if metric.type == MetricType.METRIC_OF_BOTH:
                 metric.update_value(
                     # TODO: Where does this `record` value come from? Is this wrong?
                     record=record,

--- a/aiperf/tests/metrics/test_request_throughput_metric.py
+++ b/aiperf/tests/metrics/test_request_throughput_metric.py
@@ -1,0 +1,83 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from aiperf.common.record_models import (
+    ParsedResponseRecord,
+    RequestRecord,
+    ResponseData,
+)
+from aiperf.services.records_manager.metrics.types.request_throughput_metric import (
+    RequestThroughputMetric,
+)
+
+
+@pytest.fixture
+def mock_benchmark_duration():
+    class MockBenchmarkDuration:
+        tag = "benchmark_duration"
+
+        def values(self):
+            return 3_000_000_000  # 3s
+
+    return MockBenchmarkDuration()
+
+
+@pytest.fixture
+def sample_records():
+    return [
+        ParsedResponseRecord(
+            worker_id="worker-1",
+            request=RequestRecord(start_perf_ns=0, timestamp_ns=0, has_error=False),
+            responses=[
+                ResponseData(
+                    perf_ns=10,
+                    token_count=10,
+                    raw_text=["hello"],
+                    parsed_text=["hello"],
+                )
+            ],
+        ),
+        ParsedResponseRecord(
+            worker_id="worker-1",
+            request=RequestRecord(start_perf_ns=10, timestamp_ns=10, has_error=False),
+            responses=[
+                ResponseData(
+                    perf_ns=20,
+                    token_count=10,
+                    raw_text=["world"],
+                    parsed_text=["world"],
+                )
+            ],
+        ),
+        ParsedResponseRecord(
+            worker_id="worker-1",
+            request=RequestRecord(start_perf_ns=20, timestamp_ns=20, has_error=False),
+            responses=[
+                ResponseData(
+                    perf_ns=30, token_count=10, raw_text=["done"], parsed_text=["done"]
+                )
+            ],
+        ),
+    ]
+
+
+def test_add_multiple_records(mock_benchmark_duration, sample_records):
+    request_throughput = RequestThroughputMetric()
+    for record in sample_records:
+        request_throughput.update_value(record)
+
+    metrics = {"benchmark_duration": mock_benchmark_duration}
+    request_throughput.update_value(record=None, metrics=metrics)
+
+    assert request_throughput.values() == pytest.approx(1.0)
+
+
+def test_no_records(mock_benchmark_duration):
+    metric = RequestThroughputMetric()
+
+    metric.update_value(
+        record=None, metrics={"benchmark_duration": mock_benchmark_duration}
+    )
+
+    assert metric.values() == 0.0


### PR DESCRIPTION
- Modified the `else` condition in `update` method in `request_throughput.py` to `if metrics:` so that the condition would be true and `request_throughput` would be calculated.
- Modified process logic so that all `METRIC_OF_METRICS` are calculated and available before "METRIC_OF_BOTH" metrics.