### PR TITLE
feat: MessageBusMixin for automatic @on_message hooks

### DIFF
--- a/aiperf/common/mixins/__init__.py
+++ b/aiperf/common/mixins/__init__.py
@@ -25,6 +25,9 @@ from aiperf.common.mixins.async_task_manager_mixin import (
 from aiperf.common.mixins.base_mixin import (
     BaseMixin,
 )
+from aiperf.common.mixins.communication_mixin import (
+    CommunicationMixin,
+)
 from aiperf.common.mixins.hooks_mixin import (
     HooksMixin,
 )
@@ -43,6 +46,7 @@ __all__ = [
     "AsyncTaskManagerMixin",
     "AsyncTaskManagerProtocol",
     "BaseMixin",
+    "CommunicationMixin",
     "HooksMixin",
     "MessageBusClientMixin",
     "ProcessHealthMixin",

--- a/aiperf/common/mixins/communication_mixin.py
+++ b/aiperf/common/mixins/communication_mixin.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from abc import ABC
+
+from aiperf.common.config import ServiceConfig
+from aiperf.common.factories import CommunicationFactory
+from aiperf.common.mixins.aiperf_lifecycle_mixin import AIPerfLifecycleMixin
+from aiperf.common.protocols import CommunicationProtocol
+
+
+class CommunicationMixin(AIPerfLifecycleMixin, ABC):
+    """Mixin to provide access to a CommunicationProtocol instance. This mixin should be inherited
+    by any mixin that needs access to the communication layer to create Communication clients.
+    """
+
+    def __init__(self, service_config: ServiceConfig, **kwargs) -> None:
+        super().__init__(service_config=service_config, **kwargs)
+        self.service_config = service_config
+        self.comms: CommunicationProtocol = CommunicationFactory.get_or_create_instance(
+            self.service_config.comm_backend,
+            config=self.service_config.comm_config,
+        )
+        self.attach_child_lifecycle(self.comms)


### PR DESCRIPTION
- Mixin that extends the lifecycle one for use with a pub/sub client to our message bus (event bus) (zmq proxy), etc.
- BaseService extends from this, because we may want to allow non-services to utilize the message bus.


<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/f140fd9f-1cf3-42b8-ae89-f52e66781262" />
