### PR TITLE
fix: make help because sometimes less is more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ dim := $(shell tput dim)
 
 
 help: #? show this help
-	@$(MAKE) internal-help --no-print-directory | less
+	@$(MAKE) internal-help --no-print-directory
 
 #
 # Help command is automatically generated based on the comments in the Makefile.


### PR DESCRIPTION
Don't pipe make help to less to fix issues for mac users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Help output now prints directly to the terminal instead of using a pager, making it immediately visible.
  * Improves usability in non-interactive environments (e.g., CI logs, containers) and removes dependency on external pagers.
  * Eases copying/searching of help text in terminals that don’t handle paged output well.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->