### PR TITLE
docs: Standardize custom dataset type naming convention in CLI

### DIFF
--- a/aiperf/common/config/input_config.py
+++ b/aiperf/common/config/input_config.py
@@ -192,11 +192,13 @@ class InputConfig(BaseConfig):
         CustomDatasetType | None,
         Field(
             description="The type of custom dataset to use.\n"
-            "This parameter is used in conjunction with the --input-file parameter.",
+            "This parameter is used in conjunction with the --input-file parameter.\n"
+            "[choices: single_turn, multi_turn, random_pool, mooncake_trace]",
         ),
         CLIParameter(
             name=("--custom-dataset-type"),
             group=_CLI_GROUP,
+            show_choices=False,
         ),
     ] = InputDefaults.CUSTOM_DATASET_TYPE
 

--- a/docs/benchmark_datasets.md
+++ b/docs/benchmark_datasets.md
@@ -34,7 +34,7 @@ This document describes datasets that AIPerf can use to generate stimulus. Addit
     <tr>
       <td><strong>Custom Data</strong></td>
       <td style="text-align: center;">✅</td>
-      <td>--input-file your_file.jsonl --custom-dataset-type single-turn</td>
+  <td>--input-file your_file.jsonl --custom-dataset-type single_turn</td>
     </tr>
     <tr>
     <td><strong>Mooncake</strong></td>

--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -42,7 +42,7 @@ Use these options to profile with AIPerf.
 │                                                                in the trace dataset, but this option can be used to only run a subset of the trace. The schedule will include any     │
 │                                                                requests at the end offset.                                                                                            │
 │ CUSTOM-DATASET-TYPE --custom-dataset-type                      The type of custom dataset to use. This parameter is used in conjunction with the --file parameter. [choices:          │
-│                                                                single-turn, multi-turn, random-pool, mooncake-trace] [default: mooncake-trace]                                        │
+│                                                                single_turn, multi_turn, random_pool, mooncake_trace] [default: mooncake_trace]                                        │
 │ RANDOM-SEED --random-seed                                      The seed used to generate random values. Set to some value to make the synthetic data generation deterministic. It     │
 │                                                                will use system default if not provided.                                                                               │
 ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -29,7 +29,7 @@ Use these options to profile with AIPerf.
 │ HEADER --header                                            -H  Adds a custom header to the requests. Headers must be specified as 'Header:Value' pairs. Alternatively, a string       │
 │                                                                representing a json formatted dictionary can be provided. [default: []]                                                      │
 │ INPUT-FILE --input-file                                        The file or directory path that contains the dataset to use for profiling. This parameter is used in conjunction with  │
-│                                                                the custom_dataset_type parameter to support different types of user provided datasets.                                │
+│                                                                the --custom-dataset-type parameter to support different types of user provided datasets.                                │
 │ FIXED-SCHEDULE --fixed-schedule                                Specifies to run a fixed schedule of requests. This is normally inferred from the --input-file parameter, but can be   │
 │                                                                set manually here. [default: False]                                                                                    │
 │ FIXED-SCHEDULE-AUTO-OFFSET --fixed-schedule-auto-offset        Specifies to automatically offset the timestamps in the fixed schedule, such that the first timestamp is considered 0, │
@@ -41,7 +41,7 @@ Use these options to profile with AIPerf.
 │ FIXED-SCHEDULE-END-OFFSET --fixed-schedule-end-offset          Specifies the offset in milliseconds to end the fixed schedule at. By default, the schedule ends at the last timestamp │
 │                                                                in the trace dataset, but this option can be used to only run a subset of the trace. The schedule will include any     │
 │                                                                requests at the end offset.                                                                                            │
-│ CUSTOM-DATASET-TYPE --custom-dataset-type                      The type of custom dataset to use. This parameter is used in conjunction with the --file parameter. [choices:          │
+│ CUSTOM-DATASET-TYPE --custom-dataset-type                      The type of custom dataset to use. This parameter is used in conjunction with the --input-file parameter. [choices:          │
 │                                                                single_turn, multi_turn, random_pool, mooncake_trace] [default: mooncake_trace]                                        │
 │ RANDOM-SEED --random-seed                                      The seed used to generate random values. Set to some value to make the synthetic data generation deterministic. It     │
 │                                                                will use system default if not provided.                                                                               │

--- a/docs/genai-perf-feature-comparison.md
+++ b/docs/genai-perf-feature-comparison.md
@@ -80,7 +80,7 @@ This comparison matrix shows the supported CLI options between GenAI-Perf and AI
 | **Input File** | `--input-file` | ✅ | ✅ | |
 | **Dataset Entries/Conversations** | `--num-dataset-entries` | ✅ | ✅ | |
 | **Public Dataset** | `--public-dataset`<br>`{sharegpt}` | ❌ | ✅ | |
-| **Custom Dataset Type** | `--custom-dataset-type`<br>`{single-turn,multi-turn,random-pool,mooncake-trace}` | 🟡 | ✅ | GenAI-Perf infers this from the input file |
+| **Custom Dataset Type** | `--custom-dataset-type`<br>`{single_turn,multi_turn,random_pool,mooncake_trace}` | 🟡 | ✅ | GenAI-Perf infers this from the input file |
 | **Fixed Schedule** | `--fixed-schedule` | ✅ | ✅ | |
 | **Fixed Schedule Auto Offset** | `--fixed-schedule-auto-offset` | ❌ | ✅ | |
 | **Fixed Schedule Start/End Offset** | `--fixed-schedule-start-offset`<br>`--fixed-schedule-end-offset` | ❌ | ✅ | |


### PR DESCRIPTION
Replace hyphens with underscores in custom-dataset-type parameter values for consistency across CLI arguments:
- single-turn -> single_turn
- multi-turn -> multi_turn
- random-pool -> random_pool
- mooncake-trace -> mooncake_trace

Updated documentation in:
- docs/benchmark_datasets.md
- docs/cli_options.md
- docs/genai-perf-feature-comparison.md

Request came in as part of QA NVBug: 5507190
Linear issue: AIP-380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized CLI option values to use underscores instead of hyphens (e.g., single-turn → single_turn).
  * Changed default CUSTOM-DATASET-TYPE to mooncake_trace.
  * Updated docs and examples to reference --input-file and --custom-dataset-type with new enum literals.
  * CLI help will no longer display the full choice list for the custom dataset type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->