### PR TITLE
chore: default to not streaming to align with GAP

### DIFF
--- a/aiperf/common/config/config_defaults.py
+++ b/aiperf/common/config/config_defaults.py
@@ -31,10 +31,8 @@ class EndpointDefaults:
     MODEL_SELECTION_STRATEGY = ModelSelectionStrategy.ROUND_ROBIN
     CUSTOM_ENDPOINT = None
     TYPE = EndpointType.OPENAI_CHAT_COMPLETIONS
-    STREAMING = True
-    SERVER_METRICS_URLS = ["http://localhost:8002/metrics"]
+    STREAMING = False
     URL = "localhost:8080"
-    GRPC_METHOD = ""
     TIMEOUT = 600.0
     API_KEY = None
 

--- a/tests/config/test_endpoint_config.py
+++ b/tests/config/test_endpoint_config.py
@@ -65,7 +65,7 @@ def test_streaming_validation():
         type=EndpointType.OPENAI_CHAT_COMPLETIONS,
         model_names=["gpt2"],
     )
-    assert config.streaming  # Streaming is enabled by default
+    assert not config.streaming  # Streaming is disabled by default
 
     config = EndpointConfig(
         type=EndpointType.OPENAI_CHAT_COMPLETIONS,
@@ -73,6 +73,13 @@ def test_streaming_validation():
         model_names=["gpt2"],
     )
     assert not config.streaming  # Streaming was set to False
+
+    config = EndpointConfig(
+        type=EndpointType.OPENAI_CHAT_COMPLETIONS,
+        streaming=True,
+        model_names=["gpt2"],
+    )
+    assert config.streaming  # Streaming was set to True
 
     config = EndpointConfig(
         type=EndpointType.OPENAI_EMBEDDINGS,


### PR DESCRIPTION
also removed a couple dead end defaults that should already be gone.

and no, copilot, I will not create a separate pr for that