### PR TITLE
fix: always pass module to create_enum to avoid pickle issues

### DIFF
--- a/docs/plugins/plugin-system.md
+++ b/docs/plugins/plugin-system.md
@@ -317,7 +317,7 @@ plugins.register("endpoint", "test", TestEndpoint, priority=10)
 plugins.reset_registry()  # Reset to initial state
 
 # Dynamic enum generation
-MyEndpointType = plugins.create_enum(PluginType.ENDPOINT, "MyEndpointType")
+MyEndpointType = plugins.create_enum(PluginType.ENDPOINT, "MyEndpointType", module=__name__)
 
 # Validation without importing
 errors = plugins.validate_all(check_class=True)  # {category: [(name, error), ...]}

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -22,97 +22,97 @@ else:
     PluginType = create_enum("PluginType", {
         category.replace("-", "_").upper(): category
         for category in _all_plugin_categories
-    })
+    }, module=__name__)
     PluginTypeStr: TypeAlias = str
 
 TimingModeStr: TypeAlias = str
-TimingMode = plugins.create_enum(PluginType.TIMING_STRATEGY, "TimingMode")
+TimingMode = plugins.create_enum(PluginType.TIMING_STRATEGY, "TimingMode", module=__name__)
 """Dynamic enum for timing strategy. Example: TimingMode.FIXED_SCHEDULE, TimingMode.REQUEST_RATE, TimingMode.USER_CENTRIC_RATE"""
 
 ArrivalPatternStr: TypeAlias = str
-ArrivalPattern = plugins.create_enum(PluginType.ARRIVAL_PATTERN, "ArrivalPattern")
+ArrivalPattern = plugins.create_enum(PluginType.ARRIVAL_PATTERN, "ArrivalPattern", module=__name__)
 """Dynamic enum for arrival pattern. Example: ArrivalPattern.CONCURRENCY_BURST, ArrivalPattern.CONSTANT, ArrivalPattern.GAMMA"""
 
 RampTypeStr: TypeAlias = str
-RampType = plugins.create_enum(PluginType.RAMP, "RampType")
+RampType = plugins.create_enum(PluginType.RAMP, "RampType", module=__name__)
 """Dynamic enum for ramp. Example: RampType.EXPONENTIAL, RampType.LINEAR, RampType.POISSON"""
 
 DatasetBackingStoreTypeStr: TypeAlias = str
-DatasetBackingStoreType = plugins.create_enum(PluginType.DATASET_BACKING_STORE, "DatasetBackingStoreType")
+DatasetBackingStoreType = plugins.create_enum(PluginType.DATASET_BACKING_STORE, "DatasetBackingStoreType", module=__name__)
 """Dynamic enum for dataset backing store. Example: DatasetBackingStoreType.MEMORY_MAP"""
 
 DatasetClientStoreTypeStr: TypeAlias = str
-DatasetClientStoreType = plugins.create_enum(PluginType.DATASET_CLIENT_STORE, "DatasetClientStoreType")
+DatasetClientStoreType = plugins.create_enum(PluginType.DATASET_CLIENT_STORE, "DatasetClientStoreType", module=__name__)
 """Dynamic enum for dataset client store. Example: DatasetClientStoreType.MEMORY_MAP"""
 
 DatasetSamplingStrategyStr: TypeAlias = str
-DatasetSamplingStrategy = plugins.create_enum(PluginType.DATASET_SAMPLER, "DatasetSamplingStrategy")
+DatasetSamplingStrategy = plugins.create_enum(PluginType.DATASET_SAMPLER, "DatasetSamplingStrategy", module=__name__)
 """Dynamic enum for dataset sampler. Example: DatasetSamplingStrategy.RANDOM, DatasetSamplingStrategy.SEQUENTIAL, DatasetSamplingStrategy.SHUFFLE"""
 
 ComposerTypeStr: TypeAlias = str
-ComposerType = plugins.create_enum(PluginType.DATASET_COMPOSER, "ComposerType")
+ComposerType = plugins.create_enum(PluginType.DATASET_COMPOSER, "ComposerType", module=__name__)
 """Dynamic enum for dataset composer. Example: ComposerType.CUSTOM, ComposerType.SYNTHETIC, ComposerType.SYNTHETIC_RANKINGS"""
 
 CustomDatasetTypeStr: TypeAlias = str
-CustomDatasetType = plugins.create_enum(PluginType.CUSTOM_DATASET_LOADER, "CustomDatasetType")
+CustomDatasetType = plugins.create_enum(PluginType.CUSTOM_DATASET_LOADER, "CustomDatasetType", module=__name__)
 """Dynamic enum for custom dataset loader. Example: CustomDatasetType.MOONCAKE_TRACE, CustomDatasetType.MULTI_TURN, CustomDatasetType.RANDOM_POOL"""
 
 EndpointTypeStr: TypeAlias = str
-EndpointType = plugins.create_enum(PluginType.ENDPOINT, "EndpointType")
+EndpointType = plugins.create_enum(PluginType.ENDPOINT, "EndpointType", module=__name__)
 """Dynamic enum for endpoint. Example: EndpointType.CHAT, EndpointType.CHAT_EMBEDDINGS, EndpointType.COHERE_RANKINGS"""
 
 TransportTypeStr: TypeAlias = str
-TransportType = plugins.create_enum(PluginType.TRANSPORT, "TransportType")
+TransportType = plugins.create_enum(PluginType.TRANSPORT, "TransportType", module=__name__)
 """Dynamic enum for transport. Example: TransportType.HTTP"""
 
 RecordProcessorTypeStr: TypeAlias = str
-RecordProcessorType = plugins.create_enum(PluginType.RECORD_PROCESSOR, "RecordProcessorType")
+RecordProcessorType = plugins.create_enum(PluginType.RECORD_PROCESSOR, "RecordProcessorType", module=__name__)
 """Dynamic enum for record processor. Example: RecordProcessorType.METRIC_RECORD, RecordProcessorType.RAW_RECORD_WRITER"""
 
 ResultsProcessorTypeStr: TypeAlias = str
-ResultsProcessorType = plugins.create_enum(PluginType.RESULTS_PROCESSOR, "ResultsProcessorType")
+ResultsProcessorType = plugins.create_enum(PluginType.RESULTS_PROCESSOR, "ResultsProcessorType", module=__name__)
 """Dynamic enum for results processor. Example: ResultsProcessorType.GPU_TELEMETRY_ACCUMULATOR, ResultsProcessorType.GPU_TELEMETRY_JSONL_WRITER, ResultsProcessorType.METRIC_RESULTS"""
 
 DataExporterTypeStr: TypeAlias = str
-DataExporterType = plugins.create_enum(PluginType.DATA_EXPORTER, "DataExporterType")
+DataExporterType = plugins.create_enum(PluginType.DATA_EXPORTER, "DataExporterType", module=__name__)
 """Dynamic enum for data exporter. Example: DataExporterType.CSV, DataExporterType.JSON, DataExporterType.RAW_RECORD_AGGREGATOR"""
 
 ConsoleExporterTypeStr: TypeAlias = str
-ConsoleExporterType = plugins.create_enum(PluginType.CONSOLE_EXPORTER, "ConsoleExporterType")
+ConsoleExporterType = plugins.create_enum(PluginType.CONSOLE_EXPORTER, "ConsoleExporterType", module=__name__)
 """Dynamic enum for console exporter. Example: ConsoleExporterType.API_ERRORS, ConsoleExporterType.ERRORS, ConsoleExporterType.EXPERIMENTAL_METRICS"""
 
 UITypeStr: TypeAlias = str
-UIType = plugins.create_enum(PluginType.UI, "UIType")
+UIType = plugins.create_enum(PluginType.UI, "UIType", module=__name__)
 """Dynamic enum for ui. Example: UIType.DASHBOARD, UIType.NONE, UIType.SIMPLE"""
 
 URLSelectionStrategyStr: TypeAlias = str
-URLSelectionStrategy = plugins.create_enum(PluginType.URL_SELECTION_STRATEGY, "URLSelectionStrategy")
+URLSelectionStrategy = plugins.create_enum(PluginType.URL_SELECTION_STRATEGY, "URLSelectionStrategy", module=__name__)
 """Dynamic enum for url selection strategy. Example: URLSelectionStrategy.ROUND_ROBIN"""
 
 ServiceTypeStr: TypeAlias = str
-ServiceType = plugins.create_enum(PluginType.SERVICE, "ServiceType")
+ServiceType = plugins.create_enum(PluginType.SERVICE, "ServiceType", module=__name__)
 """Dynamic enum for service. Example: ServiceType.DATASET_MANAGER, ServiceType.GPU_TELEMETRY_MANAGER, ServiceType.RECORD_PROCESSOR"""
 
 ServiceRunTypeStr: TypeAlias = str
-ServiceRunType = plugins.create_enum(PluginType.SERVICE_MANAGER, "ServiceRunType")
+ServiceRunType = plugins.create_enum(PluginType.SERVICE_MANAGER, "ServiceRunType", module=__name__)
 """Dynamic enum for service manager. Example: ServiceRunType.KUBERNETES, ServiceRunType.MULTIPROCESSING"""
 
 CommunicationBackendStr: TypeAlias = str
-CommunicationBackend = plugins.create_enum(PluginType.COMMUNICATION, "CommunicationBackend")
+CommunicationBackend = plugins.create_enum(PluginType.COMMUNICATION, "CommunicationBackend", module=__name__)
 """Dynamic enum for communication. Example: CommunicationBackend.ZMQ_DUAL_BIND, CommunicationBackend.ZMQ_IPC, CommunicationBackend.ZMQ_TCP"""
 
 CommClientTypeStr: TypeAlias = str
-CommClientType = plugins.create_enum(PluginType.COMMUNICATION_CLIENT, "CommClientType")
+CommClientType = plugins.create_enum(PluginType.COMMUNICATION_CLIENT, "CommClientType", module=__name__)
 """Dynamic enum for communication client. Example: CommClientType.PUB, CommClientType.PULL, CommClientType.PUSH"""
 
 ZMQProxyTypeStr: TypeAlias = str
-ZMQProxyType = plugins.create_enum(PluginType.ZMQ_PROXY, "ZMQProxyType")
+ZMQProxyType = plugins.create_enum(PluginType.ZMQ_PROXY, "ZMQProxyType", module=__name__)
 """Dynamic enum for zmq proxy. Example: ZMQProxyType.DEALER_ROUTER, ZMQProxyType.PUSH_PULL, ZMQProxyType.XPUB_XSUB"""
 
 PlotTypeStr: TypeAlias = str
-PlotType = plugins.create_enum(PluginType.PLOT, "PlotType")
+PlotType = plugins.create_enum(PluginType.PLOT, "PlotType", module=__name__)
 """Dynamic enum for plot. Example: PlotType.AREA, PlotType.DUAL_AXIS, PlotType.HISTOGRAM"""
 
 GPUTelemetryCollectorTypeStr: TypeAlias = str
-GPUTelemetryCollectorType = plugins.create_enum(PluginType.GPU_TELEMETRY_COLLECTOR, "GPUTelemetryCollectorType")
+GPUTelemetryCollectorType = plugins.create_enum(PluginType.GPU_TELEMETRY_COLLECTOR, "GPUTelemetryCollectorType", module=__name__)
 """Dynamic enum for gpu telemetry collector. Example: GPUTelemetryCollectorType.DCGM, GPUTelemetryCollectorType.PYNVML"""

--- a/src/aiperf/plugin/extensible_enums.py
+++ b/src/aiperf/plugin/extensible_enums.py
@@ -193,7 +193,7 @@ class ExtensibleStrEnum(str, Enum, metaclass=ExtensibleStrEnumMeta):
 
 
 def create_enum(
-    name: str, members: dict[str, str], module: str | None = None
+    name: str, members: dict[str, str], *, module: str
 ) -> type[ExtensibleStrEnum]:
     """Create a new ExtensibleStrEnum dynamically from a dict of members.
 
@@ -203,29 +203,22 @@ def create_enum(
     Args:
         name: The enum class name (e.g., "EndpointType")
         members: Dict mapping member names to values (e.g., {"CHAT": "chat"})
-        module: Optional module name for the enum. If not provided, uses the
-            caller's module. Setting this correctly is required for pickling.
+        module: Module name for the enum. Required for pickling since pickle
+            looks up classes by module.name.
 
     Returns:
         A new ExtensibleStrEnum subclass with the specified members
 
     Example:
-        >>> EndpointType = create_enum("EndpointType", {"CHAT": "chat", "COMPLETIONS": "completions"})
+        >>> EndpointType = create_enum("EndpointType", {"CHAT": "chat", "COMPLETIONS": "completions"}, module=__name__)
         >>> EndpointType.CHAT
         EndpointType.CHAT
         >>> EndpointType("chat")
         EndpointType.CHAT
     """
-    import sys
-
     enum_cls = ExtensibleStrEnum(name, members)  # type: ignore[return-value]
 
     # Set __module__ to enable pickling. Pickle looks up classes by module.name,
     # so the enum must be findable in its declared module.
-    if module is None:
-        # Get the caller's module automatically
-        frame = sys._getframe(1)
-        module = frame.f_globals.get("__name__", __name__)
-
     enum_cls.__module__ = module
     return enum_cls

--- a/src/aiperf/plugin/plugins.py
+++ b/src/aiperf/plugin/plugins.py
@@ -563,7 +563,7 @@ class _PluginRegistry:
         return meta.get("internal", False)
 
     def create_enum(
-        self, category: CategoryT, enum_name: str
+        self, category: CategoryT, enum_name: str, *, module: str
     ) -> type[ExtensibleStrEnum]:
         """Create an ExtensibleStrEnum from registered types in a category.
 
@@ -573,6 +573,8 @@ class _PluginRegistry:
         Args:
             category: Plugin category to create enum from. Supports dash/underscore normalized matching.
             enum_name: Name for the generated enum class.
+            module: Module name for the enum. Required for pickling since pickle
+                looks up classes by module.name.
 
         Returns:
             A new ExtensibleStrEnum subclass.
@@ -580,8 +582,6 @@ class _PluginRegistry:
         Raises:
             KeyError: If no types are registered for the category.
         """
-        import sys
-
         from aiperf.plugin.extensible_enums import create_enum as _create_enum
 
         # Get entries without loading the plugin classes to avoid circular imports
@@ -598,10 +598,6 @@ class _PluginRegistry:
             entry.name.replace("-", "_").upper(): entry.name
             for entry in self._types[category].values()
         }
-
-        # Get the caller's module so pickle can find the enum
-        frame = sys._getframe(2)  # 2 because we're called via wrapper
-        module = frame.f_globals.get("__name__", __name__)
 
         enum_cls = _create_enum(enum_name, members, module=module)
 

--- a/tests/unit/plugin/test_extensible_enums.py
+++ b/tests/unit/plugin/test_extensible_enums.py
@@ -349,48 +349,48 @@ class TestCreateEnum:
 
     def test_basic_creation(self):
         """create_enum creates enum from dict."""
-        MyEnum = create_enum("MyEnum", {"ONE": "one", "TWO": "two"})
+        MyEnum = create_enum("MyEnum", {"ONE": "one", "TWO": "two"}, module=__name__)
         assert MyEnum.ONE.value == "one"
         assert MyEnum.TWO.value == "two"
 
     def test_extensible(self):
         """Created enum supports registration."""
-        MyEnum = create_enum("MyEnum", {"BASE": "base"})
+        MyEnum = create_enum("MyEnum", {"BASE": "base"}, module=__name__)
         MyEnum.register("EXT", "ext")
         assert MyEnum.EXT.value == "ext"
 
     def test_case_insensitive(self):
         """Created enum supports case-insensitive lookup."""
-        MyEnum = create_enum("MyEnum", {"ITEM": "item"})
+        MyEnum = create_enum("MyEnum", {"ITEM": "item"}, module=__name__)
         assert MyEnum("item") == MyEnum.ITEM
         assert MyEnum("ITEM") == MyEnum.ITEM
         assert MyEnum("Item") == MyEnum.ITEM
 
     def test_str_subclass(self):
         """Created enum members are str subclass."""
-        MyEnum = create_enum("MyEnum", {"ITEM": "item"})
+        MyEnum = create_enum("MyEnum", {"ITEM": "item"}, module=__name__)
         assert isinstance(MyEnum.ITEM, str)
 
     def test_iteration_and_len(self):
         """Created enum supports iteration and len."""
-        MyEnum = create_enum("MyEnum", {"A": "a", "B": "b", "C": "c"})
+        MyEnum = create_enum("MyEnum", {"A": "a", "B": "b", "C": "c"}, module=__name__)
         assert len(MyEnum) == 3
         values = sorted(m.value for m in MyEnum)
         assert values == ["a", "b", "c"]
 
-    def test_module_auto_detection(self):
-        """create_enum auto-detects caller's module."""
-        MyEnum = create_enum("MyEnum", {"ITEM": "item"})
-        assert MyEnum.__module__ == __name__
+    def test_module_required(self):
+        """create_enum requires module parameter."""
+        with pytest.raises(TypeError):
+            create_enum("MyEnum", {"ITEM": "item"})  # type: ignore[call-arg]
 
     def test_module_explicit(self):
-        """create_enum accepts explicit module."""
+        """create_enum sets module from explicit argument."""
         MyEnum = create_enum("MyEnum", {"ITEM": "item"}, module="custom.module")
         assert MyEnum.__module__ == "custom.module"
 
     def test_empty_members(self):
         """create_enum handles empty dict."""
-        MyEnum = create_enum("EmptyEnum", {})
+        MyEnum = create_enum("EmptyEnum", {}, module=__name__)
         assert len(MyEnum) == 0
         assert list(MyEnum) == []
 
@@ -441,7 +441,7 @@ class TestPydanticIntegration:
 
     def test_dynamic_enum_in_model(self):
         """Dynamically created enum works in Pydantic model."""
-        DynamicEnum = create_enum("DynamicEnum", {"A": "a", "B": "b"})
+        DynamicEnum = create_enum("DynamicEnum", {"A": "a", "B": "b"}, module=__name__)
 
         class Config(BaseModel):
             value: DynamicEnum

--- a/tests/unit/plugin/test_plugins.py
+++ b/tests/unit/plugin/test_plugins.py
@@ -654,14 +654,18 @@ class TestCreateEnum:
 
     def test_create_enum_basic(self, registry_with_types: _PluginRegistry) -> None:
         """create_enum() creates enum from registered types."""
-        enum_cls = registry_with_types.create_enum("test_category", "TestEnum")
+        enum_cls = registry_with_types.create_enum(
+            "test_category", "TestEnum", module=__name__
+        )
         assert issubclass(enum_cls, ExtensibleStrEnum)
         assert hasattr(enum_cls, "TYPE_A")
         assert hasattr(enum_cls, "TYPE_B")
 
     def test_create_enum_values(self, registry_with_types: _PluginRegistry) -> None:
         """create_enum() creates correct enum values."""
-        enum_cls = registry_with_types.create_enum("test_category", "TestEnum")
+        enum_cls = registry_with_types.create_enum(
+            "test_category", "TestEnum", module=__name__
+        )
         assert enum_cls.TYPE_A.value == "type_a"
         assert enum_cls.TYPE_B.value == "type_b"
 
@@ -670,13 +674,15 @@ class TestCreateEnum:
     ) -> None:
         """create_enum() raises KeyError for empty category."""
         with pytest.raises(KeyError, match="No types registered"):
-            registry_with_types.create_enum("nonexistent", "TestEnum")
+            registry_with_types.create_enum("nonexistent", "TestEnum", module=__name__)
 
     def test_create_enum_stores_category(
         self, registry_with_types: _PluginRegistry
     ) -> None:
         """create_enum() stores plugin category on enum."""
-        enum_cls = registry_with_types.create_enum("test_category", "TestEnum")
+        enum_cls = registry_with_types.create_enum(
+            "test_category", "TestEnum", module=__name__
+        )
         assert enum_cls._plugin_category_ == "test_category"
 
 

--- a/tools/generate_plugin_artifacts.py
+++ b/tools/generate_plugin_artifacts.py
@@ -280,7 +280,7 @@ def generate_enums_py() -> str:
         '    PluginType = create_enum("PluginType", {',
         '        category.replace("-", "_").upper(): category',
         "        for category in _all_plugin_categories",
-        "    })",
+        "    }, module=__name__)",
         "    PluginTypeStr: TypeAlias = str",
         "",
     ]
@@ -293,7 +293,7 @@ def generate_enums_py() -> str:
         lines.extend(
             [
                 f"{enum_name}Str: TypeAlias = str",
-                f'{enum_name} = plugins.create_enum(PluginType.{member}, "{enum_name}")',
+                f'{enum_name} = plugins.create_enum(PluginType.{member}, "{enum_name}", module=__name__)',
                 f'"""Dynamic enum for {name.replace("_", " ")}. Example: {examples}"""',
                 "",
             ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the plugin system's enum creation mechanism to require explicit module binding for dynamically generated enums, improving consistency and reliability across the codebase. Updated documentation and test coverage to reflect the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->