### PR TITLE
fix: Typo in timeslice tutorial

### DIFF
--- a/docs/tutorials/timeslices.md
+++ b/docs/tutorials/timeslices.md
@@ -142,8 +142,7 @@ The JSON provides a hierarchical structure with all timeslices in a single file:
     "model": "Qwen/Qwen3-0.6B",
     "endpoint": "/v1/chat/completions",
     ...
-  },
-  "total_slices": 6
+  }
 }
 ```
 


### PR DESCRIPTION
There used to be a total_slices field during development, but it's redundant since most json parsers will tell you the length of the array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Timeslice Export example in tutorials to reflect current JSON structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->