### PR TITLE
feat: add total isl/osl, fix csv/json hidden metrics

### DIFF
--- a/aiperf/common/enums/metric_enums.py
+++ b/aiperf/common/enums/metric_enums.py
@@ -381,21 +381,21 @@ class MetricFlags(Flag):
     These flags are intended to be an easy way to group metrics, or turn on/off certain features.
 
     Note that the flags are a bitmask, so they can be combined using the bitwise OR operator (`|`).
-    For example, to create a flag that is both `STREAMING_ONLY` and `HIDDEN`, you can do:
+    For example, to create a flag that is both `STREAMING_ONLY` and `NO_CONSOLE`, you can do:
     ```python
-    MetricFlags.STREAMING_ONLY | MetricFlags.HIDDEN
+    MetricFlags.STREAMING_ONLY | MetricFlags.NO_CONSOLE
     ```
 
     To check if a metric has a flag, you can use the `has_flags` method.
-    For example, to check if a metric has both the `STREAMING_ONLY` and `HIDDEN` flags, you can do:
+    For example, to check if a metric has both the `STREAMING_ONLY` and `NO_CONSOLE` flags, you can do:
     ```python
-    metric.has_flags(MetricFlags.STREAMING_ONLY | MetricFlags.HIDDEN)
+    metric.has_flags(MetricFlags.STREAMING_ONLY | MetricFlags.NO_CONSOLE)
     ```
 
     To check if a metric does not have a flag(s), you can use the `missing_flags` method.
-    For example, to check if a metric does not have either the `STREAMING_ONLY` or `HIDDEN` flags, you can do:
+    For example, to check if a metric does not have either the `STREAMING_ONLY` or `NO_CONSOLE` flags, you can do:
     ```python
-    metric.missing_flags(MetricFlags.STREAMING_ONLY | MetricFlags.HIDDEN)
+    metric.missing_flags(MetricFlags.STREAMING_ONLY | MetricFlags.NO_CONSOLE)
     ```
     """
 
@@ -414,16 +414,16 @@ class MetricFlags(Flag):
     PRODUCES_TOKENS_ONLY = 1 << 2
     """Metrics that are only applicable when profiling an endpoint that produces tokens."""
 
-    HIDDEN = 1 << 3
-    """Metrics that should not be displayed in the UI."""
+    NO_CONSOLE = 1 << 3
+    """Metrics that should not be displayed in the console output, but still exported to files."""
 
     LARGER_IS_BETTER = 1 << 4
     """Metrics that are better when the value is larger. By default, it is assumed that metrics are
     better when the value is smaller."""
 
-    INTERNAL = (1 << 5) | HIDDEN
-    """Metrics that are internal to the system and not applicable to the user. This inherently means that the metric
-    is HIDDEN as well."""
+    INTERNAL = 1 << 5
+    """Metrics that are internal to the system and not applicable to the user.
+    They will not be displayed in the console output or exported to files without developer mode enabled."""
 
     SUPPORTS_AUDIO_ONLY = 1 << 6
     """Metrics that are only applicable to audio-based endpoints."""
@@ -434,9 +434,9 @@ class MetricFlags(Flag):
     SUPPORTS_REASONING = 1 << 8
     """Metrics that are only applicable to reasoning-based models and endpoints."""
 
-    EXPERIMENTAL = (1 << 9) | HIDDEN
+    EXPERIMENTAL = 1 << 9
     """Metrics that are experimental and are not yet ready for production use, and may be subject to change.
-    This inherently means that the metric is HIDDEN as well."""
+    They will not be displayed in the console output or exported to files without developer mode enabled."""
 
     STREAMING_TOKENS_ONLY = STREAMING_ONLY | PRODUCES_TOKENS_ONLY
     """Metrics that are only applicable to streamed responses and token-based endpoints.

--- a/aiperf/exporters/console_metrics_exporter.py
+++ b/aiperf/exporters/console_metrics_exporter.py
@@ -68,7 +68,12 @@ class ConsoleMetricsExporter(AIPerfLoggerMixin):
     def _should_show(self, record: MetricResult) -> bool:
         # Only show metrics that are not error-only or hidden
         metric_class = MetricRegistry.get_class(record.tag)
-        return metric_class.missing_flags(MetricFlags.ERROR_ONLY | MetricFlags.HIDDEN)
+        return metric_class.missing_flags(
+            MetricFlags.ERROR_ONLY
+            | MetricFlags.NO_CONSOLE
+            | MetricFlags.INTERNAL
+            | MetricFlags.EXPERIMENTAL
+        )
 
     def _format_row(self, record: MetricResult) -> list[str]:
         metric_class = MetricRegistry.get_class(record.tag)

--- a/aiperf/exporters/experimental_metrics_console_exporter.py
+++ b/aiperf/exporters/experimental_metrics_console_exporter.py
@@ -39,12 +39,8 @@ class ConsoleExperimentalMetricsExporter(ConsoleMetricsExporter):
 
     def _should_show(self, record: MetricResult) -> bool:
         metric_class = MetricRegistry.get_class(record.tag)
-        # Only show experimental or hidden metrics that are not internal
-        return (
-            metric_class.has_flags(MetricFlags.EXPERIMENTAL)
-            or metric_class.has_flags(MetricFlags.HIDDEN)
-            and metric_class.missing_flags(MetricFlags.INTERNAL)
-        )
+        # Only show experimental metrics
+        return metric_class.has_flags(MetricFlags.EXPERIMENTAL)
 
     def _get_title(self) -> str:
         return "[yellow]NVIDIA AIPerf | Experimental Metrics[/yellow]"

--- a/aiperf/metrics/types/benchmark_duration_metric.py
+++ b/aiperf/metrics/types/benchmark_duration_metric.py
@@ -24,7 +24,7 @@ class BenchmarkDurationMetric(BaseDerivedMetric[int]):
     short_header_hide_unit = True
     unit = MetricTimeUnit.NANOSECONDS
     display_unit = MetricTimeUnit.SECONDS
-    flags = MetricFlags.HIDDEN
+    flags = MetricFlags.NO_CONSOLE
     required_metrics = {
         MinRequestTimestampMetric.tag,
         MaxResponseTimestampMetric.tag,

--- a/aiperf/metrics/types/input_sequence_length_metric.py
+++ b/aiperf/metrics/types/input_sequence_length_metric.py
@@ -5,6 +5,7 @@ from aiperf.common.enums import GenericMetricUnit, MetricFlags
 from aiperf.common.exceptions import NoMetricValue
 from aiperf.common.models import ParsedResponseRecord
 from aiperf.metrics.base_record_metric import BaseRecordMetric
+from aiperf.metrics.derived_sum_metric import DerivedSumMetric
 from aiperf.metrics.metric_dicts import MetricRecordDict
 
 
@@ -39,3 +40,24 @@ class InputSequenceLengthMetric(BaseRecordMetric[int]):
             raise NoMetricValue("Input Token Count is not available for the record.")
 
         return record.input_token_count
+
+
+class TotalInputSequenceLengthMetric(DerivedSumMetric[int, InputSequenceLengthMetric]):
+    """
+    This is the total number of input tokens processed by the benchmark.
+
+    Formula:
+        ```
+        Total Input Sequence Length = Sum(Input Sequence Lengths)
+        ```
+    """
+
+    tag = "total_isl"
+    header = "Total Input Sequence Length"
+    short_header = "Total ISL"
+    short_header_hide_unit = True
+    flags = (
+        MetricFlags.PRODUCES_TOKENS_ONLY
+        | MetricFlags.LARGER_IS_BETTER
+        | MetricFlags.NO_CONSOLE
+    )

--- a/aiperf/metrics/types/inter_chunk_latency_metric.py
+++ b/aiperf/metrics/types/inter_chunk_latency_metric.py
@@ -33,7 +33,7 @@ class InterChunkLatencyMetric(BaseRecordMetric[list[int]]):
     short_header = "ICL"
     unit = MetricTimeUnit.NANOSECONDS
     display_unit = MetricTimeUnit.MILLISECONDS
-    flags = MetricFlags.STREAMING_TOKENS_ONLY | MetricFlags.EXPERIMENTAL
+    flags = MetricFlags.STREAMING_TOKENS_ONLY | MetricFlags.NO_CONSOLE
     required_metrics = None
 
     def _parse_record(

--- a/aiperf/metrics/types/inter_token_latency_metric.py
+++ b/aiperf/metrics/types/inter_token_latency_metric.py
@@ -27,7 +27,7 @@ class InterTokenLatencyMetric(BaseRecordMetric[float]):
     unit = MetricTimeUnit.NANOSECONDS
     display_unit = MetricTimeUnit.MILLISECONDS
     display_order = 400
-    flags = MetricFlags.STREAMING_TOKENS_ONLY | MetricFlags.LARGER_IS_BETTER
+    flags = MetricFlags.STREAMING_TOKENS_ONLY
     required_metrics = {
         RequestLatencyMetric.tag,
         TTFTMetric.tag,

--- a/aiperf/metrics/types/max_response_metric.py
+++ b/aiperf/metrics/types/max_response_metric.py
@@ -22,7 +22,7 @@ class MaxResponseTimestampMetric(BaseAggregateMetric[int]):
     short_header_hide_unit = True
     unit = MetricTimeUnit.NANOSECONDS
     display_unit = MetricDateTimeUnit.DATE_TIME
-    flags = MetricFlags.HIDDEN
+    flags = MetricFlags.NO_CONSOLE
     required_metrics = {
         RequestLatencyMetric.tag,
     }

--- a/aiperf/metrics/types/min_request_metric.py
+++ b/aiperf/metrics/types/min_request_metric.py
@@ -22,7 +22,7 @@ class MinRequestTimestampMetric(BaseAggregateMetric[int]):
     short_header_hide_unit = True
     unit = MetricTimeUnit.NANOSECONDS
     display_unit = MetricDateTimeUnit.DATE_TIME
-    flags = MetricFlags.HIDDEN
+    flags = MetricFlags.NO_CONSOLE
     required_metrics = None
 
     def __init__(self) -> None:

--- a/aiperf/metrics/types/output_sequence_length_metric.py
+++ b/aiperf/metrics/types/output_sequence_length_metric.py
@@ -48,22 +48,24 @@ class OutputSequenceLengthMetric(BaseRecordMetric[int]):
         return (record.output_token_count or 0) + (record.reasoning_token_count or 0)
 
 
-class BenchmarkTokenCountMetric(DerivedSumMetric[int, OutputSequenceLengthMetric]):
+class TotalOutputSequenceLengthMetric(
+    DerivedSumMetric[int, OutputSequenceLengthMetric]
+):
     """
     This is the total number of completion tokens processed by the benchmark.
 
     Formula:
         ```
-        Benchmark Token Count = Sum(Output Sequence Lengths)
+        Total Output Sequence Length = Sum(Output Sequence Lengths)
         ```
     """
 
-    tag = "benchmark_token_count"
-    header = "Benchmark Token Count"
-    short_header = "Tokens"
+    tag = "total_osl"
+    header = "Total Output Sequence Length"
+    short_header = "Total OSL"
     short_header_hide_unit = True
     flags = (
         MetricFlags.PRODUCES_TOKENS_ONLY
         | MetricFlags.LARGER_IS_BETTER
-        | MetricFlags.HIDDEN
+        | MetricFlags.NO_CONSOLE
     )

--- a/aiperf/metrics/types/output_token_count.py
+++ b/aiperf/metrics/types/output_token_count.py
@@ -28,7 +28,7 @@ class OutputTokenCountMetric(BaseRecordMetric[int]):
     flags = (
         MetricFlags.PRODUCES_TOKENS_ONLY
         | MetricFlags.LARGER_IS_BETTER
-        | MetricFlags.HIDDEN
+        | MetricFlags.NO_CONSOLE
     )
     required_metrics = None
 
@@ -63,3 +63,9 @@ class TotalOutputTokensMetric(DerivedSumMetric[int, OutputTokenCountMetric]):
     tag = "total_output_tokens"
     header = "Total Output Tokens"
     short_header = "Total Output"
+    short_header_hide_unit = True
+    flags = (
+        MetricFlags.PRODUCES_TOKENS_ONLY
+        | MetricFlags.LARGER_IS_BETTER
+        | MetricFlags.NO_CONSOLE
+    )

--- a/aiperf/metrics/types/output_token_throughput_metrics.py
+++ b/aiperf/metrics/types/output_token_throughput_metrics.py
@@ -7,7 +7,9 @@ from aiperf.metrics import BaseDerivedMetric, BaseRecordMetric
 from aiperf.metrics.metric_dicts import MetricRecordDict, MetricResultsDict
 from aiperf.metrics.types.benchmark_duration_metric import BenchmarkDurationMetric
 from aiperf.metrics.types.inter_token_latency_metric import InterTokenLatencyMetric
-from aiperf.metrics.types.output_sequence_length_metric import BenchmarkTokenCountMetric
+from aiperf.metrics.types.output_sequence_length_metric import (
+    TotalOutputSequenceLengthMetric,
+)
 
 
 class OutputTokenThroughputMetric(BaseDerivedMetric[float]):
@@ -26,7 +28,7 @@ class OutputTokenThroughputMetric(BaseDerivedMetric[float]):
     display_order = 800
     flags = MetricFlags.PRODUCES_TOKENS_ONLY | MetricFlags.LARGER_IS_BETTER
     required_metrics = {
-        BenchmarkTokenCountMetric.tag,
+        TotalOutputSequenceLengthMetric.tag,
         BenchmarkDurationMetric.tag,
     }
 
@@ -34,12 +36,12 @@ class OutputTokenThroughputMetric(BaseDerivedMetric[float]):
         self,
         metric_results: MetricResultsDict,
     ) -> float:
-        benchmark_token_count = metric_results.get_or_raise(BenchmarkTokenCountMetric)
+        total_osl = metric_results.get_or_raise(TotalOutputSequenceLengthMetric)
         benchmark_duration_converted = metric_results.get_converted_or_raise(
             BenchmarkDurationMetric,
             self.unit.time_unit,  # type: ignore
         )
-        return benchmark_token_count / benchmark_duration_converted  # type: ignore
+        return total_osl / benchmark_duration_converted  # type: ignore
 
 
 class OutputTokenThroughputPerUserMetric(BaseRecordMetric[float]):

--- a/aiperf/metrics/types/reasoning_token_count.py
+++ b/aiperf/metrics/types/reasoning_token_count.py
@@ -31,7 +31,7 @@ class ReasoningTokenCountMetric(BaseRecordMetric[int]):
         MetricFlags.PRODUCES_TOKENS_ONLY
         | MetricFlags.LARGER_IS_BETTER
         | MetricFlags.SUPPORTS_REASONING
-        | MetricFlags.EXPERIMENTAL
+        | MetricFlags.NO_CONSOLE
     )
     required_metrics = None
 
@@ -66,3 +66,9 @@ class TotalReasoningTokensMetric(DerivedSumMetric[int, ReasoningTokenCountMetric
     tag = "total_reasoning_tokens"
     header = "Total Reasoning Tokens"
     short_header = "Total Reasoning"
+    short_header_hide_unit = True
+    flags = (
+        MetricFlags.PRODUCES_TOKENS_ONLY
+        | MetricFlags.LARGER_IS_BETTER
+        | MetricFlags.NO_CONSOLE
+    )

--- a/aiperf/ui/dashboard/realtime_metrics_dashboard.py
+++ b/aiperf/ui/dashboard/realtime_metrics_dashboard.py
@@ -65,7 +65,9 @@ class RealtimeMetricsTable(Widget):
         if metric_class.has_flags(MetricFlags.ERROR_ONLY):
             return True
         return (
-            metric_class.has_flags(MetricFlags.HIDDEN)
+            metric_class.has_any_flags(
+                MetricFlags.NO_CONSOLE | MetricFlags.INTERNAL | MetricFlags.EXPERIMENTAL
+            )
             and not self.service_config.developer.show_internal_metrics
         )
 

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -14,7 +14,7 @@ from aiperf.common.models import (
 )
 from aiperf.common.models.record_models import TextResponseData
 from aiperf.common.types import MetricTagT
-from aiperf.metrics.metric_dicts import MetricRecordDict, MetricResultsDict
+from aiperf.metrics.metric_dicts import MetricArray, MetricRecordDict, MetricResultsDict
 from aiperf.metrics.metric_registry import MetricRegistry
 
 
@@ -108,3 +108,11 @@ def run_simple_metrics_pipeline(
             metric_results[metric.tag] = metric.derive_value(metric_results)
 
     return metric_results
+
+
+def create_metric_array(values):
+    """Create a MetricArray with test values."""
+    array = MetricArray()
+    if values:
+        array.extend(values)
+    return array

--- a/tests/metrics/test_metric_flags.py
+++ b/tests/metrics/test_metric_flags.py
@@ -58,3 +58,51 @@ class TestMetricFlags:
         assert flags.missing_flags(flags_to_check) == expected, (
             f"Expected {flags}.missing_flags({flags_to_check}) to equal {expected}"
         )
+
+    @pytest.mark.parametrize(
+        "flags, flags_to_check, expected",
+        [
+            (MetricFlags.NONE, MetricFlags.NONE, False),
+            (MetricFlags.NONE, MetricFlags.STREAMING_ONLY, False),
+            (MetricFlags.NONE, MetricFlags.STREAMING_ONLY | MetricFlags.PRODUCES_TOKENS_ONLY, False),
+            ###
+            (MetricFlags.STREAMING_ONLY, MetricFlags.NONE, False),
+            (MetricFlags.STREAMING_ONLY, MetricFlags.STREAMING_ONLY, True),
+            (MetricFlags.STREAMING_ONLY, MetricFlags.STREAMING_ONLY | MetricFlags.PRODUCES_TOKENS_ONLY, True),
+            (MetricFlags.STREAMING_ONLY, MetricFlags.PRODUCES_TOKENS_ONLY, False),
+            ###
+            (MetricFlags.PRODUCES_TOKENS_ONLY, MetricFlags.STREAMING_ONLY, False),
+            (MetricFlags.PRODUCES_TOKENS_ONLY, MetricFlags.STREAMING_ONLY | MetricFlags.PRODUCES_TOKENS_ONLY, True),
+            (MetricFlags.PRODUCES_TOKENS_ONLY, MetricFlags.PRODUCES_TOKENS_ONLY, True),
+            ###
+            (MetricFlags.STREAMING_TOKENS_ONLY, MetricFlags.STREAMING_ONLY, True),
+            (MetricFlags.STREAMING_TOKENS_ONLY, MetricFlags.STREAMING_ONLY | MetricFlags.PRODUCES_TOKENS_ONLY, True),
+            (MetricFlags.STREAMING_TOKENS_ONLY, MetricFlags.PRODUCES_TOKENS_ONLY, True),
+            (MetricFlags.STREAMING_TOKENS_ONLY, MetricFlags.NONE, False),
+            ###
+            (MetricFlags.NO_CONSOLE, MetricFlags.NO_CONSOLE, True),
+            (MetricFlags.NO_CONSOLE, MetricFlags.NO_CONSOLE | MetricFlags.INTERNAL, True),
+            (MetricFlags.NO_CONSOLE, MetricFlags.INTERNAL, False),
+            (MetricFlags.NO_CONSOLE, MetricFlags.EXPERIMENTAL, False),
+            ###
+            (MetricFlags.INTERNAL, MetricFlags.INTERNAL, True),
+            (MetricFlags.INTERNAL, MetricFlags.NO_CONSOLE, False),
+            (MetricFlags.INTERNAL, MetricFlags.NO_CONSOLE | MetricFlags.INTERNAL | MetricFlags.EXPERIMENTAL, True),
+            ###
+            (MetricFlags.EXPERIMENTAL, MetricFlags.EXPERIMENTAL, True),
+            (MetricFlags.EXPERIMENTAL, MetricFlags.NO_CONSOLE, False),
+            (MetricFlags.EXPERIMENTAL, MetricFlags.NO_CONSOLE | MetricFlags.INTERNAL | MetricFlags.EXPERIMENTAL, True),
+        ],
+    )  # fmt: skip
+    def test_has_any_flags(self, flags, flags_to_check, expected):
+        assert flags.has_any_flags(flags_to_check) == expected, (
+            f"Expected {flags}.has_any_flags({flags_to_check}) to equal {expected}"
+        )
+
+    def test_internal_does_not_inherit_no_console(self):
+        """Test that INTERNAL flag no longer inherits NO_CONSOLE"""
+        assert MetricFlags.INTERNAL.missing_flags(MetricFlags.NO_CONSOLE)
+
+    def test_experimental_does_not_inherit_no_console(self):
+        """Test that EXPERIMENTAL flag no longer inherits NO_CONSOLE"""
+        assert MetricFlags.EXPERIMENTAL.missing_flags(MetricFlags.NO_CONSOLE)

--- a/tests/metrics/test_output_sequence_length_metric.py
+++ b/tests/metrics/test_output_sequence_length_metric.py
@@ -4,12 +4,18 @@
 import pytest
 from pytest import approx
 
+from aiperf.common.enums import MetricFlags
 from aiperf.common.exceptions import NoMetricValue
-from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.metric_dicts import MetricRecordDict, MetricResultsDict
 from aiperf.metrics.types.output_sequence_length_metric import (
     OutputSequenceLengthMetric,
+    TotalOutputSequenceLengthMetric,
 )
-from tests.metrics.conftest import create_record, run_simple_metrics_pipeline
+from tests.metrics.conftest import (
+    create_metric_array,
+    create_record,
+    run_simple_metrics_pipeline,
+)
 
 
 class TestOutputSequenceLengthMetric:
@@ -51,3 +57,43 @@ class TestOutputSequenceLengthMetric:
         )
 
         assert metric_results[OutputSequenceLengthMetric.tag] == approx([5, 10, 15])
+
+    def test_output_sequence_length_with_reasoning_tokens(self):
+        """Test output sequence length includes reasoning tokens"""
+        record = create_record(output_tokens_per_response=10)
+        record.reasoning_token_count = 5
+
+        metric = OutputSequenceLengthMetric()
+        result = metric.parse_record(record, MetricRecordDict())
+        assert result == 15
+
+
+class TestTotalOutputSequenceLengthMetric:
+    @pytest.mark.parametrize(
+        "values, expected_sum",
+        [
+            ([10, 20, 30], 60),
+            ([100], 100),
+            ([], 0),
+            ([1], 1),
+            ([0, 0, 0], 0),
+        ],
+    )
+    def test_sum_calculation(self, values, expected_sum):
+        """Test that TotalOutputSequenceLengthMetric correctly sums all output tokens"""
+        metric = TotalOutputSequenceLengthMetric()
+        metric_results = MetricResultsDict()
+        metric_results[OutputSequenceLengthMetric.tag] = create_metric_array(values)
+
+        result = metric.derive_value(metric_results)
+        assert result == expected_sum
+
+    def test_metric_metadata(self):
+        """Test that TotalOutputSequenceLengthMetric has correct metadata"""
+        assert TotalOutputSequenceLengthMetric.tag == "total_osl"
+        assert TotalOutputSequenceLengthMetric.has_flags(
+            MetricFlags.PRODUCES_TOKENS_ONLY
+        )
+        assert TotalOutputSequenceLengthMetric.has_flags(MetricFlags.LARGER_IS_BETTER)
+        assert TotalOutputSequenceLengthMetric.has_flags(MetricFlags.NO_CONSOLE)
+        assert TotalOutputSequenceLengthMetric.missing_flags(MetricFlags.INTERNAL)

--- a/tests/metrics/test_output_token_count.py
+++ b/tests/metrics/test_output_token_count.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.enums import MetricFlags
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.metrics.metric_dicts import MetricRecordDict, MetricResultsDict
+from aiperf.metrics.types.output_token_count import (
+    OutputTokenCountMetric,
+    TotalOutputTokensMetric,
+)
+from tests.metrics.conftest import (
+    create_metric_array,
+    create_record,
+    run_simple_metrics_pipeline,
+)
+
+
+class TestOutputTokenCountMetric:
+    def test_output_token_count_basic(self):
+        """Test basic output token count extraction"""
+        record = create_record(output_tokens_per_response=25)
+
+        metric = OutputTokenCountMetric()
+        result = metric.parse_record(record, MetricRecordDict())
+        assert result == 25
+
+    def test_output_token_count_zero(self):
+        """Test handling of zero output tokens raises error"""
+        record = create_record(output_tokens_per_response=0)
+
+        metric = OutputTokenCountMetric()
+        with pytest.raises(NoMetricValue):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_output_token_count_none(self):
+        """Test handling of None output tokens raises error"""
+        record = create_record()
+        record.output_token_count = None
+
+        metric = OutputTokenCountMetric()
+        with pytest.raises(NoMetricValue):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_output_token_count_multiple_records(self):
+        """Test processing multiple records with different token counts"""
+        token_counts = [15, 30, 45]
+        records = [create_record(output_tokens_per_response=tc) for tc in token_counts]
+
+        metric_results = run_simple_metrics_pipeline(
+            records,
+            OutputTokenCountMetric.tag,
+        )
+        assert metric_results[OutputTokenCountMetric.tag] == token_counts
+
+    def test_output_token_count_metadata(self):
+        """Test that OutputTokenCountMetric has correct metadata"""
+        assert OutputTokenCountMetric.has_flags(MetricFlags.PRODUCES_TOKENS_ONLY)
+        assert OutputTokenCountMetric.has_flags(MetricFlags.NO_CONSOLE)
+        assert OutputTokenCountMetric.missing_flags(MetricFlags.INTERNAL)
+
+
+class TestTotalOutputTokensMetric:
+    @pytest.mark.parametrize(
+        "values, expected_sum",
+        [
+            ([10, 25, 40], 75),
+            ([150], 150),
+            ([], 0),
+            ([1], 1),
+            ([0, 0, 0], 0),
+        ],
+    )
+    def test_sum_calculation(self, values, expected_sum):
+        """Test that TotalOutputTokensMetric correctly sums all output token counts"""
+        metric = TotalOutputTokensMetric()
+        metric_results = MetricResultsDict()
+        metric_results[OutputTokenCountMetric.tag] = create_metric_array(values)
+
+        result = metric.derive_value(metric_results)
+        assert result == expected_sum
+
+    def test_metric_metadata(self):
+        """Test that TotalOutputTokensMetric has correct metadata"""
+        assert TotalOutputTokensMetric.tag == "total_output_tokens"
+        assert TotalOutputTokensMetric.has_flags(MetricFlags.PRODUCES_TOKENS_ONLY)
+        assert TotalOutputTokensMetric.has_flags(MetricFlags.LARGER_IS_BETTER)
+        assert TotalOutputTokensMetric.has_flags(MetricFlags.NO_CONSOLE)
+        assert TotalOutputTokensMetric.missing_flags(MetricFlags.INTERNAL)

--- a/tests/metrics/test_output_token_throughput_metric.py
+++ b/tests/metrics/test_output_token_throughput_metric.py
@@ -6,7 +6,9 @@ import pytest
 from aiperf.common.exceptions import NoMetricValue
 from aiperf.metrics.metric_dicts import MetricResultsDict
 from aiperf.metrics.types.benchmark_duration_metric import BenchmarkDurationMetric
-from aiperf.metrics.types.output_sequence_length_metric import BenchmarkTokenCountMetric
+from aiperf.metrics.types.output_sequence_length_metric import (
+    TotalOutputSequenceLengthMetric,
+)
 from aiperf.metrics.types.output_token_throughput_metrics import (
     OutputTokenThroughputMetric,
 )
@@ -19,7 +21,7 @@ class TestOutputTokenThroughputMetric:
 
         # 1000 tokens in 2 seconds = 500 tokens/second
         metric_results = MetricResultsDict()
-        metric_results[BenchmarkTokenCountMetric.tag] = 1000
+        metric_results[TotalOutputSequenceLengthMetric.tag] = 1000
         metric_results[BenchmarkDurationMetric.tag] = (
             2_000_000_000  # 2 seconds in nanoseconds
         )
@@ -33,7 +35,7 @@ class TestOutputTokenThroughputMetric:
 
         # 750 tokens in 1.5 seconds = 500 tokens/second
         metric_results = MetricResultsDict()
-        metric_results[BenchmarkTokenCountMetric.tag] = 750
+        metric_results[TotalOutputSequenceLengthMetric.tag] = 750
         metric_results[BenchmarkDurationMetric.tag] = (
             1_500_000_000  # 1.5 seconds in nanoseconds
         )
@@ -46,7 +48,7 @@ class TestOutputTokenThroughputMetric:
         metric = OutputTokenThroughputMetric()
 
         metric_results = MetricResultsDict()
-        metric_results[BenchmarkTokenCountMetric.tag] = 1000
+        metric_results[TotalOutputSequenceLengthMetric.tag] = 1000
         metric_results[BenchmarkDurationMetric.tag] = 0.0
 
         with pytest.raises(NoMetricValue):
@@ -57,7 +59,7 @@ class TestOutputTokenThroughputMetric:
         metric = OutputTokenThroughputMetric()
 
         metric_results = MetricResultsDict()
-        metric_results[BenchmarkTokenCountMetric.tag] = 1000
+        metric_results[TotalOutputSequenceLengthMetric.tag] = 1000
         metric_results[BenchmarkDurationMetric.tag] = None
 
         with pytest.raises(NoMetricValue):

--- a/tests/metrics/test_reasoning_token_count.py
+++ b/tests/metrics/test_reasoning_token_count.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.enums import MetricFlags
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.metrics.metric_dicts import MetricRecordDict, MetricResultsDict
+from aiperf.metrics.types.reasoning_token_count import (
+    ReasoningTokenCountMetric,
+    TotalReasoningTokensMetric,
+)
+from tests.metrics.conftest import (
+    create_metric_array,
+    create_record,
+    run_simple_metrics_pipeline,
+)
+
+
+class TestReasoningTokenCountMetric:
+    def test_reasoning_token_count_basic(self):
+        """Test basic reasoning token count extraction"""
+        record = create_record(output_tokens_per_response=10)
+        record.reasoning_token_count = 5
+
+        metric = ReasoningTokenCountMetric()
+        result = metric.parse_record(record, MetricRecordDict())
+        assert result == 5
+
+    def test_reasoning_token_count_zero(self):
+        """Test handling of zero reasoning tokens"""
+        record = create_record(output_tokens_per_response=10)
+        record.reasoning_token_count = 0
+
+        metric = ReasoningTokenCountMetric()
+        result = metric.parse_record(record, MetricRecordDict())
+        assert result == 0
+
+    def test_reasoning_token_count_none(self):
+        """Test handling of None reasoning tokens raises error"""
+        record = create_record(output_tokens_per_response=10)
+        record.reasoning_token_count = None
+
+        metric = ReasoningTokenCountMetric()
+        with pytest.raises(NoMetricValue):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_reasoning_token_count_multiple_records(self):
+        """Test processing multiple records with different reasoning token counts"""
+        records = []
+        reasoning_counts = [5, 10, 15]
+        for count in reasoning_counts:
+            record = create_record(output_tokens_per_response=20)
+            record.reasoning_token_count = count
+            records.append(record)
+
+        metric_results = run_simple_metrics_pipeline(
+            records,
+            ReasoningTokenCountMetric.tag,
+        )
+        assert metric_results[ReasoningTokenCountMetric.tag] == reasoning_counts
+
+    def test_reasoning_token_count_metadata(self):
+        """Test that ReasoningTokenCountMetric has correct metadata"""
+        assert ReasoningTokenCountMetric.has_flags(MetricFlags.PRODUCES_TOKENS_ONLY)
+        assert ReasoningTokenCountMetric.has_flags(MetricFlags.SUPPORTS_REASONING)
+        assert ReasoningTokenCountMetric.has_flags(MetricFlags.NO_CONSOLE)
+        assert ReasoningTokenCountMetric.missing_flags(MetricFlags.INTERNAL)
+
+
+class TestTotalReasoningTokensMetric:
+    @pytest.mark.parametrize(
+        "values, expected_sum",
+        [
+            ([5, 10, 20], 35),
+            ([50], 50),
+            ([], 0),
+            ([1], 1),
+            ([0, 0, 0], 0),
+        ],
+    )
+    def test_sum_calculation(self, values, expected_sum):
+        """Test that TotalReasoningTokensMetric correctly sums all reasoning token counts"""
+        metric = TotalReasoningTokensMetric()
+        metric_results = MetricResultsDict()
+        metric_results[ReasoningTokenCountMetric.tag] = create_metric_array(values)
+
+        result = metric.derive_value(metric_results)
+        assert result == expected_sum
+
+    def test_metric_metadata(self):
+        """Test that TotalReasoningTokensMetric has correct metadata and does not inherit SUPPORTS_REASONING"""
+        assert TotalReasoningTokensMetric.tag == "total_reasoning_tokens"
+        assert TotalReasoningTokensMetric.has_flags(MetricFlags.PRODUCES_TOKENS_ONLY)
+        assert TotalReasoningTokensMetric.has_flags(MetricFlags.NO_CONSOLE)
+        assert TotalReasoningTokensMetric.missing_flags(MetricFlags.SUPPORTS_REASONING)
+        assert TotalReasoningTokensMetric.missing_flags(MetricFlags.INTERNAL)

--- a/tests/ui/test_realtime_metrics_dashboard.py
+++ b/tests/ui/test_realtime_metrics_dashboard.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.config import ServiceConfig
+from aiperf.common.config.dev_config import DeveloperConfig
+from aiperf.common.models import MetricResult
+from aiperf.metrics.types.benchmark_duration_metric import BenchmarkDurationMetric
+from aiperf.metrics.types.error_request_count import ErrorRequestCountMetric
+from aiperf.metrics.types.inter_token_latency_metric import InterTokenLatencyMetric
+from aiperf.metrics.types.output_token_count import (
+    OutputTokenCountMetric,
+)
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+from aiperf.metrics.types.thinking_efficiency_metrics import ThinkingEfficiencyMetric
+from aiperf.metrics.types.ttft_metric import TTFTMetric
+from aiperf.ui.dashboard.realtime_metrics_dashboard import RealtimeMetricsTable
+
+
+@pytest.fixture
+def service_config_show_internal_false():
+    return ServiceConfig(developer=DeveloperConfig(show_internal_metrics=False))
+
+
+@pytest.fixture
+def service_config_show_internal_true():
+    return ServiceConfig(developer=DeveloperConfig(show_internal_metrics=True))
+
+
+class TestRealtimeMetricsTable:
+    @pytest.mark.parametrize(
+        "metric_tag, show_internal, should_skip",
+        [
+            # ERROR_ONLY metrics - always skipped
+            (ErrorRequestCountMetric.tag, False, True),
+            (ErrorRequestCountMetric.tag, True, True),
+            # EXPERIMENTAL metrics - skipped if show_internal_metrics is False
+            (ThinkingEfficiencyMetric.tag, False, True),
+            (ThinkingEfficiencyMetric.tag, True, False),
+            # NO_CONSOLE metrics - skipped if show_internal_metrics is False
+            (BenchmarkDurationMetric.tag, False, True),
+            (BenchmarkDurationMetric.tag, True, False),
+            (OutputTokenCountMetric.tag, False, True),
+            (OutputTokenCountMetric.tag, True, False),
+            # Normal metrics - always shown
+            (RequestLatencyMetric.tag, False, False),
+            (RequestLatencyMetric.tag, True, False),
+            (TTFTMetric.tag, False, False),
+            (TTFTMetric.tag, True, False),
+            (InterTokenLatencyMetric.tag, False, False),
+            (InterTokenLatencyMetric.tag, True, False),
+        ],
+    )  # fmt: skip
+    def test_should_skip_logic_with_real_metrics(
+        self, metric_tag, show_internal, should_skip
+    ):
+        """Test that metrics are skipped based on flags and configuration using real metrics"""
+        service_config = ServiceConfig(
+            developer=DeveloperConfig(show_internal_metrics=show_internal)
+        )
+        table = RealtimeMetricsTable(service_config)
+
+        metric_result = MetricResult(
+            tag=metric_tag,
+            header="Test Metric",
+            unit="ms",
+            avg=1.0,
+        )
+
+        assert table._should_skip(metric_result) is should_skip


### PR DESCRIPTION
## Changes

- **Added `TotalInputSequenceLengthMetric`** (tag: `total_isl`) to track total input tokens
- **Renamed `BenchmarkTokenCountMetric` to `TotalOutputSequenceLengthMetric`**: tag changed from `benchmark_token_count` to `total_osl`
- **`MetricFlags.HIDDEN` renamed to `MetricFlags.NO_CONSOLE`**: hides from console but still exports to CSV/JSON
- **`INTERNAL` and `EXPERIMENTAL` flags no longer inherit `NO_CONSOLE`**: must be explicitly filtered from both console and file exports
- **Fixed bug**: `NO_CONSOLE` metrics were incorrectly excluded from CSV/JSON exports
- **Reasoning token and inter-chunk latency metrics promoted**: changed from `EXPERIMENTAL` to `NO_CONSOLE` (now exported to files)
- **Added comprehensive unit tests** for new metrics and flag behaviors