### PR TITLE
fix: update tutorial to use dynamo version to 0.5.0

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -21,7 +21,7 @@ models using various inference solutions.
 ```bash
 # Set environment variables
 export AIPERF_REPO_TAG="main"
-export DYNAMO_PREBUILT_IMAGE_TAG="nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0"
+export DYNAMO_PREBUILT_IMAGE_TAG="nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0"
 export MODEL="Qwen/Qwen3-0.6B"
 
 # Download the Dyanmo container


### PR DESCRIPTION
To fix the issue with `Error manifest for bitnami/etcd:3.6.1 not found: manifest unknown`. See: [slack thread](https://nvidia.slack.com/archives/C09EFQACFKM/p1759344696652319)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the tutorial to reference the Dynamo prebuilt image tag v0.5.0 (replacing v0.4.0), so installation commands pull the newer runtime image.
  * Instructions now align with the latest available image, with no changes to examples or workflow steps.
  * No functional impact to the app; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->