### PR TITLE
chore: remove pandas now that we use numpy only

### DIFF
--- a/aiperf/common/enums/metric_enums.py
+++ b/aiperf/common/enums/metric_enums.py
@@ -359,7 +359,7 @@ class MetricValueType(BasePydanticBackedStrEnum):
 
     @cached_property
     def dtype(self) -> Any:
-        """Get the dtype for the metric value type (for pandas/numpy)."""
+        """Get the dtype for the metric value type (for numpy)."""
         return self.info.dtype
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
   "numpy~=2.2.6",
   "openai[aiohttp]~=1.92.2",
   "orjson~=3.10.18",
-  "pandas~=2.3.0",
   "pillow~=11.1.0",
   "psutil~=7.0.0",
   "pydantic~=2.11.4",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified metric dtype documentation to reference NumPy only.
- Chores
  - Removed pandas from project dependencies to reduce install size and simplify environment setup.
  - Fewer third-party packages required, leading to faster installations and lower footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->