### PR TITLE
chore: exclude notebook from ruff linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dev = [
 # Base settings for ruff
 line-length = 88
 indent-width = 4
-exclude = ["__pycache__", "build", "dist", ".venv", "venv"]
+exclude = ["__pycache__", "build", "dist", ".venv", "venv", "notebooks/TCO_calculator.ipynb"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary
- Add `notebooks/TCO_calculator.ipynb` to ruff exclude list to prevent linting errors on the notebook file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to exclude a notebook file from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->