### PR TITLE
chore: 0.6.0 version bump, use canonical aiperf.__version__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,12 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.version]
-path = "src/aiperf/__init__.py"
-
 [tool.hatch.metadata]
 allow-direct-references = true
 
 [project]
 name = "aiperf"
-version = "0.5.0"
+version = "0.6.0"
 description = "AIPerf is a package for performance testing of AI models"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/aiperf/__init__.py
+++ b/src/aiperf/__init__.py
@@ -1,3 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """AIPerf - AI Benchmarking Tool."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("aiperf")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/src/aiperf/cli.py
+++ b/src/aiperf/cli.py
@@ -19,14 +19,9 @@ from aiperf.common.config import ServiceConfig, UserConfig
 
 def _get_help_text() -> str:
     """Generate help text with installed plugin information."""
-    from aiperf.plugin import plugins
-
     # Get aiperf version for the title
-    try:
-        aiperf_meta = plugins.get_package_metadata("aiperf")
-        aiperf_version = aiperf_meta.version
-    except KeyError:
-        aiperf_version = "unknown"
+    from aiperf import __version__ as aiperf_version
+    from aiperf.plugin import plugins
 
     packages = plugins.list_packages()
     plugin_list = []

--- a/src/aiperf/exporters/metrics_json_exporter.py
+++ b/src/aiperf/exporters/metrics_json_exporter.py
@@ -55,13 +55,7 @@ class MetricsJsonExporter(MetricsBaseExporter):
             else None
         )
 
-        # Get AIPerf version from installed package
-        from importlib.metadata import version as get_version
-
-        try:
-            aiperf_version = get_version("aiperf")
-        except Exception:
-            aiperf_version = "unknown"
+        from aiperf import __version__ as aiperf_version
 
         # Note: server_metrics_data is exported to a separate file via ServerMetricsJsonExporter
         export_data = JsonExportData(

--- a/src/aiperf/server_metrics/csv_exporter.py
+++ b/src/aiperf/server_metrics/csv_exporter.py
@@ -157,13 +157,7 @@ class ServerMetricsCsvExporter(MetricsBaseExporter):
         buf = io.StringIO()
         writer = csv.writer(buf)
 
-        # Get AIPerf version from installed package
-        from importlib.metadata import version as get_version
-
-        try:
-            aiperf_version = get_version("aiperf")
-        except Exception:
-            aiperf_version = "unknown"
+        from aiperf import __version__ as aiperf_version
 
         # Add metadata as comments at the top of the file
         buf.write("# AIPerf Server Metrics Export (CSV)\n")

--- a/src/aiperf/server_metrics/json_exporter.py
+++ b/src/aiperf/server_metrics/json_exporter.py
@@ -123,13 +123,7 @@ class ServerMetricsJsonExporter(MetricsBaseExporter):
             exclude_unset=True,
         )
 
-        # Get AIPerf version from installed package
-        from importlib.metadata import version as get_version
-
-        try:
-            aiperf_version = get_version("aiperf")
-        except Exception:
-            aiperf_version = "unknown"
+        from aiperf import __version__ as aiperf_version
 
         export_data = ServerMetricsExportData(
             aiperf_version=aiperf_version,

--- a/src/aiperf/server_metrics/parquet_exporter.py
+++ b/src/aiperf/server_metrics/parquet_exporter.py
@@ -255,15 +255,10 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
         """
         import socket
         import sys
-        from importlib.metadata import version as get_version
 
         import orjson
 
-        # Get AIPerf version from installed package
-        try:
-            aiperf_version = get_version("aiperf")
-        except Exception:
-            aiperf_version = "unknown"
+        from aiperf import __version__ as aiperf_version
 
         # Core metadata
         metadata = {

--- a/src/aiperf/transports/base_transports.py
+++ b/src/aiperf/transports/base_transports.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib.metadata as importlib_metadata
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
@@ -67,7 +66,9 @@ class BaseTransport(AIPerfLifecycleMixin, ABC):
     def __init__(self, model_endpoint: ModelEndpointInfo, **kwargs) -> None:
         super().__init__(**kwargs)
         self.model_endpoint: ModelEndpointInfo = model_endpoint
-        self.user_agent: str = f"aiperf/{importlib_metadata.version('aiperf')}"
+        from aiperf import __version__
+
+        self.user_agent: str = f"aiperf/{__version__}"
         self.base_headers: dict[str, str] = {
             "User-Agent": self.user_agent,
         }

--- a/tests/aiperf_mock_server/pyproject.toml
+++ b/tests/aiperf_mock_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiperf-mock-server"
-version = "0.5.0"
+version = "0.6.0"
 description = "AIPerf FastAPI-based OpenAI mock server for AI performance testing"
 authors = []
 dependencies = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped project version to 0.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->