### PR TITLE
fix: move batched content one level up

### DIFF
--- a/aiperf/clients/openai/openai_chat.py
+++ b/aiperf/clients/openai/openai_chat.py
@@ -88,6 +88,5 @@ class OpenAIChatCompletionRequestConverter(AIPerfLoggerMixin):
                     }
                 )
 
-            message["content"] = message_content
-
+        message["content"] = message_content
         return [message]

--- a/aiperf/parsers/inference_result_parser.py
+++ b/aiperf/parsers/inference_result_parser.py
@@ -168,7 +168,7 @@ class InferenceResultParser(CommunicationMixin):
             for t in response.parsed_text
             if t
         )
-        output_token_count = len(tokenizer.encode(output_text))
+        output_token_count = len(tokenizer.encode(output_text)) if output_text else 0
 
         return ParsedResponseRecord(
             request=request_record,


### PR DESCRIPTION
This pull request moves batching up one level (e.g. batched texts are both "Text" not text.contents). This aligns with how GenAI-Perf did batching and how OpenAI endpoints generally do batching. The contents field is for multiple parts of one text/audio/image rather than an individual text/audio/image. Since AIPerf models the data flow well with the granularity provided by the contents field, it also retains the flexibility to in the future support providing multiple fragments of individual contents (e.g. multiple parts of an image, a text, or an audio clip).

Tested against vLLM's completions and chat endpoints.
<img width="1672" height="686" alt="Screenshot 2025-08-11 at 12 29 29 PM" src="https://github.com/user-attachments/assets/706efd19-87dd-4f2a-95e9-847fce52a7a6" />
