### PR TITLE
feat: add inter-chunk-latency metric using raw value list

### DIFF
--- a/aiperf/common/enums/metric_enums.py
+++ b/aiperf/common/enums/metric_enums.py
@@ -331,15 +331,15 @@ class MetricValueType(BasePydanticBackedStrEnum):
     )
     FLOAT_LIST = MetricValueTypeInfo(
         tag="list[float]",
-        default_factory=list[float],
-        converter=list[float],
-        dtype=list[float],
+        default_factory=list,
+        converter=lambda v: [float(x) for x in v],
+        dtype=float,
     )
     INT_LIST = MetricValueTypeInfo(
         tag="list[int]",
-        default_factory=list[int],
-        converter=list[int],
-        dtype=list[int],
+        default_factory=list,
+        converter=lambda v: [int(x) for x in v],
+        dtype=int,
     )
 
     @cached_property

--- a/aiperf/common/enums/metric_enums.py
+++ b/aiperf/common/enums/metric_enums.py
@@ -313,7 +313,7 @@ class MetricValueTypeInfo(BasePydanticEnumInfo):
 class MetricValueType(BasePydanticBackedStrEnum):
     """Defines the possible types of values for metrics.
 
-    NOTE: The string representation is important here, as it is used to automatically determine the type
+    NOTE: The string representation (tag) is important here, as it is used to automatically determine the type
     based on the python generic type definition.
     """
 
@@ -328,6 +328,18 @@ class MetricValueType(BasePydanticBackedStrEnum):
         default_factory=int,
         converter=int,
         dtype=int,
+    )
+    FLOAT_LIST = MetricValueTypeInfo(
+        tag="list[float]",
+        default_factory=list[float],
+        converter=list[float],
+        dtype=list[float],
+    )
+    INT_LIST = MetricValueTypeInfo(
+        tag="list[int]",
+        default_factory=list[int],
+        converter=list[int],
+        dtype=list[int],
     )
 
     @cached_property

--- a/aiperf/metrics/metric_dicts.py
+++ b/aiperf/metrics/metric_dicts.py
@@ -112,7 +112,7 @@ class MetricArray(Generic[MetricValueTypeVarT]):
     def _resize_if_needed(self, additional_size: int) -> None:
         """Resize the array if needed."""
         if self._size + additional_size > self._capacity:
-            self._capacity *= 2
+            self._capacity = max(self._capacity * 2, self._size + additional_size)
             new_data = np.empty(self._capacity)
             new_data[: self._size] = self._data[: self._size]
             self._data = new_data

--- a/aiperf/metrics/metric_dicts.py
+++ b/aiperf/metrics/metric_dicts.py
@@ -99,10 +99,10 @@ class MetricArray(Generic[MetricValueTypeVarT]):
         """Extend the array with a list of values."""
         self._resize_if_needed(len(values))
 
-        for value in values:
-            self._data[self._size] = value
-            self._size += 1
-            self._sum += value  # type: ignore
+        end = self._size + len(values)
+        self._data[self._size : end] = values
+        self._sum += sum(values)  # type: ignore
+        self._size = end
 
     def append(self, value: MetricValueTypeVarT) -> None:
         """Append a value to the array."""

--- a/aiperf/metrics/metric_dicts.py
+++ b/aiperf/metrics/metric_dicts.py
@@ -92,18 +92,30 @@ class MetricArray(Generic[MetricValueTypeVarT]):
         self._size = 0
         self._sum: MetricValueTypeVarT = 0  # type: ignore
 
+    def extend(self, values: list[MetricValueTypeVarT]) -> None:
+        """Extend the array with a list of values."""
+        self._resize_if_needed(len(values))
+
+        for value in values:
+            self._data[self._size] = value
+            self._size += 1
+            self._sum += value  # type: ignore
+
     def append(self, value: MetricValueTypeVarT) -> None:
         """Append a value to the array."""
-        if self._size >= self._capacity:
-            # Double capacity when full
-            self._capacity *= 2
-            new_data = np.empty(self._capacity)
-            new_data[: self._size] = self._data[: self._size]
-            self._data = new_data
+        self._resize_if_needed(1)
 
         self._data[self._size] = value
         self._size += 1
         self._sum += value  # type: ignore
+
+    def _resize_if_needed(self, additional_size: int) -> None:
+        """Resize the array if needed."""
+        if self._size + additional_size > self._capacity:
+            self._capacity *= 2
+            new_data = np.empty(self._capacity)
+            new_data[: self._size] = self._data[: self._size]
+            self._data = new_data
 
     @property
     def sum(self) -> MetricValueTypeVarT:

--- a/aiperf/metrics/metric_dicts.py
+++ b/aiperf/metrics/metric_dicts.py
@@ -87,6 +87,9 @@ class MetricArray(Generic[MetricValueTypeVarT]):
     """
 
     def __init__(self, initial_capacity: int = 10000):
+        """Initialize the array with the given initial capacity."""
+        if initial_capacity <= 0:
+            raise ValueError("Initial capacity must be greater than 0")
         self._capacity = initial_capacity
         self._data = np.empty(self._capacity)
         self._size = 0

--- a/aiperf/metrics/types/inter_chunk_latency_metric.py
+++ b/aiperf/metrics/types/inter_chunk_latency_metric.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from aiperf.common.enums import MetricFlags, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import ParsedResponseRecord
+from aiperf.metrics import BaseRecordMetric
+from aiperf.metrics.metric_dicts import MetricRecordDict
+
+
+class InterChunkLatencyMetric(BaseRecordMetric[list[int]]):
+    """
+    Calculates Inter Chunk Latency (ICL) for streaming responses.
+
+    Inter Chunk Latency measures the time gaps between consecutive response chunks
+    in a streaming response. For each request with multiple response chunks, this
+    metric computes the time difference between each adjacent pair of chunks.
+
+    Example:
+        For a streaming response with chunks arriving at times [100ms, 150ms, 210ms]:
+        ICL = [50ms, 60ms] (differences between consecutive timestamps)
+
+    All ICL values from all requests are collected into a single list for
+    statistical analysis across the entire benchmark run.
+
+    Formula:
+        ICL = [timestamps[i] - timestamps[i-1] for i in range(1, len(timestamps))]
+
+    Note: Only applicable to streaming responses with at least 2 chunks.
+    """
+
+    tag = "inter_chunk_latency"
+    header = "Inter Chunk Latency"
+    short_header = "ICL"
+    unit = MetricTimeUnit.NANOSECONDS
+    display_unit = MetricTimeUnit.MILLISECONDS
+    flags = MetricFlags.STREAMING_TOKENS_ONLY | MetricFlags.EXPERIMENTAL
+    required_metrics = None
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> list[int]:
+        """
+        This method extracts the timestamps from the responses in the given
+        ParsedResponseRecord object, computes the differences between consecutive responses (ICL),
+        and returns the results.
+
+        Raises:
+            NoMetricValue: If the record does not have at least two responses
+            ValueError: If any of the inter chunk latencies are not positive.
+        """
+        responses = record.responses
+
+        if len(responses) < 2:
+            raise NoMetricValue(
+                "Record must have at least two responses to calculate Inter Chunk Latency."
+            )
+
+        inter_chunk_latencies = []
+        for i in range(1, len(responses)):
+            chunk_latency_ns = responses[i].perf_ns - responses[i - 1].perf_ns
+            if chunk_latency_ns <= 0:
+                raise ValueError("Each inter chunk latency must be positive.")
+            inter_chunk_latencies.append(chunk_latency_ns)
+
+        return inter_chunk_latencies

--- a/aiperf/post_processors/metric_results_processor.py
+++ b/aiperf/post_processors/metric_results_processor.py
@@ -75,7 +75,12 @@ class MetricResultsProcessor(BaseMetricsProcessor):
                 if metric_type == MetricType.RECORD:
                     if tag not in self._results:
                         self._results[tag] = MetricArray()
-                    self._results[tag].append(value)  # type: ignore
+                    if isinstance(value, list):
+                        # NOTE: Right now we only support list-based metrics by extending the array.
+                        #       In the future, we possibly could support having nested arrays.
+                        self._results[tag].extend(value)  # type: ignore
+                    else:
+                        self._results[tag].append(value)  # type: ignore
 
                 elif metric_type == MetricType.AGGREGATE:
                     metric: BaseAggregateMetric = self._instances_map[tag]  # type: ignore

--- a/tests/metrics/test_inter_chunk_latency_metric.py
+++ b/tests/metrics/test_inter_chunk_latency_metric.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.inter_chunk_latency_metric import InterChunkLatencyMetric
+from tests.metrics.conftest import create_record, run_simple_metrics_pipeline
+
+
+class TestInterChunkLatencyMetric:
+    def test_inter_chunk_latency_basic(self):
+        """Test basic inter-chunk latency calculation"""
+        # Start at 100ns, responses at 110ns, 120ns, 135ns
+        # ICL = [120-110, 135-120] = [10, 15]
+        record = create_record(start_ns=100, responses=[110, 120, 135])
+
+        metric_results = run_simple_metrics_pipeline(
+            [record],
+            InterChunkLatencyMetric.tag,
+        )
+        assert metric_results[InterChunkLatencyMetric.tag] == [[10, 15]]
+
+    def test_inter_chunk_latency_two_responses(self):
+        """Test ICL with exactly two responses"""
+        # Start at 100ns, responses at 110ns, 125ns
+        # ICL = [125-110] = [15]
+        record = create_record(start_ns=100, responses=[110, 125])
+
+        metric_results = run_simple_metrics_pipeline(
+            [record],
+            InterChunkLatencyMetric.tag,
+        )
+        assert metric_results[InterChunkLatencyMetric.tag] == [[15]]
+
+    @pytest.mark.parametrize(
+        "responses, expected_icl",
+        [
+            ([100, 110, 120], [10, 10]),  # Equal intervals
+            ([100, 105, 115, 130], [5, 10, 15]),  # Increasing intervals
+            ([100, 120, 125, 135], [20, 5, 10]),  # Mixed intervals
+            ([100, 150], [50]),  # Single interval
+            ([1000, 1040, 1080, 1120, 1200], [40, 40, 40, 80]),  # Larger values
+        ],
+    )  # fmt: skip
+    def test_inter_chunk_latency_various_intervals(self, responses, expected_icl):
+        """Test ICL calculation with various response intervals"""
+        record = create_record(start_ns=50, responses=responses)
+
+        metric_results = run_simple_metrics_pipeline(
+            [record],
+            InterChunkLatencyMetric.tag,
+        )
+        assert metric_results[InterChunkLatencyMetric.tag] == [expected_icl]
+
+    def test_inter_chunk_latency_multiple_records(self):
+        """Test processing multiple records"""
+        records = [
+            create_record(start_ns=100, responses=[110, 120, 130]),  # ICL = [10, 10]
+            create_record(start_ns=200, responses=[205, 210]),  # ICL = [5]
+            create_record(start_ns=300, responses=[310, 325, 340, 360]),  # ICL = [15, 15, 20]
+        ]  # fmt: skip
+
+        metric_results = run_simple_metrics_pipeline(
+            records,
+            InterChunkLatencyMetric.tag,
+        )
+        assert metric_results[InterChunkLatencyMetric.tag] == [
+            [10, 10],
+            [5],
+            [15, 15, 20],
+        ]
+
+    @pytest.mark.parametrize("num_responses", [2, 3, 5, 10, 100])
+    def test_inter_chunk_latency_scaling(self, num_responses):
+        """Test ICL calculation scales correctly with number of responses"""
+        # Create responses with 10ns intervals starting at 100ns
+        responses = [100 + (i * 10) for i in range(num_responses)]
+        expected_icl = [10] * (num_responses - 1)
+
+        record = create_record(start_ns=50, responses=responses)
+
+        metric_results = run_simple_metrics_pipeline(
+            [record],
+            InterChunkLatencyMetric.tag,
+        )
+        assert metric_results[InterChunkLatencyMetric.tag] == [expected_icl]
+
+    def test_inter_chunk_latency_insufficient_responses(self):
+        """Test error when less than two responses"""
+        record = create_record(start_ns=100, responses=[110])  # Only one response
+
+        metric = InterChunkLatencyMetric()
+        with pytest.raises(
+            NoMetricValue,
+            match="Record must have at least two responses to calculate Inter Chunk Latency",
+        ):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_inter_chunk_latency_empty_responses(self):
+        """Test error when no responses"""
+        record = create_record(start_ns=100, responses=[])  # No responses
+
+        metric = InterChunkLatencyMetric()
+        with pytest.raises(
+            NoMetricValue,
+            match="Record must have at least two responses to calculate Inter Chunk Latency",
+        ):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_inter_chunk_latency_invalid_order(self):
+        """Test error when response timestamps are not in chronological order"""
+        record = create_record(
+            start_ns=100, responses=[120, 110, 130]
+        )  # Second response before first
+
+        metric = InterChunkLatencyMetric()
+        with pytest.raises(
+            ValueError,
+            match="Each inter chunk latency must be positive",
+        ):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_inter_chunk_latency_equal_timestamps(self):
+        """Test error when consecutive responses have equal timestamps"""
+        record = create_record(
+            start_ns=100, responses=[110, 110, 120]
+        )  # Equal timestamps
+
+        metric = InterChunkLatencyMetric()
+        with pytest.raises(
+            ValueError,
+            match="Each inter chunk latency must be positive",
+        ):
+            metric.parse_record(record, MetricRecordDict())
+
+    @pytest.mark.parametrize(
+        "responses",
+        [
+            [100, 90, 110],  # Second response before first
+            [100, 110, 105],  # Third response before second
+            [100, 110, 120, 115],  # Fourth response before third
+            [100, 100, 110],  # Equal first two timestamps
+            [100, 110, 110],  # Equal last two timestamps
+        ],
+    )  # fmt: skip
+    def test_inter_chunk_latency_invalid_timestamp_order(self, responses):
+        """Test various invalid timestamp ordering scenarios"""
+        record = create_record(start_ns=50, responses=responses)
+
+        metric = InterChunkLatencyMetric()
+        with pytest.raises(
+            ValueError,
+            match="Each inter chunk latency must be positive",
+        ):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_inter_chunk_latency_streaming_scenario(self):
+        """Test ICL in a realistic streaming scenario"""
+        # Simulate a streaming response with varying chunk arrival times
+        # First chunk comes quickly (TTFT), then subsequent chunks arrive with varying delays
+        record = create_record(
+            start_ns=1000,
+            responses=[1050, 1080, 1120, 1180, 1250, 1330],  # Increasing delays
+        )
+
+        metric_results = run_simple_metrics_pipeline(
+            [record],
+            InterChunkLatencyMetric.tag,
+        )
+
+        # Expected ICL = [1080-1050, 1120-1080, 1180-1120, 1250-1180, 1330-1250]
+        # = [30, 40, 60, 70, 80]
+        assert metric_results[InterChunkLatencyMetric.tag] == [[30, 40, 60, 70, 80]]
+
+    def test_inter_chunk_latency_direct_parse_record(self):
+        """Test direct parse_record method call"""
+        record = create_record(start_ns=100, responses=[110, 125, 140])
+        metric = InterChunkLatencyMetric()
+        metric_dict = MetricRecordDict()
+
+        result = metric.parse_record(record, metric_dict)
+
+        # Expected ICL = [125-110, 140-125] = [15, 15]
+        assert result == [15, 15]
+
+    @pytest.mark.parametrize("num_records", [1, 5, 10, 50])
+    def test_inter_chunk_latency_multiple_records_scaling(self, num_records):
+        """Test ICL calculation with multiple records of varying sizes"""
+        records = []
+        expected_results = []
+
+        for i in range(num_records):
+            # Create records with different numbers of responses
+            num_responses = 2 + (i % 5)  # 2-6 responses per record
+            start_time = 1000 + (i * 1000)
+            responses = [start_time + (j * 20) for j in range(num_responses)]
+
+            records.append(
+                create_record(start_ns=start_time - 100, responses=responses)
+            )
+            expected_results.append([20] * (num_responses - 1))
+
+        metric_results = run_simple_metrics_pipeline(
+            records,
+            InterChunkLatencyMetric.tag,
+        )
+
+        assert metric_results[InterChunkLatencyMetric.tag] == expected_results

--- a/tests/metrics/test_metric_array.py
+++ b/tests/metrics/test_metric_array.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from aiperf.metrics.metric_dicts import MetricArray
+
+
+@pytest.fixture
+def test_array():
+    """Create an empty MetricArray for testing."""
+    return MetricArray(initial_capacity=5)
+
+
+def assert_array_equal(array: MetricArray, expected_values: list) -> None:
+    """Assert that an array contains expected values."""
+    assert array._size == len(expected_values)
+    assert array._sum == sum(expected_values)
+    np.testing.assert_array_equal(array.data, expected_values)
+
+
+class TestMetricArray:
+    """Test cases for MetricArray class."""
+
+    def test_initialization_default_capacity(self):
+        """Test array initialization with default capacity."""
+        array = MetricArray()
+        assert array._capacity == 10000
+        assert array._size == 0
+        assert array._sum == 0
+
+    def test_initialization_custom_capacity(self):
+        """Test array initialization with custom capacity."""
+        array = MetricArray(initial_capacity=100)
+        assert array._capacity == 100
+        assert array._size == 0
+
+    def test_append(self, test_array: MetricArray):
+        """Test appending single values."""
+        test_array.append(1.0)
+        assert_array_equal(test_array, [1.0])
+
+        test_array.append(2.5)
+        assert_array_equal(test_array, [1.0, 2.5])
+
+    def test_extend(self, test_array: MetricArray):
+        """Test extending with multiple values."""
+        test_array.extend([1.0, 2.0, 3.0])
+        assert_array_equal(test_array, [1.0, 2.0, 3.0])
+
+        test_array.extend([4.0, 5.0])
+        assert_array_equal(test_array, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_mixed_operations(self, test_array: MetricArray):
+        """Test mixing append and extend operations."""
+        test_array.append(1.0)
+        test_array.extend([2.0, 3.0])
+        test_array.append(4.0)
+
+        assert_array_equal(test_array, [1.0, 2.0, 3.0, 4.0])
+
+    def test_resize_on_capacity_exceeded(self, test_array: MetricArray):
+        """Test that array resizes when capacity is exceeded."""
+        array = MetricArray(initial_capacity=2)
+        array.extend([1.0, 2.0])
+        assert array._capacity == 2
+
+        # This should trigger resize
+        array.append(3.0)
+        assert array._capacity == 4
+        assert_array_equal(array, [1.0, 2.0, 3.0])
+
+    def test_properties(self, test_array: MetricArray):
+        """Test sum and data properties."""
+        values = [1.0, 2.0, 3.0, 4.0]
+        test_array.extend(values)
+        assert test_array.sum == 10.0
+        assert len(test_array.data) == 4
+        np.testing.assert_array_equal(test_array.data, values)
+
+    @pytest.mark.parametrize(
+        "values,expected_min,expected_max,expected_avg,p50",
+        [
+            ([5.0], 5.0, 5.0, 5.0, 5.0),
+            ([1.0, 2.0, 3.0, 4.0, 5.0], 1.0, 5.0, 3.0, 3.0),
+            ([10.0, 20.0, 30.0, 40.0, 50.0], 10.0, 50.0, 30.0, 30.0),
+        ],
+    )
+    def test_to_result_statistics(
+        self,
+        values: list[float],
+        expected_min: float,
+        expected_max: float,
+        expected_avg: float,
+        p50: float,
+    ):
+        """Test to_result method computes statistics correctly."""
+        array = MetricArray()
+        array.extend(values)
+
+        result = array.to_result("test", "Test Metric", "ms")
+
+        assert result.tag == "test"
+        assert result.header == "Test Metric"
+        assert result.unit == "ms"
+        assert result.min == expected_min
+        assert result.max == expected_max
+        assert result.avg == expected_avg
+        assert result.p50 == p50
+        assert result.count == len(values)
+
+
+class TestMetricArrayEdgeCases:
+    """Test edge cases for MetricArray."""
+
+    def test_test_array_to_result_raises_error(self):
+        """Test that to_result raises error for empty array."""
+        with pytest.raises(IndexError):
+            MetricArray().to_result("empty", "Empty Metric", "units")
+
+    @pytest.mark.parametrize("invalid_capacity", [-1, 0])
+    def test_invalid_initial_capacity(self, invalid_capacity: int):
+        """Test behavior with invalid initial capacity."""
+        with pytest.raises(ValueError):
+            MetricArray(initial_capacity=invalid_capacity)
+
+    def test_large_batch_resize(self):
+        """Test resize behavior when adding large batch."""
+        array = MetricArray(initial_capacity=2)
+        large_batch = list(range(1, 11))
+
+        array.extend(large_batch)
+
+        assert array._capacity == 10
+        assert_array_equal(array, large_batch)

--- a/tests/metrics/test_metric_array.py
+++ b/tests/metrics/test_metric_array.py
@@ -60,7 +60,7 @@ class TestMetricArray:
 
         assert_array_equal(test_array, [1.0, 2.0, 3.0, 4.0])
 
-    def test_resize_on_capacity_exceeded(self, test_array: MetricArray):
+    def test_resize_on_capacity_exceeded(self):
         """Test that array resizes when capacity is exceeded."""
         array = MetricArray(initial_capacity=2)
         array.extend([1.0, 2.0])
@@ -114,7 +114,7 @@ class TestMetricArray:
 class TestMetricArrayEdgeCases:
     """Test edge cases for MetricArray."""
 
-    def test_test_array_to_result_raises_error(self):
+    def test_array_to_result_raises_error(self):
         """Test that to_result raises error for empty array."""
         with pytest.raises(IndexError):
             MetricArray().to_result("empty", "Empty Metric", "units")


### PR DESCRIPTION
- Inter Chunk Latency measures the time gaps between consecutive response chunks in a streaming response. 
- For each request with multiple response chunks, this metric computes the time difference between each adjacent pair of chunks.

Example:
For a request starting at 0ms, with streaming response chunks arriving at times:
`responses = [100ms, 150ms, 210ms] -> ICL = [50ms, 60ms]`
    
All ICL values from all requests are collected into a single list for statistical analysis across the entire benchmark run.

>[!Tip]
>Formula:
> ```python
> ICL = [timestamps[i] - timestamps[i-1] for i in range(1, len(timestamps))]
> ```
    
Note: Only applicable to streaming responses with at least 2 chunks.


_Experimental metric only available in dev mode._

<img width="1372" height="429" alt="Screenshot From 2025-09-23 13-34-20" src="https://github.com/user-attachments/assets/e824642d-7f8c-4040-8baa-31c7b8c0752d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Inter-Chunk Latency metric for streaming responses, reporting per-chunk latencies (displayed in milliseconds).
  - Added support for list-valued metrics (lists of integers and floats) across the metrics pipeline.

- Refactor
  - Metric storage now accepts batches of values via an extend operation and auto-resizes for larger datasets.
  - Added validation for initial metric storage capacity.

- Tests
  - Added comprehensive tests for the new latency metric and metric storage behaviors, covering correctness, edge cases, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->