### PR TITLE
chore: upgrade base python container to 3.13.11 (#552)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 FROM python:3.13-slim-bookworm AS base
 
@@ -133,7 +133,7 @@ RUN uv pip install /dist/aiperf-*.whl \
 ############################################
 ############# Runtime Image ################
 ############################################
-FROM nvcr.io/nvidia/distroless/python:3.13-v3.1.1-dev AS runtime
+FROM nvcr.io/nvidia/distroless/python:3.13-v3.1.2-dev AS runtime
 
 # Include license and attribution files
 COPY LICENSE ATTRIBUTIONS*.md /legal/


### PR DESCRIPTION
cp ff528a222fb0624cfe181d1d0f16abc59af2cac8