### PR TITLE
fix: Ensure CSV export logic parses correctly

### DIFF
--- a/aiperf/exporters/csv_exporter.py
+++ b/aiperf/exporters/csv_exporter.py
@@ -3,7 +3,9 @@
 
 import csv
 import io
+import numbers
 from collections.abc import Mapping, Sequence
+from decimal import Decimal
 
 import aiofiles
 
@@ -155,10 +157,14 @@ class CsvExporter(AIPerfLoggerMixin):
         """Format a number for CSV output."""
         if value is None:
             return ""
-        if type(value) is int:
+        # Handle bools explicitly (bool is a subclass of int)
+        if isinstance(value, bool):
+            return str(value)
+        # Integers (covers built-in int and other Integral implementations)
+        if isinstance(value, numbers.Integral):
             return f"{int(value)}"
-        if type(value) is float:
+        # Real numbers (covers built-in float and many Real implementations) and Decimal
+        if isinstance(value, numbers.Real | Decimal):
             return f"{float(value):.2f}"
-        if type(value) is bool:
-            return f"{bool(value)}"
+
         return str(value)

--- a/aiperf/exporters/csv_exporter.py
+++ b/aiperf/exporters/csv_exporter.py
@@ -155,8 +155,10 @@ class CsvExporter(AIPerfLoggerMixin):
         """Format a number for CSV output."""
         if value is None:
             return ""
-        if isinstance(value, int):
-            return str(value)
-        if isinstance(value, float):
+        if type(value) is int:
+            return f"{int(value)}"
+        if type(value) is float:
             return f"{float(value):.2f}"
+        if type(value) is bool:
+            return f"{bool(value)}"
         return str(value)

--- a/tests/clients/http/test_sse_utils.py
+++ b/tests/clients/http/test_sse_utils.py
@@ -353,8 +353,8 @@ retry: 5000"""
         result = parse_sse_message(raw_message, base_perf_ns)
         end_time = time.perf_counter()
 
-        # Should parse quickly (less than 100ms for 1000 fields)
-        assert (end_time - start_time) < 0.1
+        # Should parse quickly (less than 250ms for 1000 fields)
+        assert (end_time - start_time) < 0.250
         assert result.perf_ns == base_perf_ns
         assert len(result.packets) == 1000
 

--- a/tests/data_exporters/test_csv_exporter.py
+++ b/tests/data_exporters/test_csv_exporter.py
@@ -354,12 +354,6 @@ async def test_csv_exporter_logs_and_raises_on_write_failure(
         assert "Failed to export CSV" in called["err"]
 
 
-class DummyExporter(CsvExporter):
-    # Allow instantiation without full config
-    def __init__(self):
-        pass
-
-
 @pytest.mark.parametrize(
     "value,expected",
     [
@@ -375,7 +369,10 @@ class DummyExporter(CsvExporter):
         (False, "False"),
     ],
 )
-def test_format_number_various_types(value, expected):
+@pytest.mark.asyncio
+async def test_format_number_various_types(
+    monkeypatch, mock_user_config, value, expected
+):
     """
     Test the `_format_number` method of `DummyExporter` with various input types.
 
@@ -385,5 +382,10 @@ def test_format_number_various_types(value, expected):
     - Strings as themselves
     - Boolean values as their string representation
     """
-    exporter = DummyExporter()
+    cfg = ExporterConfig(
+        results=None,
+        user_config=mock_user_config,
+        service_config=ServiceConfig(),
+    )
+    exporter = CsvExporter(cfg)
     assert exporter._format_number(value) == expected

--- a/tests/data_exporters/test_csv_exporter.py
+++ b/tests/data_exporters/test_csv_exporter.py
@@ -352,3 +352,38 @@ async def test_csv_exporter_logs_and_raises_on_write_failure(
 
         assert called["err"] is not None
         assert "Failed to export CSV" in called["err"]
+
+
+class DummyExporter(CsvExporter):
+    # Allow instantiation without full config
+    def __init__(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, ""),
+        (142357, "142357"),
+        (0, "0"),
+        (-7, "-7"),
+        (123456.14159, "123456.14"),
+        (2.0, "2.00"),
+        (-1.234, "-1.23"),
+        ("string", "string"),
+        (True, "True"),
+        (False, "False"),
+    ],
+)
+def test_format_number_various_types(value, expected):
+    """
+    Test the `_format_number` method of `DummyExporter` with various input types.
+
+    This parameterized test verifies that the method correctly formats:
+    - None as an empty string
+    - Integers and floats as strings, with floats rounded to two decimal places
+    - Strings as themselves
+    - Boolean values as their string representation
+    """
+    exporter = DummyExporter()
+    assert exporter._format_number(value) == expected


### PR DESCRIPTION
Updated the logic and added unit testing to ensure we export the expected values to the CSV.
I've also increased the timing from 100 -> 250ms in the SSE unit test as I was sporadic getting failures on my local machine (~20% of the time) at 100ms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CSV exports now render booleans explicitly as "True"/"False" for clearer outputs.

- Bug Fixes
  - Standardized CSV number formatting: integers preserved, real numbers shown with two decimals, and non-numeric/None values handled consistently.

- Tests
  - Added parameterized tests covering varied CSV formatting cases.
  - Relaxed SSE parsing performance threshold to reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->