### PR TITLE
feat: add time to first output (non reasoning) metric

### DIFF
--- a/aiperf/metrics/types/time_to_first_output_token_metric.py
+++ b/aiperf/metrics/types/time_to_first_output_token_metric.py
@@ -8,7 +8,7 @@ from aiperf.metrics import BaseRecordMetric
 from aiperf.metrics.metric_dicts import MetricRecordDict
 
 
-class TimeToFirstOutputMetric(BaseRecordMetric[int]):
+class TimeToFirstOutputTokenMetric(BaseRecordMetric[int]):
     """
     Calculates the time elapsed from request start to the first non-reasoning output token.
 
@@ -27,8 +27,8 @@ class TimeToFirstOutputMetric(BaseRecordMetric[int]):
         Time to First Output = First Non-Reasoning Token Timestamp - Request Start Timestamp
     """
 
-    tag = "time_to_first_output"
-    header = "Time to First Output"
+    tag = "time_to_first_output_token"
+    header = "Time to First Output Token"
     short_header = "TTFO"
     unit = MetricTimeUnit.NANOSECONDS
     display_unit = MetricTimeUnit.MILLISECONDS
@@ -56,24 +56,13 @@ class TimeToFirstOutputMetric(BaseRecordMetric[int]):
             record_metrics: Dictionary of previously computed metrics for this record (unused)
 
         Returns:
-            The time to first output in nanoseconds
-
-        Raises:
-            NoMetricValue: If the record contains no responses or no non-reasoning tokens
-            ValueError: If the first non-reasoning token timestamp precedes the request start
-                timestamp, indicating invalid or corrupted timing data
+            The time to first output token in nanoseconds
         """
-
-        if len(record.responses) < 1:
-            raise NoMetricValue(
-                "Record must have at least one non-reasoning token to calculate Time to First Output."
-            )
-
         try:
             # Try and find the first non-reasoning token output and extract the timestamp.
             # This is done by checking for the first response that is either a TextResponseData or a ReasoningResponseData
             # and has a non-empty text or content field. Note that ReasoningResponseData can have both reasoning and content.
-            first_non_reasoning_token_ts: int = next(
+            first_non_reasoning_token_perf_ns: int = next(
                 response.perf_ns
                 for response in record.responses
                 if (isinstance(response.data, TextResponseData) and response.data.text)
@@ -84,13 +73,8 @@ class TimeToFirstOutputMetric(BaseRecordMetric[int]):
             )
         except StopIteration:
             raise NoMetricValue(
-                "Record must have at least one non-reasoning token to calculate Time to First Output."
+                "Record must have at least one non-reasoning token to calculate Time to First Output Token."
             ) from None
 
-        request_ts: int = record.request.start_perf_ns
-        if first_non_reasoning_token_ts < request_ts:
-            raise ValueError(
-                "First non-reasoning token timestamp is before request start timestamp, cannot compute Time to First Output."
-            )
-
-        return first_non_reasoning_token_ts - request_ts
+        request_perf_ns: int = record.request.start_perf_ns
+        return first_non_reasoning_token_perf_ns - request_perf_ns

--- a/tests/metrics/test_time_to_first_output_metric.py
+++ b/tests/metrics/test_time_to_first_output_metric.py
@@ -7,7 +7,9 @@ from aiperf.common.exceptions import NoMetricValue
 from aiperf.common.models import ParsedResponse, ParsedResponseRecord, RequestRecord
 from aiperf.common.models.record_models import ReasoningResponseData, TextResponseData
 from aiperf.metrics.metric_dicts import MetricRecordDict
-from aiperf.metrics.types.time_to_first_output_metric import TimeToFirstOutputMetric
+from aiperf.metrics.types.time_to_first_output_token_metric import (
+    TimeToFirstOutputTokenMetric,
+)
 from tests.metrics.conftest import create_record, run_simple_metrics_pipeline
 
 
@@ -65,9 +67,9 @@ class TestTimeToFirstOutputMetric:
         """Test basic time to first output with text responses"""
         record = create_record(start_ns=start_ns, responses=responses)
         metric_results = run_simple_metrics_pipeline(
-            [record], TimeToFirstOutputMetric.tag
+            [record], TimeToFirstOutputTokenMetric.tag
         )
-        assert metric_results[TimeToFirstOutputMetric.tag] == [expected_ttfo]
+        assert metric_results[TimeToFirstOutputTokenMetric.tag] == [expected_ttfo]
 
     def test_ttfo_with_reasoning_response(self):
         """Test TTFO with reasoning response that has content"""
@@ -75,9 +77,9 @@ class TestTimeToFirstOutputMetric:
             start_ns=100, responses=[(110, "reasoning", "content")]
         )
         metric_results = run_simple_metrics_pipeline(
-            [record], TimeToFirstOutputMetric.tag
+            [record], TimeToFirstOutputTokenMetric.tag
         )
-        assert metric_results[TimeToFirstOutputMetric.tag] == [10]
+        assert metric_results[TimeToFirstOutputTokenMetric.tag] == [10]
 
     @pytest.mark.parametrize(
         "responses,expected_ttfo",
@@ -105,9 +107,9 @@ class TestTimeToFirstOutputMetric:
         """Test TTFO correctly handles reasoning tokens and finds first valid content"""
         record = create_response_record(start_ns=100, responses=responses)
         metric_results = run_simple_metrics_pipeline(
-            [record], TimeToFirstOutputMetric.tag
+            [record], TimeToFirstOutputTokenMetric.tag
         )
-        assert metric_results[TimeToFirstOutputMetric.tag] == [expected_ttfo]
+        assert metric_results[TimeToFirstOutputTokenMetric.tag] == [expected_ttfo]
 
     def test_ttfo_multiple_records(self):
         """Test processing multiple records with mixed response types"""
@@ -124,14 +126,14 @@ class TestTimeToFirstOutputMetric:
 
         metric_results = run_simple_metrics_pipeline(
             records,
-            TimeToFirstOutputMetric.tag,
+            TimeToFirstOutputTokenMetric.tag,
         )
-        assert metric_results[TimeToFirstOutputMetric.tag] == [10, 10, 15]
+        assert metric_results[TimeToFirstOutputTokenMetric.tag] == [10, 10, 15]
 
     def test_ttfo_invalid_timestamp(self):
         """Test error when first non-reasoning token timestamp is before request start"""
         record = create_record(start_ns=100, responses=[90])
-        metric = TimeToFirstOutputMetric()
+        metric = TimeToFirstOutputTokenMetric()
         with pytest.raises(NoMetricValue, match="Invalid Record"):
             metric.parse_record(record, MetricRecordDict())
 
@@ -139,7 +141,7 @@ class TestTimeToFirstOutputMetric:
         """Test error when no responses are present"""
         record = create_record(start_ns=100)
         record.responses = []
-        metric = TimeToFirstOutputMetric()
+        metric = TimeToFirstOutputTokenMetric()
         with pytest.raises(NoMetricValue, match="Invalid Record"):
             metric.parse_record(record, MetricRecordDict())
 
@@ -154,7 +156,7 @@ class TestTimeToFirstOutputMetric:
     def test_ttfo_no_valid_content(self, responses):
         """Test error when no valid content tokens are present"""
         record = create_response_record(start_ns=100, responses=responses)
-        metric = TimeToFirstOutputMetric()
+        metric = TimeToFirstOutputTokenMetric()
         with pytest.raises(
             NoMetricValue,
             match="Record must have at least one non-reasoning token",


### PR DESCRIPTION
## Add Time to First Output (TTFO) Metric

Introduces a new metric for measuring latency to the first non-reasoning output token, critical for evaluating models with extended reasoning capabilities.

**What is TTFO?**

Time to First Output measures the elapsed time from request start to when the first actual output content is received, excluding reasoning tokens. This captures user-perceived latency for reasoning models, whereas TTFT measures time to any first token.

**Key Features:**
- **Reasoning-aware**: Distinguishes reasoning tokens from output content
- **Streaming-only**: Requires token-level timing data
- **Model agnostic**: For non-reasoning models, TTFO equals TTFT

**Use Cases:**
- Benchmarking reasoning models where reasoning time can be substantial
- Measuring user-perceived vs. technical first-token latency
- Comparing reasoning vs. non-reasoning model performance

**Implementation:**
- Metric tag: `time_to_first_output`
- Units: milliseconds
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metric that reports the time from request start to the first visible output token, including support for streaming responses and reasoning-aware content. If no valid output is produced, the metric is omitted with a clear message.

* **Tests**
  * Added comprehensive tests covering single and multiple responses, reasoning-content handling, aggregation across records, and error scenarios such as invalid timestamps or missing outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->