### PR TITLE
fix: graceful termination of zmq context

### DIFF
--- a/aiperf/common/constants.py
+++ b/aiperf/common/constants.py
@@ -90,3 +90,6 @@ DEFAULT_RECORDS_PROGRESS_REPORT_INTERVAL = 2.0
 
 DEFAULT_WORKER_HEALTH_CHECK_INTERVAL = 2.0
 """Default interval in seconds between worker health check messages."""
+
+DEFAULT_ZMQ_CONTEXT_TERM_TIMEOUT = 10.0
+"""Default timeout for terminating the ZMQ context in seconds."""


### PR DESCRIPTION
Gracefully terminate the zmq context with a timeout, and supress any exceptions that would cause the process to hang.

This has been tested by me on @StanleySongNV machine as a fix for the hang issue