### PR TITLE
fix(macOS): proper fix for semaphore leak warning

### DIFF
--- a/src/aiperf/cli_runner.py
+++ b/src/aiperf/cli_runner.py
@@ -14,8 +14,6 @@ def run_system_controller(
     service_config: ServiceConfig,
 ) -> None:
     """Run the system controller with the given configuration."""
-    # Suppress the resource tracker's "leaked semaphore" warning on shutdown.
-    _suppress_resource_tracker_warnings()
 
     # NOTE: On macOS, when using the Textual UI with multiprocessing, terminal corruption
     # (ASCII garbage, freezing) can occur when mouse events interfere with child processes.
@@ -109,27 +107,3 @@ def run_system_controller(
         raise
     finally:
         logger.debug("AIPerf System exited")
-
-
-def _suppress_resource_tracker_warnings() -> None:
-    """Suppress the resource tracker's "leaked semaphore" warning on shutdown.
-
-    This is because the System Controller calls os._exit() on shutdown, which does not
-    allow for cleanup of the resource tracker semaphores (OS will handle cleanup).
-
-    This MUST be set via env var because the resource tracker runs as a separate daemon
-    process that inherits the environment but NOT Python's in-memory warning filters.
-
-    The message field is left empty because regex patterns are not supported in Python < 3.14.
-    Additionally, `:` in the message breaks field parsing since PYTHONWARNINGS uses `:` as the delimiter.
-    """
-    import os
-
-    _RESOURCE_TRACKER_FILTER = "ignore::UserWarning:multiprocessing.resource_tracker"
-    _existing_warnings = os.environ.get("PYTHONWARNINGS", "")
-    if _RESOURCE_TRACKER_FILTER not in _existing_warnings:
-        os.environ["PYTHONWARNINGS"] = (
-            f"{_existing_warnings},{_RESOURCE_TRACKER_FILTER}"
-            if _existing_warnings
-            else _RESOURCE_TRACKER_FILTER
-        )

--- a/src/aiperf/common/logging.py
+++ b/src/aiperf/common/logging.py
@@ -91,6 +91,9 @@ async def cleanup_global_log_queue() -> None:
             except Exception as e:
                 _logger.debug(f"Error cleaning up log queue: {e}")
             finally:
+                from aiperf.common.resource_tracker import unregister_queue_semaphores
+
+                unregister_queue_semaphores(_global_log_queue)
                 _global_log_queue = None
 
 

--- a/src/aiperf/common/resource_tracker.py
+++ b/src/aiperf/common/resource_tracker.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities for unregistering multiprocessing semaphores from the resource tracker.
+
+When a process exits via os._exit(), garbage collection is skipped, so semaphores
+created by multiprocessing.Lock/RLock/Queue are never properly released. The
+resource tracker then warns about "leaked semaphore objects". These helpers
+explicitly unregister semaphores before os._exit() to suppress those warnings.
+"""
+
+import contextlib
+from multiprocessing import resource_tracker
+
+
+def unregister_semaphore(lock: object) -> None:
+    """Unregister a single lock/semaphore object from the resource tracker.
+
+    Works with any object that has a `_semlock` attribute (multiprocessing.Lock,
+    RLock, BoundedSemaphore, etc.). No-op if the lock has no semaphore.
+    """
+    sem = getattr(lock, "_semlock", None)
+    if sem is not None:
+        with contextlib.suppress(Exception):
+            resource_tracker.unregister(sem.name, "semaphore")
+
+
+def unregister_queue_semaphores(q: object) -> None:
+    """Unregister a multiprocessing.Queue's internal semaphores from the resource tracker.
+
+    A multiprocessing.Queue creates 3 semaphores (_rlock, _wlock, _sem) that are
+    tracked by the resource tracker. Normally these are unregistered when the
+    Lock/BoundedSemaphore objects are garbage-collected, but `os._exit()` skips GC.
+    """
+    for attr in ("_rlock", "_wlock", "_sem"):
+        lock = getattr(q, attr, None)
+        if lock is not None:
+            unregister_semaphore(lock)

--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -62,7 +62,7 @@ from aiperf.controller.system_mixins import SignalHandlerMixin
 from aiperf.credit.messages import CreditsCompleteMessage
 from aiperf.exporters.exporter_manager import ExporterManager
 from aiperf.plugin import plugins
-from aiperf.plugin.enums import PluginType, ServiceType
+from aiperf.plugin.enums import PluginType, ServiceType, UIType
 from aiperf.ui.protocols import AIPerfUIProtocol
 
 
@@ -116,17 +116,21 @@ class SystemController(SignalHandlerMixin, BaseService):
         ServiceManagerClass = plugins.get_class(
             PluginType.SERVICE_MANAGER, self.service_config.service_run_type
         )
+
+        using_dashboard = self.service_config.ui_type == UIType.DASHBOARD
+        log_queue = get_global_log_queue() if using_dashboard else None
+
         self.service_manager: ServiceManagerProtocol = ServiceManagerClass(
             required_services=self.required_services,
             user_config=self.user_config,
             service_config=self.service_config,
-            log_queue=get_global_log_queue(),
+            log_queue=log_queue,
         )
         UIClass = plugins.get_class(PluginType.UI, self.service_config.ui_type)
         self.ui: AIPerfUIProtocol = UIClass(
             service_config=self.service_config,
             user_config=self.user_config,
-            log_queue=get_global_log_queue(),
+            log_queue=log_queue,
             controller=self,
         )
         self.attach_child_lifecycle(self.ui)


### PR DESCRIPTION
Proper fix for this:

<img width="903" height="96" alt="Screenshot 2026-02-17 at 6 09 58 AM" src="https://github.com/user-attachments/assets/1cc14785-2bd4-4913-ab7e-4009b433da87" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup during shutdown to eliminate spurious warnings
  * Enhanced semaphore management in logging and progress UI components for cleaner process termination
<!-- end of auto-generated comment: release notes by coderabbit.ai -->