### PR TITLE
fix: call ensure_modules_loaded in bootstrap.py to handle spawn vs fork on macOS

### DIFF
--- a/aiperf/common/bootstrap.py
+++ b/aiperf/common/bootstrap.py
@@ -52,6 +52,10 @@ def bootstrap_and_run_service(
         if service_config.enable_yappi:
             _start_yappi_profiling()
 
+        from aiperf.module_loader import ensure_modules_loaded
+
+        ensure_modules_loaded()
+
         service = service_class(
             service_config=service_config,
             user_config=user_config,


### PR DESCRIPTION
There is still a known issue on macOS from aiperf dependency on io_counters, which is linux-only.

Team can look into resolving that later.