### PR TITLE
fix: Ensure proper container cleanup in test_docs_end_to_end to prevent port conflicts

### DIFF
--- a/docs/tutorials/gpu-telemetry.md
+++ b/docs/tutorials/gpu-telemetry.md
@@ -141,6 +141,7 @@ This path works with **vLLM, SGLang, TRT-LLM, or any inference server**. We'll u
 
 The setup includes three steps: creating a custom metrics configuration, starting the DCGM Exporter, and launching the vLLM server.
 
+<!-- setup-vllm-gpu-telemetry-default-openai-endpoint-server -->
 ```bash
 # Step 1: Create a custom metrics configuration
 cat > custom_gpu_metrics.csv << 'EOF'
@@ -204,6 +205,7 @@ docker run -d --name vllm-server \
   --host 0.0.0.0 \
   --port 8000
 ```
+<!-- /setup-vllm-gpu-telemetry-default-openai-endpoint-server -->
 
 > [!TIP]
 > You can customize the `custom_gpu_metrics.csv` file by commenting out metrics you don't need. Lines starting with `#` are ignored.
@@ -246,6 +248,7 @@ uv pip install ./aiperf
 
 ## Verify Everything is Running
 
+<!-- health-check-vllm-gpu-telemetry-default-openai-endpoint-server -->
 ```bash
 # Wait for vLLM inference server to be ready (up to 15 minutes)
 timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"Qwen/Qwen3-0.6B\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":1}")" != "200" ]; do sleep 2; done' || { echo "vLLM not ready after 15min"; exit 1; }
@@ -255,9 +258,11 @@ echo "vLLM ready, waiting for DCGM metrics to be available..."
 timeout 120 bash -c 'while true; do OUTPUT=$(curl -s localhost:9401/metrics); if echo "$OUTPUT" | grep -q "DCGM_FI_DEV_GPU_UTIL"; then break; fi; echo "Waiting for DCGM metrics..."; sleep 5; done' || { echo "GPU utilization metrics not found after 2min"; exit 1; }
 echo "DCGM GPU metrics are now available"
 ```
+<!-- /health-check-vllm-gpu-telemetry-default-openai-endpoint-server -->
 
 ## Run AIPerf Benchmark
 
+<!-- aiperf-run-vllm-gpu-telemetry-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -278,6 +283,7 @@ aiperf profile \
     --random-seed 100 \
     --gpu-telemetry
 ```
+<!-- /aiperf-run-vllm-gpu-telemetry-default-openai-endpoint-server -->
 
 ## Multi-Node GPU Telemetry Example
 


### PR DESCRIPTION
## Problem
  When running multiple server tests sequentially in `test_docs_end_to_end`, DCGM containers on port 9401 and vLLM containers on port 8000 weren't being properly cleaned up, causing "port already allocated" errors when the next test tried to start.

  ## Root Cause
  - Dynamo's `docker compose down` returns before containers fully stop
  - vLLM containers have random names, so the wildcard stop by name did not find them and correctly stop them

  ## Solution

  1. **Dynamo cleanup**:
     - Added 3-second sleep after `docker compose down` to ensure full cleanup of all related services including DCGM before proceeding

  2. **vLLM cleanup**:
     - Use `grep vllm` on image to find containers (instead of going by container name, which is randomly assigned)
     - Explicitly stop dcgm-exporter by name

  Each test now properly cleans up after itself, ensuring the next test starts with a clean environment.
  Also, the vLLM GPU Telemetry documentation now runs successfully. Dynamo GPU Telemetry is still being debugged as tracked in this [Linear ticket](https://linear.app/nvidia/issue/AIP-471/investigate-issue-where-dynamo-dcgm-exporter-is-running-but-gives).

## Gitlab 
Successful pipeline job run [here](https://gitlab-master.nvidia.com/dl/ai-dynamo/aiperf-ci/-/pipelines/36587328).

## GPU Telemetry Documentation
Added tags to the vLLM instructions to be included in docs end-to-end CI tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded GPU telemetry guide with new setup, health-check, and AIPerf benchmark sections, added closing markers and tips for vLLM/DCGM and default endpoint workflows.

* **Tests**
  * Improved test teardown to more reliably stop/remove DCGM exporter across server types and added a short sequencing delay to reduce shutdown flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->