### PR TITLE
fix: hotfix for dynamo chat api

### DIFF
--- a/aiperf/clients/openai/openai_chat.py
+++ b/aiperf/clients/openai/openai_chat.py
@@ -24,9 +24,24 @@ class OpenAIChatCompletionRequestConverter(AIPerfLoggerMixin):
         """Format payload for a chat completion request."""
 
         message = self._create_message(turn)
+        # Hotfix for Dynamo API which does not yet support a list of messages
+        if (
+            len(message["content"]) == 1
+            and "text" in message["content"][0]
+            and len(turn.texts) == 1
+        ):
+            messages = [
+                {
+                    "role": message["role"],
+                    "name": turn.texts[0].name,
+                    "content": message["content"][0].get("text"),
+                }
+            ]
+        else:
+            messages = [message]
 
         payload = {
-            "messages": [message],
+            "messages": messages,
             "model": model_endpoint.primary_model_name,
             "stream": model_endpoint.endpoint.streaming,
         }


### PR DESCRIPTION
Dynamo only supports a string for content in the chat API. OpenAI supports a string or list, so to maximize compatibility, use a string if there is only one text in the content list.