### PR TITLE
feat: Add `aiperf env` command

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -16,6 +16,10 @@ Install shell completion for this application.
 
 Analyze a mooncake trace file for ISL/OSL distributions and cache hit rates.
 
+### [`env`](#aiperf-env)
+
+Inspect AIPerf environment variables: aiperf env [subsystem] [--all] [--describe] [--defaults]
+
 ### [`profile`](#aiperf-profile)
 
 Run the Profile subcommand.
@@ -68,6 +72,28 @@ KV cache block size for analysis (default: 512).
 #### `--output-file` `<str>`
 
 Optional output path for analysis report (JSON).
+
+<hr/>
+
+## `aiperf env`
+
+Inspect AIPerf environment variables: aiperf env [subsystem] [--all] [--describe] [--defaults]
+
+#### `--subsystem` `<str>`
+
+Subsystem to filter (e.g. http, worker, zmq).
+
+#### `-a`, `--all`, `--no-all`
+
+Show all env vars, not just overridden ones.
+
+#### `-d`, `--describe`, `--no-describe`
+
+Include field descriptions.
+
+#### `--defaults`, `--no-defaults`
+
+Show reference table with defaults and constraints.
 
 <hr/>
 

--- a/src/aiperf/cli.py
+++ b/src/aiperf/cli.py
@@ -30,6 +30,7 @@ app.register_install_completion_command()
 # Register all CLI commands (lazily loaded at invocation time)
 # NOTE: The order here determines the order they will appear in docs/cli_options.md
 app.command("aiperf.cli_commands.analyze_trace:app", name="analyze-trace")
+app.command("aiperf.cli_commands.env:app", name="env")
 app.command("aiperf.cli_commands.profile:app", name="profile")
 app.command("aiperf.cli_commands.plot:app", name="plot")
 app.command("aiperf.cli_commands.plugins:app", name="plugins")

--- a/src/aiperf/cli_commands/env.py
+++ b/src/aiperf/cli_commands/env.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Environment variable inspection CLI command.
+
+aiperf env                           # Show env vars set to non-default values
+aiperf env --all                     # Show all env vars with current values
+aiperf env --describe                # Include descriptions in output
+aiperf env --defaults                # Reference table: all vars, defaults, constraints, descriptions
+aiperf env http                      # Filter to a specific subsystem
+aiperf env http --all                # All vars in that subsystem
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from cyclopts import App, Parameter
+
+app = App(name="env")
+
+
+@app.default
+def env(
+    subsystem: Annotated[
+        str | None, Parameter(help="Subsystem to filter (e.g. http, worker, zmq)")
+    ] = None,
+    *,
+    all_vars: Annotated[
+        bool,
+        Parameter(
+            name=["--all", "-a"], help="Show all env vars, not just overridden ones"
+        ),
+    ] = False,
+    describe: Annotated[
+        bool,
+        Parameter(name=["--describe", "-d"], help="Include field descriptions"),
+    ] = False,
+    defaults: Annotated[
+        bool,
+        Parameter(
+            name=["--defaults"],
+            help="Show reference table with defaults and constraints",
+        ),
+    ] = False,
+) -> None:
+    """Inspect AIPerf environment variables: aiperf env [subsystem] [--all] [--describe] [--defaults]"""
+    from aiperf.common.env_cli import show_defaults, show_env_vars
+
+    if defaults or (all_vars and describe):
+        show_defaults(subsystem=subsystem)
+    else:
+        show_env_vars(subsystem=subsystem, show_all=all_vars, describe=describe)

--- a/src/aiperf/common/env_cli.py
+++ b/src/aiperf/common/env_cli.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Display helpers for the ``aiperf env`` CLI command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic.fields import FieldInfo
+from pydantic_settings import BaseSettings
+from rich import box
+from rich.console import Console
+from rich.rule import Rule
+from rich.table import Table
+
+from aiperf.common.environment import Environment
+
+console = Console()
+
+_CONSTRAINT_SYMBOLS: dict[str, str] = {
+    "ge": ">=",
+    "le": "<=",
+    "gt": ">",
+    "lt": "<",
+    "min_length": "min length:",
+    "max_length": "max length:",
+}
+
+
+@dataclass(slots=True)
+class _SubsystemInfo:
+    """Resolved subsystem: attribute name, env_prefix, and the live settings instance."""
+
+    attr: str
+    prefix: str
+    instance: BaseSettings
+
+
+def _get_subsystems() -> list[_SubsystemInfo]:
+    """Return all subsystems from the Environment singleton."""
+    results: list[_SubsystemInfo] = []
+    for attr, _field_info in Environment.model_fields.items():
+        instance = getattr(Environment, attr)
+        if isinstance(instance, BaseSettings):
+            prefix = instance.model_config.get("env_prefix", f"AIPERF_{attr}_")
+            results.append(_SubsystemInfo(attr=attr, prefix=prefix, instance=instance))
+    return results
+
+
+def _resolve_subsystem(name: str) -> _SubsystemInfo | None:
+    """Find a subsystem by case-insensitive name match."""
+    upper = name.upper().replace("-", "_")
+    for info in _get_subsystems():
+        if info.attr == upper:
+            return info
+    return None
+
+
+def _format_value(value: object) -> str:
+    """Format a field value for display."""
+    if value is None:
+        return "None"
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, str):
+        return repr(value)
+    if isinstance(value, int):
+        return f"{value:,}"
+    if isinstance(value, float):
+        return f"{value:,}"
+    return str(value)
+
+
+def _get_constraints(field_info: FieldInfo) -> str:
+    """Extract human-readable constraints from field metadata."""
+    parts: list[str] = []
+    for meta in field_info.metadata:
+        for attr, symbol in _CONSTRAINT_SYMBOLS.items():
+            val = getattr(meta, attr, None)
+            if val is not None:
+                parts.append(f"{symbol} {val}")
+    return ", ".join(parts) if parts else ""
+
+
+def _resolve_subsystems(subsystem: str | None) -> list[_SubsystemInfo] | None:
+    """Resolve subsystem filter, printing error on invalid name. Returns None on error."""
+    if subsystem:
+        info = _resolve_subsystem(subsystem)
+        if info is None:
+            available = ", ".join(s.attr.lower() for s in _get_subsystems())
+            console.print(f"[red]Unknown subsystem:[/red] {subsystem}")
+            console.print(f"[dim]Available: {available}[/dim]")
+            return None
+        return [info]
+    return _get_subsystems()
+
+
+def _subsystem_title(info: _SubsystemInfo) -> str:
+    """Format subsystem name for section headers."""
+    return info.attr.replace("_", " ")
+
+
+def _make_table(title: str | None = None) -> Table:
+    """Create a consistently styled table."""
+    return Table(
+        title=title,
+        title_style="bold",
+        box=box.SIMPLE_HEAVY,
+        pad_edge=False,
+    )
+
+
+def show_env_vars(
+    *,
+    subsystem: str | None = None,
+    show_all: bool = False,
+    describe: bool = False,
+) -> None:
+    """Show environment variables, optionally filtered to a subsystem.
+
+    By default only shows vars that differ from their defaults (i.e. are set
+    via the process environment). ``--all`` shows every var, grouped by subsystem.
+    """
+    subsystems = _resolve_subsystems(subsystem)
+    if subsystems is None:
+        return
+
+    if show_all:
+        _show_all_grouped(subsystems)
+    else:
+        _show_overridden(subsystems, subsystem=subsystem, describe=describe)
+
+
+def _show_overridden(
+    subsystems: list[_SubsystemInfo],
+    *,
+    subsystem: str | None,
+    describe: bool,
+) -> None:
+    """Show only env vars that have been explicitly set."""
+    table = _make_table()
+    table.add_column("Env Variable", style="cyan", no_wrap=True)
+    table.add_column("Value", style="green", justify="right")
+    if describe:
+        table.add_column("Description", style="dim")
+
+    row_count = 0
+    for info in subsystems:
+        fields_set = info.instance.model_fields_set
+        for field_name, field_info in info.instance.model_fields.items():
+            if field_name not in fields_set:
+                continue
+
+            current = getattr(info.instance, field_name)
+            row: list[str] = [
+                f"{info.prefix}{field_name}",
+                _format_value(current),
+            ]
+            if describe:
+                row.append(field_info.description or "")
+            table.add_row(*row)
+            row_count += 1
+
+    if row_count == 0:
+        prefix = subsystems[0].prefix if subsystem else "AIPERF_"
+        all_flag = f"--all {subsystem}" if subsystem else "--all"
+        console.print(f"[dim]No {prefix}* environment variables are set.[/dim]")
+        console.print(
+            f"[dim]Use {all_flag} to see all variables with their defaults.[/dim]"
+        )
+        return
+
+    console.print(table)
+    all_flag = f"--all {subsystem}" if subsystem else "--all"
+    console.print(
+        f"\n[dim]{row_count} variable(s) overridden. Use {all_flag} to see all.[/dim]"
+    )
+
+
+def _show_all_grouped(subsystems: list[_SubsystemInfo]) -> None:
+    """Show all env vars grouped by subsystem."""
+    for info in subsystems:
+        fields_set = info.instance.model_fields_set
+        console.print(
+            Rule(f"{_subsystem_title(info)} ({info.prefix}*)", characters="━")
+        )
+        table = _make_table()
+        table.add_column("Env Variable", style="cyan", no_wrap=True)
+        table.add_column("Value", justify="right")
+
+        for field_name in info.instance.model_fields:
+            current = getattr(info.instance, field_name)
+            value_str = _format_value(current)
+
+            if field_name in fields_set:
+                value_str = f"[bold green]{value_str}[/bold green]"
+            else:
+                value_str = f"[dim]{value_str}[/dim]"
+
+            table.add_row(f"{info.prefix}{field_name}", value_str)
+
+        console.print(table)
+
+
+def show_defaults(*, subsystem: str | None = None) -> None:
+    """Show a reference table of all env vars with defaults, constraints, and descriptions."""
+    subsystems = _resolve_subsystems(subsystem)
+    if subsystems is None:
+        return
+
+    for info in subsystems:
+        console.print(
+            Rule(f"{_subsystem_title(info)} ({info.prefix}*)", characters="━")
+        )
+
+        for field_name, field_info in info.instance.model_fields.items():
+            default = _format_value(field_info.default)
+            constraints = _get_constraints(field_info)
+            desc = field_info.description or ""
+
+            console.print(f"  [cyan]{info.prefix}{field_name}[/cyan]")
+            parts = [f"    default: {default}"]
+            if constraints:
+                parts.append(f"  [yellow]({constraints})[/yellow]")
+            console.print("".join(parts))
+            if desc:
+                console.print(f"    [dim]{desc}[/dim]")
+        console.print()


### PR DESCRIPTION
## Summary
- Adds `aiperf env` CLI command for inspecting `AIPERF_*` environment variables
- Supports filtering by subsystem, showing all vars (`--all`), descriptions (`--describe`), and a reference table with defaults and constraints (`--defaults`)
- New files: `cli_commands/env.py` (CLI entry point) and `common/env_cli.py` (display helpers using Rich tables)

## Test plan
- [ ] `aiperf env` — shows only overridden env vars (or helpful message if none set)
- [ ] `aiperf env --all` — shows all vars grouped by subsystem, highlights overridden ones
- [ ] `aiperf env --describe` — includes field descriptions
- [ ] `aiperf env --defaults` — full reference table with defaults and constraints
- [ ] `aiperf env http` — filters to a single subsystem
- [ ] `aiperf env nonexistent` — shows error with available subsystems
- [ ] `aiperf env --help` — displays usage info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `env` command to inspect environment variables with options to show all variables, include descriptions, and display default values.
  * Added `service` command to the CLI.

* **Documentation**
  * Added comprehensive documentation for the new env subcommand with flag descriptions and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->