### PR TITLE
feat(mock-server): add fallback tokenizer support

### DIFF
--- a/integration-tests/mock_server/config.py
+++ b/integration-tests/mock_server/config.py
@@ -104,6 +104,13 @@ class MockServerConfig(BaseSettings):
         ),
     ] = []
 
+    fallback_tokenizer: Annotated[
+        str,
+        Field(
+            description="Fallback tokenizer to use if the requested tokenizer is not found",
+        ),
+    ] = "Qwen/Qwen3-0.6B"
+
     access_logs: Annotated[
         bool,
         Field(

--- a/integration-tests/mock_server/models.py
+++ b/integration-tests/mock_server/models.py
@@ -20,6 +20,10 @@ class ConfigureMessage(BaseModel):
     tokenizer_models: list[str] | None = Field(
         default=None, description="List of tokenizer models to load"
     )
+    fallback_tokenizer: str | None = Field(
+        default=None,
+        description="Fallback tokenizer to use if the requested tokenizer is not found",
+    )
 
 
 class Role(str, Enum):


### PR DESCRIPTION
This addresses a concern seen by a few users. Originally it was designed without a fallback on purpose for error simulation, but that is not relevant anymore.  We can also decide to provide failure scenarios in other ways in the future.