### PR TITLE
feat: auto-detect TTY for UI type and log formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 
 - Scalable via multiprocess support
 - Modular design for easy user modification
-- **3 UI types**: `--ui-type dashboard` (default, real-time TUI), `--ui-type simple` (progress bars), `--ui-type none` (no UI). See [CLI Options](docs/cli_options.md) for details.
+- **3 UI types**: `--ui-type dashboard` (default in TTY, real-time TUI), `--ui-type simple` (progress bars), `--ui-type none` (default in non-TTY). Automatically detects interactive terminals. See [CLI Options](docs/cli_options.md) or [User Interface](docs/tutorials/ui-types.md) for details.
 - Several benchmarking modes:
   - concurrency
   - request-rate

--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -809,7 +809,7 @@ Number of `RecordProcessor` services to spawn for parallel metric computation. H
 
 #### `--ui-type`, `--ui` `<str>`
 
-Select the user interface type for displaying benchmark progress. `dashboard` (default) shows real-time metrics in a Textual TUI, `simple` uses TQDM progress bars, `none` disables UI completely. Automatically set to `simple` when using `--verbose` or `--extra-verbose`.
+Select the user interface type for displaying benchmark progress. `dashboard` shows real-time metrics in a Textual TUI, `simple` uses TQDM progress bars, `none` disables UI completely. Defaults to `dashboard` in interactive terminals, `none` when not a TTY (e.g., piped or redirected output). Automatically set to `simple` when using `--verbose` or `--extra-verbose` in a TTY.
 <br>_Choices: [`dashboard`, `none`, `simple`]_
 <br>_Default: `dashboard`_
 

--- a/docs/tutorials/ui-types.md
+++ b/docs/tutorials/ui-types.md
@@ -11,15 +11,34 @@ AIPerf provides 3 UI types to display benchmark progress.
 
 Choose the UI type that matches your workflow:
 
-- **Dashboard** (default): Full Textual TUI with real-time metrics and GPU telemetry
+- **Dashboard**: Full Textual TUI with real-time metrics and GPU telemetry (default in interactive terminals)
 - **Simple**: TQDM progress bars for minimal overhead
-- **None**: Application logs only, no progress UI
+- **None**: Application logs only, no progress UI (default in non-interactive environments)
 
 All types display the final metrics table upon completion. UI type only affects progress display during benchmark execution.
 
 **Note:** Both `--ui-type` and `--ui` are supported interchangeably.
 
-## Dashboard (Default)
+### Automatic TTY Detection
+
+AIPerf automatically detects whether it is running in an interactive terminal (TTY):
+
+- **Interactive terminal (TTY)**: Defaults to `dashboard`
+- **Non-interactive (piped, redirected, CI/CD)**: Defaults to `none` with basic non-rich log formatting
+
+This means `aiperf profile ... | tee output.log` or `aiperf profile ... > output.log` will automatically use `--ui-type none` and plain-text logs without Rich formatting.
+
+To override the automatic detection, explicitly pass `--ui-type`:
+
+```bash
+# Force dashboard UI even when piping output
+aiperf profile ... --ui-type dashboard | tee output.log
+
+# Force no UI even in an interactive terminal
+aiperf profile ... --ui-type none
+```
+
+## Dashboard (Default in TTY)
 
 The full-featured TUI provides:
 - Real-time request and record metrics
@@ -43,7 +62,7 @@ aiperf profile \
 - Checking worker status and errors
 - Viewing GPU telemetry
 
-**Note:** Dashboard automatically switches to `simple` when using `--verbose` or `--extra-verbose` for better log visibility.
+**Note:** Dashboard automatically switches to `simple` when using `--verbose` or `--extra-verbose` in a TTY for better log visibility.
 
 ## Simple
 
@@ -78,9 +97,9 @@ INFO     Results saved to: artifacts/Qwen_Qwen3-0.6B-chat-concurrency10/
 - Terminal doesn't support rich TUI rendering
 - Running with verbose logging
 
-## None
+## None (Default in Non-TTY)
 
-Shows application logs only, no progress UI:
+Shows application logs only, no progress UI. This is the automatic default when output is piped or redirected:
 
 ```bash
 aiperf profile \
@@ -107,6 +126,6 @@ aiperf profile \
 ```
 
 **When to use:**
-- Automating benchmarks in scripts or CI/CD
-- Piping output to files
+- Automating benchmarks in scripts or CI/CD (auto-selected)
+- Piping output to files (auto-selected)
 - Minimizing UI overhead

--- a/src/aiperf/common/utils.py
+++ b/src/aiperf/common/utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import inspect
 import os
+import sys
 import traceback
 import types
 from collections.abc import Awaitable, Callable
@@ -14,6 +15,11 @@ from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.common.exceptions import AIPerfMultiError
 
 _logger = AIPerfLogger(__name__)
+
+
+def is_tty() -> bool:
+    """Check if stdout is connected to an interactive terminal."""
+    return sys.stdout is not None and getattr(sys.stdout, "isatty", lambda: False)()
 
 
 async def call_all_functions_self(

--- a/tests/unit/common/test_is_tty.py
+++ b/tests/unit/common/test_is_tty.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import io
+import logging
+import re
+import time
+
+import pytest
+
+from aiperf.common.logging import (
+    _BASIC_DATE_FORMAT,
+    _BASIC_LOG_FORMAT,
+    CustomRichHandler,
+    _create_basic_handler,
+)
+from aiperf.common.utils import is_tty
+
+
+class TestIsTTY:
+    """Tests for the is_tty utility function."""
+
+    def test_returns_true_when_stdout_is_tty(self, monkeypatch):
+        """Should return True when stdout.isatty() returns True."""
+        mock_stdout = io.StringIO()
+        mock_stdout.isatty = lambda: True
+        monkeypatch.setattr("sys.stdout", mock_stdout)
+        assert is_tty() is True
+
+    def test_returns_false_when_stdout_is_not_tty(self, monkeypatch):
+        """Should return False when stdout.isatty() returns False."""
+        mock_stdout = io.StringIO()
+        mock_stdout.isatty = lambda: False
+        monkeypatch.setattr("sys.stdout", mock_stdout)
+        assert is_tty() is False
+
+    def test_returns_false_when_stdout_is_none(self, monkeypatch):
+        """Should return False when stdout is None."""
+        monkeypatch.setattr("sys.stdout", None)
+        assert is_tty() is False
+
+    def test_returns_false_when_stdout_lacks_isatty(self, monkeypatch):
+        """Should return False when stdout has no isatty attribute (e.g. TeeStream)."""
+
+        class FakeStream:
+            pass
+
+        monkeypatch.setattr("sys.stdout", FakeStream())
+        assert is_tty() is False
+
+
+class TestBasicHandlerFormat:
+    """Tests for the basic (non-TTY) log handler millisecond formatting."""
+
+    def test_basic_handler_includes_milliseconds(self):
+        """Should include milliseconds in the basic handler output."""
+        handler = _create_basic_handler("DEBUG")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="hello",
+            args=None,
+            exc_info=None,
+        )
+        output = handler.format(record)
+        timestamp = output.split(" ")[0]
+        # Expect HH:MM:SS.mmm format
+        assert re.match(r"\d{2}:\d{2}:\d{2}\.\d{3}", timestamp)
+
+    def test_basic_handler_sets_level(self):
+        """Should set the handler level correctly."""
+        handler = _create_basic_handler("WARNING")
+        assert handler.level == logging.WARNING
+
+    def test_basic_format_string_contains_msecs(self):
+        """The format string should contain msecs placeholder."""
+        assert "%(msecs)03d" in _BASIC_LOG_FORMAT
+
+    def test_basic_date_format_excludes_microseconds(self):
+        """The date format should not contain %f since we use %(msecs)03d instead."""
+        assert "%f" not in _BASIC_DATE_FORMAT
+
+
+class TestCustomRichHandlerTimestamp:
+    """Tests for the CustomRichHandler timestamp formatting."""
+
+    @pytest.fixture()
+    def log_record(self) -> logging.LogRecord:
+        """Create a log record with a known timestamp."""
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=42,
+            msg="test message",
+            args=None,
+            exc_info=None,
+        )
+        return record
+
+    def test_timestamp_format_matches_expected_pattern(self, log_record):
+        """The rendered timestamp should be HH:MM:SS.mmm."""
+        expected_time = time.strftime("%H:%M:%S", time.localtime(log_record.created))
+        expected_ms = f"{int(log_record.msecs):03d}"
+        expected = f"{expected_time}.{expected_ms}"
+
+        handler = CustomRichHandler(show_time=False, show_level=False, show_path=False)
+        renderable = handler.render(
+            record=log_record, traceback=None, message_renderable=None
+        )
+        rendered_text = str(renderable)
+        assert expected in rendered_text
+
+    def test_timestamp_milliseconds_are_three_digits(self, log_record):
+        """Milliseconds should always be zero-padded to 3 digits."""
+        log_record.msecs = 5.0
+        handler = CustomRichHandler(show_time=False, show_level=False, show_path=False)
+        renderable = handler.render(
+            record=log_record, traceback=None, message_renderable=None
+        )
+        rendered_text = str(renderable)
+        assert re.search(r"\d{2}:\d{2}:\d{2}\.005", rendered_text)
+
+
+class TestFileHandlerFormat:
+    """Tests for file handler millisecond formatting."""
+
+    def test_file_handler_format_includes_milliseconds(self, tmp_path):
+        """File handler output should include milliseconds."""
+        from aiperf.common.logging import create_file_handler
+
+        handler = create_file_handler(tmp_path, "DEBUG")
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="file log test",
+            args=None,
+            exc_info=None,
+        )
+        output = handler.format(record)
+        # Expect YYYY-MM-DD HH:MM:SS.mmm format in the output
+        assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}", output)

--- a/tests/unit/common/test_logging_tty.py
+++ b/tests/unit/common/test_logging_tty.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiperf.common.logging import (
+    CustomRichHandler,
+    MultiProcessLogHandler,
+    _create_basic_handler,
+    setup_child_process_logging,
+    setup_rich_logging,
+)
+from aiperf.plugin.enums import UIType
+
+
+@pytest.fixture()
+def clean_root_logger():
+    """Remove all handlers from root logger before and after each test."""
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    yield
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+
+
+@pytest.fixture()
+def mock_user_config(tmp_path):
+    """Minimal mock UserConfig with artifact directory pointing to tmp_path."""
+    cfg = MagicMock()
+    cfg.output.artifact_directory = tmp_path
+    return cfg
+
+
+@pytest.fixture()
+def mock_service_config():
+    """Minimal mock ServiceConfig with INFO log level and DASHBOARD UI."""
+    cfg = MagicMock()
+    cfg.log_level = "INFO"
+    cfg.ui_type = UIType.DASHBOARD
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# _create_basic_handler
+# ---------------------------------------------------------------------------
+class TestCreateBasicHandler:
+    """Tests for the _create_basic_handler factory function."""
+
+    def test_returns_stream_handler(self):
+        """Should return a logging.StreamHandler, not a RichHandler."""
+        handler = _create_basic_handler("INFO")
+        assert isinstance(handler, logging.StreamHandler)
+        assert not isinstance(handler, CustomRichHandler)
+
+    @pytest.mark.parametrize(
+        "level_str,level_int",
+        [
+            ("DEBUG", logging.DEBUG),
+            ("INFO", logging.INFO),
+            ("WARNING", logging.WARNING),
+            ("ERROR", logging.ERROR),
+        ],
+    )
+    def test_sets_correct_log_level(self, level_str, level_int):
+        """Should set the handler level to match the requested level."""
+        handler = _create_basic_handler(level_str)
+        assert handler.level == level_int
+
+    def test_formatter_uses_expected_format(self):
+        """Should configure the formatter with the expected format string and date format."""
+        handler = _create_basic_handler("INFO")
+        fmt = handler.formatter
+        assert fmt is not None
+        assert "%(msecs)03d" in fmt._fmt
+        assert "%(levelname)" in fmt._fmt
+        assert "%(filename)s" in fmt._fmt
+        assert fmt.datefmt == "%H:%M:%S"
+
+
+# ---------------------------------------------------------------------------
+# setup_rich_logging
+# ---------------------------------------------------------------------------
+class TestSetupRichLogging:
+    """Tests for setup_rich_logging TTY-aware handler selection."""
+
+    @pytest.fixture(autouse=True)
+    def _clean(self, clean_root_logger):
+        """Ensure clean root logger for every test."""
+
+    def test_tty_uses_custom_rich_handler(
+        self, monkeypatch, mock_user_config, mock_service_config
+    ):
+        """When is_tty() is True, root logger should get a CustomRichHandler."""
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: True)
+
+        setup_rich_logging(mock_user_config, mock_service_config)
+
+        root = logging.getLogger()
+        rich_handlers = [h for h in root.handlers if isinstance(h, CustomRichHandler)]
+        assert len(rich_handlers) == 1
+
+    def test_non_tty_uses_basic_stream_handler(
+        self, monkeypatch, mock_user_config, mock_service_config
+    ):
+        """When is_tty() is False, root logger should get a basic StreamHandler."""
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: False)
+
+        setup_rich_logging(mock_user_config, mock_service_config)
+
+        root = logging.getLogger()
+        console_handlers = [
+            h for h in root.handlers if type(h) is logging.StreamHandler
+        ]
+        assert len(console_handlers) == 1
+        assert not isinstance(console_handlers[0], CustomRichHandler)
+
+    @pytest.mark.parametrize("tty", [True, False])
+    def test_file_handler_always_added(
+        self, monkeypatch, mock_user_config, mock_service_config, tty
+    ):
+        """A FileHandler should always be added regardless of TTY state."""
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: tty)
+
+        setup_rich_logging(mock_user_config, mock_service_config)
+
+        root = logging.getLogger()
+        file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 1
+
+
+# ---------------------------------------------------------------------------
+# setup_child_process_logging
+# ---------------------------------------------------------------------------
+class TestSetupChildProcessLogging:
+    """Tests for setup_child_process_logging TTY-aware handler selection."""
+
+    @pytest.fixture(autouse=True)
+    def _clean(self, clean_root_logger):
+        """Ensure clean root logger for every test."""
+
+    def test_dashboard_with_queue_uses_multiprocess_handler(
+        self, monkeypatch, mock_service_config
+    ):
+        """Dashboard UI with a log queue should use MultiProcessLogHandler."""
+        mock_service_config.ui_type = UIType.DASHBOARD
+        mock_queue = MagicMock()
+
+        # TTY state should be irrelevant when dashboard + queue
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: True)
+
+        setup_child_process_logging(
+            log_queue=mock_queue,
+            service_id="worker_1",
+            service_config=mock_service_config,
+        )
+
+        root = logging.getLogger()
+        mp_handlers = [
+            h for h in root.handlers if isinstance(h, MultiProcessLogHandler)
+        ]
+        assert len(mp_handlers) == 1
+
+    def test_non_dashboard_tty_uses_custom_rich_handler(
+        self, monkeypatch, mock_service_config
+    ):
+        """Non-dashboard UI in a TTY should use CustomRichHandler."""
+        mock_service_config.ui_type = UIType.SIMPLE
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: True)
+
+        setup_child_process_logging(
+            log_queue=None,
+            service_id="worker_1",
+            service_config=mock_service_config,
+        )
+
+        root = logging.getLogger()
+        rich_handlers = [h for h in root.handlers if isinstance(h, CustomRichHandler)]
+        assert len(rich_handlers) == 1
+
+    def test_non_dashboard_non_tty_uses_basic_handler(
+        self, monkeypatch, mock_service_config
+    ):
+        """Non-dashboard UI in a non-TTY should use a basic StreamHandler."""
+        mock_service_config.ui_type = UIType.NONE
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: False)
+
+        setup_child_process_logging(
+            log_queue=None,
+            service_id="worker_1",
+            service_config=mock_service_config,
+        )
+
+        root = logging.getLogger()
+        console_handlers = [
+            h
+            for h in root.handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, CustomRichHandler | MultiProcessLogHandler)
+        ]
+        assert len(console_handlers) == 1
+
+    def test_dashboard_without_queue_and_tty_uses_rich_handler(
+        self, monkeypatch, mock_service_config
+    ):
+        """Dashboard UI without a log queue in a TTY should fall through to CustomRichHandler."""
+        mock_service_config.ui_type = UIType.DASHBOARD
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: True)
+
+        setup_child_process_logging(
+            log_queue=None,
+            service_id="worker_1",
+            service_config=mock_service_config,
+        )
+
+        root = logging.getLogger()
+        rich_handlers = [h for h in root.handlers if isinstance(h, CustomRichHandler)]
+        assert len(rich_handlers) == 1
+
+    def test_dashboard_without_queue_and_non_tty_uses_basic_handler(
+        self, monkeypatch, mock_service_config
+    ):
+        """Dashboard UI without a log queue in a non-TTY should fall through to basic handler."""
+        mock_service_config.ui_type = UIType.DASHBOARD
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: False)
+
+        setup_child_process_logging(
+            log_queue=None,
+            service_id="worker_1",
+            service_config=mock_service_config,
+        )
+
+        root = logging.getLogger()
+        console_handlers = [
+            h
+            for h in root.handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, CustomRichHandler | MultiProcessLogHandler)
+        ]
+        assert len(console_handlers) == 1
+
+    def test_file_handler_added_when_user_config_provided(
+        self, monkeypatch, mock_service_config, mock_user_config
+    ):
+        """File handler should be added when user_config with artifact directory is provided."""
+        mock_service_config.ui_type = UIType.NONE
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: False)
+
+        setup_child_process_logging(
+            log_queue=None,
+            service_id="worker_1",
+            service_config=mock_service_config,
+            user_config=mock_user_config,
+        )
+
+        root = logging.getLogger()
+        file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 1
+
+    def test_no_file_handler_when_no_user_config(
+        self, monkeypatch, mock_service_config
+    ):
+        """No file handler should be added when user_config is None."""
+        mock_service_config.ui_type = UIType.NONE
+        monkeypatch.setattr("aiperf.common.logging.is_tty", lambda: False)
+
+        setup_child_process_logging(
+            log_queue=None,
+            service_id="worker_1",
+            service_config=mock_service_config,
+            user_config=None,
+        )
+
+        root = logging.getLogger()
+        file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 0


### PR DESCRIPTION
When stdout is not an interactive terminal (piped, redirected, or CI), default to --ui-type none and use plain-text log formatting instead of Rich. This prevents ANSI escape codes from polluting redirected output and avoids TUI crashes in non-interactive environments.

Priority when --ui-type is not explicitly set:
  1. Non-TTY → none
  2. --verbose/--extra-verbose → simple
  3. Interactive TTY → dashboard

Explicit --ui-type always takes precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic terminal detection to select appropriate UI type based on environment (interactive terminal vs. piped/redirected output).
  * Dashboard UI now defaults in interactive terminals; "none" mode defaults in non-interactive environments.

* **Documentation**
  * Updated CLI options and UI tutorials to clarify automatic terminal detection behavior and default selections across different environments.

* **Bug Fixes**
  * Improved logging output for non-interactive environments with proper formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->