### PR TITLE
fix: Expose copy all logs keybinding 'c' in dashboard ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding conventions
 - Output sequence length constraints (`--output-tokens-mean`) cannot be guaranteed unless you pass `ignore_eos` and/or `min_tokens` via `--extra-inputs` to an inference server that supports them.
 - Very high concurrency settings (typically >15,000) may lead to port exhaustion on some systems. Adjust system limits or reduce concurrency if connection failures occur.
 - Startup errors caused by invalid configuration settings can cause AIPerf to hang indefinitely. Terminate the process and check configuration settings.
+- Copying selected text may not work reliably in the dashboard UI. Use the `c` key to copy all logs.

--- a/src/aiperf/ui/dashboard/aiperf_textual_app.py
+++ b/src/aiperf/ui/dashboard/aiperf_textual_app.py
@@ -87,7 +87,7 @@ class AIPerfTextualApp(App):
         ("escape", "restore_all_panels", "Restore View"),
         Binding("ctrl+s", "screenshot", "Save Screenshot", show=False),
         Binding("l", "toggle_hide_log_viewer", "Toggle Logs", show=False),
-        Binding("c", "copy_logs", "Copy Logs", show=False),
+        Binding("c", "copy_logs", "Copy Logs"),
     ]
 
     def __init__(


### PR DESCRIPTION
- Made the `c` keybinding visible in the dashboard footer so users know they can copy logs.
- Added a Known Issues entry in README that copying selected text may not work reliably in the dashboard UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added known issue documentation noting text selection copying limitations in the dashboard with workaround instructions.

* **Bug Fixes**
  * Improved visibility and discoverability of the Copy Logs keyboard action in the user interface.
  * Enhanced test stability by adding initialization time to ensure models fully load before test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->