### PR TITLE
feat: Add cli option to use legacy max tokens option

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -56,6 +56,10 @@ The API key to use for the endpoint. If provided, it will be sent with every req
 The transport to use for the endpoint. If not provided, it will be auto-detected from the URL.This can also be used to force an alternative transport or implementation.
 <br>_Choices: [`http`]_
 
+#### `--use-legacy-max-tokens`
+
+Use the legacy 'max_tokens' field instead of 'max_completion_tokens' in request payloads. The OpenAI API now prefers 'max_completion_tokens', but some older APIs or implementations may require 'max_tokens'.
+
 ## Input Options
 
 #### `--extra-inputs` `<list>`

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -38,6 +38,7 @@ class EndpointDefaults:
     URL = "localhost:8000"
     TIMEOUT = 600.0
     API_KEY = None
+    USE_LEGACY_MAX_TOKENS = False
 
 
 @dataclass(frozen=True)

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -166,3 +166,15 @@ class EndpointConfig(BaseConfig):
             group=_CLI_GROUP,
         ),
     ] = None
+
+    use_legacy_max_tokens: Annotated[
+        bool,
+        Field(
+            description="Use the legacy 'max_tokens' field instead of 'max_completion_tokens' in request payloads. "
+            "The OpenAI API now prefers 'max_completion_tokens', but some older APIs or implementations may require 'max_tokens'.",
+        ),
+        CLIParameter(
+            name=("--use-legacy-max-tokens",),
+            group=_CLI_GROUP,
+        ),
+    ] = EndpointDefaults.USE_LEGACY_MAX_TOKENS

--- a/src/aiperf/common/models/model_endpoint_info.py
+++ b/src/aiperf/common/models/model_endpoint_info.py
@@ -98,6 +98,10 @@ class EndpointInfo(AIPerfBaseModel):
         "You can repeat this flag for multiple inputs. Inputs should be in an 'input_name:value' format. "
         "Alternatively, a string representing a json formatted dict can be provided.",
     )
+    use_legacy_max_tokens: bool = Field(
+        default=False,
+        description="Use the legacy 'max_tokens' field instead of 'max_completion_tokens' in request payloads.",
+    )
 
     @classmethod
     def from_user_config(cls, user_config: UserConfig) -> "EndpointInfo":
@@ -111,6 +115,7 @@ class EndpointInfo(AIPerfBaseModel):
             extra=user_config.input.extra,
             timeout=user_config.endpoint.timeout_seconds,
             api_key=user_config.endpoint.api_key,
+            use_legacy_max_tokens=user_config.endpoint.use_legacy_max_tokens,
         )
 
 

--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -68,7 +68,12 @@ class ChatEndpoint(BaseEndpoint):
         }
 
         if turns[-1].max_tokens is not None:
-            payload["max_completion_tokens"] = turns[-1].max_tokens
+            token_field = (
+                "max_tokens"
+                if model_endpoint.endpoint.use_legacy_max_tokens
+                else "max_completion_tokens"
+            )
+            payload[token_field] = turns[-1].max_tokens
 
         if model_endpoint.endpoint.extra:
             payload.update(model_endpoint.endpoint.extra)

--- a/tests/unit/endpoints/conftest.py
+++ b/tests/unit/endpoints/conftest.py
@@ -25,6 +25,7 @@ def create_model_endpoint(
     streaming: bool = False,
     base_url: str = "http://localhost:8000",
     extra: list[tuple[str, Any]] | None = None,
+    use_legacy_max_tokens: bool = False,
 ) -> ModelEndpointInfo:
     """Helper to create a ModelEndpointInfo with common defaults."""
     return ModelEndpointInfo(
@@ -37,6 +38,7 @@ def create_model_endpoint(
             base_url=base_url,
             streaming=streaming,
             extra=extra or [],
+            use_legacy_max_tokens=use_legacy_max_tokens,
         ),
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--use-legacy-max-tokens` CLI option to allow users to use the legacy `max_tokens` field instead of the preferred `max_completion_tokens` when making API requests. Defaults to the modern approach for new configurations while maintaining backward compatibility for legacy systems.

* **Documentation**
  * Updated CLI options documentation with the new legacy max tokens configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->