### PR TITLE
feat: support loading datasets from compressed archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ aiperf profile \
 - [Trace Benchmarking](docs/benchmark_modes/trace_replay.md) - Deterministic workload replay
 - [Custom Prompt Benchmarking](docs/tutorials/custom-prompt-benchmarking.md) - Send exact prompts as-is
 - [Custom Dataset](docs/tutorials/custom-dataset.md) - Custom dataset formats
+- [Compressed Datasets](docs/tutorials/compressed-datasets.md) - Load datasets from compressed archives
 - [ShareGPT Dataset](docs/tutorials/sharegpt.md) - Profile with ShareGPT dataset
 - [Synthetic Dataset Generation](docs/tutorials/synthetic-dataset.md) - Generate synthetic datasets
 - [Fixed Schedule](docs/tutorials/fixed-schedule.md) - Precise timestamp-based execution

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -261,6 +261,10 @@ Custom HTTP headers to include with every request. Specify as `Header:Value` pai
 
 Path to file or directory containing benchmark dataset. Required when using `--custom-dataset-type`. Supported formats depend on dataset type: JSONL for `single_turn`/`multi_turn`, JSONL for `mooncake_trace`/`bailian_trace` (timestamped traces), directories for `random_pool`. File is parsed according to `--custom-dataset-type` specification.
 
+#### `--input-file-subpath` `<str>`
+
+Relative path to the dataset file inside a compressed archive. Required for multi-file archives (zip, tar) when a specific file is needed. For single-file compression (gz, zst, xz), the inner filename is inferred by stripping the compression extension. Example: `--input-file dataset.tar.zst --input-file-subpath data/prompts.jsonl`.
+
 #### `--fixed-schedule`
 
 Run requests according to timestamps specified in the input dataset. When enabled, AIPerf replays the exact timing pattern from the dataset. This mode is automatically enabled for trace datasets.

--- a/docs/tutorials/compressed-datasets.md
+++ b/docs/tutorials/compressed-datasets.md
@@ -1,0 +1,110 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Compressed Dataset Support
+
+AIPerf can load datasets directly from compressed files and archives, avoiding the need to manually decompress before benchmarking. This works with all custom dataset types (`single_turn`, `multi_turn`, `random_pool`, `mooncake_trace`, `bailian_trace`).
+
+## Supported Formats
+
+| Type | Extensions |
+|------|-----------|
+| Single-file compression | `.gz`, `.zst`, `.xz` |
+| Multi-file archives | `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.tar.zst`, `.tar.xz` |
+
+---
+
+## Single-File Compression
+
+For `.gz`, `.zst`, and `.xz` files, AIPerf decompresses the file and infers the inner filename by stripping the compression extension (e.g., `prompts.jsonl.zst` becomes `prompts.jsonl`).
+
+```bash
+# Compress with any supported format
+gzip prompts.jsonl       # creates prompts.jsonl.gz
+zstd prompts.jsonl       # creates prompts.jsonl.zst
+xz prompts.jsonl         # creates prompts.jsonl.xz
+
+# Pass the compressed file directly
+aiperf profile \
+    --model Qwen/Qwen3-0.6B \
+    --endpoint-type chat \
+    --input-file prompts.jsonl.zst \
+    --streaming \
+    --url localhost:8000
+```
+
+Use `--input-file-subpath` to override the inferred filename if needed:
+
+```bash
+aiperf profile \
+    --input-file prompts.jsonl.zst \
+    --input-file-subpath custom_name.jsonl \
+    ...
+```
+
+---
+
+## Multi-File Archives
+
+For archives containing multiple files, use `--input-file-subpath` to specify which file to load. This is required for file-based dataset types (`single_turn`, `multi_turn`, `mooncake_trace`, `bailian_trace`).
+
+```bash
+# zip
+zip dataset.zip data/prompts.jsonl
+aiperf profile --input-file dataset.zip --input-file-subpath data/prompts.jsonl ...
+
+# tar.gz
+tar czf dataset.tar.gz data/prompts.jsonl
+aiperf profile --input-file dataset.tar.gz --input-file-subpath data/prompts.jsonl ...
+
+# tar.zst
+tar cf - data/prompts.jsonl | zstd -o dataset.tar.zst
+aiperf profile --input-file dataset.tar.zst --input-file-subpath data/prompts.jsonl ...
+```
+
+### Archives as Directories
+
+For directory-based dataset types like `random_pool`, omit `--input-file-subpath` to extract the entire archive. Each file in the archive becomes a separate pool:
+
+```bash
+zip pools.zip pool_a.jsonl pool_b.jsonl pool_c.jsonl
+
+aiperf profile \
+    --model Qwen/Qwen3-0.6B \
+    --endpoint-type chat \
+    --input-file pools.zip \
+    --custom-dataset-type random_pool \
+    --num-conversations 100 \
+    --streaming \
+    --url localhost:8000
+```
+
+---
+
+## How It Works
+
+1. AIPerf detects the compression format from the file extension
+2. The file is decompressed or extracted to a temporary directory
+3. The dataset is loaded using the standard loader pipeline
+4. The temporary directory is cleaned up after loading completes
+
+Decompression uses chunked I/O to limit memory usage. For `tar.zst` archives, decompression is fully streaming.
+
+---
+
+## CLI Reference
+
+| Option | Description |
+|--------|-------------|
+| `--input-file` | Path to the compressed file or archive |
+| `--input-file-subpath` | Relative path to a file inside an archive, or override for the inferred filename in single-file compression |
+| `--custom-dataset-type` | Dataset format (auto-detected if omitted) |
+
+---
+
+## See Also
+
+- [Custom Dataset Guide](custom-dataset.md) - Dataset formats and types
+- [Fixed Schedule](fixed-schedule.md) - Timestamp-based replay with compressed trace files

--- a/src/aiperf/common/config/config_validators.py
+++ b/src/aiperf/common/config/config_validators.py
@@ -223,6 +223,9 @@ def parse_file(value: str | None) -> Path | None:
     """
     Parses the given string value and returns a Path object if the value represents
     a valid file or directory. Returns None if the input value is empty.
+
+    Accepts regular files, directories, and compressed archive files.
+
     Args:
         value (str): The string value to parse.
     Returns:

--- a/src/aiperf/common/config/input_config.py
+++ b/src/aiperf/common/config/input_config.py
@@ -204,6 +204,21 @@ class InputConfig(BaseConfig):
         ),
     ] = InputDefaults.FILE
 
+    input_file_subpath: Annotated[
+        str | None,
+        Field(
+            description="Relative path to the dataset file inside a compressed archive. "
+            "Required for multi-file archives (zip, tar) when a specific file is needed. "
+            "For single-file compression (gz, zst, xz), the inner filename is inferred "
+            "by stripping the compression extension. "
+            "Example: `--input-file dataset.tar.zst --input-file-subpath data/prompts.jsonl`.",
+        ),
+        CLIParameter(
+            name=("--input-file-subpath",),
+            group=_CLI_GROUP,
+        ),
+    ] = None
+
     fixed_schedule: Annotated[
         bool,
         Field(

--- a/src/aiperf/dataset/archive.py
+++ b/src/aiperf/dataset/archive.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import lzma
+import shutil
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+import zstandard
+
+SINGLE_FILE_EXTENSIONS = {".gz", ".zst", ".xz"}
+ARCHIVE_EXTENSIONS = {".zip", ".tar", ".tar.gz", ".tgz", ".tar.zst", ".tar.xz"}
+ALL_COMPRESSED_EXTENSIONS = SINGLE_FILE_EXTENSIONS | ARCHIVE_EXTENSIONS
+
+# Pre-sorted longest-first to ensure .tar.gz matches before .gz
+_ARCHIVE_EXTS_SORTED = sorted(ARCHIVE_EXTENSIONS, key=len, reverse=True)
+_ALL_EXTS_SORTED = sorted(ALL_COMPRESSED_EXTENSIONS, key=len, reverse=True)
+
+
+def is_compressed_file(path: Path) -> bool:
+    """Check if the path has a recognized compressed file extension."""
+    return _get_compression_type(path) is not None
+
+
+def _get_compression_type(path: Path) -> str | None:
+    """Return the compression type string for a path, or None if not compressed."""
+    filename = path.name.lower()
+    for extension in _ARCHIVE_EXTS_SORTED:
+        if filename.endswith(extension):
+            return extension
+    for extension in SINGLE_FILE_EXTENSIONS:
+        if filename.endswith(extension):
+            return extension
+    return None
+
+
+def _strip_compression_extension(filename: str) -> str:
+    """Strip the compression extension from a filename to get the inner name."""
+    filename_lower = filename.lower()
+    for extension in _ALL_EXTS_SORTED:
+        if filename_lower.endswith(extension):
+            return filename[: -len(extension)]
+    return filename
+
+
+def extract_compressed_file(
+    source_path: Path, subpath: str | None = None
+) -> tuple[Path, Path]:
+    """Extract a compressed file to a temporary directory.
+
+    For single-file compression (.gz, .zst, .xz), the file is decompressed
+    with the compression extension stripped from the name.
+
+    For multi-file archives (.zip, .tar, .tar.gz, .tgz, .tar.zst, .tar.xz),
+    files are extracted to a temp directory. If subpath is specified,
+    returns the path to that specific file within the extracted contents.
+    If subpath is not specified for a multi-file archive, returns the
+    temp directory itself (useful for random_pool datasets).
+
+    Args:
+        source_path: Path to the compressed file.
+        subpath: For archives, the relative path to the desired file inside
+            the archive. Required for multi-file archives when a single file
+            is needed.
+
+    Returns:
+        A tuple of (extracted_path, output_dir) where extracted_path is the path
+        to the extracted file or directory, and output_dir is the temporary
+        directory that should be cleaned up after use.
+
+    Raises:
+        FileNotFoundError: If the archive or subpath doesn't exist.
+        ValueError: If the compression format is not recognized.
+    """
+    if not source_path.exists():
+        raise FileNotFoundError(f"The file '{source_path}' does not exist.")
+
+    compression_type = _get_compression_type(source_path)
+    if compression_type is None:
+        raise ValueError(f"Unrecognized compression format for '{source_path}'")
+
+    output_dir = Path(tempfile.mkdtemp(prefix="aiperf_dataset_"))
+
+    try:
+        if compression_type in SINGLE_FILE_EXTENSIONS:
+            return _decompress_single_file(
+                source_path, compression_type, output_dir, subpath
+            )
+        return _extract_archive(source_path, compression_type, output_dir, subpath)
+    except Exception:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+
+
+def _decompress_single_file(
+    source_path: Path,
+    compression_type: str,
+    output_dir: Path,
+    subpath: str | None,
+) -> tuple[Path, Path]:
+    """Decompress a single compressed file (.gz, .zst, .xz)."""
+    output_name = subpath or _strip_compression_extension(source_path.name)
+    output_path = output_dir / output_name
+
+    if compression_type == ".gz":
+        with gzip.open(source_path, "rb") as src, open(output_path, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+    elif compression_type == ".zst":
+        decompressor = zstandard.ZstdDecompressor()
+        with open(source_path, "rb") as src, open(output_path, "wb") as dst:
+            decompressor.copy_stream(src, dst)
+    elif compression_type == ".xz":
+        with lzma.open(source_path, "rb") as src, open(output_path, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+
+    return output_path, output_dir
+
+
+def _extract_archive(
+    source_path: Path,
+    compression_type: str,
+    output_dir: Path,
+    subpath: str | None,
+) -> tuple[Path, Path]:
+    """Extract a multi-file archive (.zip, .tar, .tar.gz, .tgz, .tar.zst, .tar.xz)."""
+    if compression_type == ".zip":
+        _extract_zip(source_path, output_dir)
+    elif compression_type == ".tar":
+        _extract_tar(source_path, output_dir)
+    elif compression_type in (".tar.gz", ".tgz"):
+        _extract_tar(source_path, output_dir, mode="r:gz")
+    elif compression_type == ".tar.xz":
+        _extract_tar(source_path, output_dir, mode="r:xz")
+    elif compression_type == ".tar.zst":
+        _extract_tar_zst(source_path, output_dir)
+
+    if subpath:
+        extracted_path = output_dir / subpath
+        if not extracted_path.exists():
+            raise FileNotFoundError(
+                f"Subpath '{subpath}' not found in archive '{source_path}'. "
+                f"Use --input-file-subpath to specify the correct path."
+            )
+        return extracted_path, output_dir
+
+    return output_dir, output_dir
+
+
+def _validate_zip_entry(output_dir: Path, member_name: str) -> None:
+    """Validate a zip entry path to prevent path traversal (zip slip)."""
+    resolved_target = (output_dir / member_name).resolve()
+    if not resolved_target.is_relative_to(output_dir.resolve()):
+        raise ValueError(
+            f"Zip entry '{member_name}' would extract outside target directory"
+        )
+
+
+def _extract_zip(source_path: Path, output_dir: Path) -> None:
+    with zipfile.ZipFile(source_path, "r") as archive:
+        for member_name in archive.namelist():
+            _validate_zip_entry(output_dir, member_name)
+        archive.extractall(output_dir)
+
+
+def _safe_tar_extractall(tar: tarfile.TarFile, output_dir: Path) -> None:
+    """Extract all members from a tarfile safely."""
+    try:
+        # Python 3.12+ added the filter argument to prevent path traversal and unsafe metadata.
+        # Python 3.14+ requires the filter argument.
+        tar.extractall(output_dir, filter="data")
+    except TypeError:
+        # Fall back for Python 3.10/3.11 that don't have the filter argument.
+        tar.extractall(output_dir)
+
+
+def _extract_tar(source_path: Path, output_dir: Path, mode: str = "r") -> None:
+    with tarfile.open(source_path, mode) as tar:
+        _safe_tar_extractall(tar, output_dir)
+
+
+def _extract_tar_zst(source_path: Path, output_dir: Path) -> None:
+    decompressor = zstandard.ZstdDecompressor()
+    with (
+        open(source_path, "rb") as compressed_stream,
+        decompressor.stream_reader(compressed_stream) as tar_stream,
+        tarfile.open(fileobj=tar_stream, mode="r|") as tar,
+    ):
+        _safe_tar_extractall(tar, output_dir)
+
+
+def cleanup_temp_dir(temp_dir: Path) -> None:
+    """Remove a temporary directory created during extraction."""
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir, ignore_errors=True)

--- a/src/aiperf/dataset/composer/custom.py
+++ b/src/aiperf/dataset/composer/custom.py
@@ -9,6 +9,11 @@ from aiperf.common.config import UserConfig
 from aiperf.common.models import Conversation
 from aiperf.common.tokenizer import Tokenizer
 from aiperf.common.utils import load_json_str
+from aiperf.dataset.archive import (
+    cleanup_temp_dir,
+    extract_compressed_file,
+    is_compressed_file,
+)
 from aiperf.dataset.composer.base import BaseDatasetComposer
 from aiperf.dataset.utils import check_file_exists
 from aiperf.plugin import plugins
@@ -20,7 +25,11 @@ class CustomDatasetComposer(BaseDatasetComposer):
         super().__init__(config, tokenizer)
 
     def create_dataset(self) -> list[Conversation]:
-        """Create conversations from a file or directory.
+        """Create conversations from a file, directory, or compressed archive.
+
+        Compressed archives (.gz, .zst, .xz, .zip, .tar, .tar.gz, .tgz,
+        .tar.zst, .tar.xz) are extracted to a temporary directory, loaded,
+        then cleaned up automatically.
 
         Returns:
             list[Conversation]: A list of conversation objects.
@@ -29,9 +38,29 @@ class CustomDatasetComposer(BaseDatasetComposer):
         check_file_exists(self.config.input.file)
 
         # Auto-infer dataset type if not provided
+        file_path = Path(self.config.input.file)
+        temp_dir = None
+
+        if file_path.is_file() and is_compressed_file(file_path):
+            subpath = self.config.input.input_file_subpath
+            extracted_path, temp_dir = extract_compressed_file(file_path, subpath)
+            self.info(
+                f"Extracted compressed dataset '{file_path.name}' to '{extracted_path}'"
+            )
+            file_path = extracted_path
+
+        try:
+            return self._load_from_path(file_path)
+        finally:
+            if temp_dir is not None:
+                cleanup_temp_dir(temp_dir)
+                self.debug(f"Cleaned up temporary directory: {temp_dir}")
+
+    def _load_from_path(self, file_path: Path) -> list[Conversation]:
+        """Load conversations from the given file or directory path."""
         dataset_type = self.config.input.custom_dataset_type
         if dataset_type is None:
-            dataset_type = self._infer_dataset_type(self.config.input.file)
+            dataset_type = self._infer_dataset_type(file_path)
             self.info(f"Auto-detected dataset type: {dataset_type}")
 
         # Validate synthesis options are only used with mooncake_trace
@@ -40,7 +69,7 @@ class CustomDatasetComposer(BaseDatasetComposer):
         # Set dataset sampling strategy based on inferred type if not explicitly set
         self._set_sampling_strategy(dataset_type)
 
-        self._create_loader_instance(dataset_type)
+        self._create_loader_instance(dataset_type, file_path)
         dataset = self.loader.load_dataset()
         conversations = self.loader.convert_to_conversations(dataset)
 
@@ -53,7 +82,7 @@ class CustomDatasetComposer(BaseDatasetComposer):
         self._finalize_conversations(conversations)
         return conversations
 
-    def _infer_dataset_type(self, file_path: str) -> CustomDatasetType:
+    def _infer_dataset_type(self, file_path: str | Path) -> CustomDatasetType:
         """Infer the custom dataset type from the input file.
 
         Queries all registered loaders to check if they can handle the data format.
@@ -184,11 +213,14 @@ class CustomDatasetComposer(BaseDatasetComposer):
                 f"Either remove synthesis options or use a trace dataset type."
             )
 
-    def _create_loader_instance(self, dataset_type: CustomDatasetType) -> None:
+    def _create_loader_instance(
+        self, dataset_type: CustomDatasetType, file_path: str | Path | None = None
+    ) -> None:
         """Initializes the dataset loader based on the custom dataset type.
 
         Args:
             dataset_type: The type of custom dataset to create.
+            file_path: Path to use for loading. If None, uses config.input.file.
         """
         kwargs: dict[str, Any] = {}
         loader_metadata = plugins.get_dataset_loader_metadata(dataset_type)
@@ -208,7 +240,7 @@ class CustomDatasetComposer(BaseDatasetComposer):
 
         LoaderClass = plugins.get_class(PluginType.CUSTOM_DATASET_LOADER, dataset_type)
         self.loader = LoaderClass(
-            filename=self.config.input.file,
+            filename=file_path if file_path is not None else self.config.input.file,
             user_config=self.config,
             **kwargs,
         )

--- a/tests/integration/test_compressed_dataset.py
+++ b/tests/integration/test_compressed_dataset.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for compressed dataset support."""
+
+import gzip
+import lzma
+import tarfile
+import zipfile
+from pathlib import Path
+
+import orjson
+import pytest
+import zstandard
+
+from tests.harness.utils import AIPerfCLI, AIPerfMockServer
+from tests.integration.conftest import IntegrationTestDefaults as defaults
+
+SINGLE_TURN_PROMPTS = [
+    {"text": "What is machine learning?"},
+    {"text": "Explain neural networks."},
+    {"text": "How does backpropagation work?"},
+    {"text": "What are transformers?"},
+    {"text": "Define reinforcement learning."},
+]
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    with open(path, "wb") as f:
+        for entry in entries:
+            f.write(orjson.dumps(entry) + b"\n")
+
+
+def _create_jsonl_gz(tmp_path: Path) -> Path:
+    archive = tmp_path / "prompts.jsonl.gz"
+    with gzip.open(archive, "wb") as f:
+        for entry in SINGLE_TURN_PROMPTS:
+            f.write(orjson.dumps(entry) + b"\n")
+    return archive
+
+
+def _create_jsonl_zst(tmp_path: Path) -> Path:
+    archive = tmp_path / "prompts.jsonl.zst"
+    compressor = zstandard.ZstdCompressor()
+    content = b"".join(orjson.dumps(entry) + b"\n" for entry in SINGLE_TURN_PROMPTS)
+    with open(archive, "wb") as f:
+        f.write(compressor.compress(content))
+    return archive
+
+
+def _create_jsonl_xz(tmp_path: Path) -> Path:
+    archive = tmp_path / "prompts.jsonl.xz"
+    with lzma.open(archive, "wb") as f:
+        for entry in SINGLE_TURN_PROMPTS:
+            f.write(orjson.dumps(entry) + b"\n")
+    return archive
+
+
+def _create_zip(tmp_path: Path) -> Path:
+    jsonl_file = tmp_path / "prompts.jsonl"
+    _write_jsonl(jsonl_file, SINGLE_TURN_PROMPTS)
+    archive = tmp_path / "dataset.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.write(jsonl_file, arcname="prompts.jsonl")
+    return archive
+
+
+def _create_tar_gz(tmp_path: Path) -> Path:
+    jsonl_file = tmp_path / "prompts.jsonl"
+    _write_jsonl(jsonl_file, SINGLE_TURN_PROMPTS)
+    archive = tmp_path / "dataset.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(jsonl_file, arcname="data/prompts.jsonl")
+    return archive
+
+
+def _create_tar_zst(tmp_path: Path) -> Path:
+    jsonl_file = tmp_path / "prompts.jsonl"
+    _write_jsonl(jsonl_file, SINGLE_TURN_PROMPTS)
+    tar_path = tmp_path / "dataset.tar"
+    with tarfile.open(tar_path, "w") as tf:
+        tf.add(jsonl_file, arcname="prompts.jsonl")
+    compressor = zstandard.ZstdCompressor()
+    archive = tmp_path / "dataset.tar.zst"
+    with open(tar_path, "rb") as src, open(archive, "wb") as dst:
+        compressor.copy_stream(src, dst)
+    return archive
+
+
+def _create_zip_random_pool(tmp_path: Path) -> Path:
+    pool_a = tmp_path / "pool_a.jsonl"
+    pool_b = tmp_path / "pool_b.jsonl"
+    _write_jsonl(pool_a, SINGLE_TURN_PROMPTS[:3])
+    _write_jsonl(pool_b, SINGLE_TURN_PROMPTS[3:])
+    archive = tmp_path / "pools.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.write(pool_a, arcname="pool_a.jsonl")
+        zf.write(pool_b, arcname="pool_b.jsonl")
+    return archive
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestCompressedDatasetSingleFile:
+    """Tests for single-file compressed datasets (.gz, .zst, .xz)."""
+
+    @pytest.mark.parametrize(
+        "create_archive",
+        [_create_jsonl_gz, _create_jsonl_zst, _create_jsonl_xz],
+        ids=["gzip", "zstd", "xz"],
+    )
+    async def test_single_file_compression(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+        create_archive,
+    ):
+        """Test loading datasets from single-file compressed formats."""
+        archive_path = create_archive(tmp_path)
+        request_count = len(SINGLE_TURN_PROMPTS)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {archive_path} \
+                --custom-dataset-type single_turn \
+                --request-count {request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.exit_code == 0
+        assert result.request_count == request_count
+        assert result.has_all_outputs
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestCompressedDatasetArchive:
+    """Tests for multi-file archive datasets (.zip, .tar.gz, .tar.zst)."""
+
+    async def test_zip_with_subpath(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ):
+        """Test loading a dataset from a zip archive with --input-file-subpath."""
+        archive_path = _create_zip(tmp_path)
+        request_count = len(SINGLE_TURN_PROMPTS)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {archive_path} \
+                --input-file-subpath prompts.jsonl \
+                --custom-dataset-type single_turn \
+                --request-count {request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.exit_code == 0
+        assert result.request_count == request_count
+        assert result.has_all_outputs
+
+    async def test_tar_gz_with_subpath(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ):
+        """Test loading a dataset from a tar.gz archive with nested subpath."""
+        archive_path = _create_tar_gz(tmp_path)
+        request_count = len(SINGLE_TURN_PROMPTS)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {archive_path} \
+                --input-file-subpath data/prompts.jsonl \
+                --custom-dataset-type single_turn \
+                --request-count {request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.exit_code == 0
+        assert result.request_count == request_count
+        assert result.has_all_outputs
+
+    async def test_tar_zst_with_subpath(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ):
+        """Test loading a dataset from a tar.zst archive."""
+        archive_path = _create_tar_zst(tmp_path)
+        request_count = len(SINGLE_TURN_PROMPTS)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {archive_path} \
+                --input-file-subpath prompts.jsonl \
+                --custom-dataset-type single_turn \
+                --request-count {request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.exit_code == 0
+        assert result.request_count == request_count
+        assert result.has_all_outputs
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestCompressedDatasetRandomPool:
+    """Tests for archive extraction as a directory for random_pool datasets."""
+
+    async def test_zip_as_random_pool(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ):
+        """Test extracting a zip archive as a directory for random_pool."""
+        archive_path = _create_zip_random_pool(tmp_path)
+        request_count = 10
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {archive_path} \
+                --custom-dataset-type random_pool \
+                --num-conversations {request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.exit_code == 0
+        assert result.has_all_outputs
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestCompressedDatasetAutoDetect:
+    """Tests for auto-detection of dataset type from compressed files."""
+
+    async def test_auto_detect_from_compressed_file(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ):
+        """Test that dataset type is auto-detected after decompression."""
+        archive_path = _create_jsonl_zst(tmp_path)
+        request_count = len(SINGLE_TURN_PROMPTS)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {archive_path} \
+                --request-count {request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.exit_code == 0
+        assert result.request_count == request_count
+        assert result.has_all_outputs

--- a/tests/unit/dataset/composer/test_custom_composer.py
+++ b/tests/unit/dataset/composer/test_custom_composer.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from unittest.mock import Mock, mock_open, patch
 
 import pytest
@@ -285,3 +286,123 @@ class TestSynthesisValidation:
 
         # Should not raise - max_isl doesn't trigger should_synthesize()
         composer._validate_synthesis_config(CustomDatasetType.SINGLE_TURN)
+
+
+class TestCompressedDatasetFlow:
+    """Test compressed archive handling in create_dataset."""
+
+    @patch("aiperf.dataset.composer.custom.cleanup_temp_dir")
+    @patch("aiperf.dataset.composer.custom.extract_compressed_file")
+    @patch("aiperf.dataset.composer.custom.is_compressed_file", return_value=True)
+    @patch("pathlib.Path.is_file", return_value=True)
+    @patch("aiperf.dataset.composer.custom.check_file_exists")
+    def test_create_dataset_extracts_compressed_file(
+        self,
+        mock_check_file,
+        mock_is_file,
+        mock_is_compressed,
+        mock_extract,
+        mock_cleanup,
+        custom_config,
+        mock_tokenizer,
+    ) -> None:
+        """Test that create_dataset calls extract for compressed files."""
+        extracted_path = Path("/tmp/aiperf_dataset_xyz/data.jsonl")
+        temp_dir = Path("/tmp/aiperf_dataset_xyz")
+        mock_extract.return_value = (extracted_path, temp_dir)
+
+        custom_config.input.file = Path("/path/to/data.jsonl.gz")
+
+        composer = CustomDatasetComposer(custom_config, mock_tokenizer)
+        with patch.object(composer, "_load_from_path", return_value=[]) as mock_load:
+            composer.create_dataset()
+
+        mock_extract.assert_called_once_with(Path("/path/to/data.jsonl.gz"), None)
+        mock_load.assert_called_once_with(extracted_path)
+        mock_cleanup.assert_called_once_with(temp_dir)
+
+    @patch("aiperf.dataset.composer.custom.cleanup_temp_dir")
+    @patch("aiperf.dataset.composer.custom.extract_compressed_file")
+    @patch("aiperf.dataset.composer.custom.is_compressed_file", return_value=True)
+    @patch("pathlib.Path.is_file", return_value=True)
+    @patch("aiperf.dataset.composer.custom.check_file_exists")
+    def test_create_dataset_passes_subpath(
+        self,
+        mock_check_file,
+        mock_is_file,
+        mock_is_compressed,
+        mock_extract,
+        mock_cleanup,
+        custom_config,
+        mock_tokenizer,
+    ) -> None:
+        """Test that input_file_subpath is forwarded to extract_compressed_file."""
+        extracted_path = Path("/tmp/aiperf_dataset_xyz/inner/data.jsonl")
+        temp_dir = Path("/tmp/aiperf_dataset_xyz")
+        mock_extract.return_value = (extracted_path, temp_dir)
+
+        custom_config.input.file = Path("/path/to/archive.tar.gz")
+        custom_config.input.input_file_subpath = "inner/data.jsonl"
+
+        composer = CustomDatasetComposer(custom_config, mock_tokenizer)
+        with patch.object(composer, "_load_from_path", return_value=[]):
+            composer.create_dataset()
+
+        mock_extract.assert_called_once_with(
+            Path("/path/to/archive.tar.gz"), "inner/data.jsonl"
+        )
+
+    @patch("aiperf.dataset.composer.custom.cleanup_temp_dir")
+    @patch("aiperf.dataset.composer.custom.extract_compressed_file")
+    @patch("aiperf.dataset.composer.custom.is_compressed_file", return_value=True)
+    @patch("pathlib.Path.is_file", return_value=True)
+    @patch("aiperf.dataset.composer.custom.check_file_exists")
+    def test_create_dataset_cleans_up_on_load_failure(
+        self,
+        mock_check_file,
+        mock_is_file,
+        mock_is_compressed,
+        mock_extract,
+        mock_cleanup,
+        custom_config,
+        mock_tokenizer,
+    ) -> None:
+        """Test that temp dir is cleaned up even when loading fails."""
+        extracted_path = Path("/tmp/aiperf_dataset_xyz/data.jsonl")
+        temp_dir = Path("/tmp/aiperf_dataset_xyz")
+        mock_extract.return_value = (extracted_path, temp_dir)
+
+        custom_config.input.file = Path("/path/to/data.jsonl.gz")
+
+        composer = CustomDatasetComposer(custom_config, mock_tokenizer)
+        with (
+            patch.object(
+                composer, "_load_from_path", side_effect=ValueError("parse error")
+            ),
+            pytest.raises(ValueError, match="parse error"),
+        ):
+            composer.create_dataset()
+
+        mock_cleanup.assert_called_once_with(temp_dir)
+
+    @patch("aiperf.dataset.composer.custom.extract_compressed_file")
+    @patch("aiperf.dataset.composer.custom.is_compressed_file", return_value=False)
+    @patch("pathlib.Path.is_file", return_value=True)
+    @patch("aiperf.dataset.composer.custom.check_file_exists")
+    def test_create_dataset_skips_extraction_for_plain_files(
+        self,
+        mock_check_file,
+        mock_is_file,
+        mock_is_compressed,
+        mock_extract,
+        custom_config,
+        mock_tokenizer,
+    ) -> None:
+        """Test that non-compressed files bypass extraction."""
+        custom_config.input.file = Path("/path/to/data.jsonl")
+
+        composer = CustomDatasetComposer(custom_config, mock_tokenizer)
+        with patch.object(composer, "_load_from_path", return_value=[]):
+            composer.create_dataset()
+
+        mock_extract.assert_not_called()

--- a/tests/unit/dataset/test_archive.py
+++ b/tests/unit/dataset/test_archive.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import lzma
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+import zstandard
+
+from aiperf.dataset.archive import (
+    _get_compression_type,
+    _strip_compression_extension,
+    cleanup_temp_dir,
+    extract_compressed_file,
+    is_compressed_file,
+)
+
+SAMPLE_CONTENT = b'{"text": "Hello world"}\n{"text": "Second line"}\n'
+
+
+# ============================================================================
+# is_compressed_file tests
+# ============================================================================
+
+
+class TestIsCompressedFile:
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "data.jsonl.gz",
+            "data.jsonl.zst",
+            "data.jsonl.xz",
+            "data.zip",
+            "data.tar",
+            "data.tar.gz",
+            "data.tgz",
+            "data.tar.zst",
+            "data.tar.xz",
+        ],
+    )
+    def test_compressed_extensions_detected(self, filename: str) -> None:
+        assert is_compressed_file(Path(filename)) is True
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["data.jsonl", "data.txt", "data.csv", "data.json"],
+    )
+    def test_non_compressed_extensions_not_detected(self, filename: str) -> None:
+        assert is_compressed_file(Path(filename)) is False
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["DATA.JSONL.GZ", "Data.Tar.Gz", "ARCHIVE.ZIP", "data.JSONL.ZST"],
+    )
+    def test_case_insensitive_detection(self, filename: str) -> None:
+        assert is_compressed_file(Path(filename)) is True
+
+
+# ============================================================================
+# _get_compression_type tests
+# ============================================================================
+
+
+class TestGetCompressionType:
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("data.jsonl.gz", ".gz"),
+            ("data.jsonl.zst", ".zst"),
+            ("data.jsonl.xz", ".xz"),
+            ("data.zip", ".zip"),
+            ("data.tar", ".tar"),
+            ("data.tar.gz", ".tar.gz"),
+            ("data.tgz", ".tgz"),
+            ("data.tar.zst", ".tar.zst"),
+            ("data.tar.xz", ".tar.xz"),
+        ],
+    )
+    def test_returns_correct_type(self, filename: str, expected: str) -> None:
+        assert _get_compression_type(Path(filename)) == expected
+
+    def test_tar_gz_matches_before_gz(self) -> None:
+        assert _get_compression_type(Path("data.tar.gz")) == ".tar.gz"
+
+    def test_returns_none_for_unrecognized(self) -> None:
+        assert _get_compression_type(Path("data.jsonl")) is None
+
+
+# ============================================================================
+# _strip_compression_extension tests
+# ============================================================================
+
+
+class TestStripCompressionExtension:
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("data.jsonl.gz", "data.jsonl"),
+            ("data.jsonl.zst", "data.jsonl"),
+            ("data.jsonl.xz", "data.jsonl"),
+            ("archive.tar.gz", "archive"),
+            ("archive.tgz", "archive"),
+            ("archive.tar.zst", "archive"),
+            ("archive.tar.xz", "archive"),
+            ("archive.tar", "archive"),
+            ("archive.zip", "archive"),
+            ("data.jsonl", "data.jsonl"),
+            ("no_extension", "no_extension"),
+        ],
+    )
+    def test_strips_extension(self, filename: str, expected: str) -> None:
+        assert _strip_compression_extension(filename) == expected
+
+    def test_case_insensitive_stripping(self) -> None:
+        assert _strip_compression_extension("DATA.JSONL.GZ") == "DATA.JSONL"
+
+
+# ============================================================================
+# extract_compressed_file tests - single file compression
+# ============================================================================
+
+
+class TestExtractSingleFileCompression:
+    def test_extract_gzip(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.jsonl.gz"
+        with gzip.open(archive, "wb") as f:
+            f.write(SAMPLE_CONTENT)
+
+        extracted, temp_dir = extract_compressed_file(archive)
+        try:
+            assert extracted.name == "data.jsonl"
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_zstd(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.jsonl.zst"
+        cctx = zstandard.ZstdCompressor()
+        with open(archive, "wb") as f:
+            f.write(cctx.compress(SAMPLE_CONTENT))
+
+        extracted, temp_dir = extract_compressed_file(archive)
+        try:
+            assert extracted.name == "data.jsonl"
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_xz(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.jsonl.xz"
+        with lzma.open(archive, "wb") as f:
+            f.write(SAMPLE_CONTENT)
+
+        extracted, temp_dir = extract_compressed_file(archive)
+        try:
+            assert extracted.name == "data.jsonl"
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_single_file_with_inner_path(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.jsonl.gz"
+        with gzip.open(archive, "wb") as f:
+            f.write(SAMPLE_CONTENT)
+
+        extracted, temp_dir = extract_compressed_file(archive, subpath="custom.jsonl")
+        try:
+            assert extracted.name == "custom.jsonl"
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+
+# ============================================================================
+# extract_compressed_file tests - multi-file archives
+# ============================================================================
+
+
+class TestExtractArchive:
+    def test_extract_zip(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("prompts.jsonl", SAMPLE_CONTENT)
+
+        extracted, temp_dir = extract_compressed_file(archive, subpath="prompts.jsonl")
+        try:
+            assert extracted.name == "prompts.jsonl"
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_zip_returns_dir_without_inner_path(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("prompts.jsonl", SAMPLE_CONTENT)
+
+        extracted, temp_dir = extract_compressed_file(archive)
+        try:
+            assert extracted.is_dir()
+            assert (extracted / "prompts.jsonl").read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_tar_gz(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.tar.gz"
+        inner_file = tmp_path / "prompts.jsonl"
+        inner_file.write_bytes(SAMPLE_CONTENT)
+
+        with tarfile.open(archive, "w:gz") as tf:
+            tf.add(inner_file, arcname="prompts.jsonl")
+
+        extracted, temp_dir = extract_compressed_file(archive, subpath="prompts.jsonl")
+        try:
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_tar_zst(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.tar.zst"
+        inner_file = tmp_path / "prompts.jsonl"
+        inner_file.write_bytes(SAMPLE_CONTENT)
+
+        # Create tar, then compress with zstd
+        tar_path = tmp_path / "data.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            tf.add(inner_file, arcname="prompts.jsonl")
+
+        cctx = zstandard.ZstdCompressor()
+        with open(tar_path, "rb") as f_in, open(archive, "wb") as f_out:
+            cctx.copy_stream(f_in, f_out)
+
+        extracted, temp_dir = extract_compressed_file(archive, subpath="prompts.jsonl")
+        try:
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_tar_xz(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.tar.xz"
+        inner_file = tmp_path / "prompts.jsonl"
+        inner_file.write_bytes(SAMPLE_CONTENT)
+
+        with tarfile.open(archive, "w:xz") as tf:
+            tf.add(inner_file, arcname="prompts.jsonl")
+
+        extracted, temp_dir = extract_compressed_file(archive, subpath="prompts.jsonl")
+        try:
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_plain_tar(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.tar"
+        inner_file = tmp_path / "prompts.jsonl"
+        inner_file.write_bytes(SAMPLE_CONTENT)
+
+        with tarfile.open(archive, "w") as tf:
+            tf.add(inner_file, arcname="prompts.jsonl")
+
+        extracted, temp_dir = extract_compressed_file(archive, subpath="prompts.jsonl")
+        try:
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+    def test_extract_tgz(self, tmp_path: Path) -> None:
+        archive = tmp_path / "data.tgz"
+        inner_file = tmp_path / "prompts.jsonl"
+        inner_file.write_bytes(SAMPLE_CONTENT)
+
+        with tarfile.open(archive, "w:gz") as tf:
+            tf.add(inner_file, arcname="prompts.jsonl")
+
+        extracted, temp_dir = extract_compressed_file(archive, subpath="prompts.jsonl")
+        try:
+            assert extracted.read_bytes() == SAMPLE_CONTENT
+        finally:
+            cleanup_temp_dir(temp_dir)
+
+
+# ============================================================================
+# Error handling tests
+# ============================================================================
+
+
+class TestErrorHandling:
+    def test_extract_nonexistent_file_raises_error(self) -> None:
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            extract_compressed_file(Path("/nonexistent/data.jsonl.gz"))
+
+    def test_extract_unrecognized_format_raises_error(self, tmp_path: Path) -> None:
+        plain_file = tmp_path / "data.jsonl"
+        plain_file.write_bytes(SAMPLE_CONTENT)
+
+        with pytest.raises(ValueError, match="Unrecognized compression format"):
+            extract_compressed_file(plain_file)
+
+    def test_extract_zip_path_traversal_raises_error(self, tmp_path: Path) -> None:
+        archive = tmp_path / "evil.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("../../../etc/passwd", b"malicious")
+
+        with pytest.raises(ValueError, match="outside target directory"):
+            extract_compressed_file(archive)
+
+    def test_extract_cleans_up_temp_dir_on_failure(self, tmp_path: Path) -> None:
+        archive = tmp_path / "evil.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("../../../etc/passwd", b"malicious")
+
+        with pytest.raises(ValueError):
+            extract_compressed_file(archive)
+
+        # The temp dir created during extraction should have been cleaned up.
+        # We verify by checking no aiperf_dataset_ dirs remain in the system temp.
+        import tempfile
+
+        temp_root = Path(tempfile.gettempdir())
+        leftover = [
+            d
+            for d in temp_root.iterdir()
+            if d.name.startswith("aiperf_dataset_") and d.is_dir()
+        ]
+        assert len(leftover) == 0
+
+    def test_extract_archive_missing_inner_path_raises_error(
+        self, tmp_path: Path
+    ) -> None:
+        archive = tmp_path / "data.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("prompts.jsonl", SAMPLE_CONTENT)
+
+        with pytest.raises(FileNotFoundError, match="Subpath.*not found"):
+            extract_compressed_file(archive, subpath="nonexistent.jsonl")
+
+
+# ============================================================================
+# cleanup_temp_dir tests
+# ============================================================================
+
+
+class TestCleanupTempDir:
+    def test_cleanup_removes_directory(self, tmp_path: Path) -> None:
+        temp_dir = tmp_path / "to_clean"
+        temp_dir.mkdir()
+        (temp_dir / "file.txt").write_text("test")
+
+        cleanup_temp_dir(temp_dir)
+        assert not temp_dir.exists()
+
+    def test_cleanup_nonexistent_dir_does_not_raise(self) -> None:
+        cleanup_temp_dir(Path("/nonexistent/dir"))


### PR DESCRIPTION
Add transparent extraction of compressed dataset files (.gz, .zst, .xz, .zip, .tar, .tar.gz, .tgz, .tar.zst, .tar.xz) in CustomDatasetComposer. Introduces archive utility module with zip-slip protection, new --input-file-subpath CLI option for multi-file archives, and corresponding tests and tutorial documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for compressed datasets in multiple formats (.gz, .zst, .xz, .zip, .tar, .tar.gz, .tar.zst, .tar.xz).
  * Added `--input-file-subpath` CLI option to select specific files within multi-file archives.

* **Documentation**
  * Added comprehensive guide for using compressed datasets with examples and supported formats.
  * Updated CLI options documentation with new `--input-file-subpath` parameter details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->