### PR TITLE
feat: add realtime metrics via prometheus

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -449,6 +449,20 @@ Enable GPU telemetry console display and optionally specify: (1) 'dashboard' for
 
 Disable GPU telemetry collection entirely.
 
+#### `--live-metrics-port` `<int>`
+
+Enable live metrics HTTP endpoint on the specified port. Exposes a /metrics endpoint in Prometheus Exposition Format for real-time metrics scraping by PodMonitors. Example: --live-metrics-port 9090.
+
+#### `--live-metrics-host` `<str>`
+
+Host address to bind the live metrics endpoint. Use 127.0.0.1 for localhost only (default), or 0.0.0.0 to listen on all interfaces. Only used when --live-metrics-port is specified.
+<br>_Default: `127.0.0.1`_
+
+#### `--live-metrics-shutdown-delay` `<int>`
+
+Seconds to delay shutdown after benchmark completes, allowing final metrics to be scraped. Only used when --live-metrics-port is specified. Default: 0 (no delay).
+<br>_Default: `0`_
+
 ## Server Metrics Options
 
 #### `--server-metrics` `<list>`

--- a/src/aiperf/common/constants.py
+++ b/src/aiperf/common/constants.py
@@ -22,5 +22,7 @@ STAT_KEYS = [
     "std",
 ]
 
+EXTENDED_STAT_KEYS = STAT_KEYS + ["sum", "current"]
+
 GOOD_REQUEST_COUNT_TAG = "good_request_count"
 """GoodRequestCount metric tag"""

--- a/src/aiperf/common/enums/metric_enums.py
+++ b/src/aiperf/common/enums/metric_enums.py
@@ -49,7 +49,9 @@ class BaseMetricUnit(BasePydanticBackedStrEnum):
 
     def display_name(self) -> str:
         """Get the display name of the metric unit."""
-        return self.name.lower().replace("_per_second", "/s")
+        return (
+            self.name.lower().replace("_per_second", "/s").replace("_per_user", "/user")
+        )
 
     @cached_property
     def info(self) -> BaseMetricUnitInfo:

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -32,7 +32,7 @@ from aiperf.common.utils import load_json_str
 _logger = AIPerfLogger(__name__)
 
 
-class MetricResult(JsonMetricResult):
+class MetricResult(AIPerfBaseModel):
     """The result values of a single metric."""
 
     tag: MetricTagT = Field(description="The unique identifier of the metric")
@@ -41,9 +41,27 @@ class MetricResult(JsonMetricResult):
     header: str = Field(
         description="The user friendly name of the metric (e.g. 'Inter Token Latency')"
     )
+    unit: str = Field(description="The unit of the metric, e.g. 'ms' or 'requests/sec'")
+    avg: float | None = None
+    min: int | float | None = None
+    max: int | float | None = None
+    std: float | None = None
+    p1: float | None = None
+    p5: float | None = None
+    p10: float | None = None
+    p25: float | None = None
+    p50: float | None = None
+    p75: float | None = None
+    p90: float | None = None
+    p95: float | None = None
+    p99: float | None = None
     count: int | None = Field(
         default=None,
         description="The total number of records used to calculate the metric",
+    )
+    sum: float | None = Field(
+        default=None,
+        description="The sum of the metric values",
     )
     current: float | None = Field(
         default=None,

--- a/src/aiperf/common/models/telemetry_models.py
+++ b/src/aiperf/common/models/telemetry_models.py
@@ -246,6 +246,7 @@ class GpuMetricTimeSeries:
             std=float(np.std(arr)),
             count=len(arr),
             current=float(arr[-1]),
+            sum=float(np.sum(arr)),
             p1=p1,
             p5=p5,
             p10=p10,

--- a/src/aiperf/exporters/display_units_utils.py
+++ b/src/aiperf/exporters/display_units_utils.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from urllib.parse import urlparse
 
 from aiperf.common.aiperf_logger import AIPerfLogger
-from aiperf.common.constants import STAT_KEYS
+from aiperf.common.constants import EXTENDED_STAT_KEYS
 from aiperf.common.exceptions import MetricUnitError
 from aiperf.common.models import MetricResult
 from aiperf.common.types import MetricTagT
@@ -55,7 +55,7 @@ def to_display_unit(result: MetricResult, registry: MetricRegistry) -> MetricRes
     record = result.model_copy(deep=True)
     record.unit = display_unit.value
 
-    for stat in STAT_KEYS:
+    for stat in EXTENDED_STAT_KEYS:
         val = getattr(record, stat, None)
         if val is None:
             continue

--- a/src/aiperf/metrics/metric_dicts.py
+++ b/src/aiperf/metrics/metric_dicts.py
@@ -210,4 +210,5 @@ class MetricArray(Generic[MetricValueTypeVarT]):
             p95=p95,
             p99=p99,
             count=len(self._array),
+            sum=self._array.sum,
         )

--- a/src/aiperf/records/__init__.py
+++ b/src/aiperf/records/__init__.py
@@ -11,6 +11,13 @@ __ignore__ = ["main"]
 from aiperf.records.inference_result_parser import (
     InferenceResultParser,
 )
+from aiperf.records.live_metrics_server import (
+    STAT_DISPLAY_NAMES,
+    InfoLabels,
+    LiveMetricsServer,
+    MetricsCallback,
+    format_as_prometheus,
+)
 from aiperf.records.phase_completion import (
     AllRequestsProcessedCondition,
     CompletionReason,
@@ -33,9 +40,14 @@ __all__ = [
     "DurationTimeoutCondition",
     "ErrorTrackingState",
     "InferenceResultParser",
+    "InfoLabels",
+    "LiveMetricsServer",
+    "MetricsCallback",
     "PhaseCompletionChecker",
     "PhaseCompletionCondition",
     "PhaseCompletionContext",
     "RecordProcessor",
     "RecordsManager",
+    "STAT_DISPLAY_NAMES",
+    "format_as_prometheus",
 ]

--- a/src/aiperf/records/live_metrics_server.py
+++ b/src/aiperf/records/live_metrics_server.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Live metrics HTTP server for real-time metrics exposure.
+
+Provides a simple HTTP server that exposes AIPerf realtime metrics
+in Prometheus Exposition Format (PEF) for scraping by PodMonitors.
+"""
+
+from __future__ import annotations
+
+import errno
+import inspect
+import re
+from collections.abc import Awaitable, Callable
+from importlib.metadata import version
+
+import orjson
+from aiohttp import web
+
+from aiperf.common.config import UserConfig, coerce_value
+from aiperf.common.exceptions import MetricTypeError
+from aiperf.common.hooks import on_start, on_stop
+from aiperf.common.mixins import AIPerfLifecycleMixin
+from aiperf.common.models import MetricResult
+from aiperf.metrics.metric_registry import MetricRegistry
+
+# Type alias for info labels dict
+InfoLabels = dict[str, str]
+
+# Type alias for metrics callback (can be sync or async)
+MetricsCallback = Callable[[], list[MetricResult] | Awaitable[list[MetricResult]]]
+
+# Stats to expose with human-readable names for HELP text
+STAT_DISPLAY_NAMES = {
+    "avg": "average",
+    "sum": "total",
+    "p1": "1st percentile",
+    "p5": "5th percentile",
+    "p10": "10th percentile",
+    "p25": "25th percentile",
+    "p50": "50th percentile",
+    "p75": "75th percentile",
+    "p90": "90th percentile",
+    "p95": "95th percentile",
+    "p99": "99th percentile",
+    "min": "minimum",
+    "max": "maximum",
+    "std": "standard deviation",
+}
+
+# Mapping of strings to replace in unit display names
+_REPLACE_MAP = {
+    "/": "_per_",
+    "tokens_per_sec": "tps",
+    "__": "_",
+}
+
+# Regex for sanitizing metric names to Prometheus format
+_METRIC_NAME_RE = re.compile(r"[^a-zA-Z0-9_]")
+
+
+def _sanitize_metric_name(name: str) -> str:
+    """Sanitize a metric name for Prometheus compatibility.
+
+    Prometheus metric names must match [a-zA-Z_:][a-zA-Z0-9_:]*.
+    We replace invalid characters with underscores.
+
+    Args:
+        name: The raw metric name/tag
+
+    Returns:
+        A sanitized metric name valid for Prometheus
+    """
+    sanitized = _METRIC_NAME_RE.sub("_", name.lower())
+    # Ensure it starts with a letter or underscore
+    if sanitized and sanitized[0].isdigit():
+        sanitized = "_" + sanitized
+    return sanitized
+
+
+def _format_info_metric(info_labels: InfoLabels) -> str:
+    """Format the aiperf_info metric with benchmark metadata.
+
+    Args:
+        info_labels: Dict of label name to value for the info metric
+
+    Returns:
+        Prometheus Exposition Format text for the info metric
+    """
+    if not info_labels:
+        return ""
+
+    # Add version to info metric only
+    labels = {"version": version("aiperf"), **info_labels}
+
+    # Format labels as key="value" pairs, escaping quotes in values
+    label_pairs = []
+    for key, value in labels.items():
+        escaped_value = str(value).replace("\\", "\\\\").replace('"', '\\"')
+        label_pairs.append(f'{key}="{escaped_value}"')
+
+    labels_str = ",".join(label_pairs)
+
+    lines = [
+        "# HELP aiperf_info AIPerf benchmark information",
+        "# TYPE aiperf_info gauge",
+        f"aiperf_info{{{labels_str}}} 1",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _format_labels(labels: InfoLabels) -> str:
+    """Format labels dict as Prometheus label string.
+
+    Args:
+        labels: Dict of label name to value
+
+    Returns:
+        Formatted label string like {key1="value1",key2="value2"}
+    """
+    if not labels:
+        return ""
+    label_pairs = []
+    for key, value in labels.items():
+        escaped_value = str(value).replace("\\", "\\\\").replace('"', '\\"')
+        label_pairs.append(f'{key}="{escaped_value}"')
+    return "{" + ",".join(label_pairs) + "}"
+
+
+def format_as_prometheus(
+    metrics: list[MetricResult], info_labels: InfoLabels | None = None
+) -> str:
+    """Convert MetricResult list to Prometheus Exposition Format text.
+
+    Generates raw PEF text with gauges for each metric stat.
+    Creates fresh output on each call (no caching/registry reuse).
+    Converts metrics to display units for human-readable values.
+
+    Args:
+        metrics: List of MetricResult objects from realtime metrics
+        info_labels: Optional dict of labels for the aiperf_info metric.
+            Key labels (excluding 'config') are also added to all metrics.
+
+    Returns:
+        Prometheus Exposition Format text string
+    """
+    lines: list[str] = []
+
+    # Add info metric first if labels provided
+    if info_labels:
+        lines.append(_format_info_metric(info_labels))
+
+    # Extract metric labels (exclude 'config' and 'version' which are info-only)
+    metric_labels = {
+        k: v for k, v in (info_labels or {}).items() if k not in ("config", "version")
+    }
+    labels_str = _format_labels(metric_labels)
+
+    for raw_metric in metrics:
+        # Convert to display units (e.g., ns -> ms, bytes -> MB)
+        try:
+            metric = raw_metric.to_display_unit()
+            metric_cls = MetricRegistry.get_class(metric.tag)
+            display_unit = metric_cls.display_unit or metric_cls.unit
+            unit_suffix = str(display_unit)
+            for old, new in _REPLACE_MAP.items():
+                unit_suffix = unit_suffix.replace(old, new)
+            unit_display = display_unit.display_name()
+        except MetricTypeError:
+            metric = raw_metric
+            unit_suffix = ""
+            unit_display = metric.unit
+
+        base_name = f"aiperf_{_sanitize_metric_name(metric.tag)}"
+
+        for stat, stat_display in STAT_DISPLAY_NAMES.items():
+            value = getattr(metric, stat, None)
+            if value is None:
+                continue
+
+            if stat == "sum":
+                metric_name = f"{base_name}_{unit_suffix}_total"
+            else:
+                metric_name = f"{base_name}_{stat}_{unit_suffix}"
+
+            lines.append(
+                f"# HELP {metric_name} {metric.header} {stat_display} (in {unit_display})"
+            )
+            lines.append(f"# TYPE {metric_name} gauge")
+            lines.append(f"{metric_name}{labels_str} {value}")
+
+    return "\n".join(lines) + "\n" if lines else ""
+
+
+class LiveMetricsServer(AIPerfLifecycleMixin):
+    """Live metrics HTTP server component.
+
+    Exposes AIPerf realtime metrics via HTTP in Prometheus Exposition Format.
+    Integrates with the AIPerf lifecycle for proper startup/shutdown handling.
+    """
+
+    def __init__(
+        self,
+        user_config: UserConfig,
+        metrics_callback: MetricsCallback,
+        **kwargs,
+    ) -> None:
+        """Initialize the live metrics server.
+
+        Args:
+            user_config: UserConfig for building aiperf_info labels, host, and port
+            metrics_callback: Callable that returns current MetricResult list
+        """
+        super().__init__(**kwargs)
+        self._user_config = user_config
+        self._host = user_config.live_metrics_host
+        self._port = user_config.live_metrics_port
+        self._metrics_callback = metrics_callback
+        self._info_labels = self._build_info_labels(user_config)
+        self._runner: web.AppRunner | None = None
+
+    @staticmethod
+    def _build_info_labels(user_config: UserConfig) -> InfoLabels:
+        """Build info labels for the aiperf_info metric from UserConfig.
+
+        Args:
+            user_config: The user configuration for the benchmark
+
+        Returns:
+            Dictionary of label names to values for the info metric
+        """
+        labels: InfoLabels = {}
+
+        # Key labels for easy querying
+        if user_config.benchmark_id:
+            labels["benchmark_id"] = user_config.benchmark_id
+        labels["model"] = ",".join(user_config.endpoint.model_names)
+        labels["endpoint_type"] = user_config.endpoint.type
+        labels["streaming"] = str(user_config.endpoint.streaming).lower()
+        if user_config.loadgen.concurrency is not None:
+            labels["concurrency"] = str(user_config.loadgen.concurrency)
+        if user_config.loadgen.request_rate is not None:
+            labels["request_rate"] = str(user_config.loadgen.request_rate)
+
+        # Full config as JSON for complete information
+        labels["config"] = user_config.model_dump_json(exclude_unset=True)
+
+        return labels
+
+    async def _handle_metrics(self, request: web.Request) -> web.Response:
+        """Handle GET /metrics endpoint."""
+        result = self._metrics_callback()
+
+        # Handle both sync and async callbacks
+        if inspect.isawaitable(result):
+            metrics = await result
+        else:
+            metrics = result
+
+        content = format_as_prometheus(metrics, self._info_labels)
+        return web.Response(
+            body=content,
+            content_type="text/plain",
+            charset="utf-8",
+        )
+
+    async def _handle_config(self, request: web.Request) -> web.Response:
+        """Handle GET /config endpoint."""
+        return web.Response(
+            body=self._user_config.model_dump_json(exclude_unset=True),
+            content_type="application/json",
+            charset="utf-8",
+        )
+
+    async def _handle_metrics_json(self, request: web.Request) -> web.Response:
+        """Handle GET /metrics.json endpoint."""
+        callback_result = self._metrics_callback()
+        if inspect.isawaitable(callback_result):
+            metrics = await callback_result
+        else:
+            metrics = callback_result
+        result = {
+            "aiperf_version": version("aiperf"),
+            "benchmark_id": self._user_config.benchmark_id,
+        }
+        if self._info_labels:
+            result.update(
+                {
+                    key: coerce_value(value)
+                    for key, value in self._info_labels.items()
+                    if key not in ("config", "version")
+                }
+            )
+        metrics_dict = {}
+        for metric in metrics:
+            try:
+                display_metric = metric.to_display_unit()
+            except MetricTypeError:
+                display_metric = metric
+            metrics_dict[metric.tag] = display_metric.model_dump(
+                mode="json", exclude_none=True, exclude={"tag"}
+            )
+        result["metrics"] = metrics_dict
+        content = orjson.dumps(result, option=orjson.OPT_INDENT_2)
+        return web.Response(
+            body=content,
+            content_type="application/json",
+            charset="utf-8",
+        )
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        """Handle GET /health endpoint for liveness probes."""
+        return web.Response(text="ok")
+
+    @on_start
+    async def _start_server(self) -> None:
+        """Start the HTTP server."""
+        app = web.Application()
+        app.router.add_get("/metrics", self._handle_metrics)
+        app.router.add_get("/metrics.json", self._handle_metrics_json)
+        app.router.add_get("/config", self._handle_config)
+        app.router.add_get("/health", self._handle_health)
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self._host, self._port)
+
+        try:
+            await site.start()
+        except OSError as e:
+            if e.errno == errno.EADDRINUSE:
+                raise OSError(
+                    f"Port {self._port} is already in use. "
+                    f"Use --live-metrics-port to specify a different port."
+                ) from None
+            raise
+
+        self.info(f"Live metrics available at http://{self._host}:{self._port}/metrics")
+
+    @on_stop
+    async def _stop_server(self) -> None:
+        """Stop the HTTP server."""
+        if self._runner:
+            runner = self._runner
+            self._runner = None
+            await runner.cleanup()
+            self.info("Live metrics server stopped")

--- a/tests/integration/test_live_metrics.py
+++ b/tests/integration/test_live_metrics.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for live metrics endpoint functionality."""
+
+import asyncio
+import socket
+
+import aiohttp
+import pytest
+
+from tests.integration.conftest import AIPerfCLI
+from tests.integration.conftest import IntegrationTestDefaults as defaults
+from tests.integration.models import AIPerfMockServer
+
+
+@pytest.fixture
+def live_metrics_port() -> int:
+    """Get an available port for the live metrics server."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestLiveMetrics:
+    """Tests for live metrics endpoint functionality."""
+
+    async def test_live_metrics_endpoint(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        live_metrics_port: int,
+    ):
+        """Live metrics endpoint returns valid Prometheus format with correct labels."""
+        metrics_url = f"http://127.0.0.1:{live_metrics_port}/metrics"
+        health_url = f"http://127.0.0.1:{live_metrics_port}/health"
+        captured_metrics: list[str] = []
+        health_responses: list[int] = []
+
+        async def poll_endpoints() -> None:
+            """Poll the live metrics and health endpoints while benchmark runs."""
+            async with aiohttp.ClientSession() as session:
+                # Wait for server to be ready
+                for _ in range(50):
+                    try:
+                        async with session.get(
+                            health_url, timeout=aiohttp.ClientTimeout(total=1)
+                        ) as resp:
+                            if resp.status == 200:
+                                health_responses.append(resp.status)
+                                break
+                    except (aiohttp.ClientError, asyncio.TimeoutError):
+                        pass
+                    await asyncio.sleep(0.1)
+
+                # Poll both endpoints during benchmark
+                for _ in range(20):
+                    try:
+                        async with session.get(
+                            health_url, timeout=aiohttp.ClientTimeout(total=1)
+                        ) as resp:
+                            health_responses.append(resp.status)
+                    except (aiohttp.ClientError, asyncio.TimeoutError):
+                        pass
+
+                    try:
+                        async with session.get(
+                            metrics_url, timeout=aiohttp.ClientTimeout(total=2)
+                        ) as resp:
+                            if resp.status == 200:
+                                content = await resp.text()
+                                if content.strip():
+                                    captured_metrics.append(content)
+                    except (aiohttp.ClientError, asyncio.TimeoutError):
+                        pass
+                    await asyncio.sleep(0.5)
+
+        # Run benchmark and poll concurrently
+        benchmark_task = asyncio.create_task(
+            cli.run(
+                f"""
+                aiperf profile \
+                    --model {defaults.model} \
+                    --url {aiperf_mock_server.url} \
+                    --endpoint-type chat \
+                    --request-count 20 \
+                    --request-rate 10 \
+                    --workers-max {defaults.workers_max} \
+                    --live-metrics-port {live_metrics_port} \
+                    --ui {defaults.ui}
+                """
+            )
+        )
+        poll_task = asyncio.create_task(poll_endpoints())
+
+        result = await benchmark_task
+        poll_task.cancel()
+
+        # Verify benchmark succeeded
+        assert result.exit_code == 0
+        assert result.request_count == 20
+
+        # Verify health endpoint
+        assert len(health_responses) > 0, "Should have received health responses"
+        assert all(s == 200 for s in health_responses), (
+            "All health checks should return 200"
+        )
+
+        # Verify metrics captured
+        assert len(captured_metrics) > 0, "Should have captured metrics responses"
+
+        # Find metrics with actual performance data
+        metrics_with_data = [
+            m
+            for m in captured_metrics
+            if "aiperf_request_" in m or "aiperf_output_" in m
+        ]
+        metrics_content = (
+            metrics_with_data[-1] if metrics_with_data else captured_metrics[-1]
+        )
+
+        # Verify Prometheus format
+        assert "# HELP" in metrics_content
+        assert "# TYPE" in metrics_content
+
+        # Verify info metric has version and config
+        info_lines = [
+            line for line in metrics_content.split("\n") if "aiperf_info{" in line
+        ]
+        assert len(info_lines) > 0, "Should have aiperf_info metric"
+        info_line = info_lines[0]
+        assert 'version="' in info_line, "Info metric should have version label"
+        assert 'config="' in info_line, "Info metric should have config label"
+
+        # Verify regular metrics have key labels but not config
+        metric_lines = [
+            line
+            for line in metrics_content.split("\n")
+            if line.startswith("aiperf_") and "{" in line and "aiperf_info" not in line
+        ]
+        if metric_lines:
+            sample_line = metric_lines[0]
+            assert 'model="' in sample_line, f"Should have model label: {sample_line}"
+            assert 'endpoint_type="' in sample_line, (
+                f"Should have endpoint_type: {sample_line}"
+            )
+            assert 'config="' not in sample_line, (
+                f"Should NOT have config: {sample_line}"
+            )

--- a/tests/unit/records/test_live_metrics_server.py
+++ b/tests/unit/records/test_live_metrics_server.py
@@ -1,0 +1,830 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from importlib.metadata import version
+from unittest.mock import MagicMock
+
+import orjson
+import pytest
+
+from aiperf.common.models.record_models import MetricResult
+from aiperf.records.live_metrics_server import (
+    STAT_DISPLAY_NAMES,
+    LiveMetricsServer,
+    _format_info_metric,
+    _format_labels,
+    _sanitize_metric_name,
+    format_as_prometheus,
+)
+
+
+class TestSanitizeMetricName:
+    """Tests for metric name sanitization."""
+
+    def test_lowercase_conversion(self):
+        """Test that metric names are converted to lowercase."""
+        assert _sanitize_metric_name("InterTokenLatency") == "intertokenlatency"
+
+    def test_hyphen_replacement(self):
+        """Test that hyphens are replaced with underscores."""
+        assert _sanitize_metric_name("inter-token-latency") == "inter_token_latency"
+
+    def test_space_replacement(self):
+        """Test that spaces are replaced with underscores."""
+        assert _sanitize_metric_name("inter token latency") == "inter_token_latency"
+
+    def test_special_chars_replacement(self):
+        """Test that special characters are replaced with underscores."""
+        assert _sanitize_metric_name("metric/name.value") == "metric_name_value"
+
+    def test_leading_digit_prefix(self):
+        """Test that leading digits get an underscore prefix."""
+        assert _sanitize_metric_name("99percentile") == "_99percentile"
+
+    def test_preserves_underscores(self):
+        """Test that existing underscores are preserved."""
+        assert _sanitize_metric_name("inter_token_latency") == "inter_token_latency"
+
+    def test_empty_string(self):
+        """Test handling of empty string."""
+        assert _sanitize_metric_name("") == ""
+
+
+class TestMetricsToPrometheusText:
+    """Tests for Prometheus text format conversion."""
+
+    def test_empty_metrics_list(self):
+        """Test that empty metrics list returns empty string."""
+        assert format_as_prometheus([]) == ""
+
+    def test_single_metric_with_all_stats(self):
+        """Test conversion of a single metric with all stats."""
+        metric = MetricResult(
+            tag="custom_test_metric",
+            header="Custom Test Metric",
+            unit="ms",
+            avg=10.5,
+            p1=2.0,
+            p5=3.0,
+            p10=4.0,
+            p25=6.0,
+            p50=9.0,
+            p75=12.0,
+            p90=15.0,
+            p95=18.0,
+            p99=25.0,
+            min=5.0,
+            max=30.0,
+            std=3.2,
+            sum=1050.0,
+            count=100,
+        )
+
+        result = format_as_prometheus([metric])
+
+        for stat in STAT_DISPLAY_NAMES:
+            if stat == "sum":
+                # sum uses _total suffix
+                assert "aiperf_custom_test_metric__total" in result
+            else:
+                assert f"aiperf_custom_test_metric_{stat}_" in result
+            assert "# HELP aiperf_custom_test_metric_" in result
+            assert "# TYPE aiperf_custom_test_metric_" in result
+
+        # All stats should be gauges
+        assert "# TYPE aiperf_custom_test_metric_avg_ gauge" in result
+        assert "# TYPE aiperf_custom_test_metric__total gauge" in result
+
+        assert "aiperf_custom_test_metric_avg_ 10.5" in result
+        assert "aiperf_custom_test_metric__total 1050.0" in result
+        assert "average (in ms)" in result
+        assert "total (in ms)" in result
+
+    def test_metric_with_partial_stats(self):
+        """Test conversion of a metric with only some stats."""
+        metric = MetricResult(
+            tag="custom_throughput",
+            header="Custom Throughput",
+            unit="req_s",
+            avg=125.5,
+            sum=6275.0,
+        )
+
+        result = format_as_prometheus([metric])
+
+        assert "aiperf_custom_throughput_avg_ 125.5" in result
+        assert "aiperf_custom_throughput__total 6275.0" in result
+        assert "average (in req_s)" in result
+
+        # Check absent stats are not present
+        assert "aiperf_custom_throughput_p50" not in result
+        assert "aiperf_custom_throughput_p99" not in result
+
+    def test_metric_name_sanitization(self):
+        """Test that metric names are properly sanitized."""
+        metric = MetricResult(
+            tag="Custom-Latency-Metric",
+            header="Custom Latency Metric",
+            unit="ms",
+            avg=10.0,
+        )
+
+        result = format_as_prometheus([metric])
+
+        assert "aiperf_custom_latency_metric_avg_" in result
+        assert "Custom-Latency-Metric" not in result
+
+    def test_unit_in_help_text(self):
+        """Test that unit appears in HELP text."""
+        metric = MetricResult(
+            tag="test_metric",
+            header="Test Metric",
+            unit="req_s",
+            avg=1.0,
+        )
+
+        result = format_as_prometheus([metric])
+
+        assert "# HELP aiperf_test_metric_avg_ Test Metric average (in req_s)" in result
+
+    def test_multiple_metrics(self):
+        """Test conversion of multiple metrics."""
+        metrics = [
+            MetricResult(
+                tag="metric_a",
+                header="Metric A",
+                unit="ms",
+                avg=10.0,
+            ),
+            MetricResult(
+                tag="metric_b",
+                header="Metric B",
+                unit="req_s",
+                avg=100.0,
+            ),
+        ]
+
+        result = format_as_prometheus(metrics)
+
+        assert "aiperf_metric_a_avg_ 10.0" in result
+        assert "aiperf_metric_b_avg_ 100.0" in result
+        assert "average (in ms)" in result
+        assert "average (in req_s)" in result
+
+    def test_output_ends_with_newline(self):
+        """Test that output ends with a newline."""
+        metric = MetricResult(
+            tag="test",
+            header="Test",
+            unit="ms",
+            avg=1.0,
+        )
+
+        result = format_as_prometheus([metric])
+        assert result.endswith("\n")
+
+    def test_registered_metric_uses_display_unit(self):
+        """Test that registered metrics use display_unit from MetricRegistry."""
+        # inter_token_latency is registered with display_unit=MILLISECONDS
+        metric = MetricResult(
+            tag="inter_token_latency",
+            header="Inter Token Latency",
+            unit="ns",  # Base unit (will be converted to display unit)
+            avg=10_000_000.0,  # 10ms in nanoseconds
+        )
+
+        result = format_as_prometheus([metric])
+
+        assert "aiperf_inter_token_latency_avg_ms" in result
+        assert "average (in milliseconds)" in result
+        assert "aiperf_inter_token_latency_avg_ms 10.0" in result
+
+
+class TestLiveMetricsServer:
+    """Tests for LiveMetricsServer initialization."""
+
+    def _create_mock_user_config(
+        self,
+        live_metrics_port: int = 9090,
+        live_metrics_host: str = "127.0.0.1",
+        benchmark_id: str | None = None,
+        model_names: list[str] | None = None,
+        endpoint_type: str = "openai",
+        streaming: bool = True,
+        concurrency: int | None = 10,
+        request_rate: float | None = None,
+    ) -> MagicMock:
+        """Create a mock UserConfig for testing."""
+        user_config = MagicMock()
+        user_config.live_metrics_port = live_metrics_port
+        user_config.live_metrics_host = live_metrics_host
+        user_config.benchmark_id = benchmark_id
+        user_config.endpoint.model_names = model_names or ["test-model"]
+        user_config.endpoint.type = endpoint_type
+        user_config.endpoint.streaming = streaming
+        user_config.loadgen.concurrency = concurrency
+        user_config.loadgen.request_rate = request_rate
+        user_config.model_dump_json.return_value = "{}"
+        return user_config
+
+    def test_initialization_defaults(self):
+        """Test server initialization with default values from UserConfig."""
+        user_config = self._create_mock_user_config(
+            live_metrics_port=9090,
+            live_metrics_host="127.0.0.1",
+        )
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: [],
+        )
+
+        assert server._port == 9090
+        assert server._host == "127.0.0.1"
+        assert server._runner is None
+
+    def test_initialization_custom_host(self):
+        """Test server initialization with custom host from UserConfig."""
+        user_config = self._create_mock_user_config(
+            live_metrics_port=8080,
+            live_metrics_host="0.0.0.0",
+        )
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: [],
+        )
+
+        assert server._port == 8080
+        assert server._host == "0.0.0.0"
+
+    def test_initialization_custom_id(self):
+        """Test server initialization with custom component ID."""
+        user_config = self._create_mock_user_config()
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: [],
+            id="custom_server_id",
+        )
+
+        assert server.id == "custom_server_id"
+
+    def test_stores_user_config(self):
+        """Test that user_config is stored for later access."""
+        user_config = self._create_mock_user_config()
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: [],
+        )
+
+        assert server._user_config is user_config
+
+
+class TestStatDisplayNames:
+    """Tests for STAT_DISPLAY_NAMES constant."""
+
+    def test_stats_dict_contents(self):
+        """Test that STAT_DISPLAY_NAMES contains expected stats."""
+        expected_keys = {
+            "avg",
+            "sum",
+            "p1",
+            "p5",
+            "p10",
+            "p25",
+            "p50",
+            "p75",
+            "p90",
+            "p95",
+            "p99",
+            "min",
+            "max",
+            "std",
+        }
+        assert set(STAT_DISPLAY_NAMES.keys()) == expected_keys
+
+    def test_display_names_are_human_readable(self):
+        """Test that display names are human-readable."""
+        assert STAT_DISPLAY_NAMES["avg"] == "average"
+        assert STAT_DISPLAY_NAMES["sum"] == "total"
+        assert STAT_DISPLAY_NAMES["p99"] == "99th percentile"
+        assert STAT_DISPLAY_NAMES["std"] == "standard deviation"
+        assert STAT_DISPLAY_NAMES["p1"] == "1st percentile"
+        assert STAT_DISPLAY_NAMES["p5"] == "5th percentile"
+        assert STAT_DISPLAY_NAMES["p10"] == "10th percentile"
+        assert STAT_DISPLAY_NAMES["p25"] == "25th percentile"
+        assert STAT_DISPLAY_NAMES["p75"] == "75th percentile"
+
+    def test_stats_match_metric_result_fields(self):
+        """Test that all stats are valid MetricResult fields."""
+        metric = MetricResult(
+            tag="test",
+            header="Test",
+            unit="ms",
+        )
+        for stat in STAT_DISPLAY_NAMES:
+            assert hasattr(metric, stat), f"MetricResult missing field: {stat}"
+
+
+class TestFormatLabels:
+    """Tests for _format_labels function."""
+
+    def test_empty_labels_returns_empty(self):
+        """Test that empty labels dict returns empty string."""
+        assert _format_labels({}) == ""
+
+    def test_single_label(self):
+        """Test formatting a single label."""
+        result = _format_labels({"model": "llama-3"})
+        assert result == '{model="llama-3"}'
+
+    def test_multiple_labels(self):
+        """Test formatting multiple labels."""
+        result = _format_labels({"model": "llama-3", "streaming": "true"})
+        assert 'model="llama-3"' in result
+        assert 'streaming="true"' in result
+        assert result.startswith("{")
+        assert result.endswith("}")
+
+    def test_escapes_quotes(self):
+        """Test that quotes in values are escaped."""
+        result = _format_labels({"model": 'test"model'})
+        assert r'model="test\"model"' in result
+
+    def test_escapes_backslashes(self):
+        """Test that backslashes in values are escaped."""
+        result = _format_labels({"path": r"C:\test"})
+        assert r'path="C:\\test"' in result
+
+
+class TestFormatInfoMetric:
+    """Tests for _format_info_metric function."""
+
+    def test_empty_labels_returns_empty(self):
+        """Test that empty labels dict returns empty string."""
+        assert _format_info_metric({}) == ""
+
+    def test_includes_version(self):
+        """Test that version is included in info metric."""
+        result = _format_info_metric({"test": "value"})
+
+        assert f'version="{version("aiperf")}"' in result
+
+    def test_basic_labels(self):
+        """Test formatting with basic labels."""
+        labels = {"model": "llama-3", "endpoint_url": "http://localhost:8000"}
+
+        result = _format_info_metric(labels)
+
+        assert "# HELP aiperf_info AIPerf benchmark information" in result
+        assert "# TYPE aiperf_info gauge" in result
+        assert 'model="llama-3"' in result
+        assert 'endpoint_url="http://localhost:8000"' in result
+        assert "aiperf_info{" in result
+        assert "} 1" in result
+
+    def test_escapes_quotes_in_values(self):
+        """Test that quotes in label values are escaped."""
+        labels = {"model": 'model"with"quotes'}
+
+        result = _format_info_metric(labels)
+
+        assert r'model="model\"with\"quotes"' in result
+
+    def test_escapes_backslashes_in_values(self):
+        """Test that backslashes in label values are escaped."""
+        labels = {"path": r"C:\path\to\model"}
+
+        result = _format_info_metric(labels)
+
+        assert r'path="C:\\path\\to\\model"' in result
+
+    def test_output_ends_with_newline(self):
+        """Test that output ends with a newline."""
+        result = _format_info_metric({"test": "value"})
+        assert result.endswith("\n")
+
+
+class TestFormatAsPrometheusWithInfoLabels:
+    """Tests for format_as_prometheus with info_labels parameter."""
+
+    def test_info_metric_appears_first(self):
+        """Test that info metric appears before other metrics."""
+        metric = MetricResult(
+            tag="test_metric",
+            header="Test",
+            unit="ms",
+            avg=1.0,
+        )
+        info_labels = {"model": "test-model"}
+
+        result = format_as_prometheus([metric], info_labels)
+
+        # Info metric should appear before the test metric
+        info_pos = result.find("aiperf_info")
+        metric_pos = result.find("aiperf_test_metric")
+        assert info_pos < metric_pos
+
+    def test_no_info_metric_when_labels_none(self):
+        """Test that no info metric appears when labels is None."""
+        metric = MetricResult(
+            tag="test_metric",
+            header="Test",
+            unit="ms",
+            avg=1.0,
+        )
+
+        result = format_as_prometheus([metric], info_labels=None)
+
+        assert "aiperf_info" not in result
+
+    def test_no_info_metric_when_labels_empty(self):
+        """Test that no info metric appears when labels is empty dict."""
+        metric = MetricResult(
+            tag="test_metric",
+            header="Test",
+            unit="ms",
+            avg=1.0,
+        )
+
+        result = format_as_prometheus([metric], info_labels={})
+
+        assert "aiperf_info" not in result
+
+    def test_labels_added_to_all_metrics(self):
+        """Test that key labels are added to all metrics."""
+        metric = MetricResult(
+            tag="test_metric",
+            header="Test",
+            unit="ms",
+            avg=10.0,
+            p99=20.0,
+        )
+        info_labels = {"model": "llama-3", "streaming": "true"}
+
+        result = format_as_prometheus([metric], info_labels)
+
+        assert (
+            'aiperf_test_metric_avg_{model="llama-3",streaming="true"} 10.0' in result
+        )
+        assert (
+            'aiperf_test_metric_p99_{model="llama-3",streaming="true"} 20.0' in result
+        )
+
+    def test_config_and_version_excluded_from_metrics(self):
+        """Test that 'config' and 'version' labels are not added to metrics (only to info)."""
+        metric = MetricResult(
+            tag="test_metric",
+            header="Test",
+            unit="ms",
+            avg=10.0,
+        )
+        info_labels = {"model": "llama-3", "config": '{"some":"json"}'}
+
+        result = format_as_prometheus([metric], info_labels)
+
+        # config and version should be in info metric
+        assert "config=" in result
+        assert "version=" in result
+        # but not in the test_metric line
+        metric_line = [
+            line for line in result.split("\n") if line.startswith("aiperf_test_metric")
+        ][0]
+        assert "config=" not in metric_line
+        assert "version=" not in metric_line
+        assert 'model="llama-3"' in metric_line
+
+    def test_no_labels_when_info_labels_none(self):
+        """Test that metrics have no labels when info_labels is None."""
+        metric = MetricResult(
+            tag="test_metric",
+            header="Test",
+            unit="ms",
+            avg=10.0,
+        )
+
+        result = format_as_prometheus([metric], info_labels=None)
+
+        assert "aiperf_test_metric_avg_ 10.0" in result
+
+
+class TestLiveMetricsServerBuildInfoLabels:
+    """Tests for LiveMetricsServer._build_info_labels method."""
+
+    def _create_mock_user_config(
+        self,
+        benchmark_id: str | None = None,
+        model_names: list[str] | None = None,
+        endpoint_type: str = "openai",
+        streaming: bool = True,
+        concurrency: int | None = 10,
+        request_rate: float | None = None,
+    ) -> MagicMock:
+        """Create a mock UserConfig for testing."""
+        user_config = MagicMock()
+        user_config.benchmark_id = benchmark_id
+        user_config.endpoint.model_names = model_names or ["test-model"]
+        user_config.endpoint.type = endpoint_type
+        user_config.endpoint.streaming = streaming
+        user_config.loadgen.concurrency = concurrency
+        user_config.loadgen.request_rate = request_rate
+        user_config.model_dump_json.return_value = "{}"
+        return user_config
+
+    def test_key_labels_included(self):
+        """Test that key labels are included for easy querying."""
+        user_config = self._create_mock_user_config(
+            benchmark_id="test-123",
+            model_names=["llama-3"],
+            concurrency=5,
+            request_rate=100.0,
+        )
+
+        labels = LiveMetricsServer._build_info_labels(user_config)
+
+        assert labels["benchmark_id"] == "test-123"
+        assert labels["model"] == "llama-3"
+        assert labels["endpoint_type"] == "openai"
+        assert labels["streaming"] == "true"
+        assert labels["concurrency"] == "5"
+        assert labels["request_rate"] == "100.0"
+
+    def test_config_json_included(self):
+        """Test that full config is included as JSON."""
+        user_config = self._create_mock_user_config()
+        expected_json = '{"loadgen":{"concurrency":10}}'
+        user_config.model_dump_json.return_value = expected_json
+
+        labels = LiveMetricsServer._build_info_labels(user_config)
+
+        assert labels["config"] == expected_json
+        user_config.model_dump_json.assert_called_once_with(exclude_unset=True)
+
+    def test_benchmark_id_excluded_when_none(self):
+        """Test that benchmark_id is excluded when None."""
+        user_config = self._create_mock_user_config(benchmark_id=None)
+
+        labels = LiveMetricsServer._build_info_labels(user_config)
+
+        assert "benchmark_id" not in labels
+
+    def test_concurrency_excluded_when_none(self):
+        """Test that concurrency is excluded when None."""
+        user_config = self._create_mock_user_config(concurrency=None)
+
+        labels = LiveMetricsServer._build_info_labels(user_config)
+
+        assert "concurrency" not in labels
+
+    def test_request_rate_excluded_when_none(self):
+        """Test that request_rate is excluded when None."""
+        user_config = self._create_mock_user_config(request_rate=None)
+
+        labels = LiveMetricsServer._build_info_labels(user_config)
+
+        assert "request_rate" not in labels
+
+    def test_multiple_models_as_csv(self):
+        """Test that multiple models are formatted as CSV."""
+        user_config = self._create_mock_user_config(
+            model_names=["model-a", "model-b", "model-c"]
+        )
+
+        labels = LiveMetricsServer._build_info_labels(user_config)
+
+        assert labels["model"] == "model-a,model-b,model-c"
+
+    def test_streaming_false(self):
+        """Test that streaming=false is properly formatted."""
+        user_config = self._create_mock_user_config(streaming=False)
+
+        labels = LiveMetricsServer._build_info_labels(user_config)
+
+        assert labels["streaming"] == "false"
+
+
+class TestLiveMetricsServerInfoLabelsIntegration:
+    """Tests for LiveMetricsServer initialization with user_config info labels."""
+
+    def _create_mock_user_config(
+        self,
+        live_metrics_port: int = 9090,
+        live_metrics_host: str = "127.0.0.1",
+        benchmark_id: str | None = "test-benchmark",
+        model_names: list[str] | None = None,
+        endpoint_type: str = "openai",
+        streaming: bool = True,
+        concurrency: int | None = 5,
+        request_rate: float | None = None,
+    ) -> MagicMock:
+        """Create a mock UserConfig for testing."""
+        user_config = MagicMock()
+        user_config.live_metrics_port = live_metrics_port
+        user_config.live_metrics_host = live_metrics_host
+        user_config.benchmark_id = benchmark_id
+        user_config.endpoint.model_names = model_names or ["test-model"]
+        user_config.endpoint.type = endpoint_type
+        user_config.endpoint.streaming = streaming
+        user_config.loadgen.concurrency = concurrency
+        user_config.loadgen.request_rate = request_rate
+        user_config.model_dump_json.return_value = "{}"
+        return user_config
+
+    def test_builds_info_labels_from_user_config(self):
+        """Test that info labels are built from user_config."""
+        user_config = self._create_mock_user_config()
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: [],
+        )
+
+        assert server._info_labels is not None
+        assert server._info_labels["benchmark_id"] == "test-benchmark"
+        assert server._info_labels["model"] == "test-model"
+        assert "config" in server._info_labels
+
+
+@pytest.mark.asyncio
+class TestLiveMetricsServerHandlers:
+    """Tests for LiveMetricsServer HTTP handlers."""
+
+    def _create_mock_user_config(
+        self,
+        live_metrics_port: int = 9090,
+        live_metrics_host: str = "127.0.0.1",
+        benchmark_id: str | None = "test-benchmark",
+        model_names: list[str] | None = None,
+    ) -> MagicMock:
+        """Create a mock UserConfig for testing."""
+        user_config = MagicMock()
+        user_config.live_metrics_port = live_metrics_port
+        user_config.live_metrics_host = live_metrics_host
+        user_config.benchmark_id = benchmark_id
+        user_config.endpoint.model_names = model_names or ["test-model"]
+        user_config.endpoint.type = "openai"
+        user_config.endpoint.streaming = True
+        user_config.loadgen.concurrency = 5
+        user_config.loadgen.request_rate = None
+        user_config.model_dump_json.return_value = '{"endpoint":{"type":"openai"}}'
+        return user_config
+
+    async def test_handle_metrics_sync_callback(self):
+        """Test _handle_metrics with a synchronous callback."""
+        metrics = [
+            MetricResult(tag="test", header="Test", unit="ms", avg=10.0),
+        ]
+        user_config = self._create_mock_user_config()
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: metrics,
+        )
+        request = MagicMock()
+
+        response = await server._handle_metrics(request)
+
+        assert response.content_type == "text/plain"
+        assert response.charset == "utf-8"
+        body = response.body.decode("utf-8")
+        assert "aiperf_test_avg_" in body
+
+    async def test_handle_metrics_async_callback(self):
+        """Test _handle_metrics with an asynchronous callback."""
+        metrics = [
+            MetricResult(tag="test", header="Test", unit="ms", avg=10.0),
+        ]
+
+        async def async_callback():
+            return metrics
+
+        user_config = self._create_mock_user_config()
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=async_callback,
+        )
+        request = MagicMock()
+
+        response = await server._handle_metrics(request)
+
+        assert response.content_type == "text/plain"
+        body = response.body.decode("utf-8")
+        assert "aiperf_test_avg_" in body
+
+    async def test_handle_config(self):
+        """Test _handle_config endpoint returns user config JSON."""
+        user_config = self._create_mock_user_config()
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: [],
+        )
+        request = MagicMock()
+
+        response = await server._handle_config(request)
+
+        assert response.content_type == "application/json"
+        assert response.charset == "utf-8"
+        body = response.body.decode("utf-8")
+        assert "openai" in body
+
+    async def test_handle_health(self):
+        """Test _handle_health endpoint returns 'ok'."""
+        user_config = self._create_mock_user_config()
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: [],
+        )
+        request = MagicMock()
+
+        response = await server._handle_health(request)
+
+        assert response.text == "ok"
+
+    async def test_handle_metrics_json_sync_callback(self):
+        """Test _handle_metrics_json with a synchronous callback."""
+        metrics = [
+            MetricResult(
+                tag="test_metric", header="Test", unit="ms", avg=10.0, p99=25.0
+            ),
+        ]
+        user_config = self._create_mock_user_config(benchmark_id="bench-123")
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: metrics,
+        )
+        request = MagicMock()
+
+        response = await server._handle_metrics_json(request)
+
+        assert response.content_type == "application/json"
+        assert response.charset == "utf-8"
+        body = response.body.decode("utf-8")
+        # Verify JSON structure
+        data = orjson.loads(body)
+        assert "aiperf_version" in data
+        assert data["benchmark_id"] == "bench-123"
+        assert "metrics" in data
+        assert "test_metric" in data["metrics"]
+        assert data["metrics"]["test_metric"]["avg"] == 10.0
+        assert data["metrics"]["test_metric"]["p99"] == 25.0
+        # tag should be excluded from metric dump
+        assert "tag" not in data["metrics"]["test_metric"]
+
+    async def test_handle_metrics_json_async_callback(self):
+        """Test _handle_metrics_json with an asynchronous callback."""
+        metrics = [
+            MetricResult(tag="test_metric", header="Test", unit="ms", avg=10.0),
+        ]
+
+        async def async_callback():
+            return metrics
+
+        user_config = self._create_mock_user_config()
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=async_callback,
+        )
+        request = MagicMock()
+
+        response = await server._handle_metrics_json(request)
+
+        assert response.content_type == "application/json"
+        data = orjson.loads(response.body)
+        assert "metrics" in data
+        assert "test_metric" in data["metrics"]
+
+    async def test_handle_metrics_json_includes_info_labels(self):
+        """Test that _handle_metrics_json includes info labels (except config/version)."""
+        metrics = [
+            MetricResult(tag="test", header="Test", unit="ms", avg=10.0),
+        ]
+        user_config = self._create_mock_user_config(
+            benchmark_id="bench-id",
+            model_names=["llama-3"],
+        )
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: metrics,
+        )
+        request = MagicMock()
+
+        response = await server._handle_metrics_json(request)
+
+        data = orjson.loads(response.body)
+        # Info labels should be present (except config which is excluded)
+        assert data["model"] == "llama-3"
+        assert data["endpoint_type"] == "openai"
+        assert data["streaming"] is True  # coerce_value converts "true" -> True
+        # config should NOT be in the response body directly (only in info_labels for prometheus)
+        assert "config" not in data
+
+    async def test_handle_metrics_json_empty_metrics(self):
+        """Test _handle_metrics_json with no metrics."""
+        user_config = self._create_mock_user_config(benchmark_id="bench-empty")
+        server = LiveMetricsServer(
+            user_config=user_config,
+            metrics_callback=lambda: [],
+        )
+        request = MagicMock()
+
+        response = await server._handle_metrics_json(request)
+
+        data = orjson.loads(response.body)
+        assert data["benchmark_id"] == "bench-empty"
+        assert data["metrics"] == {}


### PR DESCRIPTION
> [!IMPORTANT]
> This was added as a demo. However, a cleaned up version may be eventually submitted for real review.
> DO not review yet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Prometheus metrics support to expose live benchmark metrics via HTTP endpoint in standard Prometheus Exposition Format (default port 9090)
  * Added CLI options to enable metrics export, configure endpoint port, and set pre-completion scrape delay

* **Documentation**
  * Documented new Prometheus telemetry configuration options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->