### PR TITLE
refactor: send turn object instead of formatted payload

### DIFF
--- a/aiperf/clients/openai/openai_aiohttp.py
+++ b/aiperf/clients/openai/openai_aiohttp.py
@@ -73,11 +73,9 @@ class OpenAIClientAioHttp(AioHttpClientMixin, AIPerfLoggerMixin, ABC):
                 json.dumps(payload),
                 self.get_headers(model_endpoint),
             )
-            record.request = payload
 
         except Exception as e:
             record = RequestRecord(
-                request=payload,
                 start_perf_ns=start_perf_ns,
                 end_perf_ns=time.perf_counter_ns(),
                 error=ErrorDetails(type=e.__class__.__name__, message=str(e)),

--- a/aiperf/common/models/record_models.py
+++ b/aiperf/common/models/record_models.py
@@ -14,6 +14,7 @@ from pydantic import (
 from aiperf.common.constants import NANOS_PER_SECOND
 from aiperf.common.enums import CreditPhase, SSEFieldType
 from aiperf.common.models.base_models import AIPerfBaseModel
+from aiperf.common.models.dataset_models import Turn
 from aiperf.common.models.error_models import ErrorDetails, ErrorDetailsCount
 from aiperf.common.types import MetricTagT
 
@@ -150,9 +151,9 @@ class SSEMessage(InferenceServerResponse):
 class RequestRecord(AIPerfBaseModel):
     """Record of a request with its associated responses."""
 
-    request: Any | None = Field(
+    turn: Turn | None = Field(
         default=None,
-        description="The request payload formatted for the inference API.",
+        description="The turn associated with the request (if applicable).",
     )
     conversation_id: str | None = Field(
         default=None,

--- a/aiperf/workers/credit_processor_mixin.py
+++ b/aiperf/workers/credit_processor_mixin.py
@@ -175,6 +175,7 @@ class CreditProcessorMixin(CreditProcessorMixinRequirements):
         record.model_name = self.model_endpoint.primary_model_name
         record.conversation_id = conversation_response.conversation.session_id
         record.turn_index = 0
+        record.turn = conversation_response.conversation.turns[record.turn_index]
         return record
 
     async def _call_inference_api_internal(
@@ -232,7 +233,6 @@ class CreditProcessorMixin(CreditProcessorMixinRequirements):
                 f"Error calling inference server API at {self.model_endpoint.url}: {e}"
             )
             return RequestRecord(
-                request=formatted_payload,
                 timestamp_ns=timestamp_ns or time.time_ns(),
                 # Try and use the pre_send_perf_ns if it is available, otherwise use the current time.
                 start_perf_ns=pre_send_perf_ns or time.perf_counter_ns(),

--- a/tests/logging/test_aiperf_logger.py
+++ b/tests/logging/test_aiperf_logger.py
@@ -22,6 +22,7 @@ from aiperf.common.aiperf_logger import (
 from aiperf.common.constants import NANOS_PER_SECOND
 from aiperf.common.enums import CreditPhase
 from aiperf.common.models import RequestRecord, TextResponse
+from aiperf.common.models.dataset_models import Text, Turn
 from tests.utils.time_traveler import TimeTraveler
 
 
@@ -48,14 +49,10 @@ def standard_logger():
 @pytest.fixture
 def large_message():
     return RequestRecord(
-        request={
-            "id": "123",
-            "url": "http://localhost:8080",
-            "method": "GET",
-            "headers": {
-                "Content-Type": "application/json",
-            },
-        },
+        turn=Turn(
+            role="user",
+            texts=[Text(contents=["Hello, world!"] * 100)],
+        ),
         timestamp_ns=time.time_ns(),
         start_perf_ns=time.perf_counter_ns(),
         end_perf_ns=time.perf_counter_ns() + (1_000_000_000 * 101),


### PR DESCRIPTION
Previously, we sent the formatted payload of a request as part of the request record from a worker, however I believe it is smarter to switch to the original turn object, for a few reasons:

- This removes the need for the inference parser to query the dataset manager
  - On high concurrency settings, the single dataset manager can get overwhelmed with requests causing a spike in latency.
  - So without querying the dataset manager, this allows the inference result parsers to process the results faster,
  - As well as leave more bandwith for the workers to request conversations

- We currently have a turn -> payload converter, but not the other way around. In theory if we every needed the formatted payload, post-inference, we can just convert it again.

Note: I have not removed the conversation_id or turn_index values as to cause less upshift, and to allow for fallback