### PR TITLE
fix(aiperf): use safe_load in loader

### DIFF
--- a/src/aiperf/common/config/loader.py
+++ b/src/aiperf/common/config/loader.py
@@ -28,7 +28,7 @@ def _load_config_file(path: Path) -> dict[str, Any]:
     elif suffix in (".yaml", ".yml"):
         yaml = YAML(pure=True)
         with open(path) as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
     else:
         raise ValueError(
             f"Unsupported config file format: {suffix}. Use .json, .yaml, or .yml"

--- a/src/aiperf/plot/config.py
+++ b/src/aiperf/plot/config.py
@@ -209,7 +209,7 @@ class PlotConfig:
         try:
             yaml = YAML(typ="safe")
             with open(self.resolved_path, encoding="utf-8") as f:
-                config = yaml.load(f)
+                config = yaml.safe_load(f)
 
             if not isinstance(config, dict):
                 raise ValueError(


### PR DESCRIPTION
During an automated code review of src/aiperf/common/config/loader.py, the following issue was identified. Use safe_load in loader. yaml.load on untrusted input can construct arbitrary Python objects. I kept the patch small and re-ran syntax checks after applying it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated YAML configuration file parsing across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->