### PR TITLE
fix: Fix missing units in AIPerf plot y-axis labels

### DIFF
--- a/src/aiperf/plot/exporters/base.py
+++ b/src/aiperf/plot/exporters/base.py
@@ -83,6 +83,9 @@ class BaseExporter(AIPerfLoggerMixin, ABC):
         name = display_names.get(metric_tag, get_metric_display_name(metric_tag))
         unit = units.get(metric_tag, "")
 
+        if not unit and metric_tag in available_metrics:
+            unit = available_metrics[metric_tag].get("unit", "")
+
         label = f"{name} {stat.upper()}" if stat and stat != "value" else name
 
         if unit:

--- a/src/aiperf/plot/handlers/multi_run_handlers.py
+++ b/src/aiperf/plot/handlers/multi_run_handlers.py
@@ -46,11 +46,20 @@ class BaseMultiRunHandler:
         Returns:
             Formatted metric label
         """
-        if metric_name in available_metrics:
+        display_name = None
+        unit = ""
+
+        if "display_names" in available_metrics or "units" in available_metrics:
+            display_name = available_metrics.get("display_names", {}).get(metric_name)
+            unit = available_metrics.get("units", {}).get(metric_name, "")
+
+        if not display_name and metric_name in available_metrics:
             display_name = available_metrics[metric_name].get(
                 "display_name", metric_name
             )
             unit = available_metrics[metric_name].get("unit", "")
+
+        if display_name:
             if stat and stat not in ["avg", "value"]:
                 display_name = f"{display_name} ({stat})"
             if unit:

--- a/src/aiperf/plot/handlers/single_run_handlers.py
+++ b/src/aiperf/plot/handlers/single_run_handlers.py
@@ -158,11 +158,20 @@ class BaseSingleRunHandler:
         Returns:
             Formatted metric label
         """
-        if metric_name in available_metrics:
+        display_name = None
+        unit = ""
+
+        if "display_names" in available_metrics or "units" in available_metrics:
+            display_name = available_metrics.get("display_names", {}).get(metric_name)
+            unit = available_metrics.get("units", {}).get(metric_name, "")
+
+        if not display_name and metric_name in available_metrics:
             display_name = available_metrics[metric_name].get(
                 "display_name", metric_name
             )
             unit = available_metrics[metric_name].get("unit", "")
+
+        if display_name:
             if stat and stat not in ["avg", "value"]:
                 display_name = f"{display_name} ({stat})"
             if unit:


### PR DESCRIPTION
This PR fixes an issue where plot y-axis units (e.g., ms) were missing.
Plot label generation expected `available_metrics` to be provided in the newer `display_names / units` format.
When legacy per-metric dictionaries were returned, unit metadata was not detected and therefore not propagated to Plotly labels.

**Before fix**
<img width="2400" height="1200" alt="ttft_over_time" src="https://github.com/user-attachments/assets/e4da4e94-b16b-4626-9b21-7c3a601defa1" />

**After fix**
<img width="2400" height="1200" alt="ttft_over_time" src="https://github.com/user-attachments/assets/a85c5d45-1d44-4994-a821-59c224527ba2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset loaders now recommend default sampling strategies for automatic configuration.
  * Metric units automatically fallback from available metadata when not explicitly specified.
  * Enhanced metric label generation supporting multiple configuration formats.

* **Improvements**
  * Improved handling of metric types (COUNTER, GAUGE, HISTOGRAM) with safer value extraction and aggregation.

* **Tests**
  * Added comprehensive tests for dataset sampling strategy defaults and server metrics aggregation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->