### PR TITLE
feat: add --service-tier-dist for per-request service_tier distribution

### DIFF
--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -250,7 +250,7 @@ Specify service level objectives (SLOs) for goodput as space-separated 'KEY:VALU
 
 #### `--service-tier-dist` `<str>`
 
-Distribution of service_tier values for OpenAI API requests. Format: `tier:prob;tier:prob` (percentages 0-100 that must sum to 100). Example: `default:50;flex:30;priority:20`. Valid tiers: auto, default, flex, scale, priority.
+Distribution of service_tier values for OpenAI API requests. Format: `tier:prob;tier:prob` (percentages 0-100 that must sum to 100). Example: `default:50;flex:30;priority:20`. Common tiers: auto, default, flex, scale, priority.
 
 ### Audio Input
 

--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -248,6 +248,10 @@ Random seed for deterministic data generation. When set, makes synthetic prompts
 
 Specify service level objectives (SLOs) for goodput as space-separated 'KEY:VALUE' pairs, where KEY is a metric tag and VALUE is a number in the metric's display unit (falls back to its base unit if no display unit is defined). Examples: 'request_latency:250' (ms), 'inter_token_latency:10' (ms), `output_token_throughput_per_user:600` (tokens/s). Only metrics applicable to the current endpoint/config are considered. For more context on the definition of goodput, refer to DistServe paper: https://arxiv.org/pdf/2401.09670 and the blog: https://hao-ai-lab.github.io/blogs/distserve.
 
+#### `--service-tier-dist` `<str>`
+
+Distribution of service_tier values for OpenAI API requests. Format: `tier:prob;tier:prob` (percentages 0-100 that must sum to 100). Example: `default:50;flex:30;priority:20`. Valid tiers: auto, default, flex, scale, priority.
+
 ### Audio Input
 
 #### `--audio-batch-size`, `--batch-size-audio` `<int>`

--- a/src/aiperf/common/config/input_config.py
+++ b/src/aiperf/common/config/input_config.py
@@ -129,6 +129,20 @@ class InputConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_service_tier_mutual_exclusivity(self) -> Self:
+        """Validate that --service-tier-dist and --extra-inputs service_tier are not both set."""
+        if self.service_tier_distribution is not None and self.extra:
+            extra_dict = (
+                dict(self.extra) if isinstance(self.extra, list) else self.extra
+            )
+            if isinstance(extra_dict, dict) and "service_tier" in extra_dict:
+                raise ValueError(
+                    "Cannot use both --service-tier-dist and --extra-inputs service_tier. "
+                    "Use one or the other."
+                )
+        return self
+
+    @model_validator(mode="after")
     def validate_goodput(self) -> Self:
         """
         Validate that all keys provided to --goodput are known metric tags.
@@ -337,6 +351,21 @@ class InputConfig(BaseConfig):
         ),
     ] = InputDefaults.GOODPUT
 
+    service_tier_distribution: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Distribution of service_tier values for OpenAI API requests. "
+            "Format: `tier:prob;tier:prob` (percentages 0-100 that must sum to 100). "
+            "Example: `default:50;flex:30;priority:20`. "
+            "Valid tiers: auto, default, flex, scale, priority.",
+        ),
+        CLIParameter(
+            name=("--service-tier-dist",),
+            group=_CLI_GROUP,
+        ),
+    ] = None
+
     audio: AudioConfig = AudioConfig()
     image: ImageConfig = ImageConfig()
     video: VideoConfig = VideoConfig()
@@ -344,3 +373,13 @@ class InputConfig(BaseConfig):
     rankings: RankingsConfig = RankingsConfig()
     synthesis: SynthesisConfig = SynthesisConfig()
     conversation: ConversationConfig = ConversationConfig()
+
+    def get_service_tier_distribution(self):
+        """Get service tier distribution object, returning None if not specified."""
+        if self.service_tier_distribution is not None:
+            from aiperf.common.models.service_tier_distribution import (
+                ServiceTierDistributionParser,
+            )
+
+            return ServiceTierDistributionParser.parse(self.service_tier_distribution)
+        return None

--- a/src/aiperf/common/config/input_config.py
+++ b/src/aiperf/common/config/input_config.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
+
+if TYPE_CHECKING:
+    from aiperf.common.models.service_tier_distribution import ServiceTierDistribution
 
 from pydantic import BeforeValidator, Field, model_validator
 from typing_extensions import Self
@@ -358,7 +361,7 @@ class InputConfig(BaseConfig):
             description="Distribution of service_tier values for OpenAI API requests. "
             "Format: `tier:prob;tier:prob` (percentages 0-100 that must sum to 100). "
             "Example: `default:50;flex:30;priority:20`. "
-            "Valid tiers: auto, default, flex, scale, priority.",
+            "Common tiers: auto, default, flex, scale, priority.",
         ),
         CLIParameter(
             name=("--service-tier-dist",),
@@ -374,7 +377,7 @@ class InputConfig(BaseConfig):
     synthesis: SynthesisConfig = SynthesisConfig()
     conversation: ConversationConfig = ConversationConfig()
 
-    def get_service_tier_distribution(self):
+    def get_service_tier_distribution(self) -> "ServiceTierDistribution | None":
         """Get service tier distribution object, returning None if not specified."""
         if self.service_tier_distribution is not None:
             from aiperf.common.models.service_tier_distribution import (

--- a/src/aiperf/common/config/user_config.py
+++ b/src/aiperf/common/config/user_config.py
@@ -951,6 +951,18 @@ class UserConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_service_tier_endpoint_type(self) -> Self:
+        """Validate that --service-tier-dist is only used with chat or completions endpoints."""
+        if self.input.service_tier_distribution is not None:
+            supported = {EndpointType.CHAT, EndpointType.COMPLETIONS}
+            if self.endpoint.type not in supported:
+                raise ValueError(
+                    f"--service-tier-dist is only supported with chat and completions endpoints, "
+                    f"got endpoint type '{self.endpoint.type}'"
+                )
+        return self
+
+    @model_validator(mode="after")
     def validate_must_have_stop_condition(self) -> Self:
         """Validate that at least one stop condition is set (requests, sessions, or duration)"""
         if (

--- a/src/aiperf/common/models/dataset_models.py
+++ b/src/aiperf/common/models/dataset_models.py
@@ -123,6 +123,10 @@ class Turn(AIPerfBaseModel):
     max_tokens: int | None = Field(
         default=None, description="Maximum number of tokens to generate for this turn."
     )
+    service_tier: str | None = Field(
+        default=None,
+        description="The service_tier to use for this turn's API request.",
+    )
     texts: list[Text] = Field(
         default=[], description="Collection of text data in each turn."
     )
@@ -159,6 +163,7 @@ class Turn(AIPerfBaseModel):
             timestamp=self.timestamp,
             delay=self.delay,
             max_tokens=self.max_tokens,
+            service_tier=self.service_tier,
             texts=[Text(name=t.name, contents=list(t.contents)) for t in self.texts],
             images=[
                 Image(

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -136,6 +136,10 @@ class MetricRecordMetadata(AIPerfBaseModel):
         description="The wall clock timestamp of the request cancellation time measured as time.time_ns(), if applicable. "
         "This is only applicable to requests that were cancelled.",
     )
+    service_tier: str | None = Field(
+        default=None,
+        description="The service_tier returned by the API for this request.",
+    )
 
 
 class ProfileResults(AIPerfBaseModel):

--- a/src/aiperf/common/models/service_tier_distribution.py
+++ b/src/aiperf/common/models/service_tier_distribution.py
@@ -87,7 +87,7 @@ class ServiceTierDistribution:
         self._cumulative_probs = self._compute_cumulative_probabilities()
 
         logger.debug(
-            f"Created service tier distribution with {len(self._entries)} entries: {self}"
+            lambda: f"Created service tier distribution with {len(self._entries)} entries: {self}"
         )
 
     def _compute_cumulative_probabilities(self) -> np.ndarray:

--- a/src/aiperf/common/models/service_tier_distribution.py
+++ b/src/aiperf/common/models/service_tier_distribution.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Service tier distribution for OpenAI API requests.
+
+Allows distributing requests across different service tiers (e.g., default, flex, priority)
+with configurable probabilities. Format: ``tier:prob;tier:prob`` where probabilities are
+percentages 0-100 that must sum to 100.
+
+Example:
+    >>> from aiperf.common.models.service_tier_distribution import ServiceTierDistributionParser
+    >>> dist = ServiceTierDistributionParser.parse("default:50;flex:30;priority:20")
+    >>> tier = dist.sample()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from aiperf.common import random_generator as rng
+from aiperf.common.aiperf_logger import AIPerfLogger
+
+logger = AIPerfLogger(__name__)
+
+
+def _validate_probability_sum(entries: list[ServiceTierEntry]) -> None:
+    """Validate that probabilities sum to approximately 100.0.
+
+    Args:
+        entries: List of ServiceTierEntry objects to validate
+
+    Raises:
+        ValueError: If probabilities don't sum to 100.0 (within floating-point tolerance)
+    """
+    total_prob = sum(entry.probability for entry in entries)
+    if not np.isclose(total_prob, 100.0, rtol=1e-6, atol=1e-6):
+        raise ValueError(
+            f"Probabilities must sum to 100.0, got {total_prob:.6f}. "
+            f"Entries: {[str(e) for e in entries]}"
+        )
+
+
+@dataclass(frozen=True)
+class ServiceTierEntry:
+    """Immutable representation of a service tier with probability weight."""
+
+    tier: str
+    probability: float
+
+    def __post_init__(self) -> None:
+        """Validate tier name and probability on construction."""
+        if not self.tier or not self.tier.strip():
+            raise ValueError("Tier name must be non-empty")
+        if not 0.0 <= self.probability <= 100.0:
+            raise ValueError(f"Probability must be in [0,100], got {self.probability}")
+
+    def __str__(self) -> str:
+        return f"{self.tier}:{self.probability}%"
+
+
+class ServiceTierDistribution:
+    """Manages probability distribution of service tiers for request sampling.
+
+    Supports efficient O(log n) sampling using binary search on cumulative
+    probability distribution.
+    """
+
+    def __init__(self, entries: list[ServiceTierEntry]) -> None:
+        """Initialize distribution from list of service tier entries.
+
+        Args:
+            entries: List of ServiceTierEntry objects. Probabilities must sum to 100.
+
+        Raises:
+            ValueError: If entries is empty or probabilities don't sum to 100.
+        """
+        if not entries:
+            raise ValueError(
+                "Distribution must contain at least one service tier entry"
+            )
+
+        self._rng = rng.derive("models.service_tier.distribution")
+        self._entries = tuple(entries)
+        _validate_probability_sum(list(self._entries))
+        self._cumulative_probs = self._compute_cumulative_probabilities()
+
+        logger.debug(
+            f"Created service tier distribution with {len(self._entries)} entries: {self}"
+        )
+
+    def _compute_cumulative_probabilities(self) -> np.ndarray:
+        """Compute cumulative probability distribution for efficient sampling."""
+        probs = [entry.probability / 100.0 for entry in self._entries]
+        return np.cumsum(probs, dtype=np.float64)
+
+    def sample(self) -> str:
+        """Sample a service tier according to the distribution.
+
+        Returns:
+            Service tier string value
+        """
+        rand_val = self._rng.random()
+        idx = np.searchsorted(self._cumulative_probs, rand_val, side="right")
+        idx = min(idx, len(self._entries) - 1)
+        return self._entries[idx].tier
+
+    @property
+    def entries(self) -> tuple[ServiceTierEntry, ...]:
+        """Get immutable view of service tier entries."""
+        return self._entries
+
+    def __str__(self) -> str:
+        entries_str = ";".join(str(entry) for entry in self._entries)
+        return f"ServiceTierDistribution[{entries_str}]"
+
+    def __repr__(self) -> str:
+        return f"ServiceTierDistribution({list(self._entries)})"
+
+
+class ServiceTierDistributionParser:
+    """Parser for service tier distribution strings."""
+
+    @classmethod
+    def parse(cls, dist_str: str) -> ServiceTierDistribution:
+        """Parse a service tier distribution string.
+
+        Format: ``tier:prob;tier:prob`` where probabilities are percentages 0-100.
+
+        Args:
+            dist_str: Distribution specification string (e.g., "default:50;flex:30;priority:20")
+
+        Returns:
+            ServiceTierDistribution object
+
+        Raises:
+            ValueError: If string format is invalid
+        """
+        if not isinstance(dist_str, str) or not dist_str.strip():
+            raise ValueError("Distribution string cannot be empty")
+
+        dist_str = dist_str.strip()
+        entries: list[ServiceTierEntry] = []
+
+        for pair_str in dist_str.split(";"):
+            pair_str = pair_str.strip()
+            if not pair_str:
+                continue
+
+            parts = pair_str.rsplit(":", 1)
+            if len(parts) != 2:
+                raise ValueError(
+                    f"Invalid pair format: '{pair_str}'. Expected 'tier:probability'"
+                )
+
+            tier = parts[0].strip()
+            try:
+                probability = float(parts[1].strip())
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid probability value in '{pair_str}': {parts[1].strip()}"
+                ) from e
+
+            entries.append(ServiceTierEntry(tier=tier, probability=probability))
+
+        if not entries:
+            raise ValueError("No valid entries found in distribution string")
+
+        return ServiceTierDistribution(entries)

--- a/src/aiperf/dataset/composer/base.py
+++ b/src/aiperf/dataset/composer/base.py
@@ -37,6 +37,9 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
         # Initialize sequence distribution
         self._seq_distribution = config.input.prompt.get_sequence_distribution()
 
+        # Initialize service tier distribution
+        self._service_tier_distribution = config.input.get_service_tier_distribution()
+
         # Cache for turn-level sequence lengths to ensure ISL/OSL pairing consistency
         self._turn_sequence_cache: dict[int, tuple[int, int]] = {}
 
@@ -139,6 +142,9 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
         """
         turn.model = self._select_model_name()
         self._set_max_tokens(turn)
+
+        if self._service_tier_distribution is not None:
+            turn.service_tier = self._service_tier_distribution.sample()
 
         # Clear cached sequence lengths for this turn to free memory
         turn_id = id(turn)

--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -203,7 +203,7 @@ class ChatEndpoint(BaseEndpoint):
 
         if data or usage:
             metadata = {}
-            if service_tier := json_obj.get("service_tier"):
+            if (service_tier := json_obj.get("service_tier")) is not None:
                 metadata["service_tier"] = service_tier
             return ParsedResponse(
                 perf_ns=response.perf_ns, data=data, usage=usage, metadata=metadata

--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -58,6 +58,9 @@ class ChatEndpoint(BaseEndpoint):
             )
             payload[token_field] = turns[-1].max_tokens
 
+        if turns[-1].service_tier is not None:
+            payload["service_tier"] = turns[-1].service_tier
+
         if model_endpoint.endpoint.extra:
             payload.update(model_endpoint.endpoint.extra)
 
@@ -199,7 +202,12 @@ class ChatEndpoint(BaseEndpoint):
         usage = json_obj.get("usage") or None
 
         if data or usage:
-            return ParsedResponse(perf_ns=response.perf_ns, data=data, usage=usage)
+            metadata = {}
+            if service_tier := json_obj.get("service_tier"):
+                metadata["service_tier"] = service_tier
+            return ParsedResponse(
+                perf_ns=response.perf_ns, data=data, usage=usage, metadata=metadata
+            )
 
         return None
 

--- a/src/aiperf/endpoints/openai_completions.py
+++ b/src/aiperf/endpoints/openai_completions.py
@@ -91,7 +91,7 @@ class CompletionsEndpoint(BaseEndpoint):
 
         if data or usage:
             metadata = {}
-            if service_tier := json_obj.get("service_tier"):
+            if (service_tier := json_obj.get("service_tier")) is not None:
                 metadata["service_tier"] = service_tier
             return ParsedResponse(
                 perf_ns=response.perf_ns, data=data, usage=usage, metadata=metadata

--- a/src/aiperf/endpoints/openai_completions.py
+++ b/src/aiperf/endpoints/openai_completions.py
@@ -49,6 +49,9 @@ class CompletionsEndpoint(BaseEndpoint):
         if turn.max_tokens:
             payload["max_tokens"] = turn.max_tokens
 
+        if turn.service_tier is not None:
+            payload["service_tier"] = turn.service_tier
+
         if extra:
             payload.update(extra)
 
@@ -87,7 +90,12 @@ class CompletionsEndpoint(BaseEndpoint):
         usage = json_obj.get("usage") or None
 
         if data or usage:
-            return ParsedResponse(perf_ns=response.perf_ns, data=data, usage=usage)
+            metadata = {}
+            if service_tier := json_obj.get("service_tier"):
+                metadata["service_tier"] = service_tier
+            return ParsedResponse(
+                perf_ns=response.perf_ns, data=data, usage=usage, metadata=metadata
+            )
 
         return None
 

--- a/src/aiperf/records/record_processor_service.py
+++ b/src/aiperf/records/record_processor_service.py
@@ -159,6 +159,13 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
         metadata = self._create_metric_record_metadata(
             message.record, message.service_id
         )
+
+        # Extract response service_tier (check reversed - streaming puts metadata on last chunk)
+        for resp in reversed(parsed_record.responses):
+            if st := resp.metadata.get("service_tier"):
+                metadata.service_tier = st
+                break
+
         raw_results = await self._process_record(parsed_record, metadata)
         results = []
         for result in raw_results:

--- a/tests/unit/common/models/test_service_tier_distribution.py
+++ b/tests/unit/common/models/test_service_tier_distribution.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for service tier distribution functionality."""
+
+import pytest
+
+from aiperf.common.models.service_tier_distribution import (
+    ServiceTierDistribution,
+    ServiceTierDistributionParser,
+    ServiceTierEntry,
+)
+
+
+class TestServiceTierEntry:
+    """Test ServiceTierEntry validation and behavior."""
+
+    def test_valid_entry_creation(self):
+        entry = ServiceTierEntry("default", 50.0)
+        assert entry.tier == "default"
+        assert entry.probability == 50.0
+
+    def test_empty_tier_name_raises(self):
+        with pytest.raises(ValueError, match="Tier name must be non-empty"):
+            ServiceTierEntry("", 50.0)
+
+    def test_whitespace_tier_name_raises(self):
+        with pytest.raises(ValueError, match="Tier name must be non-empty"):
+            ServiceTierEntry("   ", 50.0)
+
+    def test_negative_probability_raises(self):
+        with pytest.raises(ValueError, match="Probability must be in"):
+            ServiceTierEntry("default", -10.0)
+
+    def test_probability_over_100_raises(self):
+        with pytest.raises(ValueError, match="Probability must be in"):
+            ServiceTierEntry("default", 110.0)
+
+    def test_str_representation(self):
+        entry = ServiceTierEntry("flex", 30.0)
+        assert str(entry) == "flex:30.0%"
+
+
+class TestServiceTierDistribution:
+    """Test ServiceTierDistribution sampling and validation."""
+
+    def test_single_tier_always_returns_that_tier(self):
+        dist = ServiceTierDistribution([ServiceTierEntry("flex", 100.0)])
+        for _ in range(100):
+            assert dist.sample() == "flex"
+
+    def test_empty_entries_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            ServiceTierDistribution([])
+
+    def test_probabilities_must_sum_to_100(self):
+        with pytest.raises(ValueError, match="sum to 100"):
+            ServiceTierDistribution(
+                [
+                    ServiceTierEntry("default", 50.0),
+                    ServiceTierEntry("flex", 30.0),
+                ]
+            )
+
+    def test_multi_tier_distribution_samples_all_tiers(self):
+        dist = ServiceTierDistribution(
+            [
+                ServiceTierEntry("default", 50.0),
+                ServiceTierEntry("flex", 30.0),
+                ServiceTierEntry("priority", 20.0),
+            ]
+        )
+        counts: dict[str, int] = {"default": 0, "flex": 0, "priority": 0}
+        for _ in range(10000):
+            tier = dist.sample()
+            counts[tier] += 1
+
+        # All tiers should be sampled at least once with 10k samples
+        assert counts["default"] > 0
+        assert counts["flex"] > 0
+        assert counts["priority"] > 0
+
+        # Rough distribution check (with wide tolerance)
+        assert 4000 < counts["default"] < 6000
+        assert 2000 < counts["flex"] < 4000
+        assert 1000 < counts["priority"] < 3000
+
+    def test_entries_property_returns_immutable_tuple(self):
+        entries = [ServiceTierEntry("default", 100.0)]
+        dist = ServiceTierDistribution(entries)
+        assert isinstance(dist.entries, tuple)
+        assert len(dist.entries) == 1
+
+    def test_str_representation(self):
+        dist = ServiceTierDistribution(
+            [
+                ServiceTierEntry("default", 60.0),
+                ServiceTierEntry("flex", 40.0),
+            ]
+        )
+        result = str(dist)
+        assert "ServiceTierDistribution" in result
+        assert "default" in result
+        assert "flex" in result
+
+
+class TestServiceTierDistributionParser:
+    """Test ServiceTierDistributionParser parsing."""
+
+    def test_parse_single_tier(self):
+        dist = ServiceTierDistributionParser.parse("flex:100")
+        assert len(dist.entries) == 1
+        assert dist.entries[0].tier == "flex"
+        assert dist.entries[0].probability == 100.0
+
+    def test_parse_multiple_tiers(self):
+        dist = ServiceTierDistributionParser.parse("default:50;flex:30;priority:20")
+        assert len(dist.entries) == 3
+        assert dist.entries[0].tier == "default"
+        assert dist.entries[0].probability == 50.0
+        assert dist.entries[1].tier == "flex"
+        assert dist.entries[1].probability == 30.0
+        assert dist.entries[2].tier == "priority"
+        assert dist.entries[2].probability == 20.0
+
+    def test_parse_with_whitespace(self):
+        dist = ServiceTierDistributionParser.parse(" default : 50 ; flex : 50 ")
+        assert len(dist.entries) == 2
+
+    def test_parse_empty_string_raises(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            ServiceTierDistributionParser.parse("")
+
+    def test_parse_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Invalid pair format"):
+            ServiceTierDistributionParser.parse("just_a_string")
+
+    def test_parse_invalid_probability_raises(self):
+        with pytest.raises(ValueError, match="Invalid probability"):
+            ServiceTierDistributionParser.parse("default:abc")
+
+    def test_parse_probabilities_not_summing_to_100_raises(self):
+        with pytest.raises(ValueError, match="sum to 100"):
+            ServiceTierDistributionParser.parse("default:50;flex:20")
+
+    @pytest.mark.parametrize(
+        "dist_str,expected_tiers",
+        [
+            ("auto:100", ["auto"]),
+            ("default:50;flex:50", ["default", "flex"]),
+            (
+                "scale:33.33;priority:33.33;default:33.34",
+                ["scale", "priority", "default"],
+            ),
+        ],
+    )
+    def test_parse_various_valid_formats(self, dist_str, expected_tiers):
+        dist = ServiceTierDistributionParser.parse(dist_str)
+        assert [e.tier for e in dist.entries] == expected_tiers

--- a/tests/unit/endpoints/test_openai_chat_completions.py
+++ b/tests/unit/endpoints/test_openai_chat_completions.py
@@ -11,7 +11,7 @@ from aiperf.common.models.model_endpoint_info import (
 )
 from aiperf.endpoints.openai_chat import ChatEndpoint
 from aiperf.plugin.enums import EndpointType
-from tests.unit.endpoints.conftest import create_request_info
+from tests.unit.endpoints.conftest import create_mock_response, create_request_info
 
 
 class TestChatEndpoint:
@@ -338,3 +338,66 @@ class TestChatEndpoint:
         assert payload["messages"][1]["content"] == user_context
         # Third message should be the turn
         assert payload["messages"][2]["role"] == (turn.role or "user")
+
+    def test_format_payload_with_service_tier(
+        self, model_endpoint, sample_conversations
+    ):
+        """Verify service_tier from Turn is included in payload."""
+        endpoint = ChatEndpoint(model_endpoint)
+        turn = sample_conversations["session_1"].turns[0]
+        turn.service_tier = "flex"
+        turns = [turn]
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=turns)
+        payload = endpoint.format_payload(request_info)
+        assert payload["service_tier"] == "flex"
+
+    def test_format_payload_without_service_tier(
+        self, model_endpoint, sample_conversations
+    ):
+        """Verify service_tier is not in payload when not set."""
+        endpoint = ChatEndpoint(model_endpoint)
+        turn = sample_conversations["session_1"].turns[0]
+        turns = [turn]
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=turns)
+        payload = endpoint.format_payload(request_info)
+        assert "service_tier" not in payload
+
+    def test_format_payload_service_tier_overridden_by_extra(
+        self, model_endpoint, sample_conversations
+    ):
+        """Verify --extra-inputs service_tier overrides Turn.service_tier."""
+        endpoint = ChatEndpoint(model_endpoint)
+        turn = sample_conversations["session_1"].turns[0]
+        turn.service_tier = "flex"
+        turns = [turn]
+        model_endpoint.endpoint.extra = {"service_tier": "priority"}
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=turns)
+        payload = endpoint.format_payload(request_info)
+        assert payload["service_tier"] == "priority"
+
+    def test_parse_response_extracts_service_tier(self, model_endpoint):
+        """Verify service_tier is extracted from response JSON into metadata."""
+        endpoint = ChatEndpoint(model_endpoint)
+        response = create_mock_response(
+            json_data={
+                "object": "chat.completion",
+                "service_tier": "flex",
+                "choices": [{"message": {"content": "Hello"}}],
+            }
+        )
+        parsed = endpoint.parse_response(response)
+        assert parsed is not None
+        assert parsed.metadata.get("service_tier") == "flex"
+
+    def test_parse_response_no_service_tier(self, model_endpoint):
+        """Verify metadata is empty when response has no service_tier."""
+        endpoint = ChatEndpoint(model_endpoint)
+        response = create_mock_response(
+            json_data={
+                "object": "chat.completion",
+                "choices": [{"message": {"content": "Hello"}}],
+            }
+        )
+        parsed = endpoint.parse_response(response)
+        assert parsed is not None
+        assert "service_tier" not in parsed.metadata

--- a/tests/unit/endpoints/test_openai_completions.py
+++ b/tests/unit/endpoints/test_openai_completions.py
@@ -12,7 +12,7 @@ from aiperf.common.models.model_endpoint_info import (
 )
 from aiperf.endpoints.openai_completions import CompletionsEndpoint
 from aiperf.plugin.enums import EndpointType
-from tests.unit.endpoints.conftest import create_request_info
+from tests.unit.endpoints.conftest import create_mock_response, create_request_info
 
 
 class TestCompletionsEndpoint:
@@ -111,3 +111,53 @@ class TestCompletionsEndpoint:
         else:
             assert "stream_options" in payload
             assert payload["stream_options"] == expected_stream_options
+
+    def test_format_payload_with_service_tier(
+        self, model_endpoint, sample_conversations
+    ):
+        """Verify service_tier from Turn is included in payload."""
+        endpoint = CompletionsEndpoint(model_endpoint)
+        turn = sample_conversations["session_1"].turns[0]
+        turn.service_tier = "flex"
+        turns = [turn]
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=turns)
+        payload = endpoint.format_payload(request_info)
+        assert payload["service_tier"] == "flex"
+
+    def test_format_payload_without_service_tier(
+        self, model_endpoint, sample_conversations
+    ):
+        """Verify service_tier is not in payload when not set."""
+        endpoint = CompletionsEndpoint(model_endpoint)
+        turn = sample_conversations["session_1"].turns[0]
+        turns = [turn]
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=turns)
+        payload = endpoint.format_payload(request_info)
+        assert "service_tier" not in payload
+
+    def test_parse_response_extracts_service_tier(self, model_endpoint):
+        """Verify service_tier is extracted from response JSON into metadata."""
+        endpoint = CompletionsEndpoint(model_endpoint)
+        response = create_mock_response(
+            json_data={
+                "object": "text_completion",
+                "service_tier": "priority",
+                "choices": [{"text": "Hello"}],
+            }
+        )
+        parsed = endpoint.parse_response(response)
+        assert parsed is not None
+        assert parsed.metadata.get("service_tier") == "priority"
+
+    def test_parse_response_no_service_tier(self, model_endpoint):
+        """Verify metadata is empty when response has no service_tier."""
+        endpoint = CompletionsEndpoint(model_endpoint)
+        response = create_mock_response(
+            json_data={
+                "object": "text_completion",
+                "choices": [{"text": "Hello"}],
+            }
+        )
+        parsed = endpoint.parse_response(response)
+        assert parsed is not None
+        assert "service_tier" not in parsed.metadata


### PR DESCRIPTION
Allows users to specify a distribution of service_tier values (e.g. `default:50;flex:30;priority:20`) that get sampled per turn and sent in OpenAI chat/completions payloads. The response service_tier is extracted into record metadata for downstream analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to specify a distribution of service tiers for API requests (format: tier:percentage;tier:percentage).
  * Service tier is now sent with requests when present and captured in response metrics.

* **Validation**
  * CLI option is disallowed alongside explicit per-request service_tier and restricted to chat/completions endpoints.

* **Tests**
  * Added unit and endpoint tests covering distribution parsing, sampling, payloads, and response extraction.

* **Documentation**
  * CLI docs updated with the new option and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->