### PR TITLE
chore: automatically detect and disable uvloop on windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "textual~=5.3.0",
   "tqdm>=4.67.1",
   "transformers>=4.52.0",
-  "uvloop~=0.21.0",
+  "uvloop~=0.21.0; platform_system != 'Windows'",
 ]
 
 # CLI Entrypoints

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -29,6 +29,7 @@ Examples:
     print(f"Workers: {Environment.WORKER.CPU_UTILIZATION_FACTOR}")
 """
 
+import platform
 from typing import Annotated
 
 from pydantic import BeforeValidator, Field, model_validator
@@ -404,6 +405,16 @@ class _ServiceSettings(BaseSettings):
         default=2.0,
         description="Maximum time in seconds to wait for simple tasks to complete when cancelling",
     )
+
+    @model_validator(mode="after")
+    def auto_disable_uvloop_on_windows(self) -> Self:
+        """Automatically disable uvloop on Windows as it's not supported."""
+        if platform.system() == "Windows" and not self.DISABLE_UVLOOP:
+            _logger.info(
+                "Windows detected: automatically disabling uvloop (not supported on Windows)"
+            )
+            self.DISABLE_UVLOOP = True
+        return self
 
 
 class _UISettings(BaseSettings):

--- a/tests/common/test_environment.py
+++ b/tests/common/test_environment.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+from pytest import param
+
+from aiperf.common.environment import _ServiceSettings
+
+
+class TestServiceSettingsUvloopWindows:
+    """Test suite for automatic uvloop disabling on Windows."""
+
+    @pytest.mark.parametrize(
+        "platform_name,expected_disable_uvloop",
+        [
+            param("Windows", True, id="windows_auto_disabled"),
+            param("Linux", False, id="linux_enabled"),
+            param("Darwin", False, id="macos_enabled"),
+        ],
+    )
+    @patch("aiperf.common.environment.platform.system")
+    def test_platform_uvloop_detection(
+        self, mock_platform, platform_name, expected_disable_uvloop
+    ):
+        """Test that uvloop is automatically disabled on Windows and enabled elsewhere."""
+        mock_platform.return_value = platform_name
+
+        settings = _ServiceSettings()
+
+        assert settings.DISABLE_UVLOOP is expected_disable_uvloop
+
+    @pytest.mark.parametrize(
+        "platform_name,manual_setting,expected_result",
+        [
+            param("Windows", False, True, id="windows_override_attempt"),
+            param("Windows", True, True, id="windows_manual_disable"),
+            param("Linux", True, True, id="linux_manual_disable"),
+            param("Linux", False, False, id="linux_default_enabled"),
+            param("Darwin", True, True, id="macos_manual_disable"),
+            param("Darwin", False, False, id="macos_default_enabled"),
+        ],
+    )
+    @patch("aiperf.common.environment.platform.system")
+    def test_manual_uvloop_settings(
+        self, mock_platform, platform_name, manual_setting, expected_result
+    ):
+        """Test manual DISABLE_UVLOOP settings across platforms."""
+        mock_platform.return_value = platform_name
+
+        settings = _ServiceSettings(DISABLE_UVLOOP=manual_setting)
+
+        assert settings.DISABLE_UVLOOP is expected_result


### PR DESCRIPTION
How it works:
- When installing on Windows: pip install will skip uvloop entirely due to the platform marker
- At runtime: The environment validator detects Windows and automatically sets DISABLE_UVLOOP=True, ensuring the asyncio event loop is used instead of uvloop in bootstrap.py
- The system gracefully falls back to Python's built-in asyncio on Windows without any user intervention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * UVLoop now automatically disables on Windows for improved platform compatibility.

* **Chores**
  * Updated uvloop dependency constraints for Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->