### PR TITLE
feat: SGLang /v1/video generation with polling support

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -124,7 +124,7 @@ Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default,
 #### `--endpoint-type` `<str>`
 
 The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
-<br>_Choices: [`chat`, `cohere_rankings`, `completions`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `template`]_
+<br>_Choices: [`chat`, `cohere_rankings`, `completions`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `video_generation`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `template`]_
 <br>_Default: `chat`_
 
 #### `--streaming`
@@ -178,6 +178,11 @@ Transport connection reuse strategy. 'pooled' (default): connections are pooled 
 | `pooled` | _default_ | Connections are pooled and reused across all requests |
 | `never` |  | New connection for each request, closed after response |
 | `sticky-user-sessions` |  | Connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing) |
+
+#### `--download-video-content`
+
+For video generation endpoints, download the video content after generation completes. When enabled, request latency includes the video download time. When disabled (default), only generation time is measured.
+<br>_Flag (no value required)_
 
 ### Input
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -46,7 +46,7 @@ GPU telemetry collection configuration. Controls GPU metrics collection frequenc
 
 ## HTTP
 
-HTTP client socket and connection configuration. Controls low-level socket options, keepalive settings, DNS caching, and connection pooling for HTTP clients. These settings optimize performance for high-throughput streaming workloads.
+HTTP client socket and connection configuration. Controls low-level socket options, keepalive settings, DNS caching, and connection pooling for HTTP clients. These settings optimize performance for high-throughput streaming workloads. Video Generation Polling: For async video generation APIs that use job polling (e.g., SGLang /v1/videos), the poll interval is controlled by VIDEO_POLL_INTERVAL. The max poll time uses the --request-timeout-seconds CLI argument.
 
 | Environment Variable | Default | Constraints | Description |
 |----------------------|---------|-------------|-------------|
@@ -68,6 +68,7 @@ HTTP client socket and connection configuration. Controls low-level socket optio
 | `AIPERF_HTTP_REQUEST_CANCELLATION_SEND_TIMEOUT` | `300.0` | ≥ 10.0, ≤ 3600.0 | Safety net timeout in seconds for waiting for HTTP request to be fully sent when request cancellation is enabled. Used as fallback when no explicit timeout is configured to prevent hanging indefinitely while waiting for the request to be written to the socket. |
 | `AIPERF_HTTP_IP_VERSION` | `'4'` | — | IP version for HTTP socket connections. Options: '4' (AF_INET, default), '6' (AF_INET6), or 'auto' (AF_UNSPEC, system chooses). |
 | `AIPERF_HTTP_TRUST_ENV` | `False` | — | Trust environment variables for HTTP client configuration. When enabled, aiohttp will read proxy settings from HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables. |
+| `AIPERF_HTTP_VIDEO_POLL_INTERVAL` | `0.1` | ≥ 0.001, ≤ 10.0 | Interval in seconds between status polls for async video generation jobs. Lower values provide faster completion detection but increase server load. Applies to the aiohttp transport. |
 
 ## LOGGING
 

--- a/docs/tutorials/sglang-video-generation.md
+++ b/docs/tutorials/sglang-video-generation.md
@@ -1,0 +1,503 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# SGLang Video Generation
+
+## Overview
+
+This guide shows how to benchmark text-to-video generation APIs using SGLang and AIPerf. You'll learn how to set up the SGLang video generation server, create input prompts, run benchmarks, and analyze the results.
+
+Video generation follows an **asynchronous job pattern**:
+1. **Submit** - POST to `/v1/videos` with your prompt, receive a job ID
+2. **Poll** - GET `/v1/videos/{id}` until status is `completed` or `failed`
+3. **Download** - GET `/v1/videos/{id}/content` to retrieve the generated video
+
+AIPerf handles this polling workflow automatically.
+
+## References
+
+For the most up-to-date information, please refer to the following resources:
+- [SGLang Video Generation API](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/openai_api.md)
+- [SGLang Diffusion Installation Guide](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/install.md)
+- [SGLang CLI Reference](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/cli.md)
+- [OpenAI Videos API](https://platform.openai.com/docs/api-reference/videos)
+
+## Supported Models
+
+AIPerf supports any SGLang-compatible text-to-video model, including:
+
+| Model | Model Path | Notes |
+|-------|------------|-------|
+| Wan2.1-T2V | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` | Lightweight, good for testing |
+| Wan2.1-T2V (14B) | `Wan-AI/Wan2.1-T2V-14B-Diffusers` | Higher quality, requires more VRAM |
+| HunyuanVideo | `tencent/HunyuanVideo` | Tencent's video generation model |
+
+## Setting Up the Server
+
+### Option 1: Docker (Recommended)
+
+**Export your Hugging Face token as an environment variable:**
+```bash
+export HF_TOKEN=<your-huggingface-token>
+```
+
+**Start the SGLang Docker container:**
+```bash
+docker run --gpus all \
+    --shm-size 32g \
+    -it \
+    --rm \
+    -p 30010:30010 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --env "HF_TOKEN=$HF_TOKEN" \
+    --ipc=host \
+    lmsysorg/sglang:dev
+```
+
+> [!NOTE]
+> The following steps are to be performed _inside_ the SGLang Docker container.
+
+**Install the diffusion dependencies:**
+```bash
+uv pip install "sglang[diffusion]" --prerelease=allow --system
+```
+
+**Set the server arguments:**
+
+> [!IMPORTANT]
+> The following arguments set up the SGLang server to use Wan2.1-T2V-1.3B on port 30010.
+> Adjust `--num-gpus`, `--ulysses-degree`, and `--ring-degree` based on your GPU configuration.
+
+**Single GPU setup:**
+```bash
+SERVER_ARGS=(
+    --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+    --text-encoder-cpu-offload
+    --pin-cpu-memory
+    --num-gpus 1
+    --port 30010
+    --host 0.0.0.0
+)
+```
+
+**Multi-GPU setup (4 GPUs with sequence parallelism):**
+```bash
+SERVER_ARGS=(
+    --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+    --text-encoder-cpu-offload
+    --pin-cpu-memory
+    --num-gpus 4
+    --ulysses-degree 2
+    --ring-degree 2
+    --port 30010
+    --host 0.0.0.0
+)
+```
+
+**Start the SGLang server:**
+```bash
+sglang serve "${SERVER_ARGS[@]}"
+```
+
+**Wait until the server is ready** (watch the logs for the following message):
+```
+Uvicorn running on http://0.0.0.0:30010 (Press CTRL+C to quit)
+```
+
+### Option 2: Native Installation
+
+**Install SGLang with diffusion support:**
+```bash
+pip install --upgrade pip
+pip install uv
+uv pip install "sglang[diffusion]" --prerelease=allow
+```
+
+**Start the server:**
+```bash
+sglang serve \
+    --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --text-encoder-cpu-offload \
+    --pin-cpu-memory \
+    --num-gpus 1 \
+    --port 30010 \
+    --host 0.0.0.0
+```
+
+## Running the Benchmark
+
+> [!NOTE]
+> The following steps are to be performed on your local machine (_outside_ the SGLang Docker container).
+
+### Basic Usage: Text-to-Video with Input File
+
+**Create an input file with video prompts:**
+```bash
+cat > video_prompts.jsonl << 'EOF'
+{"text": "A serene lake at sunset with mountains in the background"}
+{"text": "A cat playing with a ball of yarn in a cozy living room"}
+{"text": "A futuristic city with flying cars and neon lights"}
+EOF
+```
+
+**Run the benchmark:**
+```bash
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --input-file video_prompts.jsonl \
+    --custom-dataset-type single_turn \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:4" \
+    --concurrency 1 \
+    --request-count 3
+```
+
+**Done!** This sends 3 requests to `http://localhost:30010/v1/videos` and polls until each video is complete.
+
+**Sample Output (Successful Run):**
+```
+                                       NVIDIA AIPerf | Video Generation Metrics
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┓
+┃                            Metric ┃       avg ┃       min ┃       max ┃       p99 ┃       p90 ┃       p50 ┃     std ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━┩
+│              Request Latency (ms) │ 45,234.56 │ 42,123.45 │ 48,567.89 │ 48,432.12 │ 47,654.32 │ 45,012.34 │ 2634.78 │
+│    Input Sequence Length (tokens) │      8.33 │      7.00 │     10.00 │      9.98 │      9.80 │      8.00 │    1.25 │
+│ Request Throughput (requests/sec) │      0.02 │         - │         - │         - │         - │         - │       - │
+│          Request Count (requests) │      3.00 │         - │         - │         - │         - │         - │       - │
+└───────────────────────────────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴─────────┘
+```
+
+### Basic Usage: Text-to-Video with Synthetic Prompts
+
+Generate videos using synthetic prompts with configurable token lengths:
+
+```bash
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:4" \
+    --synthetic-input-tokens-mean 50 \
+    --synthetic-input-tokens-stddev 10 \
+    --concurrency 1 \
+    --request-count 5
+```
+
+## Generation Parameters
+
+Control video generation through `--extra-inputs`:
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `size` | Video resolution | `1280x720`, `720x1280`, `480x480` |
+| `seconds` | Video duration in seconds | `4`, `8`, `12` |
+| `seed` | Random seed for reproducibility | `42` |
+| `num_inference_steps` | Diffusion denoising steps | `50` |
+| `guidance_scale` | Classifier-free guidance scale | `7.5` |
+| `negative_prompt` | Concepts to exclude | `"blurry, low quality"` |
+| `fps` | Frames per second | `24` |
+| `num_frames` | Total frames to generate | `48` |
+
+**Video Download Option:**
+
+Use `--download-video-content` to include video content download in the benchmark timing. When enabled, request latency includes the time to download the generated video from the server. By default, only generation time is measured.
+
+```bash
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --input-file video_prompts.jsonl \
+    --custom-dataset-type single_turn \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:4" \
+    --download-video-content \
+    --concurrency 1 \
+    --request-count 3
+```
+
+**Example with advanced parameters:**
+```bash
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --input-file video_prompts.jsonl \
+    --custom-dataset-type single_turn \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:8" \
+    --extra-inputs "seed:42" \
+    --extra-inputs "guidance_scale:7.5" \
+    --extra-inputs "num_inference_steps:50" \
+    --concurrency 1 \
+    --request-count 3
+```
+
+## Polling Configuration
+
+AIPerf automatically handles polling for video generation. Configure polling behavior:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `--request-timeout-seconds` | Maximum wait time before timeout | `21600` (6 hours) |
+| `AIPERF_HTTP_VIDEO_POLL_INTERVAL` | Seconds between status checks (0.1-60) | `0.1` |
+
+**Example with custom timeout and polling interval:**
+```bash
+# Set slower polling (0.5s) with 20 minute timeout
+AIPERF_HTTP_VIDEO_POLL_INTERVAL=0.5 aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --input-file video_prompts.jsonl \
+    --custom-dataset-type single_turn \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:4" \
+    --request-timeout-seconds 1200 \
+    --concurrency 1 \
+    --request-count 3
+```
+
+## Advanced Usage: Extracting Generated Videos
+
+To extract and save the generated videos, use `--export-level raw` to capture the full response payloads.
+
+**Run the benchmark with raw export:**
+```bash
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --input-file video_prompts.jsonl \
+    --custom-dataset-type single_turn \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:4" \
+    --concurrency 1 \
+    --request-count 3 \
+    --export-level raw
+```
+
+**Download the generated videos:**
+
+The response contains a URL to download the video. Copy the following script to `download_videos.py`:
+
+```python
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Download generated videos from AIPerf JSONL output file."""
+import json
+import os
+from pathlib import Path
+import sys
+import urllib.request
+
+# Read input file path
+input_file = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(
+    'artifacts/Wan-AI_Wan2.1-T2V-1.3B-Diffusers-openai-video_generation-concurrency1/profile_export_raw.jsonl'
+)
+output_dir = Path(sys.argv[2]) if len(sys.argv) > 2 else Path('downloaded_videos')
+
+# Create output directory
+os.makedirs(output_dir, exist_ok=True)
+
+# Process each line in the JSONL file
+with open(input_file, 'r') as f:
+    for line_num, line in enumerate(f, 1):
+        record = json.loads(line)
+
+        # Extract video URL from responses (look for the completed status response)
+        for response in record.get('responses', []):
+            response_data = json.loads(response.get('text', '{}'))
+
+            # Check if this is a completed video response with a URL
+            if response_data.get('status') == 'completed' and response_data.get('url'):
+                video_url = response_data['url']
+                video_id = response_data.get('id', f'video_{line_num}')
+
+                # Download the video
+                filename = output_dir / f"{video_id}.mp4"
+                print(f"Downloading: {video_url}")
+
+                try:
+                    urllib.request.urlretrieve(video_url, filename)
+                    print(f"Saved: {filename.resolve()}")
+                except Exception as e:
+                    print(f"Failed to download {video_id}: {e}")
+
+print(f"\nVideos saved to: {output_dir.resolve()}")
+```
+
+**Run the script:**
+```bash
+python download_videos.py
+```
+
+**Output:**
+```
+Downloading: http://localhost:30010/v1/videos/video_abc123/content
+Saved: /path/to/downloaded_videos/video_abc123.mp4
+Downloading: http://localhost:30010/v1/videos/video_def456/content
+Saved: /path/to/downloaded_videos/video_def456.mp4
+Downloading: http://localhost:30010/v1/videos/video_ghi789/content
+Saved: /path/to/downloaded_videos/video_ghi789.mp4
+
+Videos saved to: /path/to/downloaded_videos
+```
+
+## Benchmark Scenarios
+
+### Scenario 1: Throughput Testing
+
+Test maximum throughput with multiple concurrent requests:
+
+```bash
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --extra-inputs "size:720x480" \
+    --extra-inputs "seconds:4" \
+    --synthetic-input-tokens-mean 30 \
+    --concurrency 4 \
+    --request-count 20
+```
+
+### Scenario 2: Latency Testing
+
+Test single-request latency for different video sizes:
+
+```bash
+# Short 4-second video
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:4" \
+    --synthetic-input-tokens-mean 50 \
+    --concurrency 1 \
+    --request-count 5
+
+# Longer 8-second video
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:8" \
+    --synthetic-input-tokens-mean 50 \
+    --concurrency 1 \
+    --request-count 5
+```
+
+### Scenario 3: Quality vs Speed Trade-off
+
+Compare generation quality at different inference step counts:
+
+```bash
+# Fast generation (fewer steps)
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:4" \
+    --extra-inputs "num_inference_steps:20" \
+    --synthetic-input-tokens-mean 50 \
+    --concurrency 1 \
+    --request-count 5
+
+# High quality (more steps)
+aiperf profile \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --tokenizer gpt2 \
+    --url http://localhost:30010 \
+    --endpoint-type video_generation \
+    --extra-inputs "size:1280x720" \
+    --extra-inputs "seconds:4" \
+    --extra-inputs "num_inference_steps:100" \
+    --synthetic-input-tokens-mean 50 \
+    --concurrency 1 \
+    --request-count 5
+```
+
+## Troubleshooting
+
+### Connection Refused
+
+If you see `Connection refused` errors:
+1. Verify the SGLang server is running: `curl http://localhost:30010/health`
+2. Check the port matches your server configuration
+3. If using Docker, ensure port mapping is correct (`-p 30010:30010`)
+
+### Timeout Errors
+
+If requests timeout during generation:
+1. Increase the request timeout: `--request-timeout-seconds 1200`
+2. Check server logs for errors
+3. Reduce video resolution or duration for faster generation
+
+### Out of Memory
+
+If the server crashes with OOM errors:
+1. Use a smaller model (e.g., Wan2.1-T2V-1.3B instead of 14B)
+2. Reduce video resolution: `--extra-inputs "size:720x480"`
+3. Enable CPU offloading: `--text-encoder-cpu-offload`
+4. Reduce concurrency: `--concurrency 1`
+
+### Model Not Found
+
+If you see model loading errors:
+1. Verify your Hugging Face token has access to the model
+2. Check the model path is correct
+3. Ensure sufficient disk space for model download
+
+## Response Fields
+
+The video generation API returns the following fields:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique video job identifier (mapped to `video_id` internally) |
+| `object` | Object type, always `"video"` |
+| `status` | Job status: `queued`, `in_progress`, `completed`, `failed` |
+| `progress` | Completion percentage (0-100) |
+| `url` | Download URL (only when `status=completed`) |
+| `size` | Video resolution (e.g., `"1280x720"`) |
+| `seconds` | Video duration (returned as string) |
+| `quality` | Quality setting for the generated video |
+| `model` | Model used for generation |
+| `created_at` | Unix timestamp of job creation |
+| `completed_at` | Unix timestamp of completion |
+| `expires_at` | Unix timestamp when video assets expire |
+| `inference_time_s` | Total generation time in seconds |
+| `peak_memory_mb` | Peak GPU memory usage in MB |
+| `error` | Error details if `status=failed` |
+
+## Conclusion
+
+You've successfully set up SGLang for video generation, run benchmarks with AIPerf, and learned how to download the generated videos. You can now experiment with different models, prompts, resolutions, and generation parameters to optimize your text-to-video workloads.
+
+Key takeaways:
+- Use `--endpoint-type video_generation`
+- Control video parameters via `--extra-inputs`
+- The transport handles polling automatically
+- Use `--export-level raw` to capture full responses for video extraction
+
+Now go forth and generate!

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -46,6 +46,7 @@ class EndpointDefaults:
     USE_LEGACY_MAX_TOKENS = False
     USE_SERVER_TOKEN_COUNT = False
     CONNECTION_REUSE_STRATEGY = ConnectionReuseStrategy.POOLED
+    DOWNLOAD_VIDEO_CONTENT = False
 
 
 @dataclass(frozen=True)

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -248,3 +248,18 @@ class EndpointConfig(BaseConfig):
             group=_CLI_GROUP,
         ),
     ] = EndpointDefaults.CONNECTION_REUSE_STRATEGY
+
+    download_video_content: Annotated[
+        bool,
+        Field(
+            description=(
+                "For video generation endpoints, download the video content after generation completes. "
+                "When enabled, request latency includes the video download time. "
+                "When disabled (default), only generation time is measured."
+            ),
+        ),
+        CLIParameter(
+            name=("--download-video-content",),
+            group=_CLI_GROUP,
+        ),
+    ] = EndpointDefaults.DOWNLOAD_VIDEO_CONTENT

--- a/src/aiperf/common/enums/__init__.py
+++ b/src/aiperf/common/enums/__init__.py
@@ -40,6 +40,7 @@ from aiperf.common.enums.enums import (
     SSEFieldType,
     SystemState,
     VideoFormat,
+    VideoJobStatus,
     VideoSynthType,
     WorkerStatus,
 )
@@ -92,8 +93,8 @@ __all__ = [
     "FrequencyMetricUnitInfo",
     "GPUTelemetryMode",
     "GenericMetricUnit",
-    "ImageFormat",
     "IPVersion",
+    "ImageFormat",
     "LifecycleState",
     "MediaType",
     "MessageType",
@@ -126,6 +127,7 @@ __all__ = [
     "TemperatureMetricUnit",
     "TemperatureMetricUnitInfo",
     "VideoFormat",
+    "VideoJobStatus",
     "VideoSynthType",
     "WorkerStatus",
 ]

--- a/src/aiperf/common/enums/enums.py
+++ b/src/aiperf/common/enums/enums.py
@@ -415,6 +415,22 @@ class VideoFormat(CaseInsensitiveStrEnum):
     """WebM container. Open format, optimized for web, good for VP9 codec."""
 
 
+class VideoJobStatus(CaseInsensitiveStrEnum):
+    """Status values for async video generation jobs."""
+
+    QUEUED = "queued"
+    """Job is queued and waiting to start."""
+
+    IN_PROGRESS = "in_progress"
+    """Job is currently being processed."""
+
+    COMPLETED = "completed"
+    """Job completed successfully."""
+
+    FAILED = "failed"
+    """Job failed with an error."""
+
+
 class VideoSynthType(CaseInsensitiveStrEnum):
     MOVING_SHAPES = "moving_shapes"
     """Generate videos with animated geometric shapes moving across the frame"""

--- a/src/aiperf/common/enums/metric_enums.py
+++ b/src/aiperf/common/enums/metric_enums.py
@@ -703,6 +703,9 @@ class MetricFlags(Flag):
     SUPPORTS_VIDEO_ONLY = 1 << 13
     """Metrics that are only applicable to video-based endpoints."""
 
+    PRODUCES_VIDEO_ONLY = 1 << 16
+    """Metrics that are only applicable when profiling an endpoint that produces video output."""
+
     USAGE_DIFF_ONLY = 1 << 14
     """Metrics that are only applicable when client side tokenization is enabled and the usage field is used."""
 

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -184,6 +184,11 @@ class _HTTPSettings(BaseSettings):
     Controls low-level socket options, keepalive settings, DNS caching, and connection
     pooling for HTTP clients. These settings optimize performance for high-throughput
     streaming workloads.
+
+    Video Generation Polling:
+        For async video generation APIs that use job polling (e.g., SGLang /v1/videos),
+        the poll interval is controlled by VIDEO_POLL_INTERVAL. The max poll time uses
+        the --request-timeout-seconds CLI argument.
     """
 
     model_config = SettingsConfigDict(
@@ -289,6 +294,14 @@ class _HTTPSettings(BaseSettings):
         description="Trust environment variables for HTTP client configuration. "
         "When enabled, aiohttp will read proxy settings from HTTP_PROXY, HTTPS_PROXY, "
         "and NO_PROXY environment variables.",
+    )
+    VIDEO_POLL_INTERVAL: float = Field(
+        ge=0.001,
+        le=10.0,
+        default=0.1,
+        description="Interval in seconds between status polls for async video generation jobs. "
+        "Lower values provide faster completion detection but increase server load. "
+        "Applies to the aiohttp transport.",
     )
 
 

--- a/src/aiperf/common/models/__init__.py
+++ b/src/aiperf/common/models/__init__.py
@@ -70,6 +70,7 @@ from aiperf.common.models.progress_models import (
 from aiperf.common.models.record_models import (
     BaseInferenceServerResponse,
     BaseResponseData,
+    BinaryResponse,
     EmbeddingResponseData,
     ImageDataItem,
     ImageResponseData,
@@ -93,6 +94,7 @@ from aiperf.common.models.record_models import (
     TextResponse,
     TextResponseData,
     TokenCounts,
+    VideoResponseData,
 )
 from aiperf.common.models.sequence_distribution import (
     DistributionParser,
@@ -169,6 +171,7 @@ __all__ = [
     "BaseServerMetricData",
     "BaseTimeslice",
     "BaseTraceData",
+    "BinaryResponse",
     "CPUTimes",
     "Conversation",
     "ConversationMetadata",
@@ -264,6 +267,7 @@ __all__ = [
     "TurnMetadata",
     "Usage",
     "Video",
+    "VideoResponseData",
     "WorkerProcessingStats",
     "WorkerStats",
     "WorkerTaskStats",

--- a/src/aiperf/common/models/model_endpoint_info.py
+++ b/src/aiperf/common/models/model_endpoint_info.py
@@ -112,6 +112,10 @@ class EndpointInfo(AIPerfBaseModel):
         default=EndpointDefaults.CONNECTION_REUSE_STRATEGY,
         description="Transport connection reuse strategy.",
     )
+    download_video_content: bool = Field(
+        default=EndpointDefaults.DOWNLOAD_VIDEO_CONTENT,
+        description="For video generation endpoints, download the video content after generation completes.",
+    )
 
     @property
     def base_url(self) -> str:
@@ -146,6 +150,7 @@ class EndpointInfo(AIPerfBaseModel):
             use_legacy_max_tokens=user_config.endpoint.use_legacy_max_tokens,
             use_server_token_count=user_config.endpoint.use_server_token_count,
             connection_reuse_strategy=user_config.endpoint.connection_reuse_strategy,
+            download_video_content=user_config.endpoint.download_video_content,
         )
 
 

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -307,6 +307,31 @@ class TextResponse(BaseInferenceServerResponse):
             return None
 
 
+class BinaryResponse(BaseInferenceServerResponse):
+    """Raw binary response from an inference client for non-text content types."""
+
+    content_type: str | None = Field(
+        default=None,
+        description="The content type of the response. e.g. 'video/mp4', 'application/octet-stream'.",
+    )
+    raw_bytes: bytes = Field(
+        ...,
+        description="The raw binary content of the response.",
+    )
+
+    def get_raw(self) -> Any | None:
+        """Get the raw representation of the response."""
+        return self.raw_bytes
+
+    def get_text(self) -> str | None:
+        """Get the text representation of the response."""
+        return None
+
+    def get_json(self) -> JsonObject | None:
+        """Get the JSON representation of the response."""
+        return None
+
+
 class SSEField(AIPerfBaseModel):
     """Base model for a single field in an SSE message."""
 
@@ -715,6 +740,74 @@ class ImageResponseData(BaseResponseData):
     )
 
 
+class VideoResponseData(BaseResponseData):
+    """Parsed video generation response data.
+
+    Matches SGLang/OpenAI VideoResponse schema for async job-based video generation.
+    """
+
+    video_id: str | None = Field(
+        default=None,
+        description="Unique identifier for the video job.",
+    )
+    object: str | None = Field(
+        default=None,
+        description="Object type, always 'video'.",
+    )
+    status: str | None = Field(
+        default=None,
+        description="Job status: queued, in_progress, completed, failed.",
+    )
+    progress: int | None = Field(
+        default=None,
+        description="Completion percentage (0-100).",
+    )
+    url: str | None = Field(
+        default=None,
+        description="URL to download completed video (only when status=completed).",
+    )
+    size: str | None = Field(
+        default=None,
+        description="Video resolution (e.g., '1280x720').",
+    )
+    seconds: str | None = Field(
+        default=None,
+        description="Video duration in seconds.",
+    )
+    quality: str | None = Field(
+        default=None,
+        description="Quality setting for the generated video.",
+    )
+    model: str | None = Field(
+        default=None,
+        description="Model used for generation.",
+    )
+    created_at: int | None = Field(
+        default=None,
+        description="Unix timestamp of job creation.",
+    )
+    completed_at: int | None = Field(
+        default=None,
+        description="Unix timestamp of job completion.",
+    )
+    expires_at: int | None = Field(
+        default=None,
+        description="Unix timestamp when video assets expire.",
+    )
+    inference_time_s: float | None = Field(
+        default=None,
+        description="Generation time in seconds (SGLang metric).",
+    )
+    peak_memory_mb: float | None = Field(
+        default=None,
+        description="Peak memory usage in MB (SGLang metric).",
+    )
+    error: dict[str, Any] | None = Field(
+        default=None,
+        description="Error details if job failed.",
+    )
+
+
 class ParsedResponse(AIPerfBaseModel):
     """Parsed response from a inference client."""
 
@@ -727,6 +820,7 @@ class ParsedResponse(AIPerfBaseModel):
         | EmbeddingResponseData
         | RankingsResponseData
         | ImageResponseData
+        | VideoResponseData
         | BaseResponseData
         | None
     ] = Field(

--- a/src/aiperf/endpoints/openai_video_generation.py
+++ b/src/aiperf/endpoints/openai_video_generation.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
+from aiperf.common.models import (
+    InferenceServerResponse,
+    ParsedResponse,
+    RequestInfo,
+    VideoResponseData,
+)
+from aiperf.endpoints.base_endpoint import BaseEndpoint
+
+
+class VideoGenerationEndpoint(BaseEndpoint):
+    """OpenAI/SGLang Video Generation endpoint.
+
+    Supports text-to-video generation with async job polling.
+    Compatible with SGLang's /v1/videos endpoint and OpenAI's video API.
+
+    The video generation API follows an async job pattern:
+    1. POST /v1/videos - Submit job, get job ID with status "queued"
+    2. GET /v1/videos/{id} - Poll until status is "completed" or "failed"
+    3. GET /v1/videos/{id}/content - Download the generated video
+
+    See: https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/openai_api.md
+    See: https://platform.openai.com/docs/api-reference/videos
+    """
+
+    def format_payload(self, request_info: RequestInfo) -> dict[str, Any]:
+        """Format OpenAI/SGLang Video Generation request payload from RequestInfo.
+
+        Supports all common video generation API parameters:
+        - prompt (required): Text description from turn.texts[0]
+        - model (optional): From turn.model or model_endpoint.primary_model_name
+
+        Additional parameters via --extra-inputs:
+        - size: Video resolution (e.g., "1280x720", "720x1280")
+        - seconds: Video duration (e.g., 4, 8, 12)
+        - seed: Random seed for reproducibility
+        - num_inference_steps: Diffusion denoising steps
+        - guidance_scale: Classifier-free guidance scale
+        - negative_prompt: Concepts to exclude
+        - fps: Frames per second
+        - num_frames: Total frames to generate
+
+        Args:
+            request_info: Request context including model endpoint, metadata, and turns
+
+        Returns:
+            Video generation API payload with all specified parameters
+        """
+        if not request_info.turns:
+            raise ValueError("Video generation endpoint requires at least one turn.")
+
+        turn = request_info.turns[0]
+        model_endpoint = request_info.model_endpoint
+
+        if not turn.texts or not turn.texts[0].contents:
+            raise ValueError(
+                "Video generation endpoint requires text prompt in first turn."
+            )
+
+        prompt = turn.texts[0].contents[0]
+
+        payload = {
+            "prompt": prompt,
+            "model": turn.model or model_endpoint.primary_model_name,
+        }
+
+        if model_endpoint.endpoint.extra:
+            payload.update(model_endpoint.endpoint.extra)
+
+        self.trace(lambda: f"Formatted payload: {payload}")
+        return payload
+
+    def parse_response(
+        self, response: InferenceServerResponse
+    ) -> ParsedResponse | None:
+        """Parse OpenAI/SGLang Video Generation response.
+
+        Handles the VideoResponse format returned by both initial job submission
+        and status polling requests. The response contains job metadata including
+        status, progress, and video URL when completed.
+
+        Args:
+            response: Raw response from inference server
+
+        Returns:
+            Parsed response with extracted video job data
+        """
+        json_obj = response.get_json()
+        if not json_obj:
+            self.debug(
+                lambda: f"No JSON object found in response: {response.get_raw()}"
+            )
+            return None
+
+        # Parse SGLang/OpenAI VideoResponse format
+        video_data = VideoResponseData(
+            video_id=json_obj.get("id"),
+            object=json_obj.get("object"),
+            status=json_obj.get("status"),
+            progress=json_obj.get("progress"),
+            url=json_obj.get("url"),
+            size=json_obj.get("size"),
+            seconds=json_obj.get("seconds"),
+            quality=json_obj.get("quality"),
+            model=json_obj.get("model"),
+            created_at=json_obj.get("created_at"),
+            completed_at=json_obj.get("completed_at"),
+            expires_at=json_obj.get("expires_at"),
+            inference_time_s=json_obj.get("inference_time_s"),
+            peak_memory_mb=json_obj.get("peak_memory_mb"),
+            error=json_obj.get("error"),
+        )
+
+        usage = json_obj.get("usage") or None
+
+        return ParsedResponse(perf_ns=response.perf_ns, data=video_data, usage=usage)

--- a/src/aiperf/metrics/types/video_generation_metrics.py
+++ b/src/aiperf/metrics/types/video_generation_metrics.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from aiperf.common.enums import MetricFlags, MetricSizeUnit, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import ParsedResponseRecord
+from aiperf.common.models.record_models import VideoResponseData
+from aiperf.metrics import BaseRecordMetric
+from aiperf.metrics.metric_dicts import MetricRecordDict
+
+
+class VideoInferenceTimeMetric(BaseRecordMetric[float]):
+    """Server-reported video inference time from SGLang.
+
+    Extracts the `inference_time_s` field from the video generation response,
+    which represents the actual GPU generation time reported by the server.
+    """
+
+    tag = "video_inference_time"
+    header = "Video Inference Time"
+    short_header = "Inference Time"
+    unit = MetricTimeUnit.SECONDS
+    display_unit = MetricTimeUnit.MILLISECONDS
+    display_order = 310  # After request_latency (300)
+    flags = MetricFlags.PRODUCES_VIDEO_ONLY
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> float:
+        """Extract inference_time_s from VideoResponseData."""
+        for response in record.responses:
+            if (
+                isinstance(response.data, VideoResponseData)
+                and response.data.inference_time_s is not None
+            ):
+                return response.data.inference_time_s
+
+        raise NoMetricValue("Video inference time not available in response.")
+
+
+class VideoPeakMemoryMetric(BaseRecordMetric[float]):
+    """Server-reported peak GPU memory usage from SGLang.
+
+    Extracts the `peak_memory_mb` field from the video generation response,
+    which represents the peak GPU memory used during generation.
+    """
+
+    tag = "video_peak_memory"
+    header = "Video Peak Memory"
+    short_header = "Peak Memory"
+    unit = MetricSizeUnit.MEGABYTES
+    display_order = 311  # After video_inference_time (310)
+    flags = MetricFlags.PRODUCES_VIDEO_ONLY
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> float:
+        """Extract peak_memory_mb from VideoResponseData."""
+        for response in record.responses:
+            if (
+                isinstance(response.data, VideoResponseData)
+                and response.data.peak_memory_mb is not None
+            ):
+                return response.data.peak_memory_mb
+
+        raise NoMetricValue("Video peak memory not available in response.")

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -233,6 +233,21 @@ endpoint:
       tokenizes_input: true
       metrics_title: Image Generation Metrics
 
+  video_generation:
+    class: aiperf.endpoints.openai_video_generation:VideoGenerationEndpoint
+    description: |
+      OpenAI/SGLang Video Generation endpoint for text-to-video models.
+      Supports async generation with polling. Compatible with Sora, Wan2.1,
+      HunyuanVideo via SGLang. Use --endpoint-type video_generation.
+    metadata:
+      endpoint_path: /v1/videos
+      supports_streaming: false
+      produces_tokens: false
+      produces_videos: true
+      tokenizes_input: true
+      requires_polling: true
+      metrics_title: Video Generation Metrics
+
   nim_embeddings:
     class: aiperf.endpoints.nim_embeddings:NIMEmbeddingsEndpoint
     description: |

--- a/src/aiperf/plugin/schema/plugins.schema.json
+++ b/src/aiperf/plugin/schema/plugins.schema.json
@@ -634,6 +634,12 @@
               "description": "Whether endpoint produces video-based outputs.",
               "title": "Produces Videos",
               "type": "boolean"
+            },
+            "requires_polling": {
+              "default": false,
+              "description": "Whether endpoint uses async job polling (submit job, poll for status, retrieve result).",
+              "title": "Requires Polling",
+              "type": "boolean"
             }
           },
           "required": [

--- a/src/aiperf/plugin/schema/schemas.py
+++ b/src/aiperf/plugin/schema/schemas.py
@@ -274,6 +274,10 @@ class EndpointMetadata(BaseModel):
     produces_videos: bool = Field(
         default=False, description="Whether endpoint produces video-based outputs."
     )
+    requires_polling: bool = Field(
+        default=False,
+        description="Whether endpoint uses async job polling (submit job, poll for status, retrieve result).",
+    )
 
 
 class TransportMetadata(BaseModel):

--- a/src/aiperf/post_processors/base_metrics_processor.py
+++ b/src/aiperf/post_processors/base_metrics_processor.py
@@ -40,6 +40,8 @@ class BaseMetricsProcessor(AIPerfLifecycleMixin, ABC):
             disallowed_flags |= MetricFlags.SUPPORTS_AUDIO_ONLY
         if not endpoint_metadata.supports_images:
             disallowed_flags |= MetricFlags.SUPPORTS_IMAGE_ONLY
+        if not endpoint_metadata.produces_videos:
+            disallowed_flags |= MetricFlags.PRODUCES_VIDEO_ONLY
         if not self.user_config.endpoint.streaming:
             disallowed_flags |= MetricFlags.STREAMING_ONLY
         if self.user_config.endpoint.use_server_token_count:

--- a/src/aiperf/transports/aiohttp_transport.py
+++ b/src/aiperf/transports/aiohttp_transport.py
@@ -11,11 +11,17 @@ from typing import Any
 import aiohttp
 import orjson
 
-from aiperf.common.enums import ConnectionReuseStrategy
+from aiperf.common.enums import ConnectionReuseStrategy, VideoJobStatus
 from aiperf.common.exceptions import NotInitializedError
 from aiperf.common.hooks import on_init, on_stop
 from aiperf.common.mixins import AIPerfLoggerMixin
-from aiperf.common.models import ErrorDetails, RequestInfo, RequestRecord
+from aiperf.common.models import (
+    BinaryResponse,
+    ErrorDetails,
+    RequestInfo,
+    RequestRecord,
+    TextResponse,
+)
 from aiperf.plugin.enums import TransportType
 from aiperf.transports.aiohttp_client import AioHttpClient, create_tcp_connector
 from aiperf.transports.base_transports import (
@@ -240,6 +246,12 @@ class AioHttpTransport(BaseTransport):
         # Capture lease_manager reference to avoid race with concurrent shutdown
         lease_manager = self.lease_manager
 
+        # Route video_generation to polling-based implementation
+        from aiperf.plugin.enums import EndpointType
+
+        if request_info.model_endpoint.endpoint.type == EndpointType.VIDEO_GENERATION:
+            return await self._send_video_request_with_polling(request_info, payload)
+
         try:
             url = self.build_url(request_info)
             headers = self.build_headers(request_info)
@@ -330,3 +342,240 @@ class AioHttpTransport(BaseTransport):
                 await lease_manager.release_lease(request_info.x_correlation_id)
 
         return record
+
+    def _parse_video_response(
+        self,
+        record: RequestRecord,
+        context: str,
+    ) -> tuple[dict[str, Any], TextResponse] | ErrorDetails:
+        """Parse JSON response from a video API request record.
+
+        Args:
+            record: The request record to parse
+            context: Description for error messages (e.g., "submit", "poll")
+
+        Returns:
+            Tuple of (parsed_json, text_response) on success, or ErrorDetails on failure
+        """
+        if record.error:
+            return record.error
+        if not record.responses:
+            return ErrorDetails(
+                type="VideoGenerationError",
+                message=f"No response from video {context}",
+                code=500,
+            )
+        response = record.responses[0]
+        if not isinstance(response, TextResponse):
+            return ErrorDetails(
+                type="VideoGenerationError",
+                message=f"Unexpected response type from video {context}",
+                code=500,
+            )
+        return orjson.loads(response.text), response
+
+    async def _submit_video_job(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        headers: dict[str, str],
+    ) -> tuple[str, TextResponse] | ErrorDetails:
+        """Submit video generation job via POST /v1/videos.
+
+        Returns (job_id, response) on success, ErrorDetails on failure.
+        """
+        if self.aiohttp_client is None:
+            raise NotInitializedError("AioHttpClient not initialized")
+        record = await self.aiohttp_client.post_request(
+            url, orjson.dumps(payload).decode("utf-8"), headers
+        )
+        result = self._parse_video_response(record, "submit")
+        if isinstance(result, ErrorDetails):
+            return result
+
+        job_data, response = result
+        job_id = job_data.get("id")
+        if not job_id:
+            return ErrorDetails(
+                type="VideoGenerationError",
+                message=f"No job ID returned: {job_data}",
+                code=500,
+            )
+        latency_ms = (record.end_perf_ns - record.start_perf_ns) / 1e6
+        self.info(f"Video job {job_id} submitted ({latency_ms:.0f}ms)")
+        return job_id, response
+
+    async def _poll_video_job(
+        self,
+        job_id: str,
+        poll_url: str,
+        headers: dict[str, str],
+        timeout: float,
+        poll_interval: float,
+    ) -> tuple[dict[str, Any], float] | ErrorDetails:
+        """Poll video job until completed/failed. Returns (data, elapsed) or error."""
+        if self.aiohttp_client is None:
+            raise NotInitializedError("AioHttpClient not initialized")
+        self.info(f"Polling video job {job_id}")
+        poll_start = time.perf_counter_ns()
+
+        while (time.perf_counter_ns() - poll_start) / 1e9 < timeout:
+            record = await self.aiohttp_client.get_request(poll_url, headers)
+            result = self._parse_video_response(record, "poll")
+            if isinstance(result, ErrorDetails):
+                return result
+
+            data, _ = result
+            status = data.get("status", "")
+
+            if status == VideoJobStatus.COMPLETED:
+                elapsed = (time.perf_counter_ns() - poll_start) / 1e9
+                self.info(f"Video job {job_id} completed in {elapsed:.1f}s")
+                return data, elapsed
+
+            if status == VideoJobStatus.FAILED:
+                error_info = data.get("error", {})
+                msg = (
+                    error_info.get("message", "Unknown error")
+                    if isinstance(error_info, dict)
+                    else str(error_info)
+                )
+                self.error(f"Video job {job_id} failed: {msg}")
+                return ErrorDetails(
+                    type="VideoGenerationError",
+                    message=f"Video generation failed: {msg}",
+                    code=500,
+                )
+
+            await asyncio.sleep(poll_interval)
+
+        self.error(f"Video job {job_id} timed out after {timeout}s")
+        return ErrorDetails(
+            type="TimeoutError",
+            message=f"Video generation timed out after {timeout}s",
+            code=504,
+        )
+
+    async def _download_video_content(
+        self,
+        job_id: str,
+        content_url: str,
+        headers: dict[str, str],
+    ) -> bytes | ErrorDetails:
+        """Download video content via GET /v1/videos/{id}/content.
+
+        Returns video bytes on success, ErrorDetails on failure.
+        Not used in benchmark flow - provided for optional future use.
+        """
+        if self.aiohttp_client is None:
+            raise NotInitializedError("AioHttpClient not initialized")
+        try:
+            record = await self.aiohttp_client.get_request(content_url, headers)
+            if record.error:
+                return ErrorDetails(
+                    type="VideoDownloadError",
+                    message=f"Failed to download video {job_id}: {record.error}",
+                    code=record.status or 500,
+                )
+            if record.responses and isinstance(record.responses[0], BinaryResponse):
+                self.info(
+                    f"Video {job_id} downloaded ({len(record.responses[0].raw_bytes)} bytes)"
+                )
+                return record.responses[0].raw_bytes
+            return ErrorDetails(
+                type="VideoDownloadError",
+                message=f"No content returned for video {job_id}",
+                code=500,
+            )
+        except Exception as e:
+            return ErrorDetails(
+                type="VideoDownloadError",
+                message=f"Failed to download video {job_id}: {e!r}",
+                code=500,
+            )
+
+    async def _send_video_request_with_polling(
+        self,
+        request_info: RequestInfo,
+        payload: dict[str, Any],
+    ) -> RequestRecord:
+        """Send video generation request and poll until complete."""
+        from aiperf.common.environment import Environment
+
+        if self.aiohttp_client is None:
+            raise NotInitializedError("AioHttpClient not initialized")
+
+        start_ns = time.perf_counter_ns()
+        headers = self.build_headers(request_info)
+        responses: list[TextResponse] = []
+
+        def make_record(
+            error: ErrorDetails | None = None, status: int | None = None
+        ) -> RequestRecord:
+            return RequestRecord(
+                request_headers=headers,
+                start_perf_ns=start_ns,
+                end_perf_ns=time.perf_counter_ns(),
+                responses=responses,
+                error=error,
+                status=status,
+            )
+
+        base_url = request_info.model_endpoint.endpoint.get_url(
+            request_info.url_index
+        ).rstrip("/")
+        if not base_url.startswith("http"):
+            base_url = f"http://{base_url}"
+
+        # Check if video download is enabled via --download-video-content
+        download_content = request_info.model_endpoint.endpoint.download_video_content
+
+        try:
+            # Submit job
+            result = await self._submit_video_job(
+                f"{base_url}/v1/videos", payload, headers
+            )
+            if isinstance(result, ErrorDetails):
+                return make_record(error=result)
+            job_id, submit_response = result
+            responses.append(submit_response)
+
+            # Poll for completion
+            poll_result = await self._poll_video_job(
+                job_id,
+                f"{base_url}/v1/videos/{job_id}",
+                headers,
+                timeout=request_info.model_endpoint.endpoint.timeout,
+                poll_interval=Environment.HTTP.VIDEO_POLL_INTERVAL,
+            )
+            if isinstance(poll_result, ErrorDetails):
+                return make_record(error=poll_result)
+
+            data, _ = poll_result
+            responses.append(
+                TextResponse(
+                    perf_ns=time.perf_counter_ns(),
+                    content_type="application/json",
+                    text=orjson.dumps(data).decode(),
+                )
+            )
+
+            # Optional: download video content if requested
+            if download_content:
+                content_url = (
+                    data.get("url") or f"{base_url}/v1/videos/{job_id}/content"
+                )
+                download_result = await self._download_video_content(
+                    job_id, content_url, headers
+                )
+                if isinstance(download_result, ErrorDetails):
+                    return make_record(error=download_result)
+                # Video bytes downloaded successfully (not added to responses - too large)
+
+            return make_record(status=200)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.exception(f"Video generation failed: {e!r}")
+            return make_record(error=ErrorDetails.from_exception(e))

--- a/tests/unit/endpoints/test_video_generation_endpoint.py
+++ b/tests/unit/endpoints/test_video_generation_endpoint.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for VideoGenerationEndpoint."""
+
+import pytest
+
+from aiperf.common.models import Text, Turn
+from aiperf.endpoints.openai_video_generation import VideoGenerationEndpoint
+from aiperf.plugin.enums import EndpointType
+from tests.unit.endpoints.conftest import (
+    create_endpoint_with_mock_transport,
+    create_mock_response,
+    create_model_endpoint,
+    create_request_info,
+)
+
+
+class TestVideoGenerationEndpoint:
+    """Tests for VideoGenerationEndpoint."""
+
+    @pytest.fixture
+    def model_endpoint(self):
+        """Create a test ModelEndpointInfo for video generation."""
+        return create_model_endpoint(EndpointType.VIDEO_GENERATION, model_name="sora-2")
+
+    @pytest.fixture
+    def endpoint(self, model_endpoint):
+        """Create a VideoGenerationEndpoint instance."""
+        return create_endpoint_with_mock_transport(
+            VideoGenerationEndpoint, model_endpoint
+        )
+
+    # ===== format_payload tests =====
+
+    def test_format_payload_simple_prompt(self, endpoint, model_endpoint):
+        """Test simple prompt formatting."""
+        turn = Turn(
+            texts=[Text(contents=["A cat playing piano"])],
+            model="sora-2",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["prompt"] == "A cat playing piano"
+        assert payload["model"] == "sora-2"
+
+    def test_format_payload_with_extra_inputs(self):
+        """Test payload formatting with extra inputs."""
+        model_endpoint_with_extra = create_model_endpoint(
+            EndpointType.VIDEO_GENERATION,
+            model_name="sora-2",
+            extra=[
+                ("size", "1280x720"),
+                ("seconds", 8),
+                ("seed", 42),
+            ],
+        )
+        endpoint = create_endpoint_with_mock_transport(
+            VideoGenerationEndpoint, model_endpoint_with_extra
+        )
+
+        turn = Turn(
+            texts=[Text(contents=["A dog running"])],
+            model="sora-2",
+        )
+        request_info = create_request_info(
+            model_endpoint=model_endpoint_with_extra, turns=[turn]
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["size"] == "1280x720"
+        assert payload["seconds"] == 8
+        assert payload["seed"] == 42
+
+    def test_format_payload_model_from_turn(self, endpoint, model_endpoint):
+        """Test that turn model overrides endpoint model."""
+        turn = Turn(
+            texts=[Text(contents=["A tree"])],
+            model="custom-model",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["model"] == "custom-model"
+
+    def test_format_payload_no_turns_raises(self, endpoint, model_endpoint):
+        """Test that missing turns raises ValueError."""
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
+
+        with pytest.raises(ValueError, match="requires at least one turn"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_no_text_raises(self, endpoint, model_endpoint):
+        """Test that missing text raises ValueError."""
+        turn = Turn(texts=[], model="sora-2")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        with pytest.raises(ValueError, match="requires text prompt"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_empty_text_contents_raises(self, endpoint, model_endpoint):
+        """Test that empty text contents raises ValueError."""
+        turn = Turn(texts=[Text(contents=[])], model="sora-2")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        with pytest.raises(ValueError, match="requires text prompt"):
+            endpoint.format_payload(request_info)
+
+    # ===== parse_response tests =====
+
+    def test_parse_response_queued_status(self, endpoint):
+        """Test parsing initial queued job response."""
+        json_data = {
+            "id": "video_123",
+            "object": "video",
+            "model": "sora-2",
+            "status": "queued",
+            "progress": 0,
+            "created_at": 1712697600,
+            "size": "1280x720",
+            "seconds": "8",
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.data.video_id == "video_123"
+        assert parsed.data.status == "queued"
+        assert parsed.data.progress == 0
+        assert parsed.data.size == "1280x720"
+        assert parsed.data.seconds == "8"
+        assert parsed.data.url is None
+
+    def test_parse_response_in_progress_status(self, endpoint):
+        """Test parsing in-progress job response."""
+        json_data = {
+            "id": "video_123",
+            "object": "video",
+            "model": "sora-2",
+            "status": "in_progress",
+            "progress": 45,
+            "created_at": 1712697600,
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.data.status == "in_progress"
+        assert parsed.data.progress == 45
+
+    def test_parse_response_completed_status(self, endpoint):
+        """Test parsing completed job response."""
+        json_data = {
+            "id": "video_123",
+            "object": "video",
+            "model": "sora-2",
+            "status": "completed",
+            "progress": 100,
+            "created_at": 1712697600,
+            "completed_at": 1712697660,
+            "size": "1280x720",
+            "seconds": "8",
+            "url": "http://localhost:30010/v1/videos/video_123/content",
+            "inference_time_s": 45.2,
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.data.video_id == "video_123"
+        assert parsed.data.status == "completed"
+        assert parsed.data.progress == 100
+        assert parsed.data.url == "http://localhost:30010/v1/videos/video_123/content"
+        assert parsed.data.completed_at == 1712697660
+        assert parsed.data.inference_time_s == 45.2
+
+    def test_parse_response_failed_status(self, endpoint):
+        """Test parsing failed job response."""
+        json_data = {
+            "id": "video_123",
+            "object": "video",
+            "model": "sora-2",
+            "status": "failed",
+            "progress": 30,
+            "created_at": 1712697600,
+            "error": {
+                "code": "generation_failed",
+                "message": "Failed to generate video due to content policy",
+            },
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.data.status == "failed"
+        assert parsed.data.error is not None
+        assert parsed.data.error["code"] == "generation_failed"
+
+    def test_parse_response_with_usage(self, endpoint):
+        """Test parsing response with usage information."""
+        json_data = {
+            "id": "video_123",
+            "status": "completed",
+            "url": "http://localhost/video.mp4",
+            "usage": {
+                "prompt_tokens": 50,
+                "total_tokens": 50,
+            },
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.usage is not None
+        assert parsed.usage.prompt_tokens == 50
+
+    def test_parse_response_perf_ns(self, endpoint):
+        """Test that perf_ns is preserved."""
+        json_data = {"id": "video_123", "status": "queued"}
+        mock_response = create_mock_response(perf_ns=999888777, json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.perf_ns == 999888777
+
+    def test_parse_response_no_json(self, endpoint):
+        """Test parsing when get_json returns None."""
+        mock_response = create_mock_response(json_data=None)
+        mock_response.get_raw.return_value = ""
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is None
+
+    def test_parse_response_extra_fields_ignored(self, endpoint):
+        """Test that extra fields in response are ignored."""
+        json_data = {
+            "id": "video_123",
+            "status": "completed",
+            "url": "http://localhost/video.mp4",
+            "extra_field": "ignored",
+            "peak_memory_mb": 24576.0,
+        }
+        mock_response = create_mock_response(json_data=json_data)
+
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.data.video_id == "video_123"
+        assert parsed.data.url == "http://localhost/video.mp4"

--- a/tests/unit/metrics/test_video_generation_metrics.py
+++ b/tests/unit/metrics/test_video_generation_metrics.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.enums import MetricFlags, MetricSizeUnit, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import ParsedResponse, ParsedResponseRecord
+from aiperf.common.models.record_models import TextResponseData, VideoResponseData
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.video_generation_metrics import (
+    VideoInferenceTimeMetric,
+    VideoPeakMemoryMetric,
+)
+from tests.unit.metrics.conftest import create_record
+
+
+def create_video_record(
+    start_ns: int = 100,
+    response_ns: int = 150,
+    inference_time_s: float | None = 5.5,
+    peak_memory_mb: float | None = 8192.0,
+) -> ParsedResponseRecord:
+    """Create a test record with VideoResponseData."""
+    record = create_record(start_ns=start_ns, responses=[response_ns])
+
+    # Replace the response data with VideoResponseData
+    record.responses = [
+        ParsedResponse(
+            perf_ns=response_ns,
+            data=VideoResponseData(
+                video_id="test-video-id",
+                status="completed",
+                inference_time_s=inference_time_s,
+                peak_memory_mb=peak_memory_mb,
+            ),
+        )
+    ]
+
+    return record
+
+
+class TestVideoInferenceTimeMetric:
+    def test_metric_attributes(self):
+        """Test that metric has correct attributes."""
+        assert VideoInferenceTimeMetric.tag == "video_inference_time"
+        assert VideoInferenceTimeMetric.header == "Video Inference Time"
+        assert VideoInferenceTimeMetric.unit == MetricTimeUnit.SECONDS
+        assert VideoInferenceTimeMetric.display_unit == MetricTimeUnit.MILLISECONDS
+        assert VideoInferenceTimeMetric.has_flags(MetricFlags.PRODUCES_VIDEO_ONLY)
+
+    @pytest.mark.parametrize(
+        "inference_time_s,expected",
+        [
+            (5.5, 5.5),
+            (0.0, 0.0),
+            (123.456, 123.456),
+            (0.001, 0.001),
+        ],
+        ids=["normal", "zero", "large", "small"],
+    )
+    def test_extracts_inference_time(self, inference_time_s, expected):
+        """Test that metric extracts inference_time_s correctly."""
+        record = create_video_record(inference_time_s=inference_time_s)
+        metric = VideoInferenceTimeMetric()
+        result = metric.parse_record(record, MetricRecordDict())
+        assert result == expected
+
+    def test_raises_when_inference_time_missing(self):
+        """Test that NoMetricValue is raised when inference_time_s is None."""
+        record = create_video_record(inference_time_s=None)
+        metric = VideoInferenceTimeMetric()
+
+        with pytest.raises(NoMetricValue, match="not available"):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_raises_when_no_video_response_data(self):
+        """Test that NoMetricValue is raised when response is not VideoResponseData."""
+        record = create_record(start_ns=100, responses=[150])
+        # Default create_record uses TextResponseData
+        metric = VideoInferenceTimeMetric()
+
+        with pytest.raises(NoMetricValue, match="not available"):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_finds_video_data_in_multiple_responses(self):
+        """Test that metric finds VideoResponseData among multiple responses."""
+        record = create_record(start_ns=100, responses=[150])
+
+        # Add multiple responses, with VideoResponseData in the middle
+        record.responses = [
+            ParsedResponse(
+                perf_ns=120,
+                data=TextResponseData(text="queued"),
+            ),
+            ParsedResponse(
+                perf_ns=140,
+                data=VideoResponseData(
+                    video_id="test-id",
+                    status="in_progress",
+                    inference_time_s=None,
+                ),
+            ),
+            ParsedResponse(
+                perf_ns=150,
+                data=VideoResponseData(
+                    video_id="test-id",
+                    status="completed",
+                    inference_time_s=42.5,
+                ),
+            ),
+        ]
+
+        metric = VideoInferenceTimeMetric()
+        result = metric.parse_record(record, MetricRecordDict())
+        assert result == 42.5
+
+    def test_uses_first_valid_inference_time(self):
+        """Test that metric uses first VideoResponseData with valid inference_time_s."""
+        record = create_record(start_ns=100, responses=[150])
+
+        record.responses = [
+            ParsedResponse(
+                perf_ns=120,
+                data=VideoResponseData(
+                    video_id="test-id",
+                    status="completed",
+                    inference_time_s=10.0,
+                ),
+            ),
+            ParsedResponse(
+                perf_ns=150,
+                data=VideoResponseData(
+                    video_id="test-id",
+                    status="completed",
+                    inference_time_s=20.0,
+                ),
+            ),
+        ]
+
+        metric = VideoInferenceTimeMetric()
+        result = metric.parse_record(record, MetricRecordDict())
+        # Should return first valid one
+        assert result == 10.0
+
+
+class TestVideoPeakMemoryMetric:
+    def test_metric_attributes(self):
+        """Test that metric has correct attributes."""
+        assert VideoPeakMemoryMetric.tag == "video_peak_memory"
+        assert VideoPeakMemoryMetric.header == "Video Peak Memory"
+        assert VideoPeakMemoryMetric.unit == MetricSizeUnit.MEGABYTES
+        assert VideoPeakMemoryMetric.has_flags(MetricFlags.PRODUCES_VIDEO_ONLY)
+
+    @pytest.mark.parametrize(
+        "peak_memory_mb,expected",
+        [
+            (8192.0, 8192.0),
+            (0.0, 0.0),
+            (16384.5, 16384.5),
+            (1024.0, 1024.0),
+        ],
+        ids=["normal", "zero", "large", "small"],
+    )
+    def test_extracts_peak_memory(self, peak_memory_mb, expected):
+        """Test that metric extracts peak_memory_mb correctly."""
+        record = create_video_record(peak_memory_mb=peak_memory_mb)
+        metric = VideoPeakMemoryMetric()
+        result = metric.parse_record(record, MetricRecordDict())
+        assert result == expected
+
+    def test_raises_when_peak_memory_missing(self):
+        """Test that NoMetricValue is raised when peak_memory_mb is None."""
+        record = create_video_record(peak_memory_mb=None)
+        metric = VideoPeakMemoryMetric()
+
+        with pytest.raises(NoMetricValue, match="not available"):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_raises_when_no_video_response_data(self):
+        """Test that NoMetricValue is raised when response is not VideoResponseData."""
+        record = create_record(start_ns=100, responses=[150])
+        metric = VideoPeakMemoryMetric()
+
+        with pytest.raises(NoMetricValue, match="not available"):
+            metric.parse_record(record, MetricRecordDict())

--- a/tests/unit/post_processors/test_base_metrics_processor.py
+++ b/tests/unit/post_processors/test_base_metrics_processor.py
@@ -107,6 +107,7 @@ class TestBaseMetricsProcessor:
         expected_disallowed = (
             MetricFlags.SUPPORTS_AUDIO_ONLY
             | MetricFlags.SUPPORTS_IMAGE_ONLY
+            | MetricFlags.PRODUCES_VIDEO_ONLY
             | MetricFlags.STREAMING_ONLY
             | MetricFlags.GOODPUT
             | MetricFlags.EXPERIMENTAL
@@ -134,6 +135,7 @@ class TestBaseMetricsProcessor:
                 MetricFlags.ERROR_ONLY,
                 MetricFlags.SUPPORTS_AUDIO_ONLY
                 | MetricFlags.SUPPORTS_IMAGE_ONLY
+                | MetricFlags.PRODUCES_VIDEO_ONLY
                 | MetricFlags.STREAMING_ONLY
                 | MetricFlags.GOODPUT,
             ),
@@ -144,6 +146,7 @@ class TestBaseMetricsProcessor:
                 MetricFlags.NONE,
                 MetricFlags.SUPPORTS_AUDIO_ONLY
                 | MetricFlags.SUPPORTS_IMAGE_ONLY
+                | MetricFlags.PRODUCES_VIDEO_ONLY
                 | MetricFlags.STREAMING_ONLY
                 | MetricFlags.ERROR_ONLY
                 | MetricFlags.GOODPUT,
@@ -155,6 +158,7 @@ class TestBaseMetricsProcessor:
                 MetricFlags.ERROR_ONLY,
                 MetricFlags.SUPPORTS_AUDIO_ONLY
                 | MetricFlags.SUPPORTS_IMAGE_ONLY
+                | MetricFlags.PRODUCES_VIDEO_ONLY
                 | MetricFlags.STREAMING_ONLY
                 | MetricFlags.GOODPUT,
             ),
@@ -228,6 +232,7 @@ class TestBaseMetricsProcessor:
             MetricFlags.NONE,
             MetricFlags.SUPPORTS_AUDIO_ONLY
             | MetricFlags.SUPPORTS_IMAGE_ONLY
+            | MetricFlags.PRODUCES_VIDEO_ONLY
             | MetricFlags.STREAMING_ONLY
             | MetricFlags.GOODPUT
             | MetricFlags.EXPERIMENTAL


### PR DESCRIPTION
> [!IMPORTANT]
> This is a rough vibe-coded implementation as a starter pack, but needs a lot of refinements before it would be ready to be merged in officially.
> Feel free to fork and fix/clean-up and submit a new PR for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for video generation endpoints with text-to-video models
  * New `--download-video-content` flag to include video download time in latency measurements
  * New environment variable for configuring async video job polling intervals
  * Video generation metrics: inference time and peak memory tracking

* **Documentation**
  * Added comprehensive video generation workflow guide with setup, configuration, and troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Raw output example:
```json
{
  "metadata": {
    "session_num": 0,
    "x_request_id": "99787ce3-f8b4-4960-964a-5d5283ed694e",
    "x_correlation_id": "d3a04dd9-ad56-420b-8ae3-6d08bff11685",
    "conversation_id": "d7bbde89-22cc-4e8e-852d-3ce3fcce007f",
    "turn_index": 0,
    "credit_issued_ns": 1770191404046365000,
    "request_start_ns": 1770191924725381400,
    "request_end_ns": 1770192445403751400,
    "worker_id": "worker_b4300085",
    "record_processor_id": "record_processor_839a0898",
    "benchmark_phase": "profiling",
    "was_cancelled": false
  },
  "start_perf_ns": 2516175161577,
  "payload": {
    "prompt": "A serene lake at sunset with mountains in the background",
    "model": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
    "size": "1280x720",
    "seconds": 4
  },
  "request_headers": {
    "User-Agent": "aiperf/0.5.0",
    "X-Request-ID": "99787ce3-f8b4-4960-964a-5d5283ed694e",
    "X-Correlation-ID": "d3a04dd9-ad56-420b-8ae3-6d08bff11685",
    "Content-Type": "application/json",
    "Accept": "application/json"
  },
  "status": 200,
  "responses": [
    {
      "perf_ns": 2516299355425,
      "content_type": "application/json",
      "text": "{\"id\":\"d2ce90a0-095f-4307-8eae-a633ee49022a\",\"object\":\"video\",\"model\":\"Wan-AI/Wan2.1-T2V-1.3B-Diffusers\",\"status\":\"queued\",\"progress\":0,\"created_at\":1770191404,\"size\":\"832x480\",\"seconds\":\"5\",\"quality\":\"standard\",\"remixed_from_video_id\":null,\"completed_at\":null,\"expires_at\":null,\"error\":null}"
    },
    {
      "perf_ns": 3036853531543,
      "content_type": "application/json",
      "text": "{\"id\":\"d2ce90a0-095f-4307-8eae-a633ee49022a\",\"object\":\"video\",\"model\":\"Wan-AI/Wan2.1-T2V-1.3B-Diffusers\",\"status\":\"completed\",\"progress\":100,\"created_at\":1770191404,\"size\":\"832x480\",\"seconds\":\"5\",\"quality\":\"standard\",\"remixed_from_video_id\":null,\"completed_at\":1770191924,\"expires_at\":null,\"error\":null}"
    }
  ]
}
```
