### PR TITLE
test: fix numpy random seed for image test

### DIFF
--- a/tests/generators/test_image_generator.py
+++ b/tests/generators/test_image_generator.py
@@ -6,6 +6,7 @@ import random
 from io import BytesIO
 from unittest.mock import Mock, patch
 
+import numpy as np
 import pytest
 from PIL import Image
 
@@ -165,9 +166,11 @@ class TestImageGenerator:
         mock_sample_image.return_value = test_image
 
         state = random.getstate()
+        np_state = np.random.get_state()
         try:
             # Set random seed to make the test deterministic
             random.seed(42)
+            np.random.seed(42)
             generator = ImageGenerator(base_config)
             image1 = generator.generate()
             image2 = generator.generate()
@@ -175,6 +178,7 @@ class TestImageGenerator:
             assert image1 != image2
         finally:
             random.setstate(state)
+            np.random.set_state(np_state)
 
     def test_sample_source_image_success(self, base_config, mock_file_system):
         """Test successful sampling of source image."""


### PR DESCRIPTION
FAILED tests/generators/test_image_generator.py::TestImageGenerator::test_generate_multiple_calls_different_results - AssertionError: assert 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAIAAABv85FHAAAAEklEQVR4nGP8z4ATMOGWGhZyAAPsARFe/H1mAAAAAElFTkSuQmCC' != 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAI...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability and reproducibility of image generation tests by aligning random number generators and preserving their state during execution.
  * Reduces flakiness and ensures consistent results across runs and environments.
  * Enhances verification that sequential calls produce varied outputs under controlled seeds, yielding clearer diagnostics and easier debugging when regressions occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->