### PR TITLE
feat: add video generation endpoint support for SGLang

### DIFF
--- a/src/aiperf/common/models/__init__.py
+++ b/src/aiperf/common/models/__init__.py
@@ -93,6 +93,8 @@ from aiperf.common.models.record_models import (
     TextResponse,
     TextResponseData,
     TokenCounts,
+    VideoDataItem,
+    VideoResponseData,
 )
 from aiperf.common.models.sequence_distribution import (
     DistributionParser,
@@ -264,6 +266,8 @@ __all__ = [
     "TurnMetadata",
     "Usage",
     "Video",
+    "VideoDataItem",
+    "VideoResponseData",
     "WorkerProcessingStats",
     "WorkerStats",
     "WorkerTaskStats",

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -715,6 +715,56 @@ class ImageResponseData(BaseResponseData):
     )
 
 
+class VideoDataItem(AIPerfBaseModel):
+    """Parsed video item response data."""
+
+    url: str | None = Field(
+        default=None,
+        description="The URL of the generated video.",
+    )
+    video_id: str | None = Field(
+        default=None,
+        description="The unique identifier for the generated video.",
+    )
+    duration: float | None = Field(
+        default=None,
+        description="The duration of the generated video in seconds.",
+    )
+    size: str | None = Field(
+        default=None,
+        description="The dimensions of the generated video (e.g., '1280x720').",
+    )
+    format: str | None = Field(
+        default=None,
+        description="The format/codec of the generated video (e.g., 'mp4').",
+    )
+    revised_prompt: str | None = Field(
+        default=None,
+        description="The revised prompt that was used for video generation.",
+    )
+    frames: int | None = Field(
+        default=None,
+        description="The number of frames in the generated video.",
+    )
+    fps: int | None = Field(
+        default=None,
+        description="The frames per second of the generated video.",
+    )
+
+
+class VideoResponseData(BaseResponseData):
+    """Parsed video response data."""
+
+    videos: list[VideoDataItem] = Field(
+        default_factory=list,
+        description="The generated videos from the response."
+    )
+    model: str | None = Field(
+        default=None,
+        description="The model used for video generation.",
+    )
+
+
 class ParsedResponse(AIPerfBaseModel):
     """Parsed response from a inference client."""
 

--- a/src/aiperf/endpoints/openai_video_generation.py
+++ b/src/aiperf/endpoints/openai_video_generation.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
+from aiperf.common.models import (
+    InferenceServerResponse,
+    ParsedResponse,
+    RequestInfo,
+    VideoDataItem,
+    VideoResponseData,
+)
+from aiperf.endpoints.base_endpoint import BaseEndpoint
+
+
+class VideoGenerationEndpoint(BaseEndpoint):
+    """OpenAI Video Generation endpoint.
+
+    Supports video generation from text prompts using models like Sora or SGLang video models.
+    Handles both streaming and non-streaming responses.
+
+    See: https://platform.openai.com/docs/api-reference/videos
+    See: https://docs.sglang.io/basic_usage/openai_api.html
+    """
+
+    def format_payload(self, request_info: RequestInfo) -> dict[str, Any]:
+        """Format OpenAI Video Generation request payload from RequestInfo.
+
+        Supports all OpenAI Video Generation API parameters:
+        - prompt (required): Text description from turn.texts[0]
+        - model (optional): From turn.model or model_endpoint.primary_model_name
+        - stream (optional): From model_endpoint.endpoint.streaming
+        - size, num_frames, fps, num_inference_steps, seed, response_format:
+          Pass via --extra-inputs "input_name:value"
+
+        Args:
+            request_info: Request context including model endpoint, metadata, and turns
+
+        Returns:
+            OpenAI Video Generation API payload with all specified parameters
+        """
+        if not request_info.turns:
+            raise ValueError("Video generation endpoint requires at least one turn.")
+
+        turn = request_info.turns[0]
+        model_endpoint = request_info.model_endpoint
+
+        if not turn.texts or not turn.texts[0].contents:
+            raise ValueError(
+                "Video generation endpoint requires text prompt in first turn."
+            )
+
+        prompt = turn.texts[0].contents[0]
+
+        # NOTE: response_format is set to url by default for SGLang video generation
+        payload = {
+            "prompt": prompt,
+            "model": turn.model or model_endpoint.primary_model_name,
+            "response_format": "url",
+        }
+
+        if model_endpoint.endpoint.streaming:
+            payload["stream"] = True
+
+        if model_endpoint.endpoint.extra:
+            payload.update(model_endpoint.endpoint.extra)
+
+        self.trace(lambda: f"Formatted payload: {payload}")
+        return payload
+
+    def parse_response(
+        self, response: InferenceServerResponse
+    ) -> ParsedResponse | None:
+        """Parse OpenAI Video Generation response.
+
+        Args:
+            response: Raw response from inference server
+
+        Returns:
+            Parsed response with extracted video data and usage info
+        """
+        json_obj = response.get_json()
+        if not json_obj:
+            self.debug(
+                lambda: f"No JSON object found in response: {response.get_raw()}"
+            )
+            return None
+
+        videos = []
+
+        # Handle different response formats
+        if "id" in json_obj and "data" not in json_obj:
+            # SGLang video generation response format (simple format with id at root)
+            videos.append(
+                VideoDataItem(
+                    video_id=json_obj.get("id"),
+                    url=json_obj.get("url"),
+                )
+            )
+        elif "data" in json_obj:
+            # OpenAI-compatible response format with data array
+            for item in json_obj.get("data", []):
+                videos.append(
+                    VideoDataItem(
+                        video_id=item.get("id"),
+                        url=item.get("url"),
+                        duration=item.get("duration"),
+                        size=item.get("size"),
+                        format=item.get("format"),
+                        revised_prompt=item.get("revised_prompt"),
+                        frames=item.get("frames"),
+                        fps=item.get("fps"),
+                    )
+                )
+
+        response_data = VideoResponseData(
+            videos=videos,
+            model=json_obj.get("model"),
+        )
+
+        usage = json_obj.get("usage") or None
+
+        return ParsedResponse(
+            perf_ns=response.perf_ns,
+            data=response_data,
+            usage=usage
+        )

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -233,6 +233,20 @@ endpoint:
       tokenizes_input: true
       metrics_title: Image Generation Metrics
 
+  video_generation:
+    class: aiperf.endpoints.openai_video_generation:VideoGenerationEndpoint
+    description: |
+      OpenAI Video Generation endpoint. Generates videos from text prompts using
+      models like Sora or SGLang video models. Supports streaming responses.
+      Uses /v1/videos path.
+    metadata:
+      endpoint_path: /v1/videos
+      supports_streaming: true
+      produces_tokens: false
+      produces_videos: true
+      tokenizes_input: true
+      metrics_title: Video Generation Metrics
+
   nim_embeddings:
     class: aiperf.endpoints.nim_embeddings:NIMEmbeddingsEndpoint
     description: |

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -47,6 +47,7 @@ from aiperf_mock_server.models import (
     RankingRequest,
     SolidoRAGRequest,
     TGIGenerateRequest,
+    VideoGenerationRequest,
 )
 from aiperf_mock_server.utils import (
     RequestCtx,
@@ -612,6 +613,44 @@ def _build_image_response_data(
         response_data["quality"] = req.quality
     if req.style:
         response_data["style"] = req.style
+
+    response_data["usage"] = ctx.usage
+    return response_data
+
+
+def _build_video_response_data(
+    ctx: RequestCtx, req: VideoGenerationRequest
+) -> dict[str, Any]:
+    """Build non-streaming video generation response."""
+    # Calculate video duration if frames and fps are provided
+    duration = None
+    if req.num_frames and req.fps:
+        duration = req.num_frames / req.fps
+    
+    video_id = f"video_{int(time.time())}_{hash(req.prompt) % 10000}"
+    
+    video_data: dict[str, Any] = {
+        "id": video_id,
+    }
+    
+    if req.response_format == "url":
+        video_data["url"] = f"https://mock.video.url/{video_id}.mp4"
+    
+    if req.size:
+        video_data["size"] = req.size
+    if duration:
+        video_data["duration"] = duration
+    if req.num_frames:
+        video_data["frames"] = req.num_frames
+    if req.fps:
+        video_data["fps"] = req.fps
+
+    response_data: dict[str, Any] = {
+        "id": video_id,
+        "model": req.model,
+        "created": int(time.time()),
+        "data": [video_data]
+    }
 
     response_data["usage"] = ctx.usage
     return response_data

--- a/tests/aiperf_mock_server/models.py
+++ b/tests/aiperf_mock_server/models.py
@@ -183,6 +183,20 @@ class ImageGenerationRequest(BaseModel):
     style: str | None = None
 
 
+class VideoGenerationRequest(BaseModel):
+    """Request model for OpenAI /v1/videos endpoint."""
+
+    prompt: str
+    model: str = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    response_format: Literal["url", "b64_json"] = "url"
+    stream: bool = False
+    size: str | None = None
+    num_frames: int | None = None
+    fps: int | None = None
+    num_inference_steps: int | None = None
+    seed: int | None = None
+
+
 class SolidoRAGRequest(BaseModel):
     """Request model for SOLIDO /rag/api/prompt endpoint."""
 
@@ -209,5 +223,6 @@ RequestT = (
     | CohereRerankRequest
     | TGIGenerateRequest
     | ImageGenerationRequest
+    | VideoGenerationRequest
     | SolidoRAGRequest
 )

--- a/tests/harness/fake_transport.py
+++ b/tests/harness/fake_transport.py
@@ -27,6 +27,7 @@ from aiperf_mock_server.app import (
     _build_nim_ranking_response_data,
     _build_solido_rag_response_data,
     _build_tgi_response_data,
+    _build_video_response_data,
     _compute_ranked_scores,
     _wait_for_processing,
 )
@@ -41,6 +42,7 @@ from aiperf_mock_server.models import (
     RankingRequest,
     SolidoRAGRequest,
     TGIGenerateRequest,
+    VideoGenerationRequest,
 )
 from aiperf_mock_server.utils import (
     RequestCtx,
@@ -340,6 +342,14 @@ class FakeTransport(BaseTransport):
                     ImageGenerationRequest,
                     self._do_simple,
                     build_response=_build_image_response_data,
+                )
+            case EndpointType.VIDEO_GENERATION:
+                return await self._dispatch(
+                    payload,
+                    endpoint_type,
+                    VideoGenerationRequest,
+                    self._do_simple,
+                    build_response=_build_video_response_data,
                 )
             case EndpointType.HUGGINGFACE_GENERATE:
                 return await self._dispatch(

--- a/tests/unit/endpoints/test_video_generation_endpoint.py
+++ b/tests/unit/endpoints/test_video_generation_endpoint.py
@@ -1,0 +1,307 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for VideoGenerationEndpoint."""
+
+import pytest
+
+from aiperf.common.models import Text, Turn
+from aiperf.endpoints.openai_video_generation import VideoGenerationEndpoint
+from aiperf.plugin.enums import EndpointType
+from tests.unit.endpoints.conftest import (
+    create_endpoint_with_mock_transport,
+    create_mock_response,
+    create_model_endpoint,
+    create_request_info,
+)
+
+
+class TestVideoGenerationEndpoint:
+    """Tests for VideoGenerationEndpoint."""
+
+    @pytest.fixture
+    def model_endpoint(self):
+        """Create a test ModelEndpointInfo for video generation."""
+        return create_model_endpoint(
+            EndpointType.VIDEO_GENERATION, model_name="Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+        )
+
+    @pytest.fixture
+    def streaming_model_endpoint(self):
+        """Create a test ModelEndpointInfo with streaming enabled."""
+        return create_model_endpoint(
+            EndpointType.VIDEO_GENERATION, model_name="Wan-AI/Wan2.1-T2V-1.3B-Diffusers", streaming=True
+        )
+
+    @pytest.fixture
+    def endpoint(self, model_endpoint):
+        """Create a VideoGenerationEndpoint instance."""
+        return create_endpoint_with_mock_transport(
+            VideoGenerationEndpoint, model_endpoint
+        )
+
+    @pytest.fixture
+    def streaming_endpoint(self, streaming_model_endpoint):
+        """Create a VideoGenerationEndpoint instance with streaming."""
+        return create_endpoint_with_mock_transport(
+            VideoGenerationEndpoint, streaming_model_endpoint
+        )
+
+    # ===== format_payload tests =====
+
+    def test_format_payload_simple_prompt(self, endpoint, model_endpoint):
+        """Test simple prompt formatting."""
+        turn = Turn(
+            texts=[Text(contents=["A cat playing piano"])],
+            model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["prompt"] == "A cat playing piano"
+        assert payload["model"] == "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+        assert payload["response_format"] == "url"
+        assert "stream" not in payload
+
+    def test_format_payload_with_streaming(
+        self, streaming_endpoint, streaming_model_endpoint
+    ):
+        """Test payload formatting with streaming enabled."""
+        turn = Turn(
+            texts=[Text(contents=["A dog running in a field"])],
+            model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        )
+        request_info = create_request_info(
+            model_endpoint=streaming_model_endpoint, turns=[turn]
+        )
+
+        payload = streaming_endpoint.format_payload(request_info)
+
+        assert payload["stream"] is True
+        assert payload["prompt"] == "A dog running in a field"
+
+    def test_format_payload_with_extra_inputs(self):
+        """Test payload formatting with extra inputs for video parameters."""
+        model_endpoint_with_extra = create_model_endpoint(
+            EndpointType.VIDEO_GENERATION,
+            model_name="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+            extra=[
+                ("size", "1280x720"),
+                ("num_frames", 32),
+                ("fps", 24),
+                ("num_inference_steps", 12),
+                ("seed", 42),
+            ],
+        )
+        endpoint = create_endpoint_with_mock_transport(
+            VideoGenerationEndpoint, model_endpoint_with_extra
+        )
+
+        turn = Turn(
+            texts=[Text(contents=["A bird flying"])],
+            model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        )
+        request_info = create_request_info(
+            model_endpoint=model_endpoint_with_extra, turns=[turn]
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["size"] == "1280x720"
+        assert payload["num_frames"] == 32
+        assert payload["fps"] == 24
+        assert payload["num_inference_steps"] == 12
+        assert payload["seed"] == 42
+
+    def test_format_payload_model_from_turn(self, endpoint, model_endpoint):
+        """Test that turn model overrides endpoint model."""
+        turn = Turn(
+            texts=[Text(contents=["A tree swaying"])],
+            model="custom-video-model",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["model"] == "custom-video-model"
+
+    def test_format_payload_no_turns_raises(self, endpoint, model_endpoint):
+        """Test that missing turns raises ValueError."""
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
+
+        with pytest.raises(ValueError, match="requires at least one turn"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_no_text_raises(self, endpoint, model_endpoint):
+        """Test that missing text raises ValueError."""
+        turn = Turn(texts=[], model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        with pytest.raises(ValueError, match="requires text prompt"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_empty_text_contents_raises(self, endpoint, model_endpoint):
+        """Test that empty text contents raises ValueError."""
+        turn = Turn(texts=[Text(contents=[])], model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        with pytest.raises(ValueError, match="requires text prompt"):
+            endpoint.format_payload(request_info)
+
+    # ===== parse_response tests =====
+
+    @pytest.mark.parametrize(
+        "json_data,expected_videos",
+        [
+            # Simple SGLang response format (id at root)
+            (
+                {"id": "video_123", "url": "https://example.com/video.mp4"},
+                [{"video_id": "video_123", "url": "https://example.com/video.mp4"}],
+            ),
+            # OpenAI-compatible response format with data array
+            (
+                {"data": [{"id": "video_456", "url": "https://example.com/video2.mp4"}]},
+                [{"video_id": "video_456", "url": "https://example.com/video2.mp4"}],
+            ),
+            # Response with duration, frames, fps
+            (
+                {
+                    "data": [
+                        {
+                            "id": "video_789",
+                            "url": "https://example.com/video3.mp4",
+                            "duration": 10.5,
+                            "size": "1280x720",
+                            "frames": 252,
+                            "fps": 24,
+                        }
+                    ]
+                },
+                [
+                    {
+                        "video_id": "video_789",
+                        "url": "https://example.com/video3.mp4",
+                        "duration": 10.5,
+                        "size": "1280x720",
+                        "frames": 252,
+                        "fps": 24,
+                    }
+                ],
+            ),
+            # Empty data array
+            ({"data": []}, []),
+        ],
+    )  # fmt: skip
+    def test_parse_response_video_formats(self, endpoint, json_data, expected_videos):
+        """Test parsing various video format responses."""
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert len(parsed.data.videos) == len(expected_videos)
+        for i, expected in enumerate(expected_videos):
+            assert parsed.data.videos[i].video_id == expected.get("video_id")
+            assert parsed.data.videos[i].url == expected.get("url")
+            if "duration" in expected:
+                assert parsed.data.videos[i].duration == expected["duration"]
+            if "size" in expected:
+                assert parsed.data.videos[i].size == expected["size"]
+            if "frames" in expected:
+                assert parsed.data.videos[i].frames == expected["frames"]
+            if "fps" in expected:
+                assert parsed.data.videos[i].fps == expected["fps"]
+
+    def test_parse_response_with_revised_prompt(self, endpoint):
+        """Test parsing response with revised prompt."""
+        json_data = {
+            "data": [
+                {
+                    "id": "video_123",
+                    "url": "https://example.com/video.mp4",
+                    "revised_prompt": "A beautiful cat playing piano, cinematic lighting",
+                }
+            ]
+        }  # fmt: skip
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert len(parsed.data.videos) == 1
+        assert (
+            parsed.data.videos[0].revised_prompt
+            == "A beautiful cat playing piano, cinematic lighting"
+        )
+
+    def test_parse_response_with_model_info(self, endpoint):
+        """Test parsing response with model information."""
+        json_data = {
+            "model": "Wan-AI/Wan2.1-T2V-14B-Diffusers",
+            "data": [{"id": "video_123", "url": "https://example.com/video.mp4"}],
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.data.model == "Wan-AI/Wan2.1-T2V-14B-Diffusers"
+
+    def test_parse_response_with_usage(self, endpoint):
+        """Test parsing response with usage information."""
+        json_data = {
+            "data": [{"id": "video_123", "url": "https://example.com/video.mp4"}],
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 0,
+                "total_tokens": 50,
+            },
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.usage is not None
+        assert parsed.usage.prompt_tokens == 50
+        assert parsed.usage.total_tokens == 50
+
+    def test_parse_response_perf_ns(self, endpoint):
+        """Test that perf_ns is preserved."""
+        json_data = {"id": "video_123", "url": "https://example.com/video.mp4"}
+        mock_response = create_mock_response(perf_ns=888777666, json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.perf_ns == 888777666
+
+    def test_parse_response_extra_fields_ignored(self, endpoint):
+        """Test that extra fields in response are ignored."""
+        json_data = {
+            "data": [
+                {
+                    "id": "video_123",
+                    "url": "https://example.com/video.mp4",
+                    "extra_field": "ignored",
+                    "another_field": 123,
+                }
+            ],
+            "model": "video-model",
+            "unknown_field": "value",
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.data.videos[0].video_id == "video_123"
+
+    def test_parse_response_no_json(self, endpoint):
+        """Test parsing when get_json returns None."""
+        mock_response = create_mock_response(json_data=None)
+        mock_response.get_raw.return_value = ""
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is None


### PR DESCRIPTION
- Add VideoDataItem and VideoResponseData models for video responses
- Implement VideoGenerationEndpoint class with /v1/videos API support
- Register video_generation endpoint type in plugin system
- Add comprehensive unit tests following image generation patterns
- Update mock server and fake transport for video generation testing

Enables --endpoint-type video_generation for benchmarking SGLang video models (Wan2.1, HunyuanVideo) with video-specific parameters:
- size (resolution)
- num_frames
- fps
- num_inference_steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video generation endpoint supporting text-to-video conversion with streaming capabilities
  * Integrated support for comprehensive video metadata including duration, frames, and frame rate tracking
  * Enhanced monitoring with dedicated video generation metrics dashboard

* **Tests**
  * Added comprehensive test coverage for video generation request formatting and response parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->