### PR TITLE
feat: add --slice-duration option for time slicing mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@ SPDX-License-Identifier: Apache-2.0
                 "--log-level",
                 "DEBUG",
                 "--max-workers",
-                "1",
+                "1"
             ]
         },
         {
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
             "module": "pytest",
             "args": [
                 "-n",
-                "auto",
+                "auto"
             ]
         }
     ],

--- a/aiperf/common/config/config_defaults.py
+++ b/aiperf/common/config/config_defaults.py
@@ -114,7 +114,7 @@ class TurnDelayDefaults:
 class OutputDefaults:
     ARTIFACT_DIRECTORY = Path("./artifacts")
     PROFILE_EXPORT_FILE = Path("profile_export.json")
-    SLICE_DURATION = 0
+    SLICE_DURATION = None
 
 
 @dataclass(frozen=True)

--- a/aiperf/common/config/output_config.py
+++ b/aiperf/common/config/output_config.py
@@ -34,7 +34,7 @@ class OutputConfig(BaseConfig):
     ] = OutputDefaults.ARTIFACT_DIRECTORY
 
     slice_duration: Annotated[
-        int,
+        int | None,
         Field(
             description="The duration (in milliseconds) of an individual time slice to be used post-benchmark in time-slicing mode.",
         ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new output setting for slice duration, configurable via the --slice-duration CLI option with a default value of 0.

* **Tests**
  * Updated configuration tests to cover the new slice duration setting and its default and custom values.

* **Chores**
  * Minor JSON formatting cleanup in development configuration files to ensure proper syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->