### PR TITLE
fix: disable high water mark for zmq for deadlock

### DIFF
--- a/aiperf/common/constants.py
+++ b/aiperf/common/constants.py
@@ -21,7 +21,7 @@ TASK_CANCEL_TIMEOUT_SHORT = 2.0
 TASK_CANCEL_TIMEOUT_LONG = 5.0
 """Maximum time to wait for complex tasks to complete when cancelling them (like parent tasks)."""
 
-DEFAULT_COMMS_REQUEST_TIMEOUT = 30.0
+DEFAULT_COMMS_REQUEST_TIMEOUT = 90.0
 """Default timeout for requests from req_clients to rep_clients in seconds."""
 
 DEFAULT_PULL_CLIENT_MAX_CONCURRENCY = 100_000

--- a/aiperf/zmq/pull_client.py
+++ b/aiperf/zmq/pull_client.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
-import os
 from collections.abc import Callable, Coroutine
 from typing import Any
 
 import zmq.asyncio
 
+from aiperf.common.constants import DEFAULT_PULL_CLIENT_MAX_CONCURRENCY
 from aiperf.common.decorators import implements_protocol
 from aiperf.common.enums import CommClientType
 from aiperf.common.factories import CommunicationClientFactory
@@ -78,7 +78,7 @@ class ZMQPullClient(BaseZMQClient):
             self.semaphore = asyncio.Semaphore(value=max_pull_concurrency)
         else:
             self.semaphore = asyncio.Semaphore(
-                value=int(os.getenv("AIPERF_WORKER_CONCURRENT_REQUESTS", 500))
+                value=DEFAULT_PULL_CLIENT_MAX_CONCURRENCY
             )
 
     @background_task(immediate=True, interval=None)

--- a/aiperf/zmq/zmq_base_client.py
+++ b/aiperf/zmq/zmq_base_client.py
@@ -90,6 +90,10 @@ class BaseZMQClient(AIPerfLifecycleMixin):
             self.socket.setsockopt(zmq.RCVTIMEO, ZMQSocketDefaults.RCVTIMEO)
             self.socket.setsockopt(zmq.SNDTIMEO, ZMQSocketDefaults.SNDTIMEO)
 
+            # Set high water mark
+            self.socket.setsockopt(zmq.SNDHWM, ZMQSocketDefaults.SNDHWM)
+            self.socket.setsockopt(zmq.RCVHWM, ZMQSocketDefaults.RCVHWM)
+
             # Set performance-oriented socket options
             self.socket.setsockopt(zmq.TCP_KEEPALIVE, ZMQSocketDefaults.TCP_KEEPALIVE)
             self.socket.setsockopt(

--- a/aiperf/zmq/zmq_defaults.py
+++ b/aiperf/zmq/zmq_defaults.py
@@ -38,3 +38,12 @@ class ZMQSocketDefaults:
     TCP_KEEPALIVE_CNT = 3
     IMMEDIATE = 1  # Don't queue messages
     LINGER = 0  # Don't wait on close
+
+    # High Water Mark
+    # TODO: Investigate better ways to handle this
+    # https://zeromq.org/socket-api/#high-water-mark
+    # NOTE: We set these to 0 to allow for unlimited messages to be queued. This is important to
+    #       ensure that the system does not lose messages. It does however mean that the system
+    #       could run out of memory if too many messages are queued.
+    SNDHWM = 0  # No send high water mark (unlimited)
+    RCVHWM = 0  # No receive high water mark (unlimited)


### PR DESCRIPTION
This PR _disables_ the High Water Mark of ZMQ as a stop-gap solution to the deadlock issues.

The main problem was that at too high of a concurrency, zmq was dropping messages on purpose, causing the requests from the workers to the dataset manager to timeout. In the end there was no actual deadlock, since the requests would eventually finish with a timeout.

---

**Before: 2 ISL @ 100k Concurrency**
<img width="1270" height="726" alt="Screenshot From 2025-08-06 19-48-50" src="https://github.com/user-attachments/assets/d8b8fe6f-c39f-4676-9330-6bd4fb9ec4c4" />

**After: 2 ISL @ 100k Concurrency**
<img width="1851" height="1083" alt="Screenshot From 2025-08-12 11-08-37" src="https://github.com/user-attachments/assets/0818ebcd-3a4d-44e2-8d65-b035144d2f12" />

