### PR TITLE
feat: show median in console output

### DIFF
--- a/aiperf/exporters/console_metrics_exporter.py
+++ b/aiperf/exporters/console_metrics_exporter.py
@@ -24,7 +24,7 @@ from aiperf.metrics.metric_registry import MetricRegistry
 class ConsoleMetricsExporter(AIPerfLoggerMixin):
     """A class that exports data to the console"""
 
-    STAT_COLUMN_KEYS = ["avg", "min", "max", "p99", "p90", "p75", "std"]
+    STAT_COLUMN_KEYS = ["avg", "min", "max", "p99", "p90", "p50", "std"]
 
     def __init__(self, exporter_config: ExporterConfig, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/aiperf/ui/dashboard/realtime_metrics_dashboard.py
+++ b/aiperf/ui/dashboard/realtime_metrics_dashboard.py
@@ -35,7 +35,7 @@ class RealtimeMetricsTable(Widget):
     }
     """
 
-    STATS_FIELDS = ["avg", "min", "max", "p99", "p90", "p75", "std"]
+    STATS_FIELDS = ["avg", "min", "max", "p99", "p90", "p50", "std"]
     COLUMNS = ["Metric", *STATS_FIELDS]
 
     def __init__(self, service_config: ServiceConfig, **kwargs) -> None:

--- a/tests/data_exporters/test_console_exporter.py
+++ b/tests/data_exporters/test_console_exporter.py
@@ -156,7 +156,7 @@ class TestConsoleExporter:
             max=20.0 * NANOS_PER_MILLIS,
             p99=None,
             p90=15.5 * NANOS_PER_MILLIS,
-            p75=12.3 * NANOS_PER_MILLIS,
+            p50=12.3 * NANOS_PER_MILLIS,
         )
         record = to_display_unit(record, MetricRegistry)
         row = exporter._format_row(record)


### PR DESCRIPTION
For ease, show the median in the console output. Replace p75 with p50 (median), since it is a more useful metric for users.

Before (with p75):
<img width="2008" height="336" alt="Screenshot 2025-09-24 at 4 33 49 PM" src="https://github.com/user-attachments/assets/8d3240a2-ebb1-452c-895d-445b05b1a87a" />

After (with p50):
<img width="2008" height="406" alt="Screenshot 2025-09-24 at 5 22 42 PM" src="https://github.com/user-attachments/assets/0276a2d9-03d2-45cb-8efd-cc69a33c490d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics tables now show median (p50) instead of p75 across console output and the real‑time dashboard.
  * Column order and headings updated to reflect the new percentile, with rendering and alignment adjusted accordingly.
  * Provides a more representative central tendency for latency distributions; no action needed—views update automatically.

* **Tests**
  * Updated tests to validate p50 display and formatting in metrics output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->