### PR TITLE
docs: Add README.md guide with  examples for doc test CI test scripts.

### DIFF
--- a/tests/ci/test_docs_end_to_end/parser.py
+++ b/tests/ci/test_docs_end_to_end/parser.py
@@ -35,6 +35,10 @@ class MarkdownParser:
         logger.info(f"Parsing markdown files in {directory}")
 
         for file_path in Path(directory).rglob("*.md"):
+            # Skip the documentation file for this test framework
+            if file_path.name == "DOC_CI_TEST_README.md":
+                logger.info(f"Skipping documentation file: {file_path}")
+                continue
             logger.info(f"Parsing file: {file_path}")
             self._parse_file(str(file_path))
 


### PR DESCRIPTION
The changes in the PR include README for the doc test CI.
 The README includes:
  - A clear warning at the top about escaped code blocks (using `\```bash`) so users don't get confused when copying examples
  - Explanation of how the test discovery works (looks for HTML comment tags like `setup-`, `health-check-`, and `aiperf-run-` followed by bash code blocks)
  - Step-by-step instructions for adding new server tests with complete examples
  - Common patterns for OpenAI-compatible APIs and custom APIs
  - Troubleshooting tips and best practices for keeping tests fast and reliable
  - Overview of how to run the tests (all servers, dry-run)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive README documenting end-to-end documentation tests: discovery from Markdown via comment tags; required tag blocks (setup, health-check, test commands); execution flow (build, setup, health-check, run, cleanup); validation rules; running modes (all, dry-run, per-server); examples, troubleshooting, best practices, and architecture/configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->