### PR TITLE
docs: add notes about reasoning tokens in migration guide

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -33,4 +33,41 @@ These changes allow AIPerf to better handle conversational workloads and provide
 
 <br>
 
+## Reasoning Tokens and Differences in Metrics
+
+Modern language models with reasoning capabilities such as openai/gpt-oss-120b, DeepSeek-R1, Qwen3, or similar, generate reasoning tokens before producing their final response. These reasoning tokens are typically returned in the `reasoning_content` field of the API response and represent the model's internal thought process.
+
+### Behavioral Differences
+
+> [!IMPORTANT]
+> **GenAI-Perf does not parse or process reasoning tokens**. Content in the `reasoning_content` field is ignored, which means GenAI-Perf waits until the first non-reasoning output token is generated before recording the Time to First Token (TTFT).
+
+**AIPerf** fully supports parsing and processing of reasoning tokens. The TTFT metric captures the time to generate the first token of any type, whether it's a reasoning token or an output token. Additionally, AIPerf introduces a new metric: **Time to First Output Token (TTFO)**, which measures the time to the first non-reasoning output token, equivalent to GenAI-Perf's TTFT.
+
+### Impact on Metrics
+
+When comparing benchmark results between the two tools for reasoning-capable models:
+
+#### Time to First Token (TTFT)
+
+> [!TIP]
+> When migrating from GenAI-Perf, use **AIPerf TTFO** to compare against **GenAI-Perf TTFT** for equivalent measurements of reasoning-capable models.
+
+- **AIPerf TTFT** measures time to the first token of any type (including reasoning tokens) from the start of the request, and will be lower than GenAI-Perf TTFT
+- **GenAI-Perf TTFT** measures time to the first non-reasoning output token from the start of the request, and will be higher than AIPerf TTFT
+- **AIPerf TTFO** is equivalent to GenAI-Perf TTFT
+
+By providing both TTFT and TTFO metrics, AIPerf enables more comprehensive performance analysis of reasoning-capable models by offering complete visibility into the token generation timeline.
+
+#### Output Sequence Length (OSL)
+
+> [!TIP]
+> When migrating from GenAI-Perf, use **AIPerf Output Token Count** to compare against **GenAI-Perf OSL** for equivalent measurements of reasoning-capable models.
+
+- **AIPerf OSL** includes both reasoning and output tokens, so it will be higher than GenAI-Perf OSL
+- **GenAI-Perf OSL** excludes reasoning tokens from the count, so it will be lower than AIPerf OSL
+- **AIPerf Output Token Count** is equivalent to GenAI-Perf OSL, as it excludes reasoning tokens from the count
+- **AIPerf Reasoning Token Count** is exclusive to AIPerf, as it includes reasoning tokens only
+
+By providing OSL, Reasoning Token Count, and Output Token Count metrics, AIPerf enables more comprehensive performance analysis of reasoning-capable models by providing a complete picture of the token generation process.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section explaining how reasoning tokens are treated across benchmarking tools.
  * Clarified that some tools ignore reasoning_content tokens while others parse them.
  * Introduced and defined TTFO (Time to First Output Token) and clarified its relationship to TTFT.
  * Updated guidance on comparing TTFT and Output Start Latency.
  * Refined metric descriptions to improve consistency and interpretation.
  * No functional changes; documentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->