### PR TITLE
fix: avoid PytestCollectionWarning due to TestRunner naming

### DIFF
--- a/tests/ci/test_docs_end_to_end/main.py
+++ b/tests/ci/test_docs_end_to_end/main.py
@@ -12,7 +12,7 @@ import logging
 import sys
 
 from parser import MarkdownParser
-from test_runner import TestRunner
+from test_runner import EndToEndTestRunner
 from utils import get_repo_root, setup_logging
 
 # Configure logging using centralized utility
@@ -70,7 +70,7 @@ def main():
         return 0
 
     # Run tests
-    runner = TestRunner()
+    runner = EndToEndTestRunner()
     success = runner.run_tests(servers)
 
     if success:

--- a/tests/ci/test_docs_end_to_end/test_runner.py
+++ b/tests/ci/test_docs_end_to_end/test_runner.py
@@ -22,7 +22,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 
-class TestRunner:
+class EndToEndTestRunner:
     """Runs the end-to-end tests"""
 
     def __init__(self):


### PR DESCRIPTION
```
tests/ci/test_docs_end_to_end/test_runner.py:25: 24 warnings
  /home/anthony/nvidia/projects/aiperf7/tests/ci/test_docs_end_to_end/test_runner.py:25: PytestCollectionWarning: cannot collect test class 'TestRunner' because it has a __init__ constructor (from: tests/ci/test_docs_end_to_end/test_runner.py)
    class TestRunner:
```

The `TestRunner` class is being picked up by pytest as a test class because it starts with "Test", but it has an `__init__` constructor which pytest doesn't allow for test classes. However, this isn't actually a test class, it's a utility class for orchestrating end-to-end tests.

The simplest fix is to rename the class to something that doesn't start with "Test" so pytest won't try to collect it as a test class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Renamed the internal test runner to “End-to-End Test Runner” and updated references to improve clarity in our testing suite.
  - Enhances readability of CI logs and maintainability of end-to-end test workflows.
  - No impact on application functionality or user experience; changes are limited to test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->