### PR TITLE
feat: add credit drop latency internal metric

### DIFF
--- a/aiperf/common/messages/credit_messages.py
+++ b/aiperf/common/messages/credit_messages.py
@@ -44,13 +44,6 @@ class CreditReturnMessage(BaseServiceMessage):
         description="The number of nanoseconds the credit drop was delayed by, or None if the credit was sent on time. "
         "NOTE: This is only applicable if the original credit_drop_ns was not None.",
     )
-    # TODO: Does it make more sense for this to be part of the RequestRecord?
-    pre_inference_ns: int | None = Field(
-        default=None,
-        description="The latency of the credit in nanoseconds from when it was first received to when the inference request was sent. "
-        "This can be used to trace the latency in order to identify bottlenecks or other issues.",
-        ge=0,
-    )
 
     @property
     def delayed(self) -> bool:

--- a/aiperf/common/models/record_models.py
+++ b/aiperf/common/models/record_models.py
@@ -213,6 +213,12 @@ class RequestRecord(AIPerfBaseModel):
         default=CreditPhase.PROFILING,
         description="The type of credit phase (either warmup or profiling)",
     )
+    credit_drop_latency: int | None = Field(
+        default=None,
+        description="The latency of the credit drop in nanoseconds from when it was first received by a Worker to when the inference request was actually sent. "
+        "This can be used to trace internal latency in order to identify bottlenecks or other issues.",
+        ge=0,
+    )
 
     @property
     def delayed(self) -> bool:

--- a/aiperf/metrics/types/credit_drop_latency_metric.py
+++ b/aiperf/metrics/types/credit_drop_latency_metric.py
@@ -1,0 +1,46 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+
+from aiperf.common.enums import MetricFlags
+from aiperf.common.enums.metric_enums import MetricTimeUnit
+from aiperf.common.models import ParsedResponseRecord
+from aiperf.metrics.base_record_metric import BaseRecordMetric
+from aiperf.metrics.metric_dicts import MetricRecordDict
+
+
+class CreditDropLatencyMetric(BaseRecordMetric[int]):
+    """
+    Post-processor for calculating Credit Drop Latency metrics from records. This is an internal metric that is
+    intended to be used for debugging and performance analysis of the AIPerf internal system.
+
+    It exposes how long it took from when a credit was dropped, to when the actual request was sent. This will
+    include the time it took to query the DatasetManager to get the Turn, as well as the time it took to format
+    the request.
+
+    Formula:
+        Credit Drop Latency = Request Start Time - Credit Drop Received Time
+    """
+
+    tag = "credit_drop_latency"
+    header = "Credit Drop Latency"
+    unit = MetricTimeUnit.NANOSECONDS
+    display_unit = MetricTimeUnit.MILLISECONDS
+    flags = MetricFlags.INTERNAL
+    required_metrics = None
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> int:
+        """
+        This method extracts the credit drop latency from the record and returns it.
+
+        Raises:
+            ValueError: If the record does not include a credit drop latency.
+        """
+        if record.request.credit_drop_latency is None:
+            raise ValueError("Credit Drop Latency is not included in the record.")
+
+        return record.request.credit_drop_latency

--- a/tests/timing_manager/test_fixed_schedule_strategy.py
+++ b/tests/timing_manager/test_fixed_schedule_strategy.py
@@ -65,7 +65,6 @@ class TestFixedScheduleStrategy:
                 service_id="test-consumer",
                 phase=CreditPhase.PROFILING,
                 delayed_ns=None,
-                pre_inference_ns=None,
             )
             await fixed_schedule_strategy._on_credit_return(return_message)
 


### PR DESCRIPTION
Part of the internal metrics meant for aiperf developers

there are some tweaks we can do to them eventually. Maybe a separate table, or a second color.

But we are planning on protecting these options behind env var.

<img width="1289" height="559" alt="Screenshot From 2025-08-07 13-39-47" src="https://github.com/user-attachments/assets/1b86d712-e525-45ec-a677-445432954c83" />
