### PR TITLE
fix: chat API branching logic

### DIFF
--- a/aiperf/clients/openai/openai_chat.py
+++ b/aiperf/clients/openai/openai_chat.py
@@ -45,7 +45,12 @@ class OpenAIChatCompletionRequestConverter(AIPerfLoggerMixin):
             "role": turn.role or DEFAULT_ROLE,
         }
 
-        if len(turn.texts) == 1 and len(turn.images) == 0 and len(turn.audios) == 0:
+        if (
+            len(turn.texts) == 1
+            and len(turn.texts[0].contents) == 1
+            and len(turn.images) == 0
+            and len(turn.audios) == 0
+        ):
             # Hotfix for Dynamo API which does not yet support a list of messages
             message["name"] = turn.texts[0].name
             message["content"] = (
@@ -88,6 +93,6 @@ class OpenAIChatCompletionRequestConverter(AIPerfLoggerMixin):
                     }
                 )
 
-            message["content"] = message_content
+        message["content"] = message_content
 
         return [message]


### PR DESCRIPTION
For the chatAPI, only skip the multi-modal mode if there is one text with one content. In the case where you add the multi-modal content, fix the spacing so that it actually gets appended.