### PR TITLE
chore: run unit tests on python 3.10, 3.11, 3.12 ubuntu and macOS

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -25,11 +25,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        uv venv --python ${{ matrix.python-version }}
-        uv pip install -e ".[dev]"
+        make first-time-setup PYTHON_VERSION=${{ matrix.python-version }}
     - name: Run unit tests
       run: |
-        ./.venv/bin/pytest -n auto --cov=aiperf --cov-branch --cov-report=html --cov-report=xml --cov-report=term --tb=short --log-cli-level=INFO --capture=no
+        make coverage PYTHON_VERSION=${{ matrix.python-version }}
     - name: Upload results to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
this will test 3 python versions against 2 OSes (matrix of 6 that will run simultaneously). It will only publish code coverage for the Ubuntu 3.10 one (like our existing case).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded CI test matrix to include macOS and additional Python versions (3.11, 3.12) alongside 3.10 for broader environment coverage.
  * Consolidated code coverage uploads to run from a single reference configuration for consistent reporting.

* **Chores**
  * Updated CI tooling to the latest stable runner version and refined workflow conditions.
  * Passed Python version into setup steps and added minor configuration fields to improve clarity and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->