### PR TITLE
chore: bump version of pillow dep to 12.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "nvidia-ml-py",  # Note: No version specified to be most compatible with CUDA version
   "orjson~=3.10.18",
   "pandas~=2.3.3",
-  "pillow~=11.1.0",
+  "pillow~=12.1.1",
   "plotly~=6.4.0",
   "dash~=3.1.0",
   "dash-bootstrap-components~=2.0.0",


### PR DESCRIPTION
Relates to OPS-3512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image processing dependency to a newer version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->