### PR TITLE
fix: preserve special tokens during decode for prompt block separators

### DIFF
--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -152,7 +152,10 @@ class Tokenizer:
         self._resolved_name: str | None = None
         self._call_args = {"add_special_tokens": False}
         self._encode_args = {"add_special_tokens": False}
-        self._decode_args = {"skip_special_tokens": True}
+        # Prompt generation inserts BOS/EOS tokens as block separators
+        # (see PromptGenerator._build_token_sequence). Skipping special tokens
+        # during decode would silently strip those separators.
+        self._decode_args = {"skip_special_tokens": False}
 
     def _require_init(self) -> None:
         """Raise NotInitializedError if tokenizer is not initialized."""

--- a/tests/unit/common/test_tokenizer_kwarg_overrides.py
+++ b/tests/unit/common/test_tokenizer_kwarg_overrides.py
@@ -189,7 +189,7 @@ class TestApplyKwargOverrides:
         tok = self._make_tokenizer(StandardTokenizerBackend())
         assert tok._encode_args == {"add_special_tokens": False}
         assert tok._call_args == {"add_special_tokens": False}
-        assert tok._decode_args == {"skip_special_tokens": True}
+        assert tok._decode_args == {"skip_special_tokens": False}
 
     def test_kimi_like_overrides_encode_and_call_args(self):
         tok = self._make_tokenizer(KimiLikeTokenizerBackend())
@@ -210,14 +210,14 @@ class TestApplyKwargOverrides:
         tok = self._make_tokenizer(MismatchedCallEncodeBackend())
         assert tok._encode_args == {"allow_special_tokens": False}
         assert tok._call_args == {"add_special_tokens": False}
-        assert tok._decode_args == {"skip_special_tokens": True}
+        assert tok._decode_args == {"skip_special_tokens": False}
 
     def test_none_tokenizer_is_noop(self):
         tok = Tokenizer()
         tok._apply_kwarg_overrides()
         assert tok._encode_args == {"add_special_tokens": False}
         assert tok._call_args == {"add_special_tokens": False}
-        assert tok._decode_args == {"skip_special_tokens": True}
+        assert tok._decode_args == {"skip_special_tokens": False}
 
 
 # -- End-to-end: encode/decode through Tokenizer wrapper --


### PR DESCRIPTION
This was mistakenly broken by removing the arguments in PR #727 

PromptGenerator inserts BOS/EOS tokens as block separators in token sequences. Skipping special tokens during decode silently strips these separators, producing incorrect output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated tokenizer default behavior to preserve special tokens (BOS/EOS) during decoding, ensuring proper block separation in prompt generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->