### PR TITLE
chore: less verbose logging in debug mode

### DIFF
--- a/src/aiperf/common/mixins/aiperf_lifecycle_mixin.py
+++ b/src/aiperf/common/mixins/aiperf_lifecycle_mixin.py
@@ -72,8 +72,8 @@ class AIPerfLifecycleMixin(TaskManagerMixin, HooksMixin):
             return
         old_state = self._state
         self._state = state
-        if self.is_debug_enabled:
-            self.debug(f"State changed from {old_state!r} to {state!r} for {self}")
+        if self.is_trace_enabled:
+            self.trace(f"State changed from {old_state!r} to {state!r} for {self}")
         await self.run_hooks(
             AIPerfHook.ON_STATE_CHANGE, old_state=old_state, new_state=state
         )

--- a/src/aiperf/common/mixins/command_handler_mixin.py
+++ b/src/aiperf/common/mixins/command_handler_mixin.py
@@ -79,10 +79,14 @@ class CommandHandlerMixin(MessageBusClientMixin, ABC):
         Process a command message received from the controller or another service, and forward it to the appropriate handler.
         Wait for the handler to complete and publish the response, or handle the error and publish the failure response.
         """
-        self.debug(lambda: f"Received command message: {message}")
+        self.trace_or_debug(
+            lambda: f"Received command message: {message}",
+            lambda: f"Received '{message.command}' command from '{message.service_id}' (id: {message.command_id})",
+        )
         if message.command_id in self._processed_command_ids:
-            self.debug(
-                lambda: f"Received duplicate command message: {message}. Ignoring."
+            self.trace_or_debug(
+                lambda: f"Received duplicate command message: {message}. Ignoring.",
+                lambda: f"Received duplicate command message '{message.command}' from '{message.service_id}' (id: {message.command_id}). Ignoring.",
             )
             # If we receive a duplicate command message, we just send an acknowledged response.
             await self._publish_command_acknowledged_response(message)
@@ -236,7 +240,10 @@ class CommandHandlerMixin(MessageBusClientMixin, ABC):
         a command response is received, and we use it to set the result of the future for the command ID.
         This will alert the the task that is waiting for the response to continue.
         """
-        self.debug(lambda: f"Received command response message: {message}")
+        self.trace_or_debug(
+            lambda: f"Received command response message: {message}",
+            lambda: f"Received {message.status} response for command '{message.command}' from '{message.service_id}' (id: {message.command_id})",
+        )
 
         # If the command ID is in the single response futures, we set the result of the future.
         # This will alert the the task that is waiting for the response to continue.

--- a/src/aiperf/common/mixins/hooks_mixin.py
+++ b/src/aiperf/common/mixins/hooks_mixin.py
@@ -71,7 +71,7 @@ class HooksMixin(AIPerfLoggerMixin):
                         ),
                     )
 
-        self.debug(
+        self.trace(
             lambda: f"Provided hook types: {self._provided_hook_types} for {self.__class__.__name__}"
         )
 
@@ -180,7 +180,8 @@ class HooksMixin(AIPerfLoggerMixin):
         """
         exceptions: list[Exception] = []
         for hook in self.get_hooks(*hook_types, reverse=reverse):
-            self.debug(lambda hook=hook: f"Running hook: {hook!r}")
+            if self.is_trace_enabled:
+                self.trace(f"Running hook: {hook!r}")
             try:
                 await hook(**kwargs)
             except Exception as e:

--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -300,17 +300,15 @@ class SystemController(SignalHandlerMixin, BaseService):
         service_type = message.service_type
         timestamp = message.request_ns
 
-        self.debug(lambda: f"Received heartbeat from {service_type} (ID: {service_id})")
-
         # Update the last heartbeat timestamp if the component exists
         try:
             service_info = self.service_manager.service_id_map[service_id]
             service_info.last_seen = timestamp
             service_info.state = message.state
-            self.debug(f"Updated heartbeat for {service_id} to {timestamp}")
+            self.debug(lambda: f"Updated heartbeat for '{service_id}' to {timestamp}")
         except Exception:
             self.warning(
-                f"Received heartbeat from unknown service: {service_id} ({service_type})"
+                f"Received heartbeat from unknown service: '{service_id}' ('{service_type}')"
             )
 
     @on_message(MessageType.CREDITS_COMPLETE)
@@ -324,7 +322,7 @@ class SystemController(SignalHandlerMixin, BaseService):
             message: The credits complete message to process
         """
         service_id = message.service_id
-        self.info(f"Received credits complete from {service_id}")
+        self.info(f"Received credits complete from '{service_id}'")
 
     @on_message(MessageType.STATUS)
     async def _process_status_message(self, message: StatusMessage) -> None:
@@ -341,7 +339,7 @@ class SystemController(SignalHandlerMixin, BaseService):
         state = message.state
 
         self.debug(
-            lambda: f"Received status update from {service_type} (ID: {service_id}): {state}"
+            lambda: f"Received status update from '{service_type}' (ID: '{service_id}'): {state}"
         )
 
         # Update the component state if the component exists

--- a/src/aiperf/endpoints/base_rankings_endpoint.py
+++ b/src/aiperf/endpoints/base_rankings_endpoint.py
@@ -91,7 +91,7 @@ class BaseRankingsEndpoint(BaseEndpoint):
         if extra:
             payload.update(extra)
 
-        self.debug(lambda: f"Formatted rankings payload: {payload}")
+        self.trace(lambda: f"Formatted rankings payload: {payload}")
         return payload
 
     def parse_response(

--- a/src/aiperf/endpoints/huggingface_generate.py
+++ b/src/aiperf/endpoints/huggingface_generate.py
@@ -60,7 +60,7 @@ class HuggingFaceGenerateEndpoint(BaseEndpoint):
             "parameters": parameters,
         }
 
-        self.debug(lambda: f"Formatted TGI payload: {payload}")
+        self.trace(lambda: f"Formatted TGI payload: {payload}")
         return payload
 
     def parse_response(

--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -78,7 +78,7 @@ class ChatEndpoint(BaseEndpoint):
         if model_endpoint.endpoint.extra:
             payload.update(model_endpoint.endpoint.extra)
 
-        self.debug(lambda: f"Formatted payload: {payload}")
+        self.trace(lambda: f"Formatted payload: {payload}")
         return payload
 
     def _create_messages(self, turns: list[Turn]) -> list[dict[str, Any]]:

--- a/src/aiperf/endpoints/openai_completions.py
+++ b/src/aiperf/endpoints/openai_completions.py
@@ -69,7 +69,7 @@ class CompletionsEndpoint(BaseEndpoint):
         if extra:
             payload.update(extra)
 
-        self.debug(lambda: f"Formatted payload: {payload}")
+        self.trace(lambda: f"Formatted payload: {payload}")
         return payload
 
     def parse_response(

--- a/src/aiperf/endpoints/openai_embeddings.py
+++ b/src/aiperf/endpoints/openai_embeddings.py
@@ -69,7 +69,7 @@ class EmbeddingsEndpoint(BaseEndpoint):
         if model_endpoint.endpoint.extra:
             payload.update(model_endpoint.endpoint.extra)
 
-        self.debug(lambda: f"Formatted payload: {payload}")
+        self.trace(lambda: f"Formatted payload: {payload}")
         return payload
 
     def parse_response(

--- a/src/aiperf/endpoints/openai_image_generation.py
+++ b/src/aiperf/endpoints/openai_image_generation.py
@@ -83,7 +83,7 @@ class ImageGenerationEndpoint(BaseEndpoint):
         if model_endpoint.endpoint.extra:
             payload.update(model_endpoint.endpoint.extra)
 
-        self.debug(lambda: f"Formatted payload: {payload}")
+        self.trace(lambda: f"Formatted payload: {payload}")
         return payload
 
     def parse_response(

--- a/src/aiperf/endpoints/solido_rag.py
+++ b/src/aiperf/endpoints/solido_rag.py
@@ -72,7 +72,7 @@ class SolidoEndpoint(BaseEndpoint):
         if model_endpoint.endpoint.extra:
             payload.update(model_endpoint.endpoint.extra)
 
-        self.debug(lambda: f"Formatted SOLIDO payload: {payload}")
+        self.trace(lambda: f"Formatted SOLIDO payload: {payload}")
         return payload
 
     def parse_response(

--- a/src/aiperf/endpoints/template_endpoint.py
+++ b/src/aiperf/endpoints/template_endpoint.py
@@ -155,7 +155,7 @@ class TemplateEndpoint(BaseEndpoint):
         if self._extra_fields:
             payload.update(self._extra_fields)
 
-        self.debug(lambda: f"Formatted payload: {payload}")
+        self.trace(lambda: f"Formatted payload: {payload}")
         return payload
 
     def parse_response(

--- a/src/aiperf/exporters/metrics_base_exporter.py
+++ b/src/aiperf/exporters/metrics_base_exporter.py
@@ -60,7 +60,7 @@ class MetricsBaseExporter(AIPerfLoggerMixin, ABC):
         res = metric_class.missing_flags(
             MetricFlags.EXPERIMENTAL | MetricFlags.INTERNAL
         )
-        self.debug(lambda: f"Metric '{metric.tag}' should be exported: {res}")
+        self.trace(lambda: f"Metric '{metric.tag}' should be exported: {res}")
         return res
 
     @abstractmethod

--- a/src/aiperf/exporters/metrics_csv_exporter.py
+++ b/src/aiperf/exporters/metrics_csv_exporter.py
@@ -31,11 +31,12 @@ class MetricsCsvExporter(MetricsBaseExporter):
 
     def __init__(self, exporter_config: ExporterConfig, **kwargs) -> None:
         super().__init__(exporter_config, **kwargs)
-        self.debug(
-            lambda: f"Initializing MetricsCsvExporter with config: {exporter_config}"
-        )
         self._file_path = exporter_config.user_config.output.profile_export_csv_file
         self._percentile_keys = _percentile_keys_from(STAT_KEYS)
+        self.trace_or_debug(
+            lambda: f"Initializing MetricsCsvExporter with config: {exporter_config}",
+            lambda: f"Initializing MetricsCsvExporter with file path: {self._file_path}",
+        )
 
     def get_export_info(self) -> FileExportInfo:
         return FileExportInfo(

--- a/src/aiperf/exporters/metrics_json_exporter.py
+++ b/src/aiperf/exporters/metrics_json_exporter.py
@@ -33,10 +33,11 @@ class MetricsJsonExporter(MetricsBaseExporter):
 
     def __init__(self, exporter_config: ExporterConfig, **kwargs) -> None:
         super().__init__(exporter_config, **kwargs)
-        self.debug(
-            lambda: f"Initializing MetricsJsonExporter with config: {exporter_config}"
-        )
         self._file_path = exporter_config.user_config.output.profile_export_json_file
+        self.trace_or_debug(
+            lambda: f"Initializing MetricsJsonExporter with config: {exporter_config}",
+            lambda: f"Initializing MetricsJsonExporter with file path: {self._file_path}",
+        )
 
     def get_export_info(self) -> FileExportInfo:
         return FileExportInfo(
@@ -96,7 +97,10 @@ class MetricsJsonExporter(MetricsBaseExporter):
         for metric_tag, json_result in prepared_json_metrics.items():
             setattr(export_data, metric_tag, json_result)
 
-        self.debug(lambda: f"Exporting data to JSON file: {export_data}")
+        self.trace_or_debug(
+            lambda: f"Exporting data to JSON file: {export_data}",
+            lambda: f"Exporting data to JSON file: {self._file_path}",
+        )
         return export_data.model_dump_json(
             indent=2, exclude_unset=True, exclude_none=True
         )

--- a/src/aiperf/exporters/timeslice_metrics_csv_exporter.py
+++ b/src/aiperf/exporters/timeslice_metrics_csv_exporter.py
@@ -34,10 +34,6 @@ class TimesliceMetricsCsvExporter(MetricsBaseExporter):
 
     def __init__(self, exporter_config: ExporterConfig, **kwargs) -> None:
         super().__init__(exporter_config, **kwargs)
-        self.debug(
-            lambda: f"Initializing TimesliceMetricsCsvExporter with config: {exporter_config}"
-        )
-
         if not self._results.timeslice_metric_results:
             raise DataExporterDisabled(
                 "TimesliceMetricsCsvExporter disabled: no timeslice metric results found"
@@ -47,9 +43,9 @@ class TimesliceMetricsCsvExporter(MetricsBaseExporter):
         self._file_path = (
             exporter_config.user_config.output.profile_export_timeslices_csv_file
         )
-
-        self.debug(
-            lambda: f"Initialized TimesliceMetricsCsvExporter: file={self._file_path}"
+        self.trace_or_debug(
+            lambda: f"Initializing TimesliceMetricsCsvExporter with config: {exporter_config}",
+            lambda: f"Initializing TimesliceMetricsCsvExporter with file path: {self._file_path}",
         )
 
     def get_export_info(self) -> FileExportInfo:

--- a/src/aiperf/exporters/timeslice_metrics_json_exporter.py
+++ b/src/aiperf/exporters/timeslice_metrics_json_exporter.py
@@ -31,9 +31,6 @@ class TimesliceMetricsJsonExporter(MetricsJsonExporter):
 
     def __init__(self, exporter_config: ExporterConfig, **kwargs) -> None:
         super().__init__(exporter_config, **kwargs)
-        self.debug(
-            lambda: f"Initializing TimesliceMetricsJsonExporter with config: {exporter_config}"
-        )
 
         if not self._results.timeslice_metric_results:
             raise DataExporterDisabled(
@@ -44,9 +41,9 @@ class TimesliceMetricsJsonExporter(MetricsJsonExporter):
         self._file_path = (
             exporter_config.user_config.output.profile_export_timeslices_json_file
         )
-
-        self.debug(
-            lambda: f"Initialized TimesliceMetricsJsonExporter: file={self._file_path}"
+        self.trace_or_debug(
+            lambda: f"Initializing TimesliceMetricsJsonExporter with config: {exporter_config}",
+            lambda: f"Initializing TimesliceMetricsJsonExporter with file path: {self._file_path}",
         )
 
     def get_export_info(self) -> FileExportInfo:

--- a/src/aiperf/post_processors/metric_record_processor.py
+++ b/src/aiperf/post_processors/metric_record_processor.py
@@ -66,7 +66,9 @@ class MetricRecordProcessor(BaseMetricsProcessor):
             try:
                 record_metrics[tag] = parse_func(record, record_metrics)
             except NoMetricValue as e:
-                self.debug(f"No metric value for metric '{tag}': {e!r}")
+                self.trace(
+                    lambda tag=tag, e=e: f"No metric value for metric '{tag}': {e!r}"
+                )
             except Exception as e:
                 self.warning(f"Error parsing record for metric '{tag}': {e!r}")
         return record_metrics

--- a/src/aiperf/post_processors/metric_results_processor.py
+++ b/src/aiperf/post_processors/metric_results_processor.py
@@ -96,7 +96,9 @@ class MetricResultsProcessor(BaseMetricsProcessor):
                 else:
                     raise ValueError(f"Metric '{tag}' is not a valid metric type")
             except NoMetricValue as e:
-                self.debug(f"No metric value for metric '{tag}': {e!r}")
+                self.trace(
+                    lambda tag=tag, e=e: f"No metric value for metric '{tag}': {e!r}"
+                )
             except Exception as e:
                 self.warning(f"Error processing metric '{tag}': {e!r}")
 

--- a/src/aiperf/records/inference_result_parser.py
+++ b/src/aiperf/records/inference_result_parser.py
@@ -87,7 +87,7 @@ class InferenceResultParser(CommunicationMixin):
         """Handle an inference results message."""
         self.trace_or_debug(
             lambda: f"Received inference results message: {request_record}",
-            lambda: "Received inference results",
+            lambda: f"Received inference results for credit '{request_record.credit_num}' (id: {request_record.x_request_id})",
         )
 
         # Make sure any invalid request records are converted to error records for combined processing.
@@ -123,7 +123,7 @@ class InferenceResultParser(CommunicationMixin):
                     )
 
                 self.debug(
-                    lambda: f"Received {len(record.request.responses)} responses, input_token_count: {record.input_token_count}, "
+                    lambda: f"Received {len(record.request.responses)} response packet(s), input_token_count: {record.input_token_count}, "
                     f"output_token_count: {record.output_token_count}, reasoning_token_count: {record.reasoning_token_count}"
                 )
                 return record

--- a/src/aiperf/transports/aiohttp_client.py
+++ b/src/aiperf/transports/aiohttp_client.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import aiohttp
 
+from aiperf.common.constants import NANOS_PER_SECOND
 from aiperf.common.exceptions import SSEResponseError
 from aiperf.common.mixins import AIPerfLoggerMixin
 from aiperf.common.models import (
@@ -116,6 +117,9 @@ class AioHttpClient(AIPerfLoggerMixin):
                             )
                         )
                     record.end_perf_ns = time.perf_counter_ns()
+                    self.debug(
+                        lambda: f"{method} request to {url} completed in {(record.end_perf_ns - record.start_perf_ns) / NANOS_PER_SECOND} seconds"
+                    )
         except SSEResponseError as e:
             record.end_perf_ns = time.perf_counter_ns()
             self.error(f"Error in SSE response: {e!r}")

--- a/src/aiperf/transports/aiohttp_transport.py
+++ b/src/aiperf/transports/aiohttp_transport.py
@@ -150,10 +150,8 @@ class AioHttpTransport(BaseTransport):
 
             # Serialize with orjson for performance
             json_str = orjson.dumps(payload).decode("utf-8")
-
             record = await self.aiohttp_client.post_request(url, json_str, headers)
             record.request_headers = headers
-
         except Exception as e:
             # Capture all exceptions with timing and error details
             record = RequestRecord(

--- a/src/aiperf/transports/sse_utils.py
+++ b/src/aiperf/transports/sse_utils.py
@@ -144,15 +144,16 @@ class AsyncSSEStreamReader:
 
                 raw_message = message_bytes.decode("utf-8", errors="replace").strip()
                 if not raw_message:
-                    _logger.debug(
-                        f"Skipping empty SSE message at chunk {chunk_perf_ns}"
-                    )
+                    if _logger.is_trace_enabled:
+                        _logger.trace(
+                            f"Skipping empty SSE message at chunk {chunk_perf_ns}"
+                        )
                     continue
 
                 yield SSEMessage.parse(raw_message, chunk_perf_ns)
 
-                if _logger.is_debug_enabled:
-                    _logger.debug(f"Parsed SSE message: {raw_message}...")
+                if _logger.is_trace_enabled:
+                    _logger.trace(f"Parsed SSE message: {raw_message}...")
 
         # Handle any remaining data in buffer after stream ends
         # Some servers don't send final delimiter
@@ -161,5 +162,5 @@ class AsyncSSEStreamReader:
             raw_message = buffer_remaining.decode("utf-8", errors="replace")
             yield SSEMessage.parse(raw_message, final_perf_ns)
 
-            if _logger.is_debug_enabled:
-                _logger.debug(f"Parsed final SSE message: {raw_message}...")
+            if _logger.is_trace_enabled:
+                _logger.trace(f"Parsed final SSE message: {raw_message}...")

--- a/src/aiperf/workers/worker_manager.py
+++ b/src/aiperf/workers/worker_manager.py
@@ -190,7 +190,6 @@ class WorkerManager(BaseComponentService):
                 worker_id: info.status for worker_id, info in self.worker_infos.items()
             },
         )
-        self.debug(lambda: f"Publishing worker status summary: {summary}")
         await self.publish(summary)
 
 

--- a/src/aiperf/zmq/sub_client.py
+++ b/src/aiperf/zmq/sub_client.py
@@ -155,7 +155,7 @@ class ZMQSubClient(BaseZMQClient):
         # This is optimal for our workload (84% large messages in push/pull, 45% in pub/sub)
         message = Message.from_json(message_bytes)
 
-        self.debug(
+        self.trace(
             lambda: f"Calling callbacks for message: {message}, {self._subscribers.get(topic)}"
         )
 

--- a/tests/unit/post_processors/test_metric_record_processor.py
+++ b/tests/unit/post_processors/test_metric_record_processor.py
@@ -172,14 +172,16 @@ class TestMetricRecordProcessor:
         processor = MetricRecordProcessor(mock_user_config)
         metadata = create_metric_metadata()
 
-        with patch.object(processor, "debug") as mock_debug:
+        with patch.object(processor, "trace") as mock_trace:
             result = await processor.process_record(sample_parsed_record, metadata)
 
             assert isinstance(result, MetricRecordDict)
             assert FailingMetricNoValue.tag not in result
-            mock_debug.assert_called_once()
+            mock_trace.assert_called_once()
             assert f"No metric value for metric '{FailingMetricNoValue.tag}'" in str(
-                mock_debug.call_args
+                mock_trace.call_args[0][0](
+                    tag=FailingMetricNoValue.tag, e=NoMetricValue("No value available")
+                )
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Before, we would print out the entire payload for every inference request, as well as for every record in the dataset, but we have an `inputs.json` file for that now. It would cause gigabyte or more log files at times. This PR moves a lot of debug logs to trace level, requiring `-vv`, and tries to focus a little more on what is actually important, as well as reducing duplications.


<img width="1418" height="744" alt="image" src="https://github.com/user-attachments/assets/e7485e72-41c5-4c78-97ab-87b44660e295" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined logging system with trace-level granularity for more detailed debugging when needed. Enhanced log messages with additional contextual information including quoted identifiers and detailed status updates.

* **Bug Fixes**
  * Fixed issue where request headers were incorrectly set on successful responses in the HTTP transport layer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->