### PR TITLE
feat(dataset): add raw_messages and raw_tools support to multi_turn format

### DIFF
--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -56,6 +56,16 @@ class SingleTurn(AIPerfBaseModel):
         description="Amount of milliseconds to wait before sending the turn. Supports floating point, but scheduling accuracy is at the millisecond level.",
     )
     role: str | None = Field(default=None, description="Role of the turn.")
+    raw_messages: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Pre-formatted OpenAI-compatible messages array. "
+        "When set, bypasses normal turn-based message construction in endpoints.",
+    )
+    raw_tools: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Pre-formatted OpenAI-compatible tool definitions. "
+        "When set alongside raw_messages, injected into the API payload.",
+    )
 
     @model_validator(mode="after")
     def validate_mutually_exclusive_fields(self) -> "SingleTurn":
@@ -73,6 +83,15 @@ class SingleTurn(AIPerfBaseModel):
         return self
 
     @model_validator(mode="after")
+    def validate_raw_messages_fields(self) -> "SingleTurn":
+        """Ensure raw_messages is non-empty and raw_tools requires raw_messages."""
+        if self.raw_messages is not None and not self.raw_messages:
+            raise ValueError("raw_messages must be a non-empty list")
+        if self.raw_tools is not None and self.raw_messages is None:
+            raise ValueError("raw_tools requires raw_messages to be set")
+        return self
+
+    @model_validator(mode="after")
     def validate_at_least_one_modality(self) -> "SingleTurn":
         """Ensure at least one modality is provided"""
         if not any(
@@ -85,6 +104,7 @@ class SingleTurn(AIPerfBaseModel):
                 self.audios,
                 self.video,
                 self.videos,
+                self.raw_messages,
             ]
         ):
             raise ValueError("At least one modality must be provided")

--- a/src/aiperf/dataset/loader/multi_turn.py
+++ b/src/aiperf/dataset/loader/multi_turn.py
@@ -168,6 +168,8 @@ class MultiTurnDatasetLoader(BaseFileLoader, MediaConversionMixin):
                             timestamp=single_turn.timestamp,
                             delay=single_turn.delay,
                             role=single_turn.role,
+                            raw_messages=single_turn.raw_messages,
+                            raw_tools=single_turn.raw_tools,
                         )
                     )
             conversations.append(conversation)

--- a/src/aiperf/dataset/loader/single_turn.py
+++ b/src/aiperf/dataset/loader/single_turn.py
@@ -137,6 +137,8 @@ class SingleTurnDatasetLoader(BaseFileLoader, MediaConversionMixin):
                         timestamp=single_turn.timestamp,
                         delay=single_turn.delay,
                         role=single_turn.role,
+                        raw_messages=single_turn.raw_messages,
+                        raw_tools=single_turn.raw_tools,
                     )
                 )
             conversations.append(conversation)

--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -41,8 +41,8 @@ class ChatEndpoint(BaseEndpoint):
         turns = request_info.turns
         model_endpoint = request_info.model_endpoint
 
-        if turns[-1].raw_messages is not None:
-            messages = turns[-1].raw_messages
+        if any(turn.raw_messages is not None for turn in turns):
+            messages = self._build_accumulated_raw_messages(turns)
         else:
             messages = self._create_messages(
                 turns, request_info.system_message, request_info.user_context_message
@@ -125,6 +125,30 @@ class ChatEndpoint(BaseEndpoint):
             }
             self._set_message_content(message, turn)
             messages.append(message)
+        return messages
+
+    def _build_accumulated_raw_messages(
+        self, turns: list[Turn]
+    ) -> list[dict[str, Any]]:
+        """Build accumulated messages from turns that may mix raw_messages and regular turns.
+
+        Turns with raw_messages have their messages extended into the list.
+        Turns without raw_messages (e.g. response turns) are converted via _set_message_content().
+
+        Args:
+            turns: List of turns in the request
+
+        Returns:
+            List of accumulated message dicts for OpenAI Chat Completions API
+        """
+        messages: list[dict[str, Any]] = []
+        for turn in turns:
+            if turn.raw_messages is not None:
+                messages.extend(turn.raw_messages)
+            else:
+                message: dict[str, Any] = {"role": turn.role or _DEFAULT_ROLE}
+                self._set_message_content(message, turn)
+                messages.append(message)
         return messages
 
     def _set_message_content(self, message: dict[str, Any], turn: Turn) -> None:

--- a/tests/unit/dataset/loader/test_multi_turn.py
+++ b/tests/unit/dataset/loader/test_multi_turn.py
@@ -576,3 +576,56 @@ class TestMultiTurnDatasetLoaderConvertToConversations:
         assert len(conversations[1].turns) == 1
         assert conversations[0].turns[0].texts[0].contents == ["First"]
         assert conversations[1].turns[0].texts[0].contents == ["Second"]
+
+    def test_convert_passes_through_raw_messages(self, default_user_config):
+        """Test that raw_messages are passed through to Turn objects."""
+        raw_msgs = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        data = {
+            "session_1": [
+                MultiTurn(
+                    session_id="session_1",
+                    turns=[SingleTurn(raw_messages=raw_msgs)],
+                )
+            ]
+        }
+
+        loader = MultiTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        conversations = loader.convert_to_conversations(data)
+
+        assert len(conversations) == 1
+        turn = conversations[0].turns[0]
+        assert turn.raw_messages == raw_msgs
+        assert turn.raw_tools is None
+
+    def test_convert_passes_through_raw_messages_and_raw_tools(
+        self, default_user_config
+    ):
+        """Test that raw_messages and raw_tools are both passed through."""
+        raw_msgs = [{"role": "user", "content": "Use a tool"}]
+        raw_tools = [
+            {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
+        ]
+        data = {
+            "session_1": [
+                MultiTurn(
+                    session_id="session_1",
+                    turns=[
+                        SingleTurn(raw_messages=raw_msgs, raw_tools=raw_tools),
+                    ],
+                )
+            ]
+        }
+
+        loader = MultiTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        conversations = loader.convert_to_conversations(data)
+
+        turn = conversations[0].turns[0]
+        assert turn.raw_messages == raw_msgs
+        assert turn.raw_tools == raw_tools

--- a/tests/unit/dataset/loader/test_single_turn.py
+++ b/tests/unit/dataset/loader/test_single_turn.py
@@ -132,6 +132,42 @@ class TestSingleTurn:
                 delay=delay,
             )
 
+    def test_create_with_raw_messages(self):
+        """Test creating SingleTurn with raw_messages satisfies modality check."""
+        raw_msgs = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        data = SingleTurn(raw_messages=raw_msgs)
+
+        assert data.raw_messages == raw_msgs
+        assert data.raw_tools is None
+        assert data.text is None
+
+    def test_create_with_raw_messages_and_raw_tools(self):
+        """Test creating SingleTurn with raw_messages and raw_tools."""
+        raw_msgs = [{"role": "user", "content": "Use a tool"}]
+        raw_tools = [
+            {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
+        ]
+        data = SingleTurn(raw_messages=raw_msgs, raw_tools=raw_tools)
+
+        assert data.raw_messages == raw_msgs
+        assert data.raw_tools == raw_tools
+
+    def test_validation_raw_tools_without_raw_messages_raises_error(self):
+        """Test that raw_tools without raw_messages raises validation error."""
+        with pytest.raises(ValueError, match="raw_tools requires raw_messages"):
+            SingleTurn(
+                text="Hello",
+                raw_tools=[{"type": "function", "function": {"name": "f"}}],
+            )
+
+    def test_validation_empty_raw_messages_raises_error(self):
+        """Test that empty raw_messages list raises validation error."""
+        with pytest.raises(ValueError, match="raw_messages must be a non-empty list"):
+            SingleTurn(raw_messages=[])
+
 
 class TestSingleTurnDatasetLoader:
     """Basic functionality tests for SingleTurnDatasetLoader."""
@@ -444,6 +480,40 @@ class TestSingleTurnDatasetLoaderConvertToConversations:
         assert turn.texts[0].contents == ["What is AI?"]
         assert turn.texts[1].name == "context"
         assert turn.texts[1].contents == ["AI stands for artificial intelligence"]
+
+    def test_convert_passes_through_raw_messages(self, default_user_config):
+        """Test that raw_messages are passed through to Turn objects."""
+        loader = SingleTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        raw_msgs = [{"role": "user", "content": "Hello"}]
+        data = {"session_1": [SingleTurn(raw_messages=raw_msgs)]}
+
+        conversations = loader.convert_to_conversations(data)
+
+        assert len(conversations) == 1
+        turn = conversations[0].turns[0]
+        assert turn.raw_messages == raw_msgs
+        assert turn.raw_tools is None
+
+    def test_convert_passes_through_raw_messages_and_raw_tools(
+        self, default_user_config
+    ):
+        """Test that raw_messages and raw_tools are both passed through."""
+        loader = SingleTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        raw_msgs = [{"role": "user", "content": "Use a tool"}]
+        raw_tools = [
+            {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
+        ]
+        data = {"session_1": [SingleTurn(raw_messages=raw_msgs, raw_tools=raw_tools)]}
+
+        conversations = loader.convert_to_conversations(data)
+
+        turn = conversations[0].turns[0]
+        assert turn.raw_messages == raw_msgs
+        assert turn.raw_tools == raw_tools
 
 
 class TestSingleTurnMediaEncoding:

--- a/tests/unit/endpoints/test_chat_endpoint.py
+++ b/tests/unit/endpoints/test_chat_endpoint.py
@@ -472,3 +472,77 @@ class TestChatEndpoint:
         assert payload["messages"] == raw_messages
         assert payload["temperature"] == 0.7
         assert payload["max_completion_tokens"] == 50
+
+    def test_format_payload_accumulated_raw_messages_multi_turn(
+        self, endpoint, model_endpoint
+    ):
+        """Test accumulated raw_messages across multiple turns."""
+        turn1 = Turn(
+            raw_messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+        )
+        turn2 = Turn(
+            texts=[Text(contents=["Follow up question"])],
+            role="user",
+        )
+        turn3 = Turn(
+            raw_messages=[
+                {"role": "user", "content": "Final question"},
+            ],
+        )
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[turn1, turn2, turn3],
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert len(payload["messages"]) == 4
+        assert payload["messages"][0] == {"role": "user", "content": "Hello"}
+        assert payload["messages"][1] == {"role": "assistant", "content": "Hi there!"}
+        assert payload["messages"][2]["role"] == "user"
+        assert payload["messages"][2]["content"] == "Follow up question"
+        assert payload["messages"][3] == {"role": "user", "content": "Final question"}
+
+    def test_format_payload_accumulated_raw_messages_uses_raw_tools_from_last_turn(
+        self, endpoint, model_endpoint
+    ):
+        """Test that raw_tools from last turn is used with accumulated raw_messages."""
+        raw_tools = [
+            {"type": "function", "function": {"name": "lookup", "parameters": {}}}
+        ]
+        turn1 = Turn(
+            raw_messages=[{"role": "user", "content": "Hello"}],
+        )
+        turn2 = Turn(
+            raw_messages=[{"role": "user", "content": "Use a tool"}],
+            raw_tools=raw_tools,
+        )
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[turn1, turn2],
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["tools"] == raw_tools
+        assert len(payload["messages"]) == 2
+
+    def test_format_payload_single_turn_with_raw_messages_still_works(
+        self, endpoint, model_endpoint
+    ):
+        """Test that a single turn with raw_messages uses accumulated path."""
+        raw_messages = [
+            {"role": "system", "content": "Be helpful"},
+            {"role": "user", "content": "Hi"},
+        ]
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[Turn(raw_messages=raw_messages)],
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["messages"] == raw_messages


### PR DESCRIPTION
## Summary

- Adds `raw_messages` and `raw_tools` fields to `SingleTurn`, passed through by both loaders
- `ChatEndpoint` accumulates `raw_messages` across turns, interleaving with model responses
- Validation: `raw_tools` requires `raw_messages`, `raw_messages` must be non-empty

## Motivation

Production traces have messages in format that aren't supported by multi-turn dataset, e.g.:
-  structured tool-calling conversations (tool results, and `tools` definitions).
- multiple messages from different toles in the same turn.
Using multi turn datasets for this requires some flattening.

I noticed that `mooncake_trace` supports raw messages - but using it means discarding model responses between turns, so the server's KV cache can't be fully reused across turns.

So - this adds `raw_messages`/`raw_tools` to `multi_turn` with accumulated behavior — model responses are appended to conversation history, preserving prefix cache efficiency.

## Test plan

- [x] Model validation (raw_messages alone valid, raw_tools requires raw_messages, empty rejected)
- [x] Loader pass-through (both loaders propagate to Turn)
- [x] ChatEndpoint accumulated behavior + backward compatibility
- [x] 89 tests pass, pre-commit clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-formatted OpenAI-compatible message and tool payload fields to datasets
  * These fields now propagate through the dataset pipeline and inject directly into API requests
  * Multi-turn conversations accumulate raw messages across all turns

* **Tests**
  * Added comprehensive test coverage for raw message and tool handling throughout dataset loaders and endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->