### PR TITLE
chore: add alias --num-dataset-entries to --conversation-num

### DIFF
--- a/aiperf/common/config/conversation_config.py
+++ b/aiperf/common/config/conversation_config.py
@@ -122,13 +122,16 @@ class ConversationConfig(BaseConfig):
             ge=1,
             description="The total number of unique conversations to generate.\n"
             "Each conversation represents a single request session between client and server.\n"
-            "Supported on synthetic mode only and conversations will be reused until benchmarking is complete.",
+            "Supported on synthetic mode and the custom random_pool dataset. The number of conversations \n"
+            "will be used to determine the number of entries in both the custom random_pool and synthetic \n"
+            "datasets and will be reused until benchmarking is complete.",
         ),
         Parameter(
             name=(
                 "--conversation-num",
                 "--num-conversations",
                 "--num-sessions",  # GenAI-Perf
+                "--num-dataset-entries",  # GenAI-Perf
             ),
             group=_CLI_GROUP,
         ),


### PR DESCRIPTION
### Summary

Add command line option alias `--num-dataset-entries` for `--conversation-num` for parity with GenAI-Perf.