### PR TITLE
feat: add direct worker mode to co-locate Worker in TimingManager process

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -941,6 +941,10 @@ Directory path for ZMQ IPC (Inter-Process Communication) socket files. When usin
 
 Maximum number of workers to create. If not specified, the number of workers will be determined by the formula `min(concurrency, (num CPUs * 0.75) - 1)`, with a default max cap of 32. Any value provided will still be capped by the concurrency value (if specified), but not by the max cap.
 
+#### `--workers-direct`, `--no-workers-direct`
+
+Enable direct worker mode: co-locate a single Worker inside TimingManager's process and deliver credits via method calls instead of ZMQ. Eliminates IPC overhead for ultra-low-latency benchmarks. Some endpoints enable this automatically. Use --no-workers-direct to force standard multi-process workers.
+
 ### Service
 
 #### `--log-level` `<str>`

--- a/src/aiperf/common/config/cli_parameter.py
+++ b/src/aiperf/common/config/cli_parameter.py
@@ -13,7 +13,8 @@ class CLIParameter(Parameter):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, show_env_var=False, negative=False, **kwargs)
+        kwargs.setdefault("negative", False)
+        super().__init__(*args, show_env_var=False, **kwargs)
 
 
 class DisableCLI(CLIParameter):

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -220,6 +220,7 @@ class LoadGeneratorDefaults:
 class WorkersDefaults:
     MIN = None
     MAX = None
+    DIRECT = None
 
 
 @dataclass(frozen=True)

--- a/src/aiperf/common/config/worker_config.py
+++ b/src/aiperf/common/config/worker_config.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Annotated
+from typing import Annotated, Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from aiperf.common.config.base_config import BaseConfig
 from aiperf.common.config.cli_parameter import CLIParameter, DisableCLI
@@ -37,3 +37,28 @@ class WorkersConfig(BaseConfig):
             group=_CLI_GROUP,
         ),
     ] = WorkersDefaults.MAX
+
+    direct: Annotated[
+        bool | None,
+        Field(
+            description="Enable direct worker mode: co-locate a single Worker inside TimingManager's process "
+            "and deliver credits via method calls instead of ZMQ. Eliminates IPC overhead for "
+            "ultra-low-latency benchmarks. Some endpoints enable this automatically. "
+            "Use --no-workers-direct to force standard multi-process workers.",
+        ),
+        CLIParameter(
+            name=("--workers-direct",),
+            negative=("--no-workers-direct",),
+            group=_CLI_GROUP,
+        ),
+    ] = WorkersDefaults.DIRECT
+
+    @model_validator(mode="after")
+    def validate_direct_incompatible_with_max(self) -> Self:
+        """Direct worker mode uses a single co-located worker, so --workers-max is meaningless."""
+        if self.direct and "max" in self.model_fields_set:
+            raise ValueError(
+                "--workers-direct and --workers-max cannot be used together. "
+                "Direct worker mode uses a single co-located worker."
+            )
+        return self

--- a/src/aiperf/common/config/worker_config.py
+++ b/src/aiperf/common/config/worker_config.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Annotated, Self
+from typing import Annotated
 
 from pydantic import Field, model_validator
+from typing_extensions import Self
 
 from aiperf.common.config.base_config import BaseConfig
 from aiperf.common.config.cli_parameter import CLIParameter, DisableCLI

--- a/src/aiperf/controller/direct_worker_service_manager.py
+++ b/src/aiperf/controller/direct_worker_service_manager.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from aiperf.common.types import ServiceTypeT
+from aiperf.controller.multiprocess_service_manager import MultiProcessServiceManager
+
+
+class DirectWorkerServiceManager(MultiProcessServiceManager):
+    """Service manager for direct worker mode.
+
+    Extends MultiProcessServiceManager but skips Worker spawning.
+    The Worker is co-located inside TimingManager's process and
+    receives credits via DirectCreditRouter (direct method calls).
+    All other services are spawned normally as separate processes.
+    """
+
+    async def run_service(
+        self, service_type: ServiceTypeT, num_replicas: int = 1
+    ) -> None:
+        """Run a service, skipping Worker which is managed in-process."""
+        from aiperf.plugin.enums import ServiceType
+
+        if service_type == ServiceType.WORKER:
+            self.info("Skipping Worker spawn — co-located in TimingManager process")
+            return
+        await super().run_service(service_type, num_replicas)

--- a/src/aiperf/credit/direct_credit_router.py
+++ b/src/aiperf/credit/direct_credit_router.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Zero-overhead credit router for direct worker mode.
+
+Delivers credits directly to a co-located Worker instance via method calls
+instead of ZMQ sockets. Designed for single-worker benchmarks where the
+Worker lives in TimingManager's process.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from aiperf.credit.messages import CreditReturn, FirstToken
+from aiperf.credit.structs import Credit
+
+if TYPE_CHECKING:
+    from aiperf.workers.worker import Worker
+
+
+class DirectCreditRouter:
+    """Zero-overhead credit router for direct worker mode.
+
+    Implements CreditRouterProtocol by delivering credits directly to a
+    co-located Worker instance via method calls instead of ZMQ sockets.
+    Designed for single-worker benchmarks where the Worker lives in
+    TimingManager's process.
+    """
+
+    def __init__(self) -> None:
+        self._worker: Worker | None = None
+        self._credits_complete: bool = False
+        self._on_return_callback: (
+            Callable[[str, CreditReturn], Awaitable[None]] | None
+        ) = None
+        self._on_first_token_callback: (
+            Callable[[FirstToken], Awaitable[None]] | None
+        ) = None
+
+    @property
+    def worker_id(self) -> str:
+        """Return the attached worker's service_id."""
+        if self._worker is None:
+            raise RuntimeError("No worker attached to DirectCreditRouter")
+        return self._worker.service_id
+
+    def attach_worker(self, worker: Worker) -> None:
+        """Connect a worker instance and wire callbacks.
+
+        Registers the stored return/first-token callbacks on the worker so
+        that CreditReturn and FirstToken events flow back to the caller.
+
+        Args:
+            worker: Worker instance to deliver credits to.
+        """
+        self._worker = worker
+        if self._on_return_callback is not None:
+            worker.set_credit_return_callback(
+                self._wrap_return_callback(self._on_return_callback)
+            )
+        if self._on_first_token_callback is not None:
+            worker.set_first_token_callback(self._on_first_token_callback)
+
+    def _wrap_return_callback(
+        self,
+        callback: Callable[[str, CreditReturn], Awaitable[None]],
+    ) -> Callable[[CreditReturn], Awaitable[None]]:
+        """Wrap a (worker_id, credit_return) callback into a (credit_return) callback.
+
+        The orchestrator's callback expects (worker_id, credit_return), but the
+        Worker calls its callback with just (credit_return). This wrapper injects
+        the worker_id automatically.
+        """
+        worker_id = self.worker_id
+
+        async def wrapped(credit_return: CreditReturn) -> None:
+            await callback(worker_id, credit_return)
+
+        return wrapped
+
+    def set_return_callback(
+        self,
+        callback: Callable[[str, CreditReturn], Awaitable[None]],
+    ) -> None:
+        """Register callback for credit returns.
+
+        Args:
+            callback: Async function called when credit returns.
+                     Signature: (worker_id: str, message: CreditReturn) -> None
+        """
+        self._on_return_callback = callback
+        if self._worker is not None:
+            self._worker.set_credit_return_callback(
+                self._wrap_return_callback(callback)
+            )
+
+    def set_first_token_callback(
+        self,
+        callback: Callable[[FirstToken], Awaitable[None]],
+    ) -> None:
+        """Register callback for first token events (prefill concurrency release).
+
+        Args:
+            callback: Async function called when first token is received.
+                     Signature: (message: FirstToken) -> None
+        """
+        self._on_first_token_callback = callback
+        if self._worker is not None:
+            self._worker.set_first_token_callback(callback)
+
+    async def send_credit(self, credit: Credit) -> None:
+        """Send credit directly to the attached worker.
+
+        Args:
+            credit: Credit to deliver to the worker.
+
+        Raises:
+            RuntimeError: If no worker is attached.
+        """
+        if self._worker is None:
+            raise RuntimeError("No worker attached to DirectCreditRouter")
+        self._worker.receive_credit(credit)
+
+    async def cancel_all_credits(self) -> None:
+        """Cancel all in-flight credits on the attached worker.
+
+        Raises:
+            RuntimeError: If no worker is attached.
+        """
+        if self._worker is None:
+            raise RuntimeError("No worker attached to DirectCreditRouter")
+        await self._worker.cancel_all_credits()
+
+    def mark_credits_complete(self) -> None:
+        """Mark that all credits have been issued and returned.
+
+        Called by orchestrator when benchmark completes normally.
+        """
+        self._credits_complete = True

--- a/src/aiperf/credit/direct_credit_router.py
+++ b/src/aiperf/credit/direct_credit_router.py
@@ -31,6 +31,7 @@ class DirectCreditRouter:
     def __init__(self) -> None:
         self._worker: Worker | None = None
         self._credits_complete: bool = False
+        self._in_flight_credits: set[int] = set()
         self._on_return_callback: (
             Callable[[str, CreditReturn], Awaitable[None]] | None
         ) = None
@@ -73,8 +74,10 @@ class DirectCreditRouter:
         the worker_id automatically.
         """
         worker_id = self.worker_id
+        in_flight = self._in_flight_credits
 
         async def wrapped(credit_return: CreditReturn) -> None:
+            in_flight.discard(credit_return.credit.id)
             await callback(worker_id, credit_return)
 
         return wrapped
@@ -120,6 +123,7 @@ class DirectCreditRouter:
         """
         if self._worker is None:
             raise RuntimeError("No worker attached to DirectCreditRouter")
+        self._in_flight_credits.add(credit.id)
         self._worker.receive_credit(credit)
 
     async def cancel_all_credits(self) -> None:
@@ -130,7 +134,8 @@ class DirectCreditRouter:
         """
         if self._worker is None:
             raise RuntimeError("No worker attached to DirectCreditRouter")
-        await self._worker.cancel_all_credits()
+        if self._in_flight_credits:
+            await self._worker.cancel_credits(self._in_flight_credits.copy())
 
     def mark_credits_complete(self) -> None:
         """Mark that all credits have been issued and returned.

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -111,7 +111,7 @@ ServiceType = plugins.create_enum(PluginType.SERVICE, "ServiceType", module=__na
 
 ServiceRunTypeStr: TypeAlias = str
 ServiceRunType = plugins.create_enum(PluginType.SERVICE_MANAGER, "ServiceRunType", module=__name__)
-"""Dynamic enum for service manager. Example: ServiceRunType.KUBERNETES, ServiceRunType.MULTIPROCESSING"""
+"""Dynamic enum for service manager. Example: ServiceRunType.DIRECT_WORKER, ServiceRunType.KUBERNETES, ServiceRunType.MULTIPROCESSING"""
 
 CommunicationBackendStr: TypeAlias = str
 CommunicationBackend = plugins.create_enum(PluginType.COMMUNICATION, "CommunicationBackend", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -182,6 +182,13 @@ service_manager:
       as a separate process with ZMQ IPC communication for high-performance local
       execution.
 
+  direct_worker:
+    class: aiperf.controller.direct_worker_service_manager:DirectWorkerServiceManager
+    description: |
+      Direct worker service manager. Extends multiprocessing manager but skips
+      Worker spawning since the Worker is co-located inside TimingManager's
+      process and receives credits via DirectCreditRouter.
+
 # =============================================================================
 # Endpoints
 # =============================================================================
@@ -322,6 +329,7 @@ endpoint:
       tokenizes_input: false
       supports_images: true
       requires_inline_media: true
+      direct_worker: true
       metrics_title: Image Retrieval Metrics
 
   nim_embeddings:

--- a/src/aiperf/plugin/schema/plugins.schema.json
+++ b/src/aiperf/plugin/schema/plugins.schema.json
@@ -870,6 +870,12 @@
               "description": "Whether endpoint requires media URLs to be downloaded and inlined as base64 data URLs.",
               "title": "Requires Inline Media",
               "type": "boolean"
+            },
+            "direct_worker": {
+              "default": false,
+              "description": "Whether endpoint benefits from direct worker mode (Worker co-located in TimingManager's process with credit delivery via method calls instead of ZMQ).",
+              "title": "Direct Worker",
+              "type": "boolean"
             }
           },
           "required": [

--- a/src/aiperf/plugin/schema/schemas.py
+++ b/src/aiperf/plugin/schema/schemas.py
@@ -282,6 +282,10 @@ class EndpointMetadata(BaseModel):
         default=False,
         description="Whether endpoint requires media URLs to be downloaded and inlined as base64 data URLs.",
     )
+    direct_worker: bool = Field(
+        default=False,
+        description="Whether endpoint benefits from direct worker mode (Worker co-located in TimingManager's process with credit delivery via method calls instead of ZMQ).",
+    )
 
 
 class TransportMetadata(BaseModel):

--- a/src/aiperf/timing/manager.py
+++ b/src/aiperf/timing/manager.py
@@ -22,10 +22,12 @@ from aiperf.common.messages import (
     ProfileConfigureCommand,
 )
 from aiperf.common.models import DatasetMetadata
-from aiperf.credit.sticky_router import StickyCreditRouter
+from aiperf.credit.direct_credit_router import DirectCreditRouter
+from aiperf.credit.sticky_router import CreditRouterProtocol, StickyCreditRouter
 from aiperf.timing.config import TimingConfig
 from aiperf.timing.phase.publisher import PhasePublisher
 from aiperf.timing.phase_orchestrator import PhaseOrchestrator
+from aiperf.workers.worker import Worker
 
 
 class TimingManager(BaseComponentService):
@@ -62,14 +64,25 @@ class TimingManager(BaseComponentService):
         self._dataset_configured_event = asyncio.Event()
         self._dataset_metadata: DatasetMetadata | None = None
 
-        # StickyCreditRouter handles everything: routing, sending, returns,
-        # worker lifecycle. Created early to handle worker connections
-        # immediately, as well as attaching to the lifecycle.
-        self.sticky_router: StickyCreditRouter = StickyCreditRouter(
-            service_config=service_config,
-            service_id=self.service_id,
-        )
-        self.attach_child_lifecycle(self.sticky_router)
+        if self._is_direct_worker_mode(service_config, user_config):
+            # Direct: deliver credits directly to a co-located Worker
+            direct_router = DirectCreditRouter()
+            self._direct_worker = self._create_direct_worker(
+                service_config, user_config
+            )
+            direct_router.attach_worker(self._direct_worker)
+            self.attach_child_lifecycle(self._direct_worker)
+            self.credit_router: CreditRouterProtocol = direct_router
+        else:
+            # Standard: ZMQ-based routing to separate worker processes
+            self._direct_worker = None
+            sticky_router = StickyCreditRouter(
+                service_config=service_config,
+                service_id=self.service_id,
+            )
+            self.attach_child_lifecycle(sticky_router)
+            self.credit_router = sticky_router
+
         self.event_loop_monitor = EventLoopMonitor(self.service_id)
 
         self._phase_orchestrator: PhaseOrchestrator | None = None
@@ -108,7 +121,7 @@ class TimingManager(BaseComponentService):
         self._phase_orchestrator = PhaseOrchestrator(
             config=self.config,
             phase_publisher=self.phase_publisher,
-            credit_router=self.sticky_router,
+            credit_router=self.credit_router,
             dataset_metadata=self._dataset_metadata,
         )
         await self._phase_orchestrator.initialize()
@@ -147,6 +160,34 @@ class TimingManager(BaseComponentService):
             await self._phase_orchestrator.stop()
 
         self.event_loop_monitor.stop()
+
+    @staticmethod
+    def _is_direct_worker_mode(
+        service_config: ServiceConfig, user_config: UserConfig
+    ) -> bool:
+        """Determine whether to use direct worker mode.
+
+        Resolution order:
+        1. CLI flag (--workers-direct / --no-workers-direct) — explicit override
+        2. Endpoint metadata (direct_worker: true in plugins.yaml) — default hint
+        """
+        cli_override = service_config.workers.direct
+        if cli_override is not None:
+            return cli_override
+        try:
+            return user_config._endpoint_metadata().direct_worker
+        except Exception:
+            return False
+
+    def _create_direct_worker(
+        self, service_config: ServiceConfig, user_config: UserConfig
+    ) -> Worker:
+        """Create a Worker co-located in TimingManager's process."""
+        return Worker(
+            service_config=service_config,
+            user_config=user_config,
+            service_id=f"{self.service_id}-worker",
+        )
 
 
 def main() -> None:

--- a/src/aiperf/workers/worker.py
+++ b/src/aiperf/workers/worker.py
@@ -389,12 +389,6 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         """Cancel in-flight credits directly for in-process mode."""
         await self._on_cancel_credits_message(CancelCredits(credit_ids=credit_ids))
 
-    async def cancel_all_credits(self) -> None:
-        """Cancel all in-flight credits. Used by DirectCreditRouter."""
-        credit_ids = set(self.credit_tasks.keys())
-        if credit_ids:
-            await self.cancel_credits(credit_ids)
-
     def set_credit_return_callback(
         self,
         callback: Callable[[CreditReturn], Awaitable[None]],

--- a/src/aiperf/workers/worker.py
+++ b/src/aiperf/workers/worker.py
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 
 from aiperf.common.base_component_service import BaseComponentService
 from aiperf.common.config import ServiceConfig, UserConfig
@@ -188,6 +191,16 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         # Initialized when DatasetConfiguredNotification is received via factory
         self._dataset_client: DatasetClientStoreProtocol | None = None
         self._dataset_configured_event = asyncio.Event()
+        self._engine_ready = asyncio.Event()
+
+        # In-process mode callbacks — when set, credit returns and first token events
+        # are delivered via direct method call instead of ZMQ DEALER socket.
+        self._credit_return_callback: (
+            Callable[[CreditReturn], Awaitable[None]] | None
+        ) = None
+        self._first_token_callback: Callable[[FirstToken], Awaitable[None]] | None = (
+            None
+        )
 
         # Only send FirstToken messages when prefill concurrency limiting is active.
         # Detecting first token requires parsing each SSE chunk, so skip this overhead
@@ -211,6 +224,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
     async def _send_worker_ready_message(self) -> None:
         """Send WorkerReady to announce presence."""
         await self.credit_dealer_client.send(WorkerReady(worker_id=self.service_id))
+        self._engine_ready.set()
 
     @on_message(MessageType.DATASET_CONFIGURED_NOTIFICATION)
     async def _on_dataset_configured(self, msg: DatasetConfiguredNotification) -> None:
@@ -339,7 +353,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
             first_token_sent=credit_context.first_token_sent,
             error=str(credit_context.error) if credit_context.error else None,
         )
-        self.execute_async(self.credit_dealer_client.send(credit_return))
+        self.execute_async(self._send_credit_return(credit_return))
         credit_context.returned = True
 
         # Explicitly clear references to help refcounting (GC is disabled on workers)
@@ -361,6 +375,50 @@ class Worker(BaseComponentService, ProcessHealthMixin):
                     )
                 )
 
+    # ── In-process mode public API ──────────────────────────────────────
+
+    def receive_credit(self, credit: Credit) -> None:
+        """Receive a credit directly for in-process mode.
+
+        Bypasses ZMQ deserialization. Equivalent to receiving a Credit
+        via the DEALER socket.
+        """
+        self._schedule_credit_drop_task(credit)
+
+    async def cancel_credits(self, credit_ids: set[int]) -> None:
+        """Cancel in-flight credits directly for in-process mode."""
+        await self._on_cancel_credits_message(CancelCredits(credit_ids=credit_ids))
+
+    def set_credit_return_callback(
+        self,
+        callback: Callable[[CreditReturn], Awaitable[None]],
+    ) -> None:
+        """Register callback for returning credits in in-process mode."""
+        self._credit_return_callback = callback
+
+    def set_first_token_callback(
+        self,
+        callback: Callable[[FirstToken], Awaitable[None]],
+    ) -> None:
+        """Register callback for first token events in in-process mode."""
+        self._first_token_callback = callback
+
+    # ── Credit return / first token dispatch ────────────────────────────
+
+    async def _send_credit_return(self, credit_return: CreditReturn) -> None:
+        """Send credit return via callback (in-process) or ZMQ DEALER socket."""
+        if self._credit_return_callback is not None:
+            await self._credit_return_callback(credit_return)
+        else:
+            await self.credit_dealer_client.send(credit_return)
+
+    async def _send_first_token(self, first_token: FirstToken) -> None:
+        """Send first token via callback (in-process) or ZMQ DEALER socket."""
+        if self._first_token_callback is not None:
+            await self._first_token_callback(first_token)
+        else:
+            await self.credit_dealer_client.send(first_token)
+
     async def _on_credit_drop_message_task(self, credit_context: CreditContext) -> None:
         """Handle incoming credit from TimingManager via StickyCreditRouter.
 
@@ -376,6 +434,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         For tasks cancelled before they start, the done callback handles the return.
         """
         try:
+            await self._engine_ready.wait()
             if not self.inference_client:
                 raise NotInitializedError("Inference server client not initialized.")
             await self._process_credit(credit_context)
@@ -394,7 +453,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
                 first_token_sent=credit_context.first_token_sent,
                 error=str(credit_context.error) if credit_context.error else None,
             )
-            await self.credit_dealer_client.send(credit_return)
+            await self._send_credit_return(credit_return)
             # Mark as returned AFTER send succeeds
             # If send fails/cancelled, done callback will retry
             # Router idempotency guard handles duplicates
@@ -437,7 +496,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
                     return False  # Keep looking for meaningful content
 
                 # Meaningful content found - send FirstToken to router
-                await self.credit_dealer_client.send(
+                await self._send_first_token(
                     FirstToken(
                         credit_id=credit.id,
                         phase=credit.phase,

--- a/src/aiperf/workers/worker.py
+++ b/src/aiperf/workers/worker.py
@@ -191,7 +191,6 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         # Initialized when DatasetConfiguredNotification is received via factory
         self._dataset_client: DatasetClientStoreProtocol | None = None
         self._dataset_configured_event = asyncio.Event()
-        self._engine_ready = asyncio.Event()
 
         # In-process mode callbacks — when set, credit returns and first token events
         # are delivered via direct method call instead of ZMQ DEALER socket.
@@ -220,11 +219,16 @@ class Worker(BaseComponentService, ProcessHealthMixin):
             )
         )
 
+    @property
+    def _is_direct_mode(self) -> bool:
+        """True when running in-process with direct credit delivery (no ZMQ DEALER peer)."""
+        return self._credit_return_callback is not None
+
     @on_start
     async def _send_worker_ready_message(self) -> None:
         """Send WorkerReady to announce presence."""
-        await self.credit_dealer_client.send(WorkerReady(worker_id=self.service_id))
-        self._engine_ready.set()
+        if not self._is_direct_mode:
+            await self.credit_dealer_client.send(WorkerReady(worker_id=self.service_id))
 
     @on_message(MessageType.DATASET_CONFIGURED_NOTIFICATION)
     async def _on_dataset_configured(self, msg: DatasetConfiguredNotification) -> None:
@@ -251,6 +255,8 @@ class Worker(BaseComponentService, ProcessHealthMixin):
     @on_stop
     async def _send_worker_shutdown_message(self) -> None:
         """Send WorkerShutdown to announce shutdown."""
+        if self._is_direct_mode:
+            return
         try:
             await self.credit_dealer_client.send(
                 WorkerShutdown(worker_id=self.service_id)
@@ -434,7 +440,6 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         For tasks cancelled before they start, the done callback handles the return.
         """
         try:
-            await self._engine_ready.wait()
             if not self.inference_client:
                 raise NotInitializedError("Inference server client not initialized.")
             await self._process_credit(credit_context)

--- a/src/aiperf/workers/worker.py
+++ b/src/aiperf/workers/worker.py
@@ -389,6 +389,12 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         """Cancel in-flight credits directly for in-process mode."""
         await self._on_cancel_credits_message(CancelCredits(credit_ids=credit_ids))
 
+    async def cancel_all_credits(self) -> None:
+        """Cancel all in-flight credits. Used by DirectCreditRouter."""
+        credit_ids = set(self.credit_tasks.keys())
+        if credit_ids:
+            await self.cancel_credits(credit_ids)
+
     def set_credit_return_callback(
         self,
         callback: Callable[[CreditReturn], Awaitable[None]],

--- a/tests/unit/common/config/test_worker_config.py
+++ b/tests/unit/common/config/test_worker_config.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for WorkersConfig validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from aiperf.common.config.worker_config import WorkersConfig
+
+
+class TestDirectWorkerValidation:
+    """Validate --workers-direct and --workers-max mutual exclusivity."""
+
+    @pytest.mark.parametrize(
+        ("direct", "max_workers", "should_pass"),
+        [
+            pytest.param(True, None, True, id="direct-only"),
+            pytest.param(False, None, True, id="no-direct-only"),
+            pytest.param(None, 4, True, id="max-only"),
+            pytest.param(False, 4, True, id="no-direct-with-max"),
+            pytest.param(None, None, True, id="neither"),
+            pytest.param(True, 4, False, id="direct-with-max"),
+            pytest.param(True, 1, False, id="direct-with-max-1"),
+        ],
+    )
+    def test_direct_and_max_compatibility(
+        self,
+        direct: bool | None,
+        max_workers: int | None,
+        should_pass: bool,
+    ) -> None:
+        kwargs: dict = {}
+        if direct is not None:
+            kwargs["direct"] = direct
+        if max_workers is not None:
+            kwargs["max"] = max_workers
+
+        if should_pass:
+            config = WorkersConfig(**kwargs)
+            assert config.direct == direct
+            assert config.max == max_workers
+        else:
+            with pytest.raises(
+                ValueError,
+                match="--workers-direct and --workers-max cannot be used together",
+            ):
+                WorkersConfig(**kwargs)
+
+    def test_default_values(self) -> None:
+        config = WorkersConfig()
+        assert config.direct is None
+        assert config.max is None
+        assert config.min is None

--- a/tests/unit/credit/test_direct_credit_router.py
+++ b/tests/unit/credit/test_direct_credit_router.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DirectCreditRouter.
+
+Focuses on:
+- Construction and worker attachment lifecycle
+- Direct credit delivery via send_credit / cancel_all_credits
+- Callback wiring (before and after worker attachment)
+- Credits-complete flag
+- End-to-end credit lifecycle with callbacks
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiperf.common.enums import CreditPhase
+from aiperf.credit.direct_credit_router import DirectCreditRouter
+from aiperf.credit.messages import CreditReturn, FirstToken
+from aiperf.credit.structs import Credit
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _make_credit(credit_id: int = 1) -> Credit:
+    """Create a minimal Credit for testing."""
+    return Credit(
+        id=credit_id,
+        phase=CreditPhase.PROFILING,
+        conversation_id="conv-1",
+        x_correlation_id="corr-1",
+        turn_index=0,
+        num_turns=1,
+        issued_at_ns=time.time_ns(),
+    )
+
+
+def _make_mock_worker(service_id: str = "worker-1") -> MagicMock:
+    """Create a mock Worker with the methods DirectCreditRouter requires."""
+    worker = MagicMock()
+    worker.service_id = service_id
+    worker.receive_credit = MagicMock()
+    worker.cancel_all_credits = AsyncMock()
+    worker.set_credit_return_callback = MagicMock()
+    worker.set_first_token_callback = MagicMock()
+    return worker
+
+
+# ============================================================
+# Construction & Attachment
+# ============================================================
+
+
+class TestConstructionAndAttachment:
+    """Verify worker attachment and worker_id property."""
+
+    def test_attach_worker_stores_reference(self) -> None:
+        router = DirectCreditRouter()
+        worker = _make_mock_worker()
+
+        router.attach_worker(worker)
+
+        assert router._worker is worker
+
+    def test_worker_id_returns_service_id(self) -> None:
+        router = DirectCreditRouter()
+        worker = _make_mock_worker(service_id="my-worker-42")
+        router.attach_worker(worker)
+
+        assert router.worker_id == "my-worker-42"
+
+    def test_worker_id_raises_without_worker(self) -> None:
+        router = DirectCreditRouter()
+
+        with pytest.raises(RuntimeError, match="No worker attached"):
+            _ = router.worker_id
+
+    def test_attach_worker_wires_existing_callbacks(self) -> None:
+        router = DirectCreditRouter()
+        return_cb = AsyncMock()
+        first_token_cb = AsyncMock()
+        router.set_return_callback(return_cb)
+        router.set_first_token_callback(first_token_cb)
+
+        worker = _make_mock_worker()
+        router.attach_worker(worker)
+
+        # Return callback is wrapped to inject worker_id, so check it was called with a callable
+        worker.set_credit_return_callback.assert_called_once()
+        worker.set_first_token_callback.assert_called_once_with(first_token_cb)
+
+
+# ============================================================
+# send_credit
+# ============================================================
+
+
+class TestSendCredit:
+    """Verify direct credit delivery to the attached worker."""
+
+    @pytest.mark.asyncio
+    async def test_send_credit_calls_worker_receive_credit(self) -> None:
+        router = DirectCreditRouter()
+        worker = _make_mock_worker()
+        router.attach_worker(worker)
+        credit = _make_credit()
+
+        await router.send_credit(credit)
+
+        worker.receive_credit.assert_called_once_with(credit)
+
+    @pytest.mark.asyncio
+    async def test_send_credit_raises_without_worker(self) -> None:
+        router = DirectCreditRouter()
+
+        with pytest.raises(RuntimeError, match="No worker attached"):
+            await router.send_credit(_make_credit())
+
+
+# ============================================================
+# cancel_all_credits
+# ============================================================
+
+
+class TestCancelAllCredits:
+    """Verify cancel propagation to attached worker."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_credits_calls_worker(self) -> None:
+        router = DirectCreditRouter()
+        worker = _make_mock_worker()
+        router.attach_worker(worker)
+
+        await router.cancel_all_credits()
+
+        worker.cancel_all_credits.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_credits_raises_without_worker(self) -> None:
+        router = DirectCreditRouter()
+
+        with pytest.raises(RuntimeError, match="No worker attached"):
+            await router.cancel_all_credits()
+
+
+# ============================================================
+# mark_credits_complete
+# ============================================================
+
+
+class TestMarkCreditsComplete:
+    """Verify credits-complete flag."""
+
+    def test_mark_credits_complete_sets_flag(self) -> None:
+        router = DirectCreditRouter()
+
+        assert router._credits_complete is False
+        router.mark_credits_complete()
+        assert router._credits_complete is True
+
+
+# ============================================================
+# Callback Wiring
+# ============================================================
+
+
+class TestCallbackWiring:
+    """Verify callback registration before and after worker attachment."""
+
+    def test_set_return_callback_before_attach_worker(self) -> None:
+        router = DirectCreditRouter()
+        cb = AsyncMock()
+
+        router.set_return_callback(cb)
+
+        assert router._on_return_callback is cb
+
+    def test_set_return_callback_after_attach_worker(self) -> None:
+        router = DirectCreditRouter()
+        worker = _make_mock_worker()
+        router.attach_worker(worker)
+        cb = AsyncMock()
+
+        router.set_return_callback(cb)
+
+        assert router._on_return_callback is cb
+        # Return callback is wrapped to inject worker_id
+        worker.set_credit_return_callback.assert_called_once()
+
+    def test_set_first_token_callback_before_attach_worker(self) -> None:
+        router = DirectCreditRouter()
+        cb = AsyncMock()
+
+        router.set_first_token_callback(cb)
+
+        assert router._on_first_token_callback is cb
+
+    def test_set_first_token_callback_after_attach_worker(self) -> None:
+        router = DirectCreditRouter()
+        worker = _make_mock_worker()
+        router.attach_worker(worker)
+        cb = AsyncMock()
+
+        router.set_first_token_callback(cb)
+
+        assert router._on_first_token_callback is cb
+        worker.set_first_token_callback.assert_called_once_with(cb)
+
+    def test_callbacks_wired_to_worker_on_attach(self) -> None:
+        router = DirectCreditRouter()
+        return_cb = AsyncMock()
+        first_token_cb = AsyncMock()
+        router.set_return_callback(return_cb)
+        router.set_first_token_callback(first_token_cb)
+
+        worker = _make_mock_worker()
+        router.attach_worker(worker)
+
+        # Return callback is wrapped to inject worker_id
+        worker.set_credit_return_callback.assert_called_once()
+        worker.set_first_token_callback.assert_called_once_with(first_token_cb)
+
+    def test_no_callbacks_wired_when_none_registered(self) -> None:
+        router = DirectCreditRouter()
+        worker = _make_mock_worker()
+
+        router.attach_worker(worker)
+
+        worker.set_credit_return_callback.assert_not_called()
+        worker.set_first_token_callback.assert_not_called()
+
+
+# ============================================================
+# Integration Flow
+# ============================================================
+
+
+class TestIntegrationFlow:
+    """Verify end-to-end credit lifecycle through the router."""
+
+    @pytest.mark.asyncio
+    async def test_full_credit_lifecycle_send_and_return(self) -> None:
+        """Send credit, simulate worker processing, CreditReturn flows back via callback."""
+        router = DirectCreditRouter()
+        received_returns: list[tuple[str, CreditReturn]] = []
+
+        async def on_return(worker_id: str, msg: CreditReturn) -> None:
+            received_returns.append((worker_id, msg))
+
+        router.set_return_callback(on_return)
+
+        # Build a worker mock that invokes the return callback when it receives a credit
+        worker = _make_mock_worker(service_id="w-1")
+        stored_return_cb: list[Callable] = []
+
+        def capture_return_cb(cb: Callable[[CreditReturn], Awaitable[None]]) -> None:
+            stored_return_cb.append(cb)
+
+        worker.set_credit_return_callback = MagicMock(side_effect=capture_return_cb)
+        router.attach_worker(worker)
+
+        credit = _make_credit(credit_id=42)
+        await router.send_credit(credit)
+        worker.receive_credit.assert_called_once_with(credit)
+
+        # Simulate the worker firing the wrapped return callback (worker calls with just credit_return)
+        assert len(stored_return_cb) == 1
+        credit_return = CreditReturn(credit=credit, first_token_sent=True)
+        await stored_return_cb[0](credit_return)
+
+        # The wrapper injects worker_id automatically
+        assert len(received_returns) == 1
+        assert received_returns[0] == ("w-1", credit_return)
+
+    @pytest.mark.asyncio
+    async def test_full_credit_lifecycle_with_first_token(self) -> None:
+        """Send credit, FirstToken flows back via callback."""
+        router = DirectCreditRouter()
+        received_tokens: list[FirstToken] = []
+
+        async def on_first_token(msg: FirstToken) -> None:
+            received_tokens.append(msg)
+
+        router.set_first_token_callback(on_first_token)
+
+        worker = _make_mock_worker(service_id="w-2")
+        stored_ft_cb: list[Callable] = []
+
+        def capture_ft_cb(cb: Callable[[FirstToken], Awaitable[None]]) -> None:
+            stored_ft_cb.append(cb)
+
+        worker.set_first_token_callback = MagicMock(side_effect=capture_ft_cb)
+        router.attach_worker(worker)
+
+        credit = _make_credit(credit_id=99)
+        await router.send_credit(credit)
+
+        # Simulate the worker firing the first-token callback
+        assert len(stored_ft_cb) == 1
+        ft = FirstToken(credit_id=99, phase=CreditPhase.PROFILING, ttft_ns=5_000_000)
+        await stored_ft_cb[0](ft)
+
+        assert len(received_tokens) == 1
+        assert received_tokens[0] is ft

--- a/tests/unit/credit/test_direct_credit_router.py
+++ b/tests/unit/credit/test_direct_credit_router.py
@@ -46,7 +46,7 @@ def _make_mock_worker(service_id: str = "worker-1") -> MagicMock:
     worker = MagicMock()
     worker.service_id = service_id
     worker.receive_credit = MagicMock()
-    worker.cancel_all_credits = AsyncMock()
+    worker.cancel_credits = AsyncMock()
     worker.set_credit_return_callback = MagicMock()
     worker.set_first_token_callback = MagicMock()
     return worker
@@ -132,14 +132,28 @@ class TestCancelAllCredits:
     """Verify cancel propagation to attached worker."""
 
     @pytest.mark.asyncio
-    async def test_cancel_all_credits_calls_worker(self) -> None:
+    async def test_cancel_all_credits_passes_tracked_ids(self) -> None:
+        router = DirectCreditRouter()
+        worker = _make_mock_worker()
+        router.attach_worker(worker)
+
+        await router.send_credit(_make_credit(credit_id=1))
+        await router.send_credit(_make_credit(credit_id=2))
+        await router.cancel_all_credits()
+
+        worker.cancel_credits.assert_awaited_once()
+        cancelled_ids = worker.cancel_credits.call_args[0][0]
+        assert cancelled_ids == {1, 2}
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_credits_noop_when_no_in_flight(self) -> None:
         router = DirectCreditRouter()
         worker = _make_mock_worker()
         router.attach_worker(worker)
 
         await router.cancel_all_credits()
 
-        worker.cancel_all_credits.assert_awaited_once()
+        worker.cancel_credits.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cancel_all_credits_raises_without_worker(self) -> None:

--- a/tests/unit/timing/test_timing_manager.py
+++ b/tests/unit/timing/test_timing_manager.py
@@ -245,11 +245,11 @@ class TestTimingManagerStartProfilingAndInitialization:
         mgr = create_manager(user_config)
         assert mgr.config.phase_configs[0].timing_mode == TimingMode.REQUEST_RATE
 
-    def test_creates_phase_publisher_and_sticky_router(
+    def test_creates_phase_publisher_and_credit_router(
         self, create_manager, user_config
     ) -> None:
         mgr = create_manager(user_config)
-        assert mgr.phase_publisher is not None and mgr.sticky_router is not None
+        assert mgr.phase_publisher is not None and mgr.credit_router is not None
 
     def test_no_orchestrator_and_event_not_set_initially(
         self, create_manager, user_config

--- a/tests/unit/workers/test_worker_direct_credit.py
+++ b/tests/unit/workers/test_worker_direct_credit.py
@@ -1,0 +1,351 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Worker direct credit delivery methods.
+
+Focuses on:
+- receive_credit() and cancel_credits() public API
+- Callback setter methods (set_credit_return_callback, set_first_token_callback)
+- _send_credit_return routing (callback vs ZMQ)
+- _send_first_token routing (callback vs ZMQ)
+- End-to-end callback wiring during credit processing
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aiperf.common.config.service_config import ServiceConfig
+from aiperf.common.config.user_config import UserConfig
+from aiperf.common.enums import CreditPhase
+from aiperf.common.models import (
+    Conversation,
+    RequestRecord,
+    SSEMessage,
+    Text,
+    Turn,
+)
+from aiperf.credit.messages import CreditReturn, FirstToken
+from aiperf.credit.structs import Credit
+from aiperf.workers.worker import Worker
+from tests.harness.fake_tokenizer import FakeTokenizer
+
+# ============================================================
+# Fixtures
+# ============================================================
+
+
+def _make_credit(
+    *,
+    credit_id: int = 1,
+    phase: CreditPhase = CreditPhase.PROFILING,
+    conversation_id: str = "conv-1",
+    x_correlation_id: str = "corr-1",
+    turn_index: int = 0,
+    num_turns: int = 1,
+    issued_at_ns: int = 1_000_000,
+) -> Credit:
+    """Helper to build a Credit with sensible defaults."""
+    return Credit(
+        id=credit_id,
+        phase=phase,
+        conversation_id=conversation_id,
+        x_correlation_id=x_correlation_id,
+        turn_index=turn_index,
+        num_turns=num_turns,
+        issued_at_ns=issued_at_ns,
+    )
+
+
+@pytest.fixture
+async def worker(
+    user_config: UserConfig,
+    service_config: ServiceConfig,
+    fake_tokenizer: FakeTokenizer,
+    skip_service_registration,
+) -> Worker:
+    """Create a fully initialized and started Worker."""
+    w = Worker(
+        service_config=service_config,
+        user_config=user_config,
+        service_id="test-worker",
+    )
+    await w.initialize()
+    await w.start()
+    yield w
+    await w.stop()
+
+
+# ============================================================
+# receive_credit
+# ============================================================
+
+
+@pytest.mark.asyncio
+class TestReceiveCredit:
+    """Verify receive_credit delegates to the internal scheduling path."""
+
+    async def test_receive_credit_calls_schedule_credit_drop_task(
+        self, worker: Worker, monkeypatch
+    ) -> None:
+        """receive_credit() should delegate to _schedule_credit_drop_task."""
+        mock_schedule = Mock()
+        monkeypatch.setattr(worker, "_schedule_credit_drop_task", mock_schedule)
+
+        credit = _make_credit()
+        worker.receive_credit(credit)
+
+        mock_schedule.assert_called_once_with(credit)
+
+    async def test_receive_credit_with_valid_credit_struct(
+        self, worker: Worker, monkeypatch
+    ) -> None:
+        """receive_credit() passes the exact Credit struct through to scheduling."""
+        captured = []
+        monkeypatch.setattr(
+            worker, "_schedule_credit_drop_task", lambda c: captured.append(c)
+        )
+
+        credit = _make_credit(credit_id=42, conversation_id="special-conv")
+        worker.receive_credit(credit)
+
+        assert len(captured) == 1
+        assert captured[0].id == 42
+        assert captured[0].conversation_id == "special-conv"
+
+
+# ============================================================
+# cancel_credits
+# ============================================================
+
+
+@pytest.mark.asyncio
+class TestCancelCredits:
+    """Verify cancel_credits creates CancelCredits and delegates."""
+
+    async def test_cancel_credits_creates_cancel_message_and_delegates(
+        self, worker: Worker, monkeypatch
+    ) -> None:
+        """cancel_credits() should build a CancelCredits and call _on_cancel_credits_message."""
+        mock_handler = AsyncMock()
+        monkeypatch.setattr(worker, "_on_cancel_credits_message", mock_handler)
+
+        await worker.cancel_credits({10, 20, 30})
+
+        mock_handler.assert_called_once()
+        msg = mock_handler.call_args[0][0]
+        assert msg.credit_ids == {10, 20, 30}
+
+
+# ============================================================
+# Callback setters
+# ============================================================
+
+
+@pytest.mark.asyncio
+class TestCallbackSetters:
+    """Verify callback setter methods store the callback on the worker."""
+
+    async def test_set_credit_return_callback_stores_callback(
+        self, worker: Worker
+    ) -> None:
+        callback = AsyncMock()
+        worker.set_credit_return_callback(callback)
+        assert worker._credit_return_callback is callback
+
+    async def test_set_first_token_callback_stores_callback(
+        self, worker: Worker
+    ) -> None:
+        callback = AsyncMock()
+        worker.set_first_token_callback(callback)
+        assert worker._first_token_callback is callback
+
+
+# ============================================================
+# _send_credit_return routing
+# ============================================================
+
+
+@pytest.mark.asyncio
+class TestSendCreditReturnRouting:
+    """Verify _send_credit_return routes to callback or ZMQ."""
+
+    async def test_send_credit_return_uses_callback_when_set(
+        self, worker: Worker
+    ) -> None:
+        """When a callback is registered, _send_credit_return should invoke it."""
+        callback = AsyncMock()
+        worker.set_credit_return_callback(callback)
+
+        credit_return = CreditReturn(credit=_make_credit())
+        await worker._send_credit_return(credit_return)
+
+        callback.assert_awaited_once_with(credit_return)
+
+    async def test_send_credit_return_uses_zmq_when_no_callback(
+        self, worker: Worker, monkeypatch
+    ) -> None:
+        """When no callback is registered, _send_credit_return should use the DEALER socket."""
+        mock_send = AsyncMock()
+        monkeypatch.setattr(worker.credit_dealer_client, "send", mock_send)
+
+        credit_return = CreditReturn(credit=_make_credit())
+        await worker._send_credit_return(credit_return)
+
+        mock_send.assert_awaited_once_with(credit_return)
+
+    async def test_send_credit_return_awaits_callback(self, worker: Worker) -> None:
+        """The callback should be properly awaited (not just called)."""
+        was_awaited = False
+
+        async def slow_callback(cr: CreditReturn) -> None:
+            nonlocal was_awaited
+            await asyncio.sleep(0)
+            was_awaited = True
+
+        worker.set_credit_return_callback(slow_callback)
+
+        await worker._send_credit_return(CreditReturn(credit=_make_credit()))
+        assert was_awaited
+
+
+# ============================================================
+# _send_first_token routing
+# ============================================================
+
+
+@pytest.mark.asyncio
+class TestSendFirstTokenRouting:
+    """Verify _send_first_token routes to callback or ZMQ."""
+
+    async def test_send_first_token_uses_callback_when_set(
+        self, worker: Worker
+    ) -> None:
+        """When a callback is registered, _send_first_token should invoke it."""
+        callback = AsyncMock()
+        worker.set_first_token_callback(callback)
+
+        first_token = FirstToken(credit_id=1, phase=CreditPhase.PROFILING, ttft_ns=500)
+        await worker._send_first_token(first_token)
+
+        callback.assert_awaited_once_with(first_token)
+
+    async def test_send_first_token_uses_zmq_when_no_callback(
+        self, worker: Worker, monkeypatch
+    ) -> None:
+        """When no callback is registered, _send_first_token should use the DEALER socket."""
+        mock_send = AsyncMock()
+        monkeypatch.setattr(worker.credit_dealer_client, "send", mock_send)
+
+        first_token = FirstToken(credit_id=1, phase=CreditPhase.PROFILING, ttft_ns=500)
+        await worker._send_first_token(first_token)
+
+        mock_send.assert_awaited_once_with(first_token)
+
+
+# ============================================================
+# Integration: callback wired correctly through credit flow
+# ============================================================
+
+
+@pytest.mark.asyncio
+class TestCreditReturnCallbackIntegration:
+    """Verify credit return callback is invoked during actual credit processing."""
+
+    async def test_credit_return_flows_through_callback_after_processing(
+        self, worker: Worker, monkeypatch
+    ) -> None:
+        """After processing a credit, the CreditReturn should be delivered via callback."""
+        returned = []
+        callback = AsyncMock(side_effect=lambda cr: returned.append(cr))
+        worker.set_credit_return_callback(callback)
+
+        # Engine is ready
+        worker._engine_ready.set()
+
+        # Stub out _process_credit so the full pipeline completes without needing
+        # real inference clients, dataset clients, etc.
+        monkeypatch.setattr(worker, "_process_credit", AsyncMock())
+
+        credit = _make_credit(credit_id=99)
+        worker.receive_credit(credit)
+
+        # Allow the scheduled task to run
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert len(returned) == 1
+        assert returned[0].credit.id == 99
+        assert not returned[0].cancelled
+
+    async def test_first_token_flows_through_callback_during_streaming(
+        self, worker: Worker, monkeypatch
+    ) -> None:
+        """When prefill_concurrency is enabled and streaming yields content,
+        the FirstToken callback should fire during _process_credit."""
+        first_tokens = []
+        ft_callback = AsyncMock(side_effect=lambda ft: first_tokens.append(ft))
+        cr_callback = AsyncMock()
+        worker.set_first_token_callback(ft_callback)
+        worker.set_credit_return_callback(cr_callback)
+
+        # Enable prefill concurrency so first_token_callback is created
+        worker._prefill_concurrency_enabled = True
+
+        # Engine is ready
+        worker._engine_ready.set()
+
+        # We need _process_credit to actually run (not be mocked) so the
+        # first_token_callback closure is exercised.  But we need to mock the
+        # deeper dependencies.
+
+        # Mock session manager to return a session
+        mock_session = Mock()
+        mock_session.x_correlation_id = "corr-1"
+        mock_session.turn_index = 0
+        mock_session.turn_list = [Turn(role="user", texts=[Text(contents=["hello"])])]
+        mock_session.conversation = Conversation(session_id="conv-1", turns=[])
+        mock_session.url_index = None
+        mock_session.advance_turn = Mock()
+        mock_session.store_response = Mock()
+        monkeypatch.setattr(
+            worker.session_manager, "get", Mock(return_value=mock_session)
+        )
+
+        # Mock inference_client.send_request to simulate a streaming request
+        # that invokes the first_token_callback
+        async def mock_send_request(request_info, first_token_callback=None):
+            if first_token_callback is not None:
+                # Simulate receiving a meaningful SSE chunk
+                msg = SSEMessage(perf_ns=100_000)
+                # The callback checks endpoint.parse_response — mock it
+                await first_token_callback(50_000, msg)
+            return RequestRecord()
+
+        monkeypatch.setattr(worker.inference_client, "send_request", mock_send_request)
+
+        # Mock endpoint.parse_response to return meaningful content
+        mock_endpoint = Mock()
+        mock_endpoint.parse_response = Mock(
+            return_value=Mock(data=Mock())  # non-None data
+        )
+        mock_endpoint.extract_response_data = Mock(return_value=[])
+        monkeypatch.setattr(worker.inference_client, "endpoint", mock_endpoint)
+
+        # Mock _send_inference_result_message
+        monkeypatch.setattr(worker, "_send_inference_result_message", AsyncMock())
+
+        credit = _make_credit(credit_id=77)
+        worker.receive_credit(credit)
+
+        # Allow the scheduled task to run
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert len(first_tokens) == 1
+        assert first_tokens[0].credit_id == 77
+        assert first_tokens[0].phase == CreditPhase.PROFILING
+        assert first_tokens[0].ttft_ns == 50_000

--- a/tests/unit/workers/test_worker_direct_credit.py
+++ b/tests/unit/workers/test_worker_direct_credit.py
@@ -262,9 +262,6 @@ class TestCreditReturnCallbackIntegration:
         callback = AsyncMock(side_effect=lambda cr: returned.append(cr))
         worker.set_credit_return_callback(callback)
 
-        # Engine is ready
-        worker._engine_ready.set()
-
         # Stub out _process_credit so the full pipeline completes without needing
         # real inference clients, dataset clients, etc.
         monkeypatch.setattr(worker, "_process_credit", AsyncMock())
@@ -293,9 +290,6 @@ class TestCreditReturnCallbackIntegration:
 
         # Enable prefill concurrency so first_token_callback is created
         worker._prefill_concurrency_enabled = True
-
-        # Engine is ready
-        worker._engine_ready.set()
 
         # We need _process_credit to actually run (not be mocked) so the
         # first_token_callback closure is exercised.  But we need to mock the


### PR DESCRIPTION
Eliminates ZMQ IPC overhead for single-worker benchmarks by delivering credits via direct method calls. Enabled automatically for endpoints with direct_worker metadata or explicitly via --workers-direct CLI flag. Adds DirectCreditRouter, DirectWorkerServiceManager, and supporting config/tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added `--workers-direct` / `--no-workers-direct` CLI options to run a direct-worker mode (co-located worker with in-process credit delivery); using it with an explicit worker-count is now disallowed.
  - Direct-worker execution path can be enabled for endpoints (metadata flag).

* **Documentation**
  - Updated CLI options docs to describe the new flags.

* **Tests**
  - Added unit and integration tests covering direct-worker behavior and credit routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->