### PR TITLE
feat: Refactor ShareGPT from BasePublicDatasetLoader to BaseFileLoader

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -228,7 +228,7 @@ Pre-configured public dataset to download and use for benchmarking (e.g., `share
 #### `--custom-dataset-type` `<str>`
 
 Format specification for custom dataset provided via `--input-file`. Determines parsing logic and expected file structure. Options: `single_turn` (JSONL with single exchanges), `multi_turn` (JSONL with conversation history), `mooncake_trace` (timestamped trace files), `random_pool` (directory of reusable prompts). Requires `--input-file`. Mutually exclusive with `--public-dataset`.
-<br>_Choices: [`mooncake_trace`, `multi_turn`, `random_pool`, `single_turn`]_
+<br>_Choices: [`mooncake_trace`, `multi_turn`, `random_pool`, `sharegpt`, `single_turn`]_
 
 #### `--dataset-sampling-strategy` `<str>`
 

--- a/src/aiperf/dataset/dataset_manager.py
+++ b/src/aiperf/dataset/dataset_manager.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import gc
 import time
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import orjson
@@ -19,6 +21,7 @@ from aiperf.common.enums import (
     PublicDatasetType,
 )
 from aiperf.common.environment import Environment
+from aiperf.common.exceptions import DatasetLoaderError
 from aiperf.common.hooks import on_command, on_request, on_stop
 from aiperf.common.messages import (
     ConversationRequestMessage,
@@ -45,13 +48,35 @@ from aiperf.plugin.enums import (
     DatasetBackingStoreType,
     PluginType,
 )
+from aiperf.transports.aiohttp_client import AioHttpClient
 
 if TYPE_CHECKING:
+    from aiperf.dataset.loader.base_loader import BaseLoader
     from aiperf.dataset.protocols import (
         DatasetBackingStoreProtocol,
         DatasetClientStoreProtocol,
     )
     from aiperf.endpoints.protocols import EndpointProtocol
+
+AIPERF_DATASET_CACHE_DIR = Path(".cache/aiperf/datasets")
+
+
+@dataclass
+class PublicDatasetSpec:
+    tag: str
+    url: str
+    filename: str
+    loader_cls: type[BaseLoader]
+
+
+PUBLIC_DATASETS: dict[PublicDatasetType, PublicDatasetSpec] = {
+    PublicDatasetType.SHAREGPT: PublicDatasetSpec(
+        tag="ShareGPT",
+        url="https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json",
+        filename="ShareGPT_V3_unfiltered_cleaned_split.json",
+        loader_cls=ShareGPTLoader,
+    )
+}
 
 
 class DatasetManager(ReplyClientMixin, BaseComponentService):
@@ -166,8 +191,10 @@ class DatasetManager(ReplyClientMixin, BaseComponentService):
         )
         endpoint: EndpointProtocol = EndpointClass(model_endpoint=model_endpoint)
         self.debug(
-            lambda: f"Created endpoint protocol for {model_endpoint.endpoint.type}, "
-            f"class: {endpoint.__class__.__name__}",
+            lambda: (
+                f"Created endpoint protocol for {model_endpoint.endpoint.type}, "
+                f"class: {endpoint.__class__.__name__}"
+            ),
         )
         session_payloads_map: dict[str, list] = {}
         for conversation in self.dataset.values():
@@ -246,21 +273,68 @@ class DatasetManager(ReplyClientMixin, BaseComponentService):
 
     async def _load_public_dataset(self) -> list[Conversation]:
         public_dataset_type = self.user_config.input.public_dataset
-        match public_dataset_type:
-            case PublicDatasetType.SHAREGPT:
-                loader = ShareGPTLoader(self.user_config, self.tokenizer)
-            case _:
-                raise ValueError(
-                    f"Unsupported public dataset type: {public_dataset_type}"
-                )
+        spec = PUBLIC_DATASETS.get(public_dataset_type)
+        if spec is None:
+            raise ValueError(f"Unsupported public dataset type: {public_dataset_type}")
 
-        dataset = await loader.load_dataset()
+        cache_path = await self._download_public_dataset(
+            tag=spec.tag,
+            url=spec.url,
+            filename=spec.filename,
+        )
+        loader = spec.loader_cls(
+            user_config=self.user_config,
+            tokenizer=self.tokenizer,
+            filename=str(cache_path),
+        )
+
+        dataset = loader.load_dataset()
         # Only use loader's recommended strategy if user hasn't explicitly set one
         if "dataset_sampling_strategy" not in self.user_config.input.model_fields_set:
             self.user_config.input.dataset_sampling_strategy = (
-                loader.get_recommended_sampling_strategy()
+                spec.loader_cls.get_preferred_sampling_strategy()
             )
-        return await loader.convert_to_conversations(dataset)
+        return loader.convert_to_conversations(dataset)
+
+    async def _download_public_dataset(self, tag: str, url: str, filename: str) -> Path:
+        cache_filepath = AIPERF_DATASET_CACHE_DIR / filename
+
+        if cache_filepath.exists():
+            self.info(f"Loading {tag} dataset from local cache {cache_filepath}")
+            return cache_filepath
+
+        self.info(f"No local dataset cache found, downloading {tag} from {url}")
+        http_client = AioHttpClient(timeout=Environment.DATASET.PUBLIC_DATASET_TIMEOUT)
+        try:
+            record = await http_client.get_request(
+                url, headers={"Accept": "application/json"}
+            )
+            if record.error is not None:
+                raise DatasetLoaderError(
+                    f"Error downloading {tag} dataset from {url}: "
+                    f"{record.error.type} ({record.error.code}): {record.error.message}"
+                )
+            if not record.responses:
+                raise DatasetLoaderError(
+                    f"Error downloading {tag} dataset from {url}: empty response body"
+                )
+            dataset = record.responses[0].text
+        except Exception as e:
+            raise DatasetLoaderError(
+                f"Error downloading {tag} dataset from {url}: {e}"
+            ) from e
+        finally:
+            await http_client.close()
+
+        try:
+            await asyncio.to_thread(cache_filepath.parent.mkdir, parents=True, exist_ok=True)
+            await asyncio.to_thread(cache_filepath.write_text, dataset)
+        except Exception as e:
+            raise DatasetLoaderError(
+                f"Error saving {tag} dataset to local cache: {e}"
+            ) from e
+
+        return cache_filepath
 
     def _load_custom_dataset(self) -> list[Conversation]:
         ComposerClass = plugins.get_class(

--- a/src/aiperf/dataset/loader/base_loader.py
+++ b/src/aiperf/dataset/loader/base_loader.py
@@ -23,7 +23,7 @@ class BaseLoader(AIPerfLoggerMixin, ABC):
         **kwargs: Additional arguments to pass to the base class.
     """
 
-    def __init__(self, *, user_config: UserConfig, **kwargs):
+    def __init__(self, *, user_config: UserConfig, **kwargs) -> None:
         self.user_config = user_config
         super().__init__(user_config=user_config, **kwargs)
         # Create session ID generator (deterministic when seed is set)
@@ -55,6 +55,6 @@ class BaseFileLoader(BaseLoader):
         **kwargs: Additional arguments to pass to the base class.
     """
 
-    def __init__(self, *, filename: str, user_config: UserConfig, **kwargs):
+    def __init__(self, *, filename: str, user_config: UserConfig, **kwargs) -> None:
         super().__init__(user_config=user_config, **kwargs)
         self.filename = filename

--- a/src/aiperf/dataset/loader/base_public_dataset.py
+++ b/src/aiperf/dataset/loader/base_public_dataset.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -12,11 +13,16 @@ from aiperf.dataset.loader.base_loader import BaseLoader
 from aiperf.plugin.enums import DatasetSamplingStrategy
 from aiperf.transports.aiohttp_client import AioHttpClient
 
+# Deprecated: use AIPERF_DATASET_CACHE_DIR from aiperf.dataset.dataset_manager instead.
 AIPERF_DATASET_CACHE_DIR = Path(".cache/aiperf/datasets")
 
 
 class BasePublicDatasetLoader(BaseLoader):
     """Base class for loading public datasets from remote URLs with caching support.
+
+    Deprecated: Use BaseFileLoader instead. Public dataset loaders should extend
+    BaseFileLoader, and download/caching is handled by
+    DatasetManager._download_public_dataset(). See ShareGPTLoader for a migration example.
 
     This abstract base class provides a common interface and implementation for downloading,
     caching, and loading public datasets. It handles the HTTP download logic, local caching
@@ -45,7 +51,14 @@ class BasePublicDatasetLoader(BaseLoader):
     url: ClassVar[str]
     filename: ClassVar[str] = "dataset.json"
 
-    def __init__(self, user_config: UserConfig, **kwargs):
+    def __init__(self, user_config: UserConfig, **kwargs) -> None:
+        warnings.warn(
+            "BasePublicDatasetLoader is deprecated. Extend BaseFileLoader instead "
+            "and let DatasetManager handle download/caching. "
+            "See ShareGPTLoader for a migration example.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(user_config=user_config, **kwargs)
         self.http_client = AioHttpClient(
             timeout=Environment.DATASET.PUBLIC_DATASET_TIMEOUT

--- a/src/aiperf/dataset/loader/sharegpt.py
+++ b/src/aiperf/dataset/loader/sharegpt.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from typing import Any
 
 from aiperf.common import random_generator as rng
@@ -9,16 +10,15 @@ from aiperf.common.enums import ModelSelectionStrategy
 from aiperf.common.models import Conversation, Text, Turn
 from aiperf.common.tokenizer import Tokenizer
 from aiperf.common.utils import load_json_str
-from aiperf.dataset.loader.base_public_dataset import BasePublicDatasetLoader
+from aiperf.dataset.loader.base_loader import BaseFileLoader
 from aiperf.plugin.enums import DatasetSamplingStrategy
 
 
-class ShareGPTLoader(BasePublicDatasetLoader):
+class ShareGPTLoader(BaseFileLoader):
     """ShareGPT dataset loader for loading and processing ShareGPT conversation data.
 
-    This loader downloads and processes the ShareGPT dataset from HuggingFace.
-    It handles downloading, caching, validation, and conversion of ShareGPT
-    conversations into the AIPerf conversation format.
+    This loader parses ShareGPT conversation data from a local file.
+    Public dataset downloads will be handled separately and cached locally.
 
     The loader filters conversations based on:
     - Minimum conversation length (at least 2 turns required)
@@ -26,17 +26,17 @@ class ShareGPTLoader(BasePublicDatasetLoader):
     - Configurable max prompt length and total sequence length
 
     Example:
-        >>> loader = ShareGPTLoader(user_config, tokenizer)
-        >>> dataset = await loader.load_dataset()
-        >>> conversations = await loader.convert_to_conversations(dataset)
+        >>> loader = ShareGPTLoader(user_config, tokenizer, "sharegpt.json")
+        >>> dataset = loader.load_dataset()
+        >>> conversations = loader.convert_to_conversations(dataset)
         >>> print(f"Loaded {len(conversations)} valid conversations")
     """
 
     tag = "ShareGPT"
-    url = "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
-    filename = "ShareGPT_V3_unfiltered_cleaned_split.json"
 
-    def __init__(self, user_config: UserConfig, tokenizer: Tokenizer, **kwargs):
+    def __init__(
+        self, user_config: UserConfig, tokenizer: Tokenizer, filename: str, **kwargs
+    ) -> None:
         self.tokenizer = tokenizer
         self.user_config = user_config
         self.output_tokens_mean = self.user_config.input.prompt.output_tokens.mean
@@ -44,23 +44,81 @@ class ShareGPTLoader(BasePublicDatasetLoader):
 
         self._rng = rng.derive("dataset.loader.sharegpt")
 
-        super().__init__(user_config=user_config, tokenizer=tokenizer, **kwargs)
+        super().__init__(
+            filename=filename, user_config=user_config, tokenizer=tokenizer, **kwargs
+        )
 
-    async def load_dataset(self) -> dict[str, Any]:
+    @classmethod
+    def can_load(
+        cls, data: dict[str, Any] | None = None, filename: str | Path | None = None
+    ) -> bool:
+        """Check if this loader can handle the given data format.
+
+        ShareGPT entries include a "conversations" list with "value" fields.
         """
-        Load the dataset from the local cache or download it from the URL.
+        if data is None:
+            return False
+
+        conversations = data.get("conversations")
+        if not isinstance(conversations, list) or not conversations:
+            return False
+
+        first_conversation = conversations[0]
+        return isinstance(first_conversation, dict) and "value" in first_conversation
+
+    @classmethod
+    def get_preferred_sampling_strategy(cls) -> DatasetSamplingStrategy:
+        """Get the preferred dataset sampling strategy for ShareGPT."""
+        return DatasetSamplingStrategy.SEQUENTIAL
+
+    def load_dataset(self) -> list[dict[str, Any]]:
+        """
+        Load the dataset from a local file.
 
         Returns:
-            dict[str, Any]: The loaded dataset.
+            list[dict[str, Any]]: The loaded dataset.
         """
-        loaded_dataset = await self._load_dataset(
-            headers={"Accept": "application/json"}
+        with open(self.filename) as f:
+            return load_json_str(f.read())
+
+    def is_valid_sequence(
+        self,
+        prompt_len: int,
+        output_len: int,
+        min_seq_len: int = 4,
+        max_prompt_len: int = 1024,
+        max_total_len: int = 2048,
+        skip_min_output_len_check: bool = False,
+    ) -> bool:
+        """Validate a sequence based on prompt and output lengths.
+
+        Adopted from ``vllm/benchmarks/benchmark_dataset.py``.
+
+        Args:
+            prompt_len: The length of the prompt.
+            output_len: The length of the output.
+            min_seq_len: The minimum length of the sequence.
+            max_prompt_len: The maximum length of the prompt.
+            max_total_len: The maximum length of the total sequence.
+            skip_min_output_len_check: Whether to skip the minimum output length check.
+
+        Returns:
+            True if the sequence is valid, False otherwise.
+        """
+        prompt_too_short = prompt_len < min_seq_len
+        prompt_too_long = prompt_len > max_prompt_len
+        output_too_short = (not skip_min_output_len_check) and (
+            output_len < min_seq_len
         )
-        return load_json_str(loaded_dataset)
+        combined_too_long = (prompt_len + output_len) > max_total_len
+
+        return not (
+            prompt_too_short or output_too_short or prompt_too_long or combined_too_long
+        )
 
     # TODO: distribute this work across the processors
-    async def convert_to_conversations(
-        self, dataset: dict[str, Any]
+    def convert_to_conversations(
+        self, dataset: list[dict[str, Any]]
     ) -> list[Conversation]:
         """
         Convert the loaded dataset to conversations.
@@ -111,7 +169,9 @@ class ShareGPTLoader(BasePublicDatasetLoader):
             )
 
         self.debug(
-            lambda: f"Filtered to {len(filtered_dataset)} dataset entries out of {len(dataset)} (skipped {skipped_entries})"
+            lambda: (
+                f"Filtered to {len(filtered_dataset)} dataset entries out of {len(dataset)} (skipped {skipped_entries})"
+            )
         )
         return filtered_dataset
 
@@ -127,7 +187,3 @@ class ShareGPTLoader(BasePublicDatasetLoader):
             return model_name
         else:
             raise ValueError(f"Invalid model selection strategy: {selection_strategy}.")
-
-    def get_recommended_sampling_strategy(self) -> DatasetSamplingStrategy:
-        """Get the recommended sampling strategy for this dataset."""
-        return DatasetSamplingStrategy.SEQUENTIAL

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -371,6 +371,11 @@ custom_dataset_loader:
       from predefined pools of system/user/assistant messages with configurable
       distributions.
 
+  sharegpt:
+    class: aiperf.dataset.loader.sharegpt:ShareGPTLoader
+    description: |
+      ShareGPT dataset loader for parsing the ShareGPT JSON file into conversations.
+
   single_turn:
     class: aiperf.dataset.loader.single_turn:SingleTurnDatasetLoader
     description: |

--- a/tests/unit/dataset/loader/test_can_load.py
+++ b/tests/unit/dataset/loader/test_can_load.py
@@ -9,6 +9,7 @@ from pytest import param
 from aiperf.dataset.loader.mooncake_trace import MooncakeTraceDatasetLoader
 from aiperf.dataset.loader.multi_turn import MultiTurnDatasetLoader
 from aiperf.dataset.loader.random_pool import RandomPoolDatasetLoader
+from aiperf.dataset.loader.sharegpt import ShareGPTLoader
 from aiperf.dataset.loader.single_turn import SingleTurnDatasetLoader
 from aiperf.plugin.enums import CustomDatasetType
 
@@ -148,6 +149,25 @@ class TestMooncakeTraceCanLoad:
     def test_can_load(self, data, expected):
         """Test various data formats for MooncakeTrace pydantic validation."""
         assert MooncakeTraceDatasetLoader.can_load(data) is expected
+
+
+class TestShareGPTCanLoad:
+    """Tests for ShareGPTLoader.can_load() method."""
+
+    @pytest.mark.parametrize(
+        "data,expected",
+        [
+            param({"conversations": [{"value": "Hello"}]}, True, id="valid_conversations"),
+            param({"conversations": [{"value": "Hello"}, {"value": "World"}]}, True, id="multi_turn"),
+            param({"conversations": []}, False, id="empty_conversations"),
+            param({"conversations": [{"no_value_key": "Hello"}]}, False, id="missing_value_key"),
+            param({"conversations": "not a list"}, False, id="conversations_not_list"),
+            param({"turns": [{"value": "Hello"}]}, False, id="wrong_key"),
+            param(None, False, id="none_data"),
+        ],
+    )  # fmt: skip
+    def test_can_load(self, data, expected):
+        assert ShareGPTLoader.can_load(data) is expected
 
 
 class TestCustomDatasetComposerInferType:

--- a/tests/unit/dataset/loader/test_sharegpt.py
+++ b/tests/unit/dataset/loader/test_sharegpt.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
+import json
+import warnings
 
 import pytest
 
 from aiperf.common.models import Conversation
 from aiperf.dataset.loader import ShareGPTLoader
+from aiperf.dataset.loader.base_public_dataset import BasePublicDatasetLoader
 from aiperf.plugin.enums import DatasetSamplingStrategy
 
 
@@ -15,9 +17,10 @@ class TestShareGPTLoader:
     """Test suite for ShareGPTLoader class"""
 
     @pytest.fixture
-    async def sharegpt_loader(self, user_config, mock_tokenizer_cls):
+    async def sharegpt_loader(self, user_config, mock_tokenizer_cls, tmp_path):
         tokenizer = mock_tokenizer_cls.from_pretrained("test-model")
-        return ShareGPTLoader(user_config, tokenizer)
+        filename = tmp_path / "sharegpt.json"
+        return ShareGPTLoader(user_config, tokenizer, str(filename))
 
     async def test_initialization(self, sharegpt_loader: ShareGPTLoader):
         """Test initialization of ShareGPTLoader"""
@@ -25,12 +28,6 @@ class TestShareGPTLoader:
         assert sharegpt_loader.user_config is not None
         assert sharegpt_loader.turn_count == 0
         assert sharegpt_loader.tag == "ShareGPT"
-        assert (
-            sharegpt_loader.url
-            == "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
-        )
-        assert sharegpt_loader.filename == "ShareGPT_V3_unfiltered_cleaned_split.json"
-        assert isinstance(sharegpt_loader.cache_filepath, Path)
 
     async def test_convert_to_conversations(self, sharegpt_loader: ShareGPTLoader):
         """Test converting single entry dataset to conversations"""
@@ -42,7 +39,7 @@ class TestShareGPTLoader:
                 ]
             }
         ]
-        conversations = await sharegpt_loader.convert_to_conversations(dataset)
+        conversations = sharegpt_loader.convert_to_conversations(dataset)
 
         assert len(conversations) == 1
         assert isinstance(conversations[0], Conversation)
@@ -77,7 +74,7 @@ class TestShareGPTLoader:
                 ]
             },
         ]
-        conversations = await sharegpt_loader.convert_to_conversations(dataset)
+        conversations = sharegpt_loader.convert_to_conversations(dataset)
 
         assert len(conversations) == 1
         assert isinstance(conversations[0], Conversation)
@@ -87,9 +84,37 @@ class TestShareGPTLoader:
         assert turn.max_tokens == len(["This", "is", "test", "output"])
         assert turn.model == "test-model"
 
-    async def test_get_recommended_sampling_strategy(
-        self, sharegpt_loader: ShareGPTLoader
-    ):
-        """Test that ShareGPTLoader returns the correct recommended sampling strategy."""
-        strategy = sharegpt_loader.get_recommended_sampling_strategy()
+    async def test_load_dataset(self, user_config, mock_tokenizer_cls, tmp_path):
+        """Test that load_dataset reads and parses JSON from the given file."""
+        data = [{"conversations": [{"value": "Hello"}, {"value": "World"}]}]
+        filename = tmp_path / "sharegpt.json"
+        filename.write_text(json.dumps(data))
+
+        tokenizer = mock_tokenizer_cls.from_pretrained("test-model")
+        loader = ShareGPTLoader(user_config, tokenizer, str(filename))
+
+        result = loader.load_dataset()
+        assert result == data
+
+    async def test_get_preferred_sampling_strategy(self):
+        """Test that ShareGPTLoader returns the correct preferred sampling strategy."""
+        strategy = ShareGPTLoader.get_preferred_sampling_strategy()
         assert strategy == DatasetSamplingStrategy.SEQUENTIAL
+
+
+class TestBasePublicDatasetLoaderDeprecation:
+    """Test that BasePublicDatasetLoader emits a deprecation warning on instantiation."""
+
+    @pytest.mark.asyncio
+    async def test_deprecation_warning_on_init(self, user_config):
+        class ConcreteLoader(BasePublicDatasetLoader):
+            tag = "Test"
+            url = "http://example.com/data.json"
+            filename = "data.json"
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ConcreteLoader(user_config=user_config)
+
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        assert any("BaseFileLoader" in str(w.message) for w in caught)

--- a/tests/unit/dataset/test_dataset_manager.py
+++ b/tests/unit/dataset/test_dataset_manager.py
@@ -9,7 +9,7 @@ import pytest
 from aiperf.common.config import EndpointConfig, InputConfig, ServiceConfig, UserConfig
 from aiperf.common.config.config_defaults import InputDefaults
 from aiperf.common.enums import PublicDatasetType
-from aiperf.common.exceptions import ServiceError
+from aiperf.common.exceptions import DatasetLoaderError, ServiceError
 from aiperf.common.messages import (
     ConversationRequestMessage,
     ConversationTurnRequestMessage,
@@ -254,16 +254,19 @@ class TestDatasetManagerSamplingStrategyDefaults:
     """Test default sampling strategy behavior for different dataset types."""
 
     @pytest.mark.asyncio
+    @patch("aiperf.dataset.dataset_manager.DatasetManager._download_public_dataset")
     @patch("aiperf.dataset.loader.sharegpt.ShareGPTLoader.load_dataset")
     @patch("aiperf.dataset.loader.sharegpt.ShareGPTLoader.convert_to_conversations")
     async def test_public_dataset_uses_loader_recommended_strategy(
         self,
         mock_convert,
         mock_load,
+        mock_download,
         mock_tokenizer,
     ):
         """Test that public datasets use the loader's recommended sampling strategy."""
         # Mock dataset loading
+        mock_download.return_value = Path("sharegpt.json")
         mock_load.return_value = {}
         mock_convert.return_value = create_mock_conversations(
             ["session-1", "session-2"]
@@ -319,16 +322,19 @@ class TestDatasetManagerSamplingStrategyDefaults:
         )
 
     @pytest.mark.asyncio
+    @patch("aiperf.dataset.dataset_manager.DatasetManager._download_public_dataset")
     @patch("aiperf.dataset.loader.sharegpt.ShareGPTLoader.load_dataset")
     @patch("aiperf.dataset.loader.sharegpt.ShareGPTLoader.convert_to_conversations")
     async def test_explicit_strategy_overrides_loader_recommendation(
         self,
         mock_convert,
         mock_load,
+        mock_download,
         mock_tokenizer,
     ):
         """Test that explicitly set strategy is not overridden by loader recommendation."""
         # Mock dataset loading
+        mock_download.return_value = Path("sharegpt.json")
         mock_load.return_value = {}
         mock_convert.return_value = create_mock_conversations(["session-1"])
 
@@ -538,3 +544,126 @@ class TestDatasetManagerFallbackHandlers:
 
         with pytest.raises(ServiceError, match="out of range"):
             await dataset_manager._handle_conversation_turn_request(request)
+
+
+class TestDownloadPublicDataset:
+    """Tests for DatasetManager._download_public_dataset()."""
+
+    @pytest.fixture
+    def dataset_manager(self, mock_tokenizer):
+        config = UserConfig(endpoint=EndpointConfig(model_names=["test-model"]))
+        return DatasetManager(ServiceConfig(), config)
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_path_without_downloading(
+        self, dataset_manager, tmp_path
+    ):
+        """Returns cached path immediately when file already exists."""
+        cached_file = tmp_path / "dataset.json"
+        cached_file.write_text("[]")
+
+        with patch("aiperf.dataset.dataset_manager.AIPERF_DATASET_CACHE_DIR", tmp_path):
+            result = await dataset_manager._download_public_dataset(
+                tag="Test", url="http://example.com/data.json", filename="dataset.json"
+            )
+
+        assert result == cached_file
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_downloads_and_saves(self, dataset_manager, tmp_path):
+        """Downloads dataset and writes to cache when file does not exist."""
+        mock_record = AsyncMock()
+        mock_record.error = None
+        mock_record.responses = [AsyncMock(text='[{"data": 1}]')]
+
+        with (
+            patch("aiperf.dataset.dataset_manager.AIPERF_DATASET_CACHE_DIR", tmp_path),
+            patch("aiperf.dataset.dataset_manager.AioHttpClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get_request.return_value = mock_record
+            mock_client_cls.return_value = mock_client
+
+            result = await dataset_manager._download_public_dataset(
+                tag="Test", url="http://example.com/data.json", filename="dataset.json"
+            )
+
+        assert result == tmp_path / "dataset.json"
+        assert result.read_text() == '[{"data": 1}]'
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_download_error_raises_dataset_loader_error(
+        self, dataset_manager, tmp_path
+    ):
+        """Wraps download exceptions in DatasetLoaderError and still closes the client."""
+        with (
+            patch("aiperf.dataset.dataset_manager.AIPERF_DATASET_CACHE_DIR", tmp_path),
+            patch("aiperf.dataset.dataset_manager.AioHttpClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get_request.side_effect = RuntimeError("network error")
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(DatasetLoaderError, match="Error downloading"):
+                await dataset_manager._download_public_dataset(
+                    tag="Test",
+                    url="http://example.com/data.json",
+                    filename="dataset.json",
+                )
+
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_http_error_response_raises_dataset_loader_error(
+        self, dataset_manager, tmp_path
+    ):
+        """Raises DatasetLoaderError with HTTP status when server returns an error response."""
+        mock_error = AsyncMock()
+        mock_error.message = "Not Found"
+        mock_record = AsyncMock()
+        mock_record.error = mock_error
+        mock_record.status = 404
+
+        with (
+            patch("aiperf.dataset.dataset_manager.AIPERF_DATASET_CACHE_DIR", tmp_path),
+            patch("aiperf.dataset.dataset_manager.AioHttpClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get_request.return_value = mock_record
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(DatasetLoaderError, match="Error downloading"):
+                await dataset_manager._download_public_dataset(
+                    tag="Test",
+                    url="http://example.com/data.json",
+                    filename="dataset.json",
+                )
+
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_response_raises_dataset_loader_error(
+        self, dataset_manager, tmp_path
+    ):
+        """Raises DatasetLoaderError when response has no error but empty body."""
+        mock_record = AsyncMock()
+        mock_record.error = None
+        mock_record.responses = []
+
+        with (
+            patch("aiperf.dataset.dataset_manager.AIPERF_DATASET_CACHE_DIR", tmp_path),
+            patch("aiperf.dataset.dataset_manager.AioHttpClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get_request.return_value = mock_record
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(DatasetLoaderError, match="empty response body"):
+                await dataset_manager._download_public_dataset(
+                    tag="Test",
+                    url="http://example.com/data.json",
+                    filename="dataset.json",
+                )
+
+        mock_client.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

Closes #628

- Refactors `ShareGPTLoader` from `BasePublicDatasetLoader` to `BaseFileLoader`, separating download/caching from parsing so public datasets reuse the same file-based loader pattern as local datasets
- Extracts download/cache logic into `DatasetManager._download_public_dataset()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spec-driven public dataset support with automatic download, cache directory, and local caching behavior
  * ShareGPT loader switched to file-based loading and exposes a preferred sampling strategy

* **Deprecations**
  * Public dataset base loader now emits a deprecation notice; migrate to the newer file-based/manager approach

* **Improvements**
  * Sequence validation to improve dataset quality
  * CLI option updated to include ShareGPT dataset type

* **Tests**
  * Unit tests added/updated for file-based loading, caching, and download error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->