### PR TITLE
chroe: update openai version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "cyclopts>=3,<4",
   "ffmpeg-python~=0.2.0",
   "numpy~=1.26.4",
-  "openai[aiohttp]~=1.92.2",
+  "openai[aiohttp]>=1.92.2",
 
   "orjson~=3.10.18",
   "pillow~=11.1.0",


### PR DESCRIPTION
we are pinning an older version of openai in aiperf ~ "openai[aiohttp]~=1.92.2"
https://github.com/ai-dynamo/aiperf/blob/14b542ad951c09123ef4298c26e8f6203b596975/pyproject.toml#L35

where as Dynamo ToT main vllm runtime uses openai==2.3.0

This causes error while using aiperf in dynamo image
```
ImportError: cannot import name 'ResponseReasoningTextDeltaEvent' from 'openai.types.responses' (/opt/dynamo/venv/lib/python3.12/site-packages/openai/types/responses/__init__.py)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version constraint for an external AI SDK to a minimum version, allowing newer minor and patch releases.
  * Improves compatibility and reduces installation conflicts across environments.
  * No changes to functionality, UI, or APIs; existing workflows remain unaffected.
  * If unexpected behavior occurs after future upgrades, consider pinning to a previously known-good version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->