### PR TITLE
feat: Add input sequence length metric

### DIFF
--- a/aiperf/common/record_models.py
+++ b/aiperf/common/record_models.py
@@ -224,9 +224,6 @@ class RequestRecord(AIPerfBaseModel):
         default=CreditPhase.PROFILING,
         description="The type of credit phase (either warmup or profiling)",
     )
-    input_token_count: int | None = Field(
-        default=None, description="The number of tokens in the input prompt."
-    )
 
     @property
     def delayed(self) -> bool:
@@ -351,9 +348,9 @@ class ParsedResponseRecord(AIPerfBaseModel):
     )
     request: RequestRecord = Field(description="The original request record")
     responses: list[ResponseData] = Field(description="The parsed response data.")
-    isl: int | None = Field(
+    input_token_count: int | None = Field(
         default=None,
-        description="The Input Sequence Length (ISL) of the request. If None, the ISL was not available or able to be computed.",
+        description="The number of tokens in the input, None if the numbers of tokens cannot be calculated",
     )
 
     @cached_property

--- a/aiperf/services/inference_result_parser/inference_result_parser.py
+++ b/aiperf/services/inference_result_parser/inference_result_parser.py
@@ -120,58 +120,6 @@ class InferenceResultParser(BaseComponentService):
     @on_configure
     async def _configure(self, message: CommandMessage) -> None:
         """Configure the inference result parser."""
-        self.logger.debug(
-            f"Configuring inference result parser with message: {message}"
-        )
-        self.user_config = (
-            message.data if isinstance(message.data, UserConfig) else None
-        )
-
-        # TODO: This is a hack to get the tokenizer for the default model.
-        # We should remove this once we have a better way to get the tokenizer from the user config.
-        await self.get_tokenizer(
-            os.getenv("AIPERF_MODEL", "deepseek-ai/DeepSeek-R1-Distill-Llama-8B")
-        )
-
-        if self.user_config:
-            # TODO: Does this code actually work as intended? Maybe refactor this to use a loop.
-            await asyncio.gather(
-                *[self.get_tokenizer(model) for model in self.user_config.model_names]
-            )
-            self.logger.info(
-                "Initialized tokenizers for %d models", len(self.tokenizers)
-            )
-
-    async def _compute_input_token_count(
-        self, request_record: RequestRecord, tokenizer: Tokenizer
-    ) -> int:
-        "Extract the input prompt text from the request record and return token count."
-        input_data = request_record.request
-        prompt = None
-        if "messages" in input_data:
-            prompt = " ".join(
-                m["content"] for m in input_data["messages"] if "content" in m
-            )
-        elif "input" in input_data:
-            if isinstance(input_data["input"], list):
-                prompt = " ".join(input_data["input"])
-            else:
-                prompt = input_data["input"]
-        elif "prompt" in input_data:
-            if isinstance(input_data["prompt"], list):
-                prompt = " ".join(input_data["prompt"])
-            else:
-                prompt = input_data["prompt"]
-        elif "inputs" in input_data:
-            if isinstance(input_data["inputs"], list):
-                prompt = " ".join(input_data["inputs"])
-            else:
-                prompt = input_data["inputs"]
-
-        if prompt is None:
-            raise ValueError("Unable to extract prompt from input.")
-
-        return len(tokenizer.encode(prompt))
 
     async def _on_inference_results(self, message: InferenceResultsMessage) -> None:
         """Handle an inference results message."""
@@ -243,24 +191,26 @@ class InferenceResultParser(BaseComponentService):
                 worker_id=message.service_id,
                 request=message.record,
                 responses=[],
-                isl=None,
+                input_token_count=None,
             )
 
         tokenizer = await self.get_tokenizer(message.record.model_name)
         resp = await self.extractor.extract_response_data(message.record, tokenizer)
-        isl = await self.compute_isl(message.record, tokenizer)
+        input_token_count = await self.compute_input_token_count(
+            message.record, tokenizer
+        )
 
         return ParsedResponseRecord(
             worker_id=message.service_id,
             request=message.record,
             responses=resp,
-            isl=isl,
+            input_token_count=input_token_count,
         )
 
-    async def compute_isl(
+    async def compute_input_token_count(
         self, record: RequestRecord, tokenizer: Tokenizer
     ) -> int | None:
-        """Compute the ISL for a given request record."""
+        """Compute the number of tokens in the input for a given request record."""
         if record.conversation_id is None or record.turn_index is None:
             self.warning(
                 lambda: f"Conversation ID or turn index is None: {record.conversation_id=} {record.turn_index=}"

--- a/aiperf/services/records_manager/metrics/types/input_sequence_length_metric.py
+++ b/aiperf/services/records_manager/metrics/types/input_sequence_length_metric.py
@@ -27,12 +27,12 @@ class InputSequenceLengthMetric(BaseMetric):
         metrics: dict[str, "BaseMetric"] | None = None,
     ):
         self._check_record(record)
-        input_token_count = record.request.input_token_count
+        input_token_count = record.input_token_count
         self.metric.append(input_token_count)
 
     def values(self):
         """
-        Returns the list of Input Sequence Length (ITL) metrics.
+        Returns the list of Input Sequence Length (ISL) metrics.
         """
         return self.metric
 
@@ -45,5 +45,5 @@ class InputSequenceLengthMetric(BaseMetric):
         """
         if not record or not record.valid:
             raise ValueError("Invalid Record")
-        if not record.request.input_token_count:
+        if record.input_token_count is None:
             raise ValueError("Input Token Count is not available for the record.")

--- a/aiperf/tests/metrics/test_input_sequence_length_metric.py
+++ b/aiperf/tests/metrics/test_input_sequence_length_metric.py
@@ -19,12 +19,14 @@ def make_record(input_token_count: int) -> ParsedResponseRecord:
         timestamp_ns=2,
         end_perf_ns=3,
     )
-    request.input_token_count = input_token_count
     response = ResponseData(
         perf_ns=2, raw_text=["test"], parsed_text=["test"], token_count=1, metadata={}
     )
     return ParsedResponseRecord(
-        worker_id="worker", request=request, responses=[response]
+        worker_id="worker",
+        request=request,
+        responses=[response],
+        input_token_count=input_token_count,
     )
 
 

--- a/aiperf/tests/metrics/test_output_sequence_length_metric.py
+++ b/aiperf/tests/metrics/test_output_sequence_length_metric.py
@@ -15,7 +15,7 @@ from aiperf.services.records_manager.metrics.types.output_sequence_length_metric
 def make_record(token_counts):
     responses = [
         ResponseData(
-            perf_ns=0,
+            perf_ns=100,
             raw_text=["test"],
             parsed_text=["test"],
             token_count=count,
@@ -24,9 +24,17 @@ def make_record(token_counts):
         for count in token_counts
     ]
     request = RequestRecord(
-        start_perf_ns=1, timestamp_ns=2, end_perf_ns=3, has_error=False
+        start_perf_ns=1,
+        timestamp_ns=2,
+        end_perf_ns=10,
+        has_error=False,
     )
-    return ParsedResponseRecord(worker_id="w1", request=request, responses=responses)
+    return ParsedResponseRecord(
+        worker_id="w1",
+        request=request,
+        responses=responses,
+        input_token_count=1,
+    )
 
 
 def test_osl_metric_with_multiple_records():


### PR DESCRIPTION
- Added a method to calculate `input_token_count` in `InferenceResultParser`.
- Added `input_tokens` field in `RequestRecord`.
- Added `InputSequenceLengthMetric` class.
- Miscellaneous fixes that were throwing error.
- Unit tests.
