### PR TITLE
fix: GPU Telemetry System Controller Using Deprecated 'endpoints_tested'

### DIFF
--- a/aiperf/controller/system_controller.py
+++ b/aiperf/controller/system_controller.py
@@ -379,7 +379,7 @@ class SystemController(SignalHandlerMixin, BaseService):
             self.info(f"GPU telemetry disabled{reason_msg}")
         else:
             self.info(
-                f"GPU telemetry enabled - {len(message.endpoints_reachable)}/{len(message.endpoints_tested)} endpoint(s) reachable"
+                f"GPU telemetry enabled - {len(message.endpoints_reachable)}/{len(message.endpoints_configured)} endpoint(s) reachable"
             )
 
     @on_message(MessageType.COMMAND_RESPONSE)


### PR DESCRIPTION
Changed to updated `endpoints_configured`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated telemetry status reporting to display the correct endpoint configuration metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->