### PR TITLE
refactor: split out console and data exporters

### DIFF
--- a/aiperf/common/enums/__init__.py
+++ b/aiperf/common/enums/__init__.py
@@ -24,6 +24,7 @@ from aiperf.common.enums.communication_enums import (
     ZMQProxyType,
 )
 from aiperf.common.enums.data_exporter_enums import (
+    ConsoleExporterType,
     DataExporterType,
 )
 from aiperf.common.enums.dataset_enums import (
@@ -102,6 +103,7 @@ __all__ = [
     "CommandType",
     "CommunicationBackend",
     "ComposerType",
+    "ConsoleExporterType",
     "CreditPhase",
     "CustomDatasetType",
     "DataExporterType",

--- a/aiperf/common/enums/data_exporter_enums.py
+++ b/aiperf/common/enums/data_exporter_enums.py
@@ -4,7 +4,10 @@
 from aiperf.common.enums.base_enums import CaseInsensitiveStrEnum
 
 
+class ConsoleExporterType(CaseInsensitiveStrEnum):
+    METRICS = "metrics"
+    ERRORS = "errors"
+
+
 class DataExporterType(CaseInsensitiveStrEnum):
-    CONSOLE = "console"
-    CONSOLE_ERROR = "console_error"
     JSON = "json"

--- a/aiperf/common/factories.py
+++ b/aiperf/common/factories.py
@@ -10,6 +10,7 @@ from aiperf.common.enums import (
     CommClientType,
     CommunicationBackend,
     ComposerType,
+    ConsoleExporterType,
     CustomDatasetType,
     DataExporterType,
     EndpointType,
@@ -34,6 +35,7 @@ from aiperf.common.types import (
 if TYPE_CHECKING:
     # NOTE: These imports are for the factory class type hints.
     #       We do not want to import these classes directly.
+
     from aiperf.clients.model_endpoint_info import ModelEndpointInfo
     from aiperf.common.config import (
         BaseZMQCommunicationConfig,
@@ -44,6 +46,7 @@ if TYPE_CHECKING:
     from aiperf.common.protocols import (
         CommunicationClientProtocol,
         CommunicationProtocol,
+        ConsoleExporterProtocol,
         DataExporterProtocol,
         InferenceClientProtocol,
         RecordProcessorProtocol,
@@ -379,6 +382,25 @@ class ComposerFactory(AIPerfFactory[ComposerType, "BaseDatasetComposer"]):
         **kwargs,
     ) -> "BaseDatasetComposer":
         return super().create_instance(class_type, **kwargs)
+
+
+class ConsoleExporterFactory(
+    AIPerfFactory[ConsoleExporterType, "ConsoleExporterProtocol"]
+):
+    """Factory for registering and creating ConsoleExporterProtocol instances based on the specified data exporter type.
+    see: :class:`aiperf.common.factories.AIPerfFactory` for more details.
+    """
+
+    @classmethod
+    def create_instance(  # type: ignore[override]
+        cls,
+        class_type: ConsoleExporterType | str,
+        exporter_config: "ExporterConfig",
+        **kwargs,
+    ) -> "ConsoleExporterProtocol":
+        return super().create_instance(
+            class_type, exporter_config=exporter_config, **kwargs
+        )
 
 
 class CustomDatasetFactory(

--- a/aiperf/common/protocols.py
+++ b/aiperf/common/protocols.py
@@ -38,9 +38,12 @@ from aiperf.common.types import (
 )
 
 if TYPE_CHECKING:
+    from rich.console import Console
+
     from aiperf.common.config import ServiceConfig, UserConfig
     from aiperf.common.enums.metric_enums import MetricValueTypeT
     from aiperf.common.models.record_models import MetricResult
+    from aiperf.exporters.exporter_config import ExporterConfig
     from aiperf.metrics.metric_dicts import MetricRecordDict
 
 
@@ -294,12 +297,26 @@ class MessageBusClientProtocol(PubClientProtocol, SubClientProtocol, Protocol):
 
 
 @runtime_checkable
+class ConsoleExporterProtocol(Protocol):
+    """Protocol for console exporters.
+    Any class implementing this protocol will be provided an ExporterConfig and must provide an
+    `export` method that takes a rich Console and a width and handles exporting them appropriately.
+    """
+
+    def __init__(self, exporter_config: "ExporterConfig") -> None: ...
+
+    async def export(self, console: "Console", width: int | None = None) -> None: ...
+
+
+@runtime_checkable
 class DataExporterProtocol(Protocol):
     """
     Protocol for data exporters.
-    Any class implementing this protocol must provide an `export` method
-    that takes a list of Record objects and handles exporting them appropriately.
+    Any class implementing this protocol will be provided an ExporterConfig and must provide an
+    `export` method that handles exporting the data appropriately.
     """
+
+    def __init__(self, exporter_config: "ExporterConfig") -> None: ...
 
     async def export(self) -> None: ...
 

--- a/aiperf/exporters/__init__.py
+++ b/aiperf/exporters/__init__.py
@@ -11,8 +11,8 @@ __ignore__ = []
 from aiperf.exporters.console_error_exporter import (
     ConsoleErrorExporter,
 )
-from aiperf.exporters.console_exporter import (
-    ConsoleExporter,
+from aiperf.exporters.console_metrics_exporter import (
+    ConsoleMetricsExporter,
 )
 from aiperf.exporters.exporter_config import (
     ExporterConfig,
@@ -27,7 +27,7 @@ from aiperf.exporters.json_exporter import (
 
 __all__ = [
     "ConsoleErrorExporter",
-    "ConsoleExporter",
+    "ConsoleMetricsExporter",
     "ExporterConfig",
     "ExporterManager",
     "JsonExportData",

--- a/aiperf/exporters/console_error_exporter.py
+++ b/aiperf/exporters/console_error_exporter.py
@@ -4,20 +4,23 @@
 from rich.console import Console
 from rich.table import Table
 
-from aiperf.common.enums import DataExporterType
-from aiperf.common.factories import DataExporterFactory
+from aiperf.common.decorators import implements_protocol
+from aiperf.common.enums import ConsoleExporterType
+from aiperf.common.factories import ConsoleExporterFactory
 from aiperf.common.models import ErrorDetailsCount
+from aiperf.common.protocols import ConsoleExporterProtocol
 from aiperf.exporters.exporter_config import ExporterConfig
 
 
-@DataExporterFactory.register(DataExporterType.CONSOLE_ERROR)
+@implements_protocol(ConsoleExporterProtocol)
+@ConsoleExporterFactory.register(ConsoleExporterType.ERRORS)
 class ConsoleErrorExporter:
     """A class that exports error data to the console"""
 
     def __init__(self, exporter_config: ExporterConfig, **kwargs):
         self._results = exporter_config.results
 
-    async def export(self, width: int | None = None) -> None:
+    async def export(self, console: Console, width: int | None = None) -> None:
         if not self._results.error_summary:
             return
 
@@ -28,7 +31,6 @@ class ConsoleErrorExporter:
         table.add_column("Count", justify="right", style="yellow")
         self._construct_table(table, self._results.error_summary)
 
-        console = Console()
         console.print("\n")
         console.print(table)
         console.file.flush()

--- a/aiperf/exporters/console_metrics_exporter.py
+++ b/aiperf/exporters/console_metrics_exporter.py
@@ -8,19 +8,20 @@ from rich.console import Console
 from rich.table import Table
 
 from aiperf.common.decorators import implements_protocol
-from aiperf.common.enums import DataExporterType, MetricFlags
+from aiperf.common.enums import MetricFlags
+from aiperf.common.enums.data_exporter_enums import ConsoleExporterType
 from aiperf.common.exceptions import MetricUnitError
-from aiperf.common.factories import DataExporterFactory
+from aiperf.common.factories import ConsoleExporterFactory
 from aiperf.common.mixins import AIPerfLoggerMixin
 from aiperf.common.models import MetricResult
-from aiperf.common.protocols import DataExporterProtocol
+from aiperf.common.protocols import ConsoleExporterProtocol
 from aiperf.exporters.exporter_config import ExporterConfig
 from aiperf.metrics.metric_registry import MetricRegistry
 
 
-@implements_protocol(DataExporterProtocol)
-@DataExporterFactory.register(DataExporterType.CONSOLE)
-class ConsoleExporter(AIPerfLoggerMixin):
+@implements_protocol(ConsoleExporterProtocol)
+@ConsoleExporterFactory.register(ConsoleExporterType.METRICS)
+class ConsoleMetricsExporter(AIPerfLoggerMixin):
     """A class that exports data to the console"""
 
     STAT_COLUMN_KEYS = ["avg", "min", "max", "p99", "p90", "p75", "std"]
@@ -33,7 +34,7 @@ class ConsoleExporter(AIPerfLoggerMixin):
             exporter_config.user_config.output.show_internal_metrics
         )
 
-    async def export(self, width: int | None = None) -> None:
+    async def export(self, console: Console, width: int | None = None) -> None:
         if not self._results.records:
             self.warning("No records to export")
             return
@@ -44,7 +45,6 @@ class ConsoleExporter(AIPerfLoggerMixin):
             table.add_column(key, justify="right", style="green")
         self._construct_table(table, self._results.records)
 
-        console = Console()
         console.print("\n")
         console.print(table)
         console.file.flush()

--- a/tests/data_exporters/test_console_exporter.py
+++ b/tests/data_exporters/test_console_exporter.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from rich.console import Console
 
 from aiperf.common.config import EndpointConfig, UserConfig
 from aiperf.common.constants import NANOS_PER_MILLIS
 from aiperf.common.enums import EndpointType
 from aiperf.common.models import MetricResult, ProfileResults
-from aiperf.exporters import ConsoleExporter, ExporterConfig
+from aiperf.exporters import ExporterConfig
+from aiperf.exporters.console_metrics_exporter import ConsoleMetricsExporter
 
 
 @pytest.fixture
@@ -81,8 +83,8 @@ def mock_exporter_config(sample_records, mock_endpoint_config):
 class TestConsoleExporter:
     @pytest.mark.asyncio
     async def test_export_prints_expected_table(self, mock_exporter_config, capsys):
-        exporter = ConsoleExporter(mock_exporter_config)
-        await exporter.export(width=100)
+        exporter = ConsoleMetricsExporter(mock_exporter_config)
+        await exporter.export(Console(), width=100)
         output = capsys.readouterr().out
         assert "NVIDIA AIPerf | LLM Metrics" in output
         assert "Time to First Token (ms)" in output
@@ -126,7 +128,7 @@ class TestConsoleExporter:
                 ),
                 user_config=input_config,
             )
-            exporter = ConsoleExporter(config)
+            exporter = ConsoleMetricsExporter(config)
 
             # Test with actual metric behavior: use hidden metrics vs normal metrics
             if is_hidden_metric:
@@ -148,7 +150,7 @@ class TestConsoleExporter:
             assert exporter._should_skip(record) is should_skip
 
     def test_format_row_formats_values_correctly(self, mock_exporter_config):
-        exporter = ConsoleExporter(mock_exporter_config)
+        exporter = ConsoleMetricsExporter(mock_exporter_config)
         # Request latency metric expects values in nanoseconds (native unit)
         # but displays in milliseconds.
         record = MetricResult(
@@ -173,5 +175,5 @@ class TestConsoleExporter:
         assert row[6] == "12.30"
 
     def test_get_title_returns_expected_string(self, mock_exporter_config):
-        exporter = ConsoleExporter(mock_exporter_config)
+        exporter = ConsoleMetricsExporter(mock_exporter_config)
         assert exporter._get_title() == "NVIDIA AIPerf | LLM Metrics"


### PR DESCRIPTION
This splits the exporters into 2 type:

- DataExporters: these produce files, etc. like JSON
- ConsoleExporters: these display information to the user after the profile is done.

The data exporters still will export as soon as the results come in, however the console exporters are now ran as the last step before exiting the process, once everything else is stopped.

This was necessary to enable the TUI to display results after it closes, as without it, the console data would be cleared on close.