### PR TITLE
chore: remove unused sum-aggregate metric type

### DIFF
--- a/aiperf/common/enums/metric_enums.py
+++ b/aiperf/common/enums/metric_enums.py
@@ -292,10 +292,6 @@ class MetricType(CaseInsensitiveStrEnum):
     These metrics can be tracked over time and compared to each other.
     Examples: request latency, ISL, ITL, OSL, etc."""
 
-    SUM_AGGREGATE = "sum_aggregate"
-    """Metrics that are assigned as the sum aggregator for a specific metric.
-    Examples: total request count, benchmark duration, etc."""
-
     AGGREGATE = "aggregate"
     """Metrics that keep track of one or more values over time, that are updated for each request, such as total counts, min/max values, etc.
     These metrics may or may not change each request, and are affected by other requests.

--- a/aiperf/metrics/metric_registry.py
+++ b/aiperf/metrics/metric_registry.py
@@ -201,8 +201,6 @@ class MetricRegistry:
             MetricType.RECORD: {MetricType.RECORD},
             # Aggregate metrics can depend on other record or aggregate metrics
             MetricType.AGGREGATE: {MetricType.RECORD, MetricType.AGGREGATE},
-            # Sum aggregate metrics can only depend on record metrics
-            MetricType.SUM_AGGREGATE: {MetricType.RECORD},
             # Derived metrics can depend on any other metric type
             MetricType.DERIVED: {
                 MetricType.RECORD,


### PR DESCRIPTION
this was added on accident as part of a PR, and is not used, as we went with a different approach