### PR TITLE
fix: correct ISL token count and fix zmq message size

### DIFF
--- a/src/aiperf/common/models/dataset_models.py
+++ b/src/aiperf/common/models/dataset_models.py
@@ -146,6 +146,46 @@ class Turn(AIPerfBaseModel):
             delay_ms=self.delay,
         )
 
+    def copy_with_stripped_media(self) -> "Turn":
+        """Create a copy of this turn with multimodal data replaced by placeholders.
+
+        This preserves text data (needed for tokenization) but replaces potentially
+        large image/audio/video contents with small placeholder strings. This is
+        more efficient than a full deep copy followed by stripping.
+
+        Returns:
+            A new Turn with stripped multimodal contents.
+        """
+        return Turn(
+            model=self.model,
+            role=self.role,
+            timestamp=self.timestamp,
+            delay=self.delay,
+            max_tokens=self.max_tokens,
+            texts=[Text(name=t.name, contents=list(t.contents)) for t in self.texts],
+            images=[
+                Image(
+                    name=img.name,
+                    contents=[f"image_{i}" for i in range(len(img.contents))],
+                )
+                for img in self.images
+            ],
+            audios=[
+                Audio(
+                    name=aud.name,
+                    contents=[f"audio_{i}" for i in range(len(aud.contents))],
+                )
+                for aud in self.audios
+            ],
+            videos=[
+                Video(
+                    name=vid.name,
+                    contents=[f"video_{i}" for i in range(len(vid.contents))],
+                )
+                for vid in self.videos
+            ],
+        )
+
 
 class ConversationMetadata(AIPerfBaseModel):
     """Metadata of a conversation."""

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -447,10 +447,6 @@ class RequestRecord(AIPerfBaseModel):
         default=None,
         description="The original request info.",
     )
-    turns: list[Turn] = Field(
-        default_factory=list,
-        description="The actual turns of the request. This will include assistant turns as well as user turns in multi-turn conversations.",
-    )
     request_headers: dict[str, str] | None = Field(
         default=None,
         description="The headers of the request.",
@@ -509,6 +505,11 @@ class RequestRecord(AIPerfBaseModel):
         description="Comprehensive trace data captured via a trace config. "
         "Includes detailed timing for connection establishment, DNS resolution, request/response events, etc. "
         "The type of the trace data is determined by the transport and library used.",
+    )
+    turns: list[Turn] = Field(
+        default_factory=list,
+        description="Deep copy of the request turns. This is a copy of the turns from request_info, "
+        "made to avoid mutating the original session data when stripping multimodal content.",
     )
 
     @field_validator("trace_data", mode="before")

--- a/src/aiperf/timing/manager.py
+++ b/src/aiperf/timing/manager.py
@@ -3,7 +3,6 @@
 
 
 import asyncio
-import gc
 
 from aiperf.common.base_component_service import BaseComponentService
 from aiperf.common.config import ServiceConfig, UserConfig
@@ -129,13 +128,6 @@ class TimingManager(BaseComponentService):
         if not self._phase_orchestrator:
             raise InvalidStateError("No phase orchestrator configured")
 
-        # Disable GC during profiling to eliminate unpredictable latency spikes.
-        # Collect and freeze first to minimize memory pressure during the benchmark.
-        self.debug("Disabling garbage collection for stable timing")
-        gc.collect()
-        gc.freeze()
-        gc.disable()
-
         # Start event loop health monitoring only during the benchmark
         self.event_loop_monitor.start()
 
@@ -164,16 +156,6 @@ class TimingManager(BaseComponentService):
             await self._phase_orchestrator.stop()
 
         self.event_loop_monitor.stop()
-        self._re_enable_gc()
-
-    def _re_enable_gc(self) -> None:
-        """Re-enable garbage collection."""
-        self.debug(
-            "Re-enabling garbage collection to allow the timing manager "
-            "to clean up resources"
-        )
-        gc.unfreeze()
-        gc.enable()
 
 
 def main() -> None:

--- a/tests/unit/common/conftest.py
+++ b/tests/unit/common/conftest.py
@@ -1,14 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Shared fixtures and helpers for common tests, especially bootstrap tests."""
 
 import multiprocessing
-from unittest.mock import MagicMock
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from aiperf.common.base_service import BaseService
 from aiperf.common.config import ServiceConfig
+from aiperf.timing.manager import TimingManager
+from aiperf.workers.worker import Worker
 
 
 class DummyService(BaseService):
@@ -29,6 +32,26 @@ class DummyService(BaseService):
         self.stopped_event.set()
 
 
+class DummyWorker(DummyService):
+    """Dummy service named 'Worker' to test GC disabling."""
+
+    pass
+
+
+# Override the class name to simulate the Worker service
+DummyWorker.__name__ = Worker.__name__
+
+
+class DummyTimingManager(DummyService):
+    """Dummy service named 'TimingManager' to test GC disabling."""
+
+    pass
+
+
+# Override the class name to simulate the TimingManager service
+DummyTimingManager.__name__ = TimingManager.__name__
+
+
 @pytest.fixture
 def mock_log_queue() -> MagicMock:
     """Create a mock multiprocessing.Queue for testing."""
@@ -44,3 +67,52 @@ def service_config_no_uvloop(
 
     monkeypatch.setattr(Environment.SERVICE, "DISABLE_UVLOOP", True)
     return service_config
+
+
+@dataclass
+class MockGC:
+    """Container for mocked GC functions."""
+
+    collect: MagicMock
+    freeze: MagicMock
+    set_threshold: MagicMock
+    disable: MagicMock
+    call_order: list[str] = field(default_factory=list)
+
+
+@pytest.fixture
+def mock_gc() -> MockGC:
+    """Mock garbage collection functions for testing bootstrap GC behavior.
+
+    Returns a MockGC dataclass with mocked gc functions and a call_order list
+    that tracks the order of GC operations.
+    """
+    call_order: list[str] = []
+
+    def track_collect(*args, **kwargs):
+        call_order.append("collect")
+
+    def track_freeze(*args, **kwargs):
+        call_order.append("freeze")
+
+    def track_set_threshold(*args, **kwargs):
+        call_order.append("set_threshold")
+
+    def track_disable(*args, **kwargs):
+        call_order.append("disable")
+
+    with (
+        patch("gc.collect", side_effect=track_collect) as mock_collect,
+        patch("gc.freeze", side_effect=track_freeze) as mock_freeze,
+        patch(
+            "gc.set_threshold", side_effect=track_set_threshold
+        ) as mock_set_threshold,
+        patch("gc.disable", side_effect=track_disable) as mock_disable,
+    ):
+        yield MockGC(
+            collect=mock_collect,
+            freeze=mock_freeze,
+            set_threshold=mock_set_threshold,
+            disable=mock_disable,
+            call_order=call_order,
+        )

--- a/tests/unit/common/test_bootstrap_gc.py
+++ b/tests/unit/common/test_bootstrap_gc.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for garbage collection disabling in bootstrap.py"""
+
+import pytest
+
+from aiperf.common.bootstrap import bootstrap_and_run_service
+from aiperf.common.config import ServiceConfig, UserConfig
+from tests.unit.common.conftest import (
+    DummyService,
+    DummyTimingManager,
+    DummyWorker,
+    MockGC,
+)
+
+
+class TestBootstrapGarbageCollection:
+    """Test the garbage collection disabling in bootstrap.py"""
+
+    @pytest.fixture(autouse=True)
+    def setup_bootstrap_mocks(
+        self,
+        mock_psutil_process,
+        mock_setup_child_process_logging,
+    ):
+        """Combine common bootstrap mocks that are used but not called in tests."""
+        pass
+
+    def test_gc_disabled_for_worker_service(
+        self,
+        service_config_no_uvloop: ServiceConfig,
+        user_config: UserConfig,
+        mock_log_queue,
+        mock_gc: MockGC,
+    ):
+        """Test that GC is disabled for Worker service."""
+        bootstrap_and_run_service(
+            DummyWorker,
+            service_config=service_config_no_uvloop,
+            user_config=user_config,
+            log_queue=mock_log_queue,
+            service_id="test_worker",
+        )
+
+        # Verify GC was disabled
+        assert mock_gc.collect.call_count == 3  # Called 3 times in a loop
+        mock_gc.freeze.assert_called_once()
+        mock_gc.set_threshold.assert_called_once_with(0)
+        mock_gc.disable.assert_called_once()
+
+    def test_gc_disabled_for_timing_manager_service(
+        self,
+        service_config_no_uvloop: ServiceConfig,
+        user_config: UserConfig,
+        mock_log_queue,
+        mock_gc: MockGC,
+    ):
+        """Test that GC is disabled for TimingManager service."""
+        bootstrap_and_run_service(
+            DummyTimingManager,
+            service_config=service_config_no_uvloop,
+            user_config=user_config,
+            log_queue=mock_log_queue,
+            service_id="test_timing_manager",
+        )
+
+        # Verify GC was disabled
+        assert mock_gc.collect.call_count == 3  # Called 3 times in a loop
+        mock_gc.freeze.assert_called_once()
+        mock_gc.set_threshold.assert_called_once_with(0)
+        mock_gc.disable.assert_called_once()
+
+    def test_gc_not_disabled_for_other_services(
+        self,
+        service_config_no_uvloop: ServiceConfig,
+        user_config: UserConfig,
+        mock_log_queue,
+        mock_gc: MockGC,
+    ):
+        """Test that GC is NOT disabled for services other than Worker and TimingManager."""
+        bootstrap_and_run_service(
+            DummyService,
+            service_config=service_config_no_uvloop,
+            user_config=user_config,
+            log_queue=mock_log_queue,
+            service_id="test_dummy",
+        )
+
+        # Verify GC was NOT disabled
+        mock_gc.collect.assert_not_called()
+        mock_gc.freeze.assert_not_called()
+        mock_gc.set_threshold.assert_not_called()
+        mock_gc.disable.assert_not_called()
+
+    def test_gc_operations_occur_in_correct_order(
+        self,
+        service_config_no_uvloop: ServiceConfig,
+        user_config: UserConfig,
+        mock_log_queue,
+        mock_gc: MockGC,
+    ):
+        """Test that GC operations occur in the correct order: collect -> freeze -> set_threshold -> disable."""
+        bootstrap_and_run_service(
+            DummyWorker,
+            service_config=service_config_no_uvloop,
+            user_config=user_config,
+            log_queue=mock_log_queue,
+            service_id="test_worker",
+        )
+
+        # Verify order: collect (3x), freeze, set_threshold, disable
+        expected = [
+            "collect",
+            "collect",
+            "collect",
+            "freeze",
+            "set_threshold",
+            "disable",
+        ]
+        assert mock_gc.call_order == expected

--- a/tests/unit/metrics/conftest.py
+++ b/tests/unit/metrics/conftest.py
@@ -1,22 +1,57 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
 Shared fixtures for testing AIPerf metrics.
 
 """
 
-from aiperf.common.enums import MetricType
+from aiperf.common.enums import (
+    CreditPhase,
+    EndpointType,
+    MetricType,
+    ModelSelectionStrategy,
+)
 from aiperf.common.exceptions import NoMetricValue
 from aiperf.common.models import (
     ErrorDetails,
     ParsedResponse,
     ParsedResponseRecord,
+    RequestInfo,
     RequestRecord,
+)
+from aiperf.common.models.model_endpoint_info import (
+    EndpointInfo,
+    ModelEndpointInfo,
+    ModelInfo,
+    ModelListInfo,
 )
 from aiperf.common.models.record_models import TextResponseData, TokenCounts
 from aiperf.common.types import MetricTagT
 from aiperf.metrics.metric_dicts import MetricArray, MetricRecordDict, MetricResultsDict
 from aiperf.metrics.metric_registry import MetricRegistry
+
+
+def _create_test_request_info(model_name: str = "test-model") -> RequestInfo:
+    """Create a RequestInfo for testing metrics."""
+    return RequestInfo(
+        model_endpoint=ModelEndpointInfo(
+            models=ModelListInfo(
+                models=[ModelInfo(name=model_name)],
+                model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            ),
+            endpoint=EndpointInfo(
+                type=EndpointType.CHAT,
+                base_url="http://localhost:8000/v1/test",
+            ),
+        ),
+        turns=[],
+        turn_index=0,
+        credit_num=0,
+        credit_phase=CreditPhase.PROFILING,
+        x_request_id="test-request-id",
+        x_correlation_id="test-correlation-id",
+        conversation_id="test-conversation",
+    )
 
 
 def create_record(
@@ -38,8 +73,7 @@ def create_record(
     responses = responses or [start_ns + 50]  # Single response 50ns later
 
     request = RequestRecord(
-        conversation_id="test-conversation",
-        turn_index=0,
+        request_info=_create_test_request_info(),
         model_name="test-model",
         start_perf_ns=start_ns,
         timestamp_ns=start_ns,

--- a/tests/unit/metrics/test_image_metrics.py
+++ b/tests/unit/metrics/test_image_metrics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
@@ -20,15 +20,9 @@ def run_image_metrics_pipeline(
     records: list[ParsedResponseRecord],
     *metric_tags: str,
 ) -> dict:
-    """
-    Helper to run metrics pipeline for image metrics with automatic dependency inclusion.
-
-    Automatically includes NumImagesMetric and RequestLatencyMetric when needed by
-    ImageThroughputMetric or ImageLatencyMetric.
-    """
+    """Run metrics pipeline for image metrics with automatic dependency inclusion."""
     all_metrics = set(metric_tags)
 
-    # If any image throughput/latency metric is requested, add dependencies
     if (
         ImageThroughputMetric.tag in all_metrics
         or ImageLatencyMetric.tag in all_metrics
@@ -44,93 +38,84 @@ def create_record_with_images(
     responses: list[int] | None = None,
     images_per_turn: list[int] | None = None,
 ) -> ParsedResponseRecord:
-    """
-    Create a test record with images.
+    """Create a test record with images.
 
     Args:
         start_ns: Start timestamp in nanoseconds
         responses: List of response timestamps
         images_per_turn: List of image counts per turn (e.g., [2, 3] = 2 images in turn 0, 3 in turn 1)
     """
-
     responses = responses or [start_ns + 50]
     images_per_turn = images_per_turn or [1]
 
-    # Create base record
     record = create_record(start_ns=start_ns, responses=responses)
-
-    # Add turns with images
-    turns = []
-    for num_images in images_per_turn:
-        # Each Image object has a contents list with the actual image data
-        images = [
-            Image(name=f"image_{i}", contents=[f"data_{i}"]) for i in range(num_images)
-        ]
-        turns.append(Turn(images=images))
-
-    # Update the request with turns containing images
+    turns = [
+        Turn(
+            images=[Image(name=f"image_{i}", contents=[f"data_{i}"]) for i in range(n)]
+        )
+        for n in images_per_turn
+    ]
+    record.request.request_info.turns = turns
     record.request.turns = turns
 
     return record
+
+
+def set_turns_on_record(record: ParsedResponseRecord, turns: list[Turn]) -> None:
+    """Set turns on both request_info and request for a record."""
+    record.request.request_info.turns = turns
+    record.request.turns = turns
 
 
 class TestNumImagesMetric:
     @pytest.mark.parametrize(
         "images_per_turn,expected",
         [
-            ([1], 1),  # Single image
-            ([5], 5),  # Multiple images in single turn
-            ([2, 3], 5),  # Multiple turns (2+3=5)
+            ([1], 1),
+            ([5], 5),
+            ([2, 3], 5),
         ],
-    )
+        ids=["single_image", "multiple_in_turn", "multiple_turns"],
+    )  # fmt: skip
     def test_num_images_counting(self, images_per_turn, expected):
-        """Test counting images in various configurations"""
-        record = create_record_with_images(
-            start_ns=100, responses=[150], images_per_turn=images_per_turn
-        )
-
+        """Test counting images in various configurations."""
+        record = create_record_with_images(images_per_turn=images_per_turn)
         metric_results = run_image_metrics_pipeline([record], NumImagesMetric.tag)
         assert metric_results[NumImagesMetric.tag] == [expected]
 
     def test_num_images_batched_contents(self):
-        """Test counting images with batched contents in a single Image object"""
-
+        """Test counting images with batched contents in a single Image object."""
         record = create_record(start_ns=100, responses=[150])
-
-        # Create a single Image object with multiple contents (batched)
-        image_with_batch = Image(name="batch", contents=["data1", "data2", "data3"])
-        record.request.turns = [Turn(images=[image_with_batch])]
+        turns = [
+            Turn(images=[Image(name="batch", contents=["data1", "data2", "data3"])])
+        ]
+        set_turns_on_record(record, turns)
 
         metric_results = run_image_metrics_pipeline([record], NumImagesMetric.tag)
         assert metric_results[NumImagesMetric.tag] == [3]
 
     def test_num_images_multiple_records(self):
-        """Test counting images across multiple records"""
+        """Test counting images across multiple records."""
         records = [
             create_record_with_images(start_ns=10, responses=[25], images_per_turn=[1]),
             create_record_with_images(start_ns=20, responses=[35], images_per_turn=[2]),
             create_record_with_images(start_ns=30, responses=[50], images_per_turn=[3]),
         ]
-
         metric_results = run_image_metrics_pipeline(records, NumImagesMetric.tag)
         assert metric_results[NumImagesMetric.tag] == [1, 2, 3]
 
-    def test_num_images_no_images_error(self):
-        """Test error when record has no images"""
-
+    @pytest.mark.parametrize(
+        "turns",
+        [
+            [Turn(images=[])],
+            [],
+        ],
+        ids=["empty_images", "no_turns"],
+    )  # fmt: skip
+    def test_num_images_error_cases(self, turns):
+        """Test error when record has no images."""
         record = create_record(start_ns=100, responses=[150])
-        # Create turns without images
-        record.request.turns = [Turn(images=[])]
-
-        metric = NumImagesMetric()
-        with pytest.raises(NoMetricValue, match="at least one image"):
-            metric.parse_record(record, MetricRecordDict())
-
-    def test_num_images_no_turns(self):
-        """Test error when record has no turns"""
-
-        record = create_record(start_ns=100, responses=[150])
-        record.request.turns = []
+        set_turns_on_record(record, turns)
 
         metric = NumImagesMetric()
         with pytest.raises(NoMetricValue, match="at least one image"):
@@ -141,36 +126,33 @@ class TestImageThroughputMetric:
     @pytest.mark.parametrize(
         "images_per_turn,latency_ns,expected_throughput",
         [
-            ([1], 1_000_000_000, 1.0),    # 1 image, 1 second = 1 img/s
-            ([10], 2_000_000_000, 5.0),   # 10 images, 2 seconds = 5 img/s
-            ([3], 500_000_000, 6.0),      # 3 images, 0.5 seconds = 6 img/s
-            ([2, 3], 1_000_000_000, 5.0), # 5 images (2+3), 1 second = 5 img/s
+            ([1], 1_000_000_000, 1.0),
+            ([10], 2_000_000_000, 5.0),
+            ([3], 500_000_000, 6.0),
+            ([2, 3], 1_000_000_000, 5.0),
         ],
+        ids=["1img_1s", "10img_2s", "3img_0.5s", "5img_multi_turn"],
     )  # fmt: skip
     def test_image_throughput_calculation(
         self, images_per_turn, latency_ns, expected_throughput
     ):
-        """Test image throughput calculation with various configurations"""
+        """Test image throughput calculation with various configurations."""
         record = create_record_with_images(
-            start_ns=0,
-            responses=[latency_ns],
-            images_per_turn=images_per_turn,
+            start_ns=0, responses=[latency_ns], images_per_turn=images_per_turn
         )
-
         metric_results = run_image_metrics_pipeline([record], ImageThroughputMetric.tag)
         assert metric_results[ImageThroughputMetric.tag] == [expected_throughput]
 
     def test_image_throughput_multiple_records(self):
-        """Test throughput across multiple records"""
+        """Test throughput across multiple records."""
         records = [
             create_record_with_images(
                 start_ns=0, responses=[1_000_000_000], images_per_turn=[2]
-            ),  # 2 img/s
+            ),
             create_record_with_images(
                 start_ns=0, responses=[500_000_000], images_per_turn=[3]
-            ),  # 6 img/s
+            ),
         ]
-
         metric_results = run_image_metrics_pipeline(records, ImageThroughputMetric.tag)
         assert metric_results[ImageThroughputMetric.tag] == [2.0, 6.0]
 
@@ -179,75 +161,61 @@ class TestImageLatencyMetric:
     @pytest.mark.parametrize(
         "images_per_turn,latency_ns,expected_latency_ms",
         [
-            ([1], 1_000_000_000, 1000.0),     # 1000ms / 1 image = 1000 ms/img
-            ([10], 1_000_000_000, 100.0),     # 1000ms / 10 images = 100 ms/img
-            ([3], 500_000_000, 166.666666),   # 500ms / 3 images = ~166.67 ms/img
-            ([2, 3], 1_000_000_000, 200.0),   # 1000ms / 5 images (2+3) = 200 ms/img
-            ([1], 10_000_000, 10.0),          # 10ms / 1 image = 10 ms/img (fast processing)
+            ([1], 1_000_000_000, 1000.0),
+            ([10], 1_000_000_000, 100.0),
+            ([3], 500_000_000, 166.666666),
+            ([2, 3], 1_000_000_000, 200.0),
+            ([1], 10_000_000, 10.0),
         ],
+        ids=["1img_1s", "10img_1s", "3img_0.5s", "5img_multi_turn", "fast_processing"],
     )  # fmt: skip
     def test_image_latency_calculation(
         self, images_per_turn, latency_ns, expected_latency_ms
     ):
-        """Test image latency calculation with various configurations"""
+        """Test image latency calculation with various configurations."""
         record = create_record_with_images(
-            start_ns=0,
-            responses=[latency_ns],
-            images_per_turn=images_per_turn,
+            start_ns=0, responses=[latency_ns], images_per_turn=images_per_turn
         )
-
         metric_results = run_image_metrics_pipeline([record], ImageLatencyMetric.tag)
-        # Use approx comparison for floating point values
         assert metric_results[ImageLatencyMetric.tag][0] == pytest.approx(
             expected_latency_ms, rel=1e-5
         )
 
     def test_image_latency_multiple_records(self):
-        """Test latency across multiple records"""
+        """Test latency across multiple records."""
         records = [
             create_record_with_images(
                 start_ns=0, responses=[1_000_000_000], images_per_turn=[2]
-            ),  # 500 ms/img
+            ),
             create_record_with_images(
                 start_ns=0, responses=[500_000_000], images_per_turn=[5]
-            ),  # 100 ms/img
+            ),
         ]
-
         metric_results = run_image_metrics_pipeline(records, ImageLatencyMetric.tag)
         assert metric_results[ImageLatencyMetric.tag] == [500.0, 100.0]
 
 
 class TestImageMetricsIntegration:
     def test_image_throughput_and_latency_are_inverses(self):
-        """Test that throughput and latency are mathematical inverses"""
-        # When dealing with the same record, throughput * latency = images * time_unit_conversion
-        # images/sec * ms/image should equal images * 1000 (converting seconds to milliseconds)
+        """Test that throughput and latency are mathematical inverses."""
         record = create_record_with_images(
-            start_ns=0,
-            responses=[2_000_000_000],  # 2 seconds
-            images_per_turn=[4],
+            start_ns=0, responses=[2_000_000_000], images_per_turn=[4]
         )
-
         metric_results = run_image_metrics_pipeline(
-            [record],
-            ImageThroughputMetric.tag,
-            ImageLatencyMetric.tag,
+            [record], ImageThroughputMetric.tag, ImageLatencyMetric.tag
         )
 
-        throughput = metric_results[ImageThroughputMetric.tag][0]  # images/second
-        latency = metric_results[ImageLatencyMetric.tag][0]  # ms/image
+        throughput = metric_results[ImageThroughputMetric.tag][0]
+        latency = metric_results[ImageLatencyMetric.tag][0]
 
         # throughput (img/s) * latency (ms/img) = ms/s = 1000
         assert abs(throughput * latency - 1000.0) < 0.001
 
     def test_all_metrics_together(self):
-        """Test computing all image metrics together"""
+        """Test computing all image metrics together."""
         record = create_record_with_images(
-            start_ns=0,
-            responses=[1_000_000_000],  # 1 second
-            images_per_turn=[2, 3],  # 5 images total
+            start_ns=0, responses=[1_000_000_000], images_per_turn=[2, 3]
         )
-
         metric_results = run_image_metrics_pipeline(
             [record],
             NumImagesMetric.tag,
@@ -256,5 +224,5 @@ class TestImageMetricsIntegration:
         )
 
         assert metric_results[NumImagesMetric.tag] == [5]
-        assert metric_results[ImageThroughputMetric.tag] == [5.0]  # 5 images / 1 second
-        assert metric_results[ImageLatencyMetric.tag] == [200.0]  # 1000ms / 5 images
+        assert metric_results[ImageThroughputMetric.tag] == [5.0]
+        assert metric_results[ImageLatencyMetric.tag] == [200.0]

--- a/tests/unit/records/test_usage_passthrough.py
+++ b/tests/unit/records/test_usage_passthrough.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for usage field passthrough in InferenceResultParser.
 
@@ -20,6 +20,7 @@ from aiperf.common.models import (
 )
 from aiperf.common.tokenizer import Tokenizer
 from aiperf.records.inference_result_parser import InferenceResultParser
+from tests.unit.records.conftest import create_test_request_info
 
 
 @pytest.fixture
@@ -76,10 +77,10 @@ def parser():
 def create_test_record() -> RequestRecord:
     """Helper to create a simple test RequestRecord."""
     return RequestRecord(
-        conversation_id="test",
-        turn_index=0,
         model_name="test-model",
-        turns=[Turn(role="user", texts=[Text(contents=["Test input"])])],
+        request_info=create_test_request_info(
+            turns=[Turn(role="user", texts=[Text(contents=["Test input"])])]
+        ),
     )
 
 

--- a/tests/unit/workers/test_worker.py
+++ b/tests/unit/workers/test_worker.py
@@ -1,18 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import Mock
+import asyncio
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from aiperf.common.config.service_config import ServiceConfig
 from aiperf.common.config.user_config import UserConfig
+from aiperf.common.enums import CreditPhase
 from aiperf.common.models import (
+    Conversation,
     ParsedResponse,
     ReasoningResponseData,
     RequestRecord,
     SSEMessage,
     TextResponseData,
 )
+from aiperf.credit.structs import Credit, CreditContext
 from aiperf.workers.worker import Worker
 from tests.harness.fake_communication import FakeCommunication as FakeCommunication
 from tests.harness.fake_service_manager import FakeServiceManager as FakeServiceManager
@@ -233,3 +237,80 @@ class TestWorkerFirstTokenCallback:
         results = [await callback(msg.perf_ns, msg) for msg in messages]
 
         assert results == [False, False, True]
+
+
+# --- Fixture for CreditContext ---
+
+
+@pytest.fixture
+def sample_credit_context() -> CreditContext:
+    """Create a sample CreditContext for testing."""
+    return CreditContext(
+        credit=Credit(
+            id=1,
+            phase=CreditPhase.PROFILING,
+            conversation_id="test-conv-123",
+            x_correlation_id="test-correlation-id",
+            turn_index=0,
+            num_turns=1,
+            issued_at_ns=1000000,
+        ),
+        drop_perf_ns=2000000,
+    )
+
+
+# --- RetrieveConversation Tests ---
+
+
+@pytest.mark.asyncio
+class TestRetrieveConversation:
+    """Test suite for Worker's _retrieve_conversation method."""
+
+    async def test_returns_from_dataset_client_when_available(
+        self, mock_worker, sample_credit_context
+    ):
+        """When _dataset_client is set, should return conversation from it."""
+        expected_conversation = Conversation(session_id="test-conv-123", turns=[])
+        mock_client = AsyncMock()
+        mock_client.get_conversation = AsyncMock(return_value=expected_conversation)
+        mock_worker._dataset_client = mock_client
+
+        result = await mock_worker._retrieve_conversation(
+            conversation_id="test-conv-123",
+            credit_context=sample_credit_context,
+        )
+
+        assert result == expected_conversation
+        mock_client.get_conversation.assert_called_once_with("test-conv-123")
+
+    async def test_raises_cancelled_error_when_stop_requested_and_no_client(
+        self, mock_worker, sample_credit_context
+    ):
+        """When _dataset_client is None and stop_requested, should raise CancelledError."""
+        mock_worker._dataset_client = None
+        mock_worker.stop_requested = True
+
+        with pytest.raises(asyncio.CancelledError, match="Stop requested"):
+            await mock_worker._retrieve_conversation(
+                conversation_id="test-conv-123",
+                credit_context=sample_credit_context,
+            )
+
+    async def test_falls_back_to_dataset_manager_when_no_client_and_not_stopping(
+        self, monkeypatch, mock_worker, sample_credit_context
+    ):
+        """When _dataset_client is None and not stopping, should request from DatasetManager."""
+        mock_worker._dataset_client = None
+        expected_conversation = Conversation(session_id="test-conv-123", turns=[])
+        mock_fallback = AsyncMock(return_value=expected_conversation)
+        monkeypatch.setattr(
+            mock_worker, "_request_conversation_from_dataset_manager", mock_fallback
+        )
+
+        result = await mock_worker._retrieve_conversation(
+            conversation_id="test-conv-123",
+            credit_context=sample_credit_context,
+        )
+
+        assert result == expected_conversation
+        mock_fallback.assert_called_once_with("test-conv-123", sample_credit_context)


### PR DESCRIPTION
This matches the way that GenAI-Perf would calculate ISL, as it computed it from the combined content of the messages as one large string. the system and user prefixes would each be in there and get combined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined token counting to uniformly process all prompt components for consistency.
  * Optimized request payloads by reducing media content size while preserving metric data.

* **Refactor**
  * Restructured internal request data organization for improved data access patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->