### PR TITLE
chore: update pyproject.toml license field to be compliant with wheeltamer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "aiperf"
 version = "0.1.1"
 description = "AIPerf is a package for performance testing of AI models"
 readme = "README.md"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 license-files = ["LICENSE"]
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },


### PR DESCRIPTION
This PR cherry-picks https://github.com/ai-dynamo/aiperf/commit/2f08a7843da807ad72d4fddb1e1309cf8821ffc6 from main into the `release/0.1.1` branch.