### PR TITLE
fix: hide extraneous zmq cli options from help (#260)

### DIFF
--- a/aiperf/common/config/cli_parameter.py
+++ b/aiperf/common/config/cli_parameter.py
@@ -25,7 +25,7 @@ class DisableCLI(CLIParameter):
     This is a subclass of the CLIParameter class that is used to set a CLI parameter to disabled.
     """
 
-    def __init__(self, reason: str, *args, **kwargs):
+    def __init__(self, reason: str = "Not supported via command line", *args, **kwargs):
         super().__init__(*args, parse=False, **kwargs)
 
 

--- a/aiperf/common/config/zmq_config.py
+++ b/aiperf/common/config/zmq_config.py
@@ -9,7 +9,7 @@ from typing import Annotated, ClassVar
 from pydantic import BaseModel, Field, model_validator
 from typing_extensions import Self
 
-from aiperf.common.config.cli_parameter import CLIParameter
+from aiperf.common.config.cli_parameter import CLIParameter, DisableCLI
 from aiperf.common.config.groups import Groups
 from aiperf.common.enums import CommAddress, CommunicationBackend
 
@@ -210,30 +210,36 @@ class ZMQTCPConfig(BaseZMQCommunicationConfig):
             group=_CLI_GROUP,
         ),
     ] = "127.0.0.1"
-    records_push_pull_port: int = Field(
+    records_push_pull_port: Annotated[int, DisableCLI()] = Field(
         default=5557, description="Port for inference push/pull messages"
     )
-    credit_drop_port: int = Field(
+    credit_drop_port: Annotated[int, DisableCLI()] = Field(
         default=5562, description="Port for credit drop operations"
     )
-    credit_return_port: int = Field(
+    credit_return_port: Annotated[int, DisableCLI()] = Field(
         default=5563, description="Port for credit return operations"
     )
-    dataset_manager_proxy_config: ZMQTCPProxyConfig = Field(  # type: ignore
+    dataset_manager_proxy_config: Annotated[  # type: ignore
+        ZMQTCPProxyConfig, DisableCLI()
+    ] = Field(
         default=ZMQTCPProxyConfig(
             frontend_port=5661,
             backend_port=5662,
         ),
         description="Configuration for the ZMQ Proxy. If provided, the proxy will be created and started.",
     )
-    event_bus_proxy_config: ZMQTCPProxyConfig = Field(  # type: ignore
+    event_bus_proxy_config: Annotated[  # type: ignore
+        ZMQTCPProxyConfig, DisableCLI()
+    ] = Field(
         default=ZMQTCPProxyConfig(
             frontend_port=5663,
             backend_port=5664,
         ),
         description="Configuration for the ZMQ Proxy. If provided, the proxy will be created and started.",
     )
-    raw_inference_proxy_config: ZMQTCPProxyConfig = Field(  # type: ignore
+    raw_inference_proxy_config: Annotated[  # type: ignore
+        ZMQTCPProxyConfig, DisableCLI()
+    ] = Field(
         default=ZMQTCPProxyConfig(
             frontend_port=5665,
             backend_port=5666,
@@ -290,15 +296,21 @@ class ZMQIPCConfig(BaseZMQCommunicationConfig):
         ),
     ] = None
 
-    dataset_manager_proxy_config: ZMQIPCProxyConfig = Field(  # type: ignore
+    dataset_manager_proxy_config: Annotated[  # type: ignore
+        ZMQIPCProxyConfig, DisableCLI()
+    ] = Field(
         default=ZMQIPCProxyConfig(name="dataset_manager_proxy"),
         description="Configuration for the ZMQ Dealer Router Proxy. If provided, the proxy will be created and started.",
     )
-    event_bus_proxy_config: ZMQIPCProxyConfig = Field(  # type: ignore
+    event_bus_proxy_config: Annotated[  # type: ignore
+        ZMQIPCProxyConfig, DisableCLI()
+    ] = Field(
         default=ZMQIPCProxyConfig(name="event_bus_proxy"),
         description="Configuration for the ZMQ XPUB/XSUB Proxy. If provided, the proxy will be created and started.",
     )
-    raw_inference_proxy_config: ZMQIPCProxyConfig = Field(  # type: ignore
+    raw_inference_proxy_config: Annotated[  # type: ignore
+        ZMQIPCProxyConfig, DisableCLI()
+    ] = Field(
         default=ZMQIPCProxyConfig(name="raw_inference_proxy"),
         description="Configuration for the ZMQ Push/Pull Proxy. If provided, the proxy will be created and started.",
     )

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+from cyclopts.exceptions import UnknownOptionError
+
+from aiperf.cli import app
+
+
+@pytest.fixture
+def disabled_parameters() -> list[str]:
+    """Parameters that should NOT appear in help due to DisableCLI()"""
+    return [
+        "--service-config.zmq-tcp.event-bus-proxy-config.frontend-port",
+        "--service-config.zmq-tcp.event-bus-proxy-config.backend-port",
+        "--service-config.zmq-tcp.event-bus-proxy-config.control-port",
+        "--service-config.zmq-tcp.event-bus-proxy-config.capture-port",
+        "--service-config.zmq-tcp.dataset-manager-proxy-config.frontend-port",
+        "--service-config.zmq-tcp.dataset-manager-proxy-config.backend-port",
+        "--service-config.zmq-tcp.dataset-manager-proxy-config.control-port",
+        "--service-config.zmq-tcp.dataset-manager-proxy-config.capture-port",
+        "--service-config.zmq-tcp.raw-inference-proxy-config.frontend-port",
+        "--service-config.zmq-tcp.raw-inference-proxy-config.backend-port",
+        "--service-config.zmq-tcp.raw-inference-proxy-config.control-port",
+        "--service-config.zmq-tcp.raw-inference-proxy-config.capture-port",
+    ]
+
+
+class TestCLIHelp:
+    def test_profile_help_does_not_show_parameters(self, capsys):
+        """This test is to ensure that the help text for the profile command does
+        not show miscellaneous un-grouped parameters."""
+        app(["profile", "-h"])
+        assert "─ Parameters ─" not in capsys.readouterr().out
+
+    def test_no_args_does_not_crash(self, capsys):
+        """This test is to ensure that the CLI does not crash when no arguments are provided."""
+        app([])
+        out = capsys.readouterr().out
+        assert "Usage: aiperf COMMAND" in out
+        assert "─ Commands ─" in out
+
+    def test_disable_cli_parameters_not_in_help(self, capsys, disabled_parameters):
+        """Test that certain parameters marked with DisableCLI() are not shown in help text."""
+        app(["profile", "-h"])
+        help_output = capsys.readouterr().out
+
+        for param in disabled_parameters:
+            assert param not in help_output, (
+                f"DisableCLI parameter '{param}' should not appear in help text"
+            )
+
+    def test_disable_cli_parameters_not_recognized(
+        self, disabled_parameters: list[str]
+    ) -> None:
+        """Test that certain parameters marked with DisableCLI() are not recognized."""
+        for param in disabled_parameters:
+            with pytest.raises(UnknownOptionError):
+                # Note: For now we just assume that "123" is a valid value for the parameter
+                app(["profile", param, "123"], exit_on_error=False, print_error=False)


### PR DESCRIPTION
cherry-pick #260 