### PR TITLE
fix: inform user of processing delay, fix potential race condition

### DIFF
--- a/aiperf/post_processors/processing_stats_streamer.py
+++ b/aiperf/post_processors/processing_stats_streamer.py
@@ -97,7 +97,7 @@ class ProcessingStatsStreamer(BaseStreamingPostProcessor):
             self.final_request_count = phase_complete_msg.completed
             self.end_time_ns = phase_complete_msg.end_ns
             self.info(f"Updating final request count to {self.final_request_count}")
-            if self.final_request_count == self.processing_stats.total_records:
+            if self.processing_stats.total_records >= self.final_request_count:
                 # If we received all the records before the credit phase complete message,
                 # then send a message to the event bus to signal that we received all the records.
                 await self.publish(


### PR DESCRIPTION
- When all the requests have been completed, usually not all the records have been processed. If this is the case, then print a log message so they know we are not "hanging"
- Fix potential for race condition causing actual hangs if the credits complete comes in after the last record is already processed.