### PR TITLE
fix: pre-commit to skip mkinit in hook and only run on changed lines

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,17 +11,26 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 2
-    - name: Get modified files
-      id: modified-files
-      run: echo "modified_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+        fetch-depth: 1
+
+    - name: Fetch base commit
+      run: |
+        git remote add base "${{ github.event.pull_request.base.repo.clone_url }}"
+        git fetch --no-tags --depth=1 base ${{ github.event.pull_request.base.sha }}
+
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+
     - name: Install dependencies
       run: |
         make setup-venv
         make setup-mkinit
+
     - uses: pre-commit/action@v3.0.1
+      env:
+        SKIP: mkinit
       with:
-        extra_args: --files ${{ steps.modified-files.outputs.modified_files }}
+        extra_args: >-
+          --from-ref ${{ github.event.pull_request.base.sha }}
+          --to-ref   ${{ github.sha }}


### PR DESCRIPTION
The mkinit script changes files in the GitHub runners, resulting in the GitHub action always failing. Skip running it in the GitHub action.

In addition, update pre-commit to only run on the PR diff rather than on the whole file. This is similar to how pre-commit runs locally.