### PR TITLE
feat: Env option to ignore SSL certificate verification for testing

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -64,6 +64,7 @@ HTTP client socket and connection configuration. Controls low-level socket optio
 | `AIPERF_HTTP_FORCE_CLOSE` | `False` | — | Force close connections after each request |
 | `AIPERF_HTTP_ENABLE_CLEANUP_CLOSED` | `False` | — | Enable cleanup of closed ssl connections |
 | `AIPERF_HTTP_USE_DNS_CACHE` | `True` | — | Enable DNS cache |
+| `AIPERF_HTTP_SSL_VERIFY` | `True` | — | Enable SSL certificate verification. Set to False to disable verification. WARNING: Disabling this is insecure and should only be used for testing in a trusted environment. |
 
 ## LOGGING
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
   "pytest-xdist>=3.8.0",
   "ruff>=0.0.0",
   "scipy>=1.13.0",
+  "trustme>=1.0.0",
 ]
 
 [tool.ruff]

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
 Environment Configuration Module
@@ -255,6 +255,11 @@ class _HTTPSettings(BaseSettings):
     USE_DNS_CACHE: bool = Field(
         default=True,
         description="Enable DNS cache",
+    )
+    SSL_VERIFY: bool = Field(
+        default=True,
+        description="Enable SSL certificate verification. Set to False to disable verification. "
+        "WARNING: Disabling this is insecure and should only be used for testing in a trusted environment.",
     )
 
 

--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
@@ -230,6 +230,11 @@ class SystemController(SignalHandlerMixin, BaseService):
         duration = time.perf_counter() - begin
         self._parse_responses_for_errors(responses, "Configure Profiling")
         self.info(f"All services configured in {duration:.2f} seconds")
+
+        if not Environment.HTTP.SSL_VERIFY:
+            self.warning(
+                "SSL certificate verification is DISABLED - this is insecure. This should only be used for testing in a trusted environment."
+            )
 
     async def _start_profiling_all_services(self) -> None:
         """Tell all services to start profiling."""

--- a/src/aiperf/transports/http_defaults.py
+++ b/src/aiperf/transports/http_defaults.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import socket
 from dataclasses import dataclass
@@ -77,6 +77,7 @@ class AioHttpDefaults:
     KEEPALIVE_TIMEOUT = Environment.HTTP.KEEPALIVE_TIMEOUT  # Keepalive timeout
     HAPPY_EYEBALLS_DELAY = None  # Happy eyeballs delay (None = disabled)
     SOCKET_FAMILY = socket.AF_INET  # Family of the socket (IPv4)
+    SSL_VERIFY = Environment.HTTP.SSL_VERIFY  # Enable SSL certificate verification
 
     @classmethod
     def get_default_kwargs(cls) -> dict[str, Any]:
@@ -91,4 +92,5 @@ class AioHttpDefaults:
             "keepalive_timeout": cls.KEEPALIVE_TIMEOUT or None,
             "happy_eyeballs_delay": cls.HAPPY_EYEBALLS_DELAY,
             "family": cls.SOCKET_FAMILY,
+            "ssl": cls.SSL_VERIFY,
         }

--- a/tests/unit/transports/test_tcp_connector.py
+++ b/tests/unit/transports/test_tcp_connector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Test suite for create_tcp_connector function.
 
@@ -7,12 +7,17 @@ TCP connector for use with aiohttp.ClientSession.
 """
 
 import socket
+import ssl
 from unittest.mock import Mock, patch
 
+import aiohttp
 import pytest
+import trustme
+from aiohttp import web
 
-from aiperf.common.environment import Environment
+from aiperf.common.environment import Environment, _HTTPSettings
 from aiperf.transports.aiohttp_client import create_tcp_connector
+from aiperf.transports.http_defaults import AioHttpDefaults
 
 ################################################################################
 # Test create_tcp_connector
@@ -232,3 +237,196 @@ class TestCreateTcpConnector:
 
             with pytest.raises(OSError, match="Invalid socket option"):
                 socket_factory(addr_info)
+
+    @pytest.mark.parametrize("ssl_verify", [True, False])
+    def test_ssl_verify_passed_to_connector(
+        self, ssl_verify: bool, monkeypatch
+    ) -> None:
+        """Test that SSL_VERIFY setting is correctly passed to the connector."""
+        monkeypatch.setattr(AioHttpDefaults, "SSL_VERIFY", ssl_verify)
+
+        with patch("aiohttp.TCPConnector") as mock_connector_class:
+            mock_connector = Mock()
+            mock_connector_class.return_value = mock_connector
+
+            create_tcp_connector()
+
+            call_kwargs = mock_connector_class.call_args[1]
+            assert call_kwargs["ssl"] is ssl_verify
+
+    def test_ssl_can_be_overridden_by_kwargs(self, monkeypatch) -> None:
+        """Test that SSL setting can be overridden via kwargs."""
+        # Even if SSL_VERIFY is True, passing ssl=False should override
+        monkeypatch.setattr(AioHttpDefaults, "SSL_VERIFY", True)
+
+        with patch("aiohttp.TCPConnector") as mock_connector_class:
+            mock_connector = Mock()
+            mock_connector_class.return_value = mock_connector
+
+            create_tcp_connector(ssl=False)
+
+            call_kwargs = mock_connector_class.call_args[1]
+            assert call_kwargs["ssl"] is False
+
+
+class TestAioHttpDefaults:
+    """Test suite for AioHttpDefaults class."""
+
+    def test_ssl_verify_reads_from_environment(self) -> None:
+        """Test that SSL_VERIFY is read from Environment.HTTP.SSL_VERIFY."""
+        assert AioHttpDefaults.SSL_VERIFY is Environment.HTTP.SSL_VERIFY
+
+    def test_ssl_verify_default_is_true(self, monkeypatch) -> None:
+        """Test that SSL_VERIFY defaults to True when env var is not set."""
+        monkeypatch.delenv("AIPERF_HTTP_SSL_VERIFY", raising=False)
+        settings = _HTTPSettings()
+        assert settings.SSL_VERIFY is True
+
+    def test_ssl_verify_can_be_disabled_via_env(self, monkeypatch) -> None:
+        """Test that SSL_VERIFY can be disabled via environment variable."""
+        monkeypatch.setenv("AIPERF_HTTP_SSL_VERIFY", "false")
+        settings = _HTTPSettings()
+        assert settings.SSL_VERIFY is False
+
+    def test_get_default_kwargs_includes_ssl(self, monkeypatch) -> None:
+        """Test that get_default_kwargs includes ssl parameter."""
+        monkeypatch.setattr(AioHttpDefaults, "SSL_VERIFY", True)
+        kwargs = AioHttpDefaults.get_default_kwargs()
+        assert "ssl" in kwargs
+        assert kwargs["ssl"] is True
+
+    @pytest.mark.parametrize("ssl_value", [True, False])
+    def test_get_default_kwargs_ssl_reflects_setting(
+        self, ssl_value: bool, monkeypatch
+    ) -> None:
+        """Test that ssl in kwargs reflects the SSL_VERIFY setting."""
+        monkeypatch.setattr(AioHttpDefaults, "SSL_VERIFY", ssl_value)
+        kwargs = AioHttpDefaults.get_default_kwargs()
+        assert kwargs["ssl"] is ssl_value
+
+
+class TestSSLVerificationWithServer:
+    """Integration tests for SSL verification using a real HTTPS server."""
+
+    @pytest.fixture(autouse=True)
+    def reset_ssl_verify_to_default(self, monkeypatch):
+        """Ensure SSL_VERIFY is set to default (True) regardless of local env settings."""
+        monkeypatch.setattr(Environment.HTTP, "SSL_VERIFY", True)
+        monkeypatch.setattr(AioHttpDefaults, "SSL_VERIFY", True)
+
+    @pytest.fixture
+    def ca(self) -> trustme.CA:
+        """Create a certificate authority for testing."""
+        return trustme.CA()
+
+    @pytest.fixture
+    def server_ssl_ctx(self, ca: trustme.CA) -> "trustme.SSLContext":
+        """Create SSL context for the server."""
+        server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ca.issue_cert("127.0.0.1", "localhost").configure_cert(server_ctx)
+        return server_ctx
+
+    @pytest.fixture
+    async def https_server(
+        self, server_ssl_ctx: "trustme.SSLContext"
+    ) -> tuple[str, web.AppRunner]:
+        """Start an HTTPS server with certificate from test CA."""
+
+        async def handler(request: web.Request) -> web.Response:
+            return web.Response(
+                text='{"status": "ok"}', content_type="application/json"
+            )
+
+        app = web.Application()
+        app.router.add_get("/health", handler)
+
+        runner = web.AppRunner(app)
+        await runner.setup()
+
+        # Find an available port
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+
+        site = web.TCPSite(runner, "127.0.0.1", port, ssl_context=server_ssl_ctx)
+        await site.start()
+
+        url = f"https://127.0.0.1:{port}"
+
+        yield url, runner
+
+        await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_connection_succeeds_with_ssl_verify_disabled(
+        self, https_server: tuple[str, web.AppRunner]
+    ) -> None:
+        """Test that connection succeeds when SSL verification is disabled."""
+        url, _ = https_server
+
+        connector = create_tcp_connector(ssl=False)
+        try:
+            async with (
+                aiohttp.ClientSession(connector=connector) as session,
+                session.get(f"{url}/health") as response,
+            ):
+                assert response.status == 200
+                data = await response.json()
+                assert data["status"] == "ok"
+        finally:
+            await connector.close()
+
+    @pytest.mark.asyncio
+    async def test_connection_fails_with_ssl_verify_enabled(
+        self, https_server: tuple[str, web.AppRunner]
+    ) -> None:
+        """Test that connection fails when SSL verification is enabled with untrusted CA."""
+        url, _ = https_server
+
+        connector = create_tcp_connector(ssl=True)
+        try:
+            async with aiohttp.ClientSession(connector=connector) as session:
+                with pytest.raises(aiohttp.ClientConnectorCertificateError):
+                    async with session.get(f"{url}/health"):
+                        pass
+        finally:
+            await connector.close()
+
+    @pytest.mark.asyncio
+    async def test_default_ssl_verification_rejects_untrusted_cert(
+        self, https_server: tuple[str, web.AppRunner]
+    ) -> None:
+        """Test that default SSL verification rejects certificates from untrusted CA."""
+        url, _ = https_server
+
+        connector = create_tcp_connector()
+        try:
+            async with aiohttp.ClientSession(connector=connector) as session:
+                with pytest.raises(aiohttp.ClientConnectorCertificateError):
+                    async with session.get(f"{url}/health"):
+                        pass
+        finally:
+            await connector.close()
+
+    @pytest.mark.asyncio
+    async def test_connection_succeeds_with_trusted_ca(
+        self, ca: trustme.CA, https_server: tuple[str, web.AppRunner]
+    ) -> None:
+        """Test that connection succeeds when the CA is trusted."""
+        url, _ = https_server
+
+        # Create client SSL context that trusts our test CA
+        client_ctx = ssl.create_default_context()
+        ca.configure_trust(client_ctx)
+
+        connector = create_tcp_connector(ssl=client_ctx)
+        try:
+            async with (
+                aiohttp.ClientSession(connector=connector) as session,
+                session.get(f"{url}/health") as response,
+            ):
+                assert response.status == 200
+                data = await response.json()
+                assert data["status"] == "ok"
+        finally:
+            await connector.close()


### PR DESCRIPTION
`export AIPERF_HTTP_SSL_VERIFY=false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable SSL certificate verification control for HTTP connections.

* **Documentation**
  * Added documentation for the AIPERF_HTTP_SSL_VERIFY environment variable.

* **Tests**
  * Added comprehensive tests for SSL verification behavior.

* **Chores**
  * Added trustme development dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->