### PR TITLE
feat: add nvclip endpoint support

### DIFF
--- a/docs/genai-perf-feature-comparison.md
+++ b/docs/genai-perf-feature-comparison.md
@@ -44,7 +44,7 @@ This comparison matrix shows the supported CLI options between GenAI-Perf and AI
 | **dynamic_grpc** | Dynamic gRPC service calls | ✅ | ❌ | |
 | **huggingface_generate** | HuggingFace transformers generate API | ✅ | ❌ | |
 | **image_retrieval** | Image search and retrieval endpoints | ✅ | ❌ | |
-| **nvclip** | NVIDIA CLIP model endpoints | ✅ | ❌ | |
+| **nvclip** | NVIDIA CLIP model endpoints | ✅ | ✅ | |
 | **multimodal** | Multi-modal (text + image/audio) endpoints | ✅ | 🟡 | use `chat` for AIPerf instead |
 | **generate** | Generic text generation endpoints | ✅ | ❌ | |
 | **kserve** | KServe model serving endpoints | ✅ | ❌ | |

--- a/src/aiperf/common/enums/plugin_enums.py
+++ b/src/aiperf/common/enums/plugin_enums.py
@@ -30,6 +30,7 @@ class EndpointType(CaseInsensitiveStrEnum):
     HF_TEI_RANKINGS = "hf_tei_rankings"
     NIM_RANKINGS = "nim_rankings"
     SOLIDO_RAG = "solido_rag"
+    NVCLIP = "nvclip"
 
 
 class TransportType(CaseInsensitiveStrEnum):

--- a/src/aiperf/endpoints/__init__.py
+++ b/src/aiperf/endpoints/__init__.py
@@ -16,6 +16,9 @@ from aiperf.endpoints.hf_tei_rankings import (
 from aiperf.endpoints.nim_rankings import (
     NIMRankingsEndpoint,
 )
+from aiperf.endpoints.nvclip import (
+    NVClipEndpoint,
+)
 from aiperf.endpoints.openai_chat import (
     ChatEndpoint,
 )
@@ -38,5 +41,6 @@ __all__ = [
     "EmbeddingsEndpoint",
     "HFTeiRankingsEndpoint",
     "NIMRankingsEndpoint",
+    "NVClipEndpoint",
     "SolidoEndpoint",
 ]

--- a/src/aiperf/endpoints/nvclip.py
+++ b/src/aiperf/endpoints/nvclip.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from aiperf.common.decorators import implements_protocol
+from aiperf.common.enums import EndpointType
+from aiperf.common.factories import EndpointFactory
+from aiperf.common.models import ParsedResponse
+from aiperf.common.models.metadata import EndpointMetadata
+from aiperf.common.models.record_models import EmbeddingResponseData, RequestInfo
+from aiperf.common.protocols import EndpointProtocol, InferenceServerResponse
+from aiperf.common.types import RequestOutputT
+from aiperf.endpoints.base_endpoint import BaseEndpoint
+
+
+@implements_protocol(EndpointProtocol)
+@EndpointFactory.register(EndpointType.NVCLIP)
+class NVClipEndpoint(BaseEndpoint):
+    """NVIDIA CLIP endpoint.
+
+    Generates vector embeddings for text and image inputs.
+    Supports multimodal embedding generation.
+    """
+
+    @classmethod
+    def metadata(cls) -> EndpointMetadata:
+        """Return NVCLIP endpoint metadata."""
+        return EndpointMetadata(
+            endpoint_path="/v1/embeddings",
+            supports_streaming=False,
+            produces_tokens=False,
+            tokenizes_input=True,
+            metrics_title="NVClip Metrics",
+        )
+
+    def format_payload(self, request_info: RequestInfo) -> RequestOutputT:
+        """Format payload for an NVCLIP request.
+
+        Args:
+            request_info: Request context including model endpoint, metadata, and turns
+
+        Returns:
+            NVCLIP API payload
+        """
+        if len(request_info.turns) != 1:
+            raise ValueError("NVCLIP endpoint only supports one turn.")
+
+        turn = request_info.turns[0]
+
+        if turn.max_tokens:
+            self.error("Max_tokens is provided but is not supported for nvclip.")
+
+        input_items = []
+
+        for text in turn.texts:
+            input_items.extend(content for content in text.contents if content)
+
+        for image in turn.images:
+            input_items.extend(content for content in image.contents if content)
+
+        if not input_items:
+            raise ValueError(
+                "NVCLIP endpoint requires at least one text or image input."
+            )
+
+        model_endpoint = request_info.model_endpoint
+
+        payload: dict[str, Any] = {
+            "model": turn.model or model_endpoint.primary_model_name,
+            "input": input_items,
+        }
+
+        if model_endpoint.endpoint.extra:
+            payload.update(model_endpoint.endpoint.extra)
+
+        self.debug(lambda: f"Formatted payload: {payload}")
+        return payload
+
+    def parse_response(
+        self, response: InferenceServerResponse
+    ) -> ParsedResponse | None:
+        """Parse NVCLIP response.
+
+        Args:
+            response: Raw response from inference server
+
+        Returns:
+            Parsed response with extracted embeddings
+        """
+        json_obj = response.get_json()
+        if not json_obj:
+            self.debug(
+                lambda: f"No JSON object found in response: {response.get_raw()}"
+            )
+            return None
+
+        data = json_obj.get("data", [])
+        if not data:
+            self.debug(lambda: f"No data found in response: {json_obj}")
+            return None
+
+        if all(
+            isinstance(item, dict) and item.get("object") == "embedding"
+            for item in data
+        ):
+            embeddings = [
+                item.get("embedding")
+                for item in data
+                if item.get("embedding") is not None
+            ]
+            if not embeddings:
+                return None
+            return ParsedResponse(
+                perf_ns=response.perf_ns,
+                data=EmbeddingResponseData(embeddings=embeddings),
+            )
+
+        else:
+            raise ValueError(f"Received invalid list in response: {json_obj}")

--- a/tests/endpoints/conftest.py
+++ b/tests/endpoints/conftest.py
@@ -3,12 +3,12 @@
 """Shared fixtures and helpers for endpoint tests."""
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from aiperf.common.enums import EndpointType, ModelSelectionStrategy
-from aiperf.common.models import Text, Turn
+from aiperf.common.models import Image, Text, Turn
 from aiperf.common.models.model_endpoint_info import (
     EndpointInfo,
     ModelEndpointInfo,
@@ -16,6 +16,7 @@ from aiperf.common.models.model_endpoint_info import (
     ModelListInfo,
 )
 from aiperf.common.models.record_models import RequestInfo
+from aiperf.common.protocols import InferenceServerResponse
 
 
 def create_model_endpoint(
@@ -64,6 +65,34 @@ def create_request_info(
         **turn_kwargs,
     )
     return RequestInfo(model_endpoint=model_endpoint, turns=[turn])
+
+
+def create_multimodal_request_info(
+    model_endpoint: ModelEndpointInfo,
+    texts: list[str] | None = None,
+    images: list[str] | None = None,
+    model: str | None = None,
+    **turn_kwargs,
+) -> RequestInfo:
+    """Helper to create RequestInfo with text and/or image content."""
+    text_objs = [Text(contents=texts)] if texts else []
+    image_objs = [Image(contents=images)] if images else []
+
+    turn = Turn(
+        texts=text_objs,
+        images=image_objs,
+        model=model,
+        **turn_kwargs,
+    )
+    return RequestInfo(model_endpoint=model_endpoint, turns=[turn])
+
+
+def create_mock_response(json_data: dict | None, perf_ns: int = 123456789) -> Mock:
+    """Helper to create a mock InferenceServerResponse."""
+    mock_response = Mock(spec=InferenceServerResponse)
+    mock_response.perf_ns = perf_ns
+    mock_response.get_json.return_value = json_data
+    return mock_response
 
 
 @pytest.fixture

--- a/tests/endpoints/test_nvclip_endpoint.py
+++ b/tests/endpoints/test_nvclip_endpoint.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.enums import EndpointType
+from aiperf.common.models.record_models import EmbeddingResponseData, RequestInfo
+from aiperf.endpoints.nvclip import NVClipEndpoint
+from tests.endpoints.conftest import (
+    create_endpoint_with_mock_transport,
+    create_mock_response,
+    create_model_endpoint,
+    create_multimodal_request_info,
+)
+
+
+@pytest.fixture
+def nvclip_model_endpoint():
+    """Create a test ModelEndpointInfo for nvclip."""
+    return create_model_endpoint(EndpointType.NVCLIP, model_name="nvclip-model")
+
+
+@pytest.fixture
+def nvclip_endpoint(nvclip_model_endpoint):
+    """Create a NVClipEndpoint instance."""
+    return create_endpoint_with_mock_transport(NVClipEndpoint, nvclip_model_endpoint)
+
+
+class TestNVClipFormatPayload:
+    """Tests for NVClipEndpoint format_payload functionality."""
+
+    @pytest.mark.parametrize(
+        "texts,images,expected_input",
+        [
+            (["text1"], None, ["text1"]),
+            (None, ["image1"], ["image1"]),
+            (["text1"], ["image1"], ["text1", "image1"]),
+            (
+                ["text1", "text2"],
+                ["image1", "image2"],
+                ["text1", "text2", "image1", "image2"],
+            ),
+        ],
+    )
+    def test_multimodal_inputs(
+        self, nvclip_endpoint, nvclip_model_endpoint, texts, images, expected_input
+    ):
+        """Test various combinations of text and image inputs."""
+        request_info = create_multimodal_request_info(
+            nvclip_model_endpoint, texts=texts, images=images, model="nvclip-model"
+        )
+
+        payload = nvclip_endpoint.format_payload(request_info)
+
+        assert payload["model"] == "nvclip-model"
+        assert payload["input"] == expected_input
+
+    def test_filters_empty_inputs(self, nvclip_endpoint, nvclip_model_endpoint):
+        """Test that empty strings are filtered from inputs."""
+        request_info = create_multimodal_request_info(
+            nvclip_model_endpoint,
+            texts=["Valid", "", "Another"],
+            images=["img1", ""],
+            model="nvclip-model",
+        )
+
+        payload = nvclip_endpoint.format_payload(request_info)
+
+        assert payload["input"] == ["Valid", "Another", "img1"]
+
+    def test_no_inputs_raises_error(self, nvclip_endpoint, nvclip_model_endpoint):
+        """Test that empty inputs raise ValueError."""
+        request_info = create_multimodal_request_info(
+            nvclip_model_endpoint, model="nvclip-model"
+        )
+
+        with pytest.raises(
+            ValueError, match="requires at least one text or image input"
+        ):
+            nvclip_endpoint.format_payload(request_info)
+
+    def test_model_fallback(self, nvclip_endpoint, nvclip_model_endpoint):
+        """Test fallback to endpoint model when turn model is None."""
+        request_info = create_multimodal_request_info(
+            nvclip_model_endpoint, texts=["Test"]
+        )
+
+        payload = nvclip_endpoint.format_payload(request_info)
+
+        assert payload["model"] == nvclip_model_endpoint.primary_model_name
+
+    def test_extra_parameters(self):
+        """Test extra parameters are included in payload."""
+        model_endpoint = create_model_endpoint(
+            EndpointType.NVCLIP,
+            model_name="nvclip-model",
+            extra=[("encoding_format", "base64")],
+        )
+        endpoint = create_endpoint_with_mock_transport(NVClipEndpoint, model_endpoint)
+        request_info = create_multimodal_request_info(
+            model_endpoint, texts=["Test"], images=["img1"], model="nvclip-model"
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["encoding_format"] == "base64"
+
+    def test_only_one_turn_supported(self, nvclip_endpoint, nvclip_model_endpoint):
+        """Test that multiple turns raise ValueError."""
+        from aiperf.common.models import Text, Turn
+
+        turns = [
+            Turn(texts=[Text(contents=["Turn 1"])]),
+            Turn(texts=[Text(contents=["Turn 2"])]),
+        ]
+        request_info = RequestInfo(model_endpoint=nvclip_model_endpoint, turns=turns)
+
+        with pytest.raises(ValueError, match="only supports one turn"):
+            nvclip_endpoint.format_payload(request_info)
+
+
+class TestNVClipParseResponse:
+    """Tests for NVClipEndpoint parse_response functionality."""
+
+    @pytest.mark.parametrize(
+        "embeddings_data,expected_count",
+        [
+            ([{"object": "embedding", "embedding": [0.1, 0.2]}], 1),
+            (
+                [
+                    {"object": "embedding", "embedding": [0.1, 0.2]},
+                    {"object": "embedding", "embedding": [0.3, 0.4]},
+                ],
+                2,
+            ),
+            (
+                [
+                    {"object": "embedding", "embedding": [0.1, 0.2]},
+                    {"object": "embedding", "embedding": None},
+                    {"object": "embedding", "embedding": [0.3, 0.4]},
+                ],
+                2,
+            ),
+        ],
+    )
+    def test_parse_embeddings(self, nvclip_endpoint, embeddings_data, expected_count):
+        """Test parsing valid embedding responses."""
+        response = create_mock_response({"data": embeddings_data})
+
+        parsed = nvclip_endpoint.parse_response(response)
+
+        assert parsed is not None
+        assert isinstance(parsed.data, EmbeddingResponseData)
+        assert len(parsed.data.embeddings) == expected_count
+
+    @pytest.mark.parametrize(
+        "json_data",
+        [
+            None,
+            {},
+            {"data": []},
+            {"data": [{"object": "embedding"}]},
+            {"data": [{"object": "embedding", "embedding": None}]},
+        ],
+    )
+    def test_returns_none_for_invalid_data(self, nvclip_endpoint, json_data):
+        """Test that invalid or missing data returns None."""
+        response = create_mock_response(json_data)
+
+        parsed = nvclip_endpoint.parse_response(response)
+
+        assert parsed is None
+
+    @pytest.mark.parametrize(
+        "embeddings_data",
+        [
+            [
+                {"object": "embedding", "embedding": [0.1]},
+                {"object": "wrong_type", "embedding": [0.2]},
+            ],
+            [{"object": "embedding", "embedding": [0.1]}, "not a dict"],
+        ],
+    )
+    def test_invalid_object_type_raises(self, nvclip_endpoint, embeddings_data):
+        """Test that invalid object types raise ValueError."""
+        response = create_mock_response({"data": embeddings_data})
+
+        with pytest.raises(ValueError, match="invalid list"):
+            nvclip_endpoint.parse_response(response)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA CLIP endpoint support to AIPerf for generating embeddings from multimodal content.
  * Support for text-only, image-only, or combined text and image inputs in endpoint payloads.

* **Documentation**
  * Updated endpoint support matrix to reflect NVIDIA CLIP availability in AIPerf.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->