### PR TITLE
fix: handle unknown prometheus metrics

### DIFF
--- a/src/aiperf/server_metrics/accumulator.py
+++ b/src/aiperf/server_metrics/accumulator.py
@@ -243,9 +243,8 @@ class ServerMetricsAccumulator(BaseMetricsProcessor):
                     continue
 
                 if base_name not in metrics:
-                    # Create appropriate type-specific metric data
                     match metric_entry.metric_type:
-                        case PrometheusMetricType.GAUGE:
+                        case PrometheusMetricType.GAUGE | PrometheusMetricType.UNKNOWN:
                             metrics[base_name] = GaugeMetricData(
                                 description=metric_entry.description,
                                 series=[series_stats],

--- a/src/aiperf/server_metrics/csv_exporter.py
+++ b/src/aiperf/server_metrics/csv_exporter.py
@@ -41,6 +41,7 @@ HISTOGRAM_STAT_KEYS = [
 
 STAT_KEYS_MAP = {
     PrometheusMetricType.GAUGE: GAUGE_STAT_KEYS,
+    PrometheusMetricType.UNKNOWN: GAUGE_STAT_KEYS,
     PrometheusMetricType.COUNTER: COUNTER_STAT_KEYS,
     PrometheusMetricType.HISTOGRAM: HISTOGRAM_STAT_KEYS,
 }

--- a/src/aiperf/server_metrics/export_stats.py
+++ b/src/aiperf/server_metrics/export_stats.py
@@ -86,7 +86,7 @@ def compute_stats(
         42.47
     """
     match metric_type:
-        case PrometheusMetricType.GAUGE:
+        case PrometheusMetricType.GAUGE | PrometheusMetricType.UNKNOWN:
             return _compute_gauge_stats(
                 time_series,
                 time_filter,

--- a/src/aiperf/server_metrics/json_exporter.py
+++ b/src/aiperf/server_metrics/json_exporter.py
@@ -195,7 +195,7 @@ class ServerMetricsJsonExporter(MetricsBaseExporter):
                 # Get or create metric entry with appropriate type
                 if metric_name not in metrics:
                     match metric_data.type:
-                        case PrometheusMetricType.GAUGE:
+                        case PrometheusMetricType.GAUGE | PrometheusMetricType.UNKNOWN:
                             metric_class = GaugeMetricData
                         case PrometheusMetricType.COUNTER:
                             metric_class = CounterMetricData

--- a/src/aiperf/server_metrics/parquet_exporter.py
+++ b/src/aiperf/server_metrics/parquet_exporter.py
@@ -340,7 +340,10 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
         for time_series_collection in hierarchy.endpoints.values():
             for metric_entry in time_series_collection.metrics.values():
                 total_metrics += 1
-                if metric_entry.metric_type == PrometheusMetricType.GAUGE:
+                if metric_entry.metric_type in (
+                    PrometheusMetricType.GAUGE,
+                    PrometheusMetricType.UNKNOWN,
+                ):
                     type_counts["gauge"] += 1
                 elif metric_entry.metric_type == PrometheusMetricType.COUNTER:
                     type_counts["counter"] += 1
@@ -446,6 +449,7 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
                 if metric_type in (
                     PrometheusMetricType.GAUGE,
                     PrometheusMetricType.COUNTER,
+                    PrometheusMetricType.UNKNOWN,
                 ):
                     rows = self._collect_scalar_rows(
                         endpoint_url,
@@ -495,6 +499,7 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
                 if metric_type in (
                     PrometheusMetricType.GAUGE,
                     PrometheusMetricType.COUNTER,
+                    PrometheusMetricType.UNKNOWN,
                 ):
                     rows.extend(
                         self._collect_scalar_rows(
@@ -547,7 +552,10 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
             return []
 
         metric_type = metric_entry.metric_type
-        is_gauge = metric_type == PrometheusMetricType.GAUGE
+        is_gauge = metric_type in (
+            PrometheusMetricType.GAUGE,
+            PrometheusMetricType.UNKNOWN,
+        )
 
         # Infer unit for this metric
         unit = infer_unit(metric_name, metric_entry.description)

--- a/src/aiperf/server_metrics/storage.py
+++ b/src/aiperf/server_metrics/storage.py
@@ -890,8 +890,14 @@ class ServerMetricEntry:
         return cls(
             metric_type=metric_family.type,
             description=metric_family.description,
-            data=ScalarTimeSeries()
-            if metric_family.type
-            in (PrometheusMetricType.GAUGE, PrometheusMetricType.COUNTER)
-            else HistogramTimeSeries(),
+            data=(
+                ScalarTimeSeries()
+                if metric_family.type
+                in (
+                    PrometheusMetricType.GAUGE,
+                    PrometheusMetricType.COUNTER,
+                    PrometheusMetricType.UNKNOWN,
+                )
+                else HistogramTimeSeries()
+            ),
         )

--- a/tests/server_metrics/test_storage.py
+++ b/tests/server_metrics/test_storage.py
@@ -463,45 +463,32 @@ class TestServerMetricKey:
 class TestServerMetricEntry:
     """Tests for ServerMetricEntry class."""
 
-    def test_from_gauge_metric_family(self) -> None:
-        """Test creating entry from gauge metric family."""
+    @pytest.mark.parametrize(
+        "metric_type,expected_data_type",
+        [
+            (PrometheusMetricType.GAUGE, ScalarTimeSeries),
+            (PrometheusMetricType.COUNTER, ScalarTimeSeries),
+            (PrometheusMetricType.HISTOGRAM, HistogramTimeSeries),
+            (PrometheusMetricType.UNKNOWN, ScalarTimeSeries),
+        ],
+    )
+    def test_from_metric_family(
+        self,
+        metric_type: PrometheusMetricType,
+        expected_data_type: type,
+    ) -> None:
+        """Test creating entry from metric family produces correct data type."""
         family = MetricFamily(
-            type=PrometheusMetricType.GAUGE,
-            description="Test gauge",
+            type=metric_type,
+            description=f"Test {metric_type.value}",
             samples=[],
         )
 
         entry = ServerMetricEntry.from_metric_family(family)
 
-        assert entry.metric_type == PrometheusMetricType.GAUGE
-        assert entry.description == "Test gauge"
-        assert isinstance(entry.data, ScalarTimeSeries)
-
-    def test_from_counter_metric_family(self) -> None:
-        """Test creating entry from counter metric family."""
-        family = MetricFamily(
-            type=PrometheusMetricType.COUNTER,
-            description="Test counter",
-            samples=[],
-        )
-
-        entry = ServerMetricEntry.from_metric_family(family)
-
-        assert entry.metric_type == PrometheusMetricType.COUNTER
-        assert isinstance(entry.data, ScalarTimeSeries)
-
-    def test_from_histogram_metric_family(self) -> None:
-        """Test creating entry from histogram metric family."""
-        family = MetricFamily(
-            type=PrometheusMetricType.HISTOGRAM,
-            description="Test histogram",
-            samples=[],
-        )
-
-        entry = ServerMetricEntry.from_metric_family(family)
-
-        assert entry.metric_type == PrometheusMetricType.HISTOGRAM
-        assert isinstance(entry.data, HistogramTimeSeries)
+        assert entry.metric_type == metric_type
+        assert entry.description == f"Test {metric_type.value}"
+        assert isinstance(entry.data, expected_data_type)
 
 
 class TestServerMetricsTimeSeries:

--- a/tests/unit/server_metrics/test_accumulator.py
+++ b/tests/unit/server_metrics/test_accumulator.py
@@ -111,25 +111,33 @@ class TestServerMetricsResultsProcessor:
 
         assert result is None
 
+    @pytest.mark.parametrize(
+        "metric_type,metric_name",
+        [
+            (PrometheusMetricType.GAUGE, "cache_usage"),
+            (PrometheusMetricType.UNKNOWN, "unknown_metric"),
+        ],
+    )
     async def test_export_results_with_data(
         self,
         mock_user_config: UserConfig,
+        metric_type: PrometheusMetricType,
+        metric_name: str,
     ) -> None:
         """Test export_results returns ServerMetricsResults with collected data."""
         processor = ServerMetricsAccumulator(mock_user_config)
 
-        # Add multiple records
         for i in range(5):
-            gauge = MetricFamily(
-                type=PrometheusMetricType.GAUGE,
-                description="KV cache usage",
+            family = MetricFamily(
+                type=metric_type,
+                description="Test metric",
                 samples=[MetricSample(labels=None, value=0.4 + i * 0.05)],
             )
             record = ServerMetricsRecord(
                 endpoint_url="http://node1:8081/metrics",
                 timestamp_ns=1_000_000_000 + i * 100_000_000,
                 endpoint_latency_ns=5_000_000,
-                metrics={"cache_usage": gauge},
+                metrics={metric_name: family},
             )
             await processor.process_server_metrics_record(record)
 

--- a/tests/unit/server_metrics/test_csv_exporter.py
+++ b/tests/unit/server_metrics/test_csv_exporter.py
@@ -10,7 +10,7 @@ from typing import TypeAlias
 import pytest
 
 from aiperf.common.config import EndpointConfig, UserConfig
-from aiperf.common.enums import GenericMetricUnit
+from aiperf.common.enums import GenericMetricUnit, PrometheusMetricType
 from aiperf.common.exceptions import DataExporterDisabled
 from aiperf.common.models import (
     CounterMetricData,
@@ -28,7 +28,11 @@ from aiperf.common.models import (
     ServerMetricsResults,
 )
 from aiperf.plugin.enums import EndpointType
-from aiperf.server_metrics.csv_exporter import CsvMetricInfo, ServerMetricsCsvExporter
+from aiperf.server_metrics.csv_exporter import (
+    STAT_KEYS_MAP,
+    CsvMetricInfo,
+    ServerMetricsCsvExporter,
+)
 from tests.unit.conftest import create_exporter_config
 
 MetricDataType: TypeAlias = GaugeMetricData | CounterMetricData | HistogramMetricData
@@ -324,6 +328,17 @@ def server_metrics_results_with_labeled_metrics():
         },
     )
     return _create_server_metrics_results({"localhost:8081": endpoint_summary})
+
+
+class TestStatKeysMap:
+    """Test STAT_KEYS_MAP covers all expected metric types."""
+
+    def test_unknown_metric_type_uses_gauge_stat_keys(self):
+        """Test UNKNOWN type maps to the same stat keys as GAUGE."""
+        assert (
+            STAT_KEYS_MAP[PrometheusMetricType.UNKNOWN]
+            is STAT_KEYS_MAP[PrometheusMetricType.GAUGE]
+        )
 
 
 class TestServerMetricsCsvExporterInitialization:

--- a/tests/unit/server_metrics/test_export_stats_basic.py
+++ b/tests/unit/server_metrics/test_export_stats_basic.py
@@ -6,12 +6,14 @@
 import pytest
 
 from aiperf.common.constants import NANOS_PER_SECOND
+from aiperf.common.enums import PrometheusMetricType
 from aiperf.common.models.server_metrics_models import TimeRangeFilter
 from aiperf.server_metrics.export_stats import (
     _compute_counter_stats,
     _compute_gauge_stats,
     _compute_histogram_stats,
     _compute_histogram_timeslices,
+    compute_stats,
 )
 from aiperf.server_metrics.storage import (
     ServerMetricKey,
@@ -85,6 +87,31 @@ class TestGaugeExportStats:
         assert result.stats.avg == 14.5  # (10+11+...+19)/10
         assert result.stats.min == 10.0
         assert result.stats.max == 19.0
+
+
+# =============================================================================
+# Unknown Metric Type Tests
+# =============================================================================
+
+
+class TestUnknownExportStats:
+    """Test UNKNOWN metric type is routed to gauge stats."""
+
+    def test_unknown_type_computes_gauge_stats(self):
+        """Test UNKNOWN metric type produces identical results to GAUGE."""
+        ts = ServerMetricsTimeSeries()
+        add_gauge_samples(ts, "unknown_metric", [10.0, 20.0, 30.0])
+
+        result = compute_stats(
+            metric_type=PrometheusMetricType.UNKNOWN,
+            time_series=get_gauge(ts, "unknown_metric"),
+            time_filter=make_time_filter(),
+        )
+
+        assert result is not None
+        assert result.stats.avg == 20.0
+        assert result.stats.min == 10.0
+        assert result.stats.max == 30.0
 
 
 # =============================================================================

--- a/tests/unit/server_metrics/test_export_stats_edge_cases_aggressive.py
+++ b/tests/unit/server_metrics/test_export_stats_edge_cases_aggressive.py
@@ -96,37 +96,24 @@ class TestEmptyTimeSeriesHandling:
 
         assert result is None
 
-    def test_compute_stats_with_empty_gauge(self) -> None:
-        """Test compute_stats dispatcher handles empty gauge series."""
-        series = ScalarTimeSeries()
-
+    @pytest.mark.parametrize(
+        "metric_type,series_factory",
+        [
+            (PrometheusMetricType.GAUGE, ScalarTimeSeries),
+            (PrometheusMetricType.UNKNOWN, ScalarTimeSeries),
+            (PrometheusMetricType.COUNTER, ScalarTimeSeries),
+            (PrometheusMetricType.HISTOGRAM, HistogramTimeSeries),
+        ],
+    )
+    def test_compute_stats_with_empty_series(
+        self,
+        metric_type: PrometheusMetricType,
+        series_factory: type,
+    ) -> None:
+        """Test compute_stats dispatcher returns None for empty series."""
         result = compute_stats(
-            metric_type=PrometheusMetricType.GAUGE,
-            time_series=series,
-            time_filter=make_time_filter(),
-        )
-
-        assert result is None
-
-    def test_compute_stats_with_empty_counter(self) -> None:
-        """Test compute_stats dispatcher handles empty counter series."""
-        series = ScalarTimeSeries()
-
-        result = compute_stats(
-            metric_type=PrometheusMetricType.COUNTER,
-            time_series=series,
-            time_filter=make_time_filter(),
-        )
-
-        assert result is None
-
-    def test_compute_stats_with_empty_histogram(self) -> None:
-        """Test compute_stats dispatcher handles empty histogram series."""
-        series = HistogramTimeSeries()
-
-        result = compute_stats(
-            metric_type=PrometheusMetricType.HISTOGRAM,
-            time_series=series,
+            metric_type=metric_type,
+            time_series=series_factory(),
             time_filter=make_time_filter(),
         )
 

--- a/tests/unit/server_metrics/test_storage_edge_cases.py
+++ b/tests/unit/server_metrics/test_storage_edge_cases.py
@@ -473,6 +473,7 @@ class TestServerMetricEntry:
             (PrometheusMetricType.GAUGE, ScalarTimeSeries),
             (PrometheusMetricType.COUNTER, ScalarTimeSeries),
             (PrometheusMetricType.HISTOGRAM, HistogramTimeSeries),
+            (PrometheusMetricType.UNKNOWN, ScalarTimeSeries),
         ],
     )
     def test_from_metric_family(


### PR DESCRIPTION
When asked to parse prometheus endpoint that publish unknown metrics it fails with error. This commit treats unknown as gauges and adds unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized handling of metrics with unknown types, ensuring they are properly exported and computed consistently with gauge metrics across all export formats and computation processes.

* **Tests**
  * Expanded test coverage for unknown metric types, including parameterized tests for various export and computation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->