### PR TITLE
docs: remove --fixed-schedule known issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,4 @@ NVIDIA AIPerf | LLM Metrics
 - Output sequence length constraints (`--output-tokens-mean`) cannot be guaranteed unless you pass `ignore_eos` and/or `min_tokens` via `--extra-inputs` to an inference server that supports them.
 - Very high concurrency settings (typically >15,000 concurrency) may lead to port exhaustion on some systems, causing connection failures during benchmarking. If encountered, consider adjusting system limits or reducing concurrency.
 - Startup errors caused by invalid configuration settings can cause AIPerf to hang indefinitely. If AIPerf appears to freeze during initialization, terminate the process and check configuration settings.
-- Mooncake trace format currently requires the `--fixed-schedule` option to be set.
 - Dashboard UI may cause corrupted ANSI sequences on macOS or certain terminal environments, making the terminal unusable. Run `reset` command to restore normal terminal functionality, or switch to `--ui simple` for a lightweight progress bar interface.


### PR DESCRIPTION
Fixed by @the-david-oy in #273 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to remove an outdated Known Issue stating that Mooncake trace format requires the --fixed-schedule option.
  * Clarified current behavior to better reflect the latest capabilities and configuration expectations.
  * Reduced potential confusion for users by ensuring the documentation no longer references deprecated limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->