### PR TITLE
feat: add builtin tiktoken tokenizer support

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -158,6 +158,40 @@ This document provides attribution information for public domain assets used in 
 >     party to this document and has no duty or obligation with respect to
 >     this CC0 or use of the Work.
 
+## Tokenizer Data
+
+### OpenAI tiktoken Encoding Data
+
+**Asset Information:**
+- **File(s)**: `o200k_base.tiktoken` (pre-cached in Docker image at `/opt/tiktoken_cache/`)
+- **Source**: [openai/tiktoken](https://github.com/openai/tiktoken) via `https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken`
+- **Author**: OpenAI and Shantanu Jain
+- **License**: MIT License
+
+**License Text:**
+
+> MIT License
+>
+> Copyright (c) 2022 OpenAI, Shantanu Jain
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
 ## Usage Summary
 
 - **All assets are public domain** - no legal restrictions on use

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -194,9 +194,9 @@ This document provides attribution information for public domain assets used in 
 
 ## Usage Summary
 
-- **All assets are public domain** - no legal restrictions on use
-- **No attribution legally required** but recommended as good practice
-- **Compatible with Apache 2.0** license used by this project
+- **Public domain assets** (ShareGPT conversation data) - no legal restrictions on use
+- **MIT-licensed assets** (tiktoken encoding data) - permissive, requires copyright notice retention
+- **All assets compatible with Apache 2.0** license used by this project
 - **No endorsement implied** by original sources
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,10 +133,6 @@ RUN mkdir -p /app /app/artifacts /app/.cache \
     && chown -R 1000:1000 /app \
     && chmod -R 755 /app
 
-# Pre-cache tiktoken o200k_base encoding for --tokenizer builtin (MIT license, see ATTRIBUTIONS.md)
-RUN mkdir -p /opt/tiktoken_cache \
-    && TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache python -c "import tiktoken; tiktoken.get_encoding('o200k_base')"
-
 # Install only the dependencies using uv
 COPY pyproject.toml .
 RUN uv sync --active --no-install-project
@@ -148,6 +144,10 @@ RUN uv pip install /dist/aiperf-*.whl \
 
 # Remove setuptools as it is not needed for the runtime image
 RUN uv pip uninstall setuptools
+
+# Pre-cache tiktoken o200k_base encoding for --tokenizer builtin (MIT license, see ATTRIBUTIONS.md)
+RUN mkdir -p /opt/tiktoken_cache \
+    && TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache python -c "import tiktoken; tiktoken.get_encoding('o200k_base')"
 
 ############################################
 ############### Test Image #################

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,9 +135,7 @@ RUN mkdir -p /app /app/artifacts /app/.cache \
 
 # Pre-cache tiktoken o200k_base encoding for --tokenizer builtin (MIT license, see ATTRIBUTIONS.md)
 RUN mkdir -p /opt/tiktoken_cache \
-    && CACHE_KEY=$(python -c "import hashlib; print(hashlib.sha1(b'https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken').hexdigest())") \
-    && wget -q -O /opt/tiktoken_cache/$CACHE_KEY \
-       https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken
+    && TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache python -c "import tiktoken; tiktoken.get_encoding('o200k_base')"
 
 # Install only the dependencies using uv
 COPY pyproject.toml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,12 @@ RUN mkdir -p /app /app/artifacts /app/.cache \
     && chown -R 1000:1000 /app \
     && chmod -R 755 /app
 
+# Pre-cache tiktoken o200k_base encoding for --tokenizer builtin (MIT license, see ATTRIBUTIONS.md)
+RUN mkdir -p /opt/tiktoken_cache \
+    && CACHE_KEY=$(python -c "import hashlib; print(hashlib.sha1(b'https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken').hexdigest())") \
+    && wget -q -O /opt/tiktoken_cache/$CACHE_KEY \
+       https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken
+
 # Install only the dependencies using uv
 COPY pyproject.toml .
 RUN uv sync --active --no-install-project
@@ -156,7 +162,8 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 ENV VIRTUAL_ENV=/opt/aiperf/venv \
-    PATH="/opt/aiperf/venv/bin:${PATH}"
+    PATH="/opt/aiperf/venv/bin:${PATH}" \
+    TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache
 
 ENTRYPOINT ["/bin/bash", "-c"]
 
@@ -184,8 +191,12 @@ ENV HOME=/app
 # Copy the virtual environment and set up
 COPY --from=env-builder --chown=1000:1000 /opt/aiperf/venv /opt/aiperf/venv
 
+# Copy pre-cached tiktoken encoding for zero-network --tokenizer builtin
+COPY --from=env-builder --chown=1000:1000 /opt/tiktoken_cache /opt/tiktoken_cache
+
 ENV VIRTUAL_ENV=/opt/aiperf/venv \
-    PATH="/opt/aiperf/venv/bin:${PATH}"
+    PATH="/opt/aiperf/venv/bin:${PATH}" \
+    TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache
 
 # Set bash as entrypoint
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -666,7 +666,7 @@ Display HTTP trace timing metrics in the console at the end of the benchmark. Sh
 
 #### `--tokenizer` `<str>`
 
-HuggingFace tokenizer identifier or local path for token counting in prompts and responses. Accepts model names (e.g., `meta-llama/Llama-2-7b-hf`) or filesystem paths to tokenizer files. If not specified, defaults to the value of `--model-names`. Essential for accurate token-based metrics (input/output token counts, token throughput).
+HuggingFace tokenizer identifier, local path, or `builtin` for token counting in prompts and responses. Accepts model names (e.g., `meta-llama/Llama-2-7b-hf`), filesystem paths to tokenizer files, or `builtin` for a zero-network-access tokenizer backed by tiktoken (o200k_base encoding). If not specified, defaults to the value of `--model-names`. Essential for accurate token-based metrics (input/output token counts, token throughput).
 
 #### `--tokenizer-revision` `<str>`
 

--- a/docs/reference/tokenizer-auto-detection.md
+++ b/docs/reference/tokenizer-auto-detection.md
@@ -17,11 +17,26 @@ AIPerf resolves tokenizer names **before** spawning services via lightweight Hub
 
 Pre-flight is skipped when `--use-server-token-count` is set with a non-synthetic dataset, or when the endpoint type doesn't require tokenization.
 
+## Built-in Tokenizer
+
+Pass `--tokenizer builtin` to use a zero-network-access tokenizer backed by [tiktoken](https://github.com/openai/tiktoken) with the `o200k_base` encoding (GPT-4o / o1 / o3, 200k vocabulary). This skips all HuggingFace Hub alias resolution and downloads.
+
+Use this when you don't need a model-specific tokenizer and just want token counts for performance metrics. The encoding data is downloaded once on first use and cached locally by tiktoken -- subsequent runs require no network access.
+
+```bash
+aiperf run --tokenizer builtin ...
+```
+
+## Automatic Cache Detection
+
+When a HuggingFace tokenizer has been previously downloaded, AIPerf detects it in the local HF cache and loads directly without any network calls. This applies to both alias resolution and tokenizer loading -- no `model_info()` API call, no ETag update check. First run downloads as normal; every subsequent run is fully offline.
+
 ## Alias Resolution
 
 1. **Local paths**: Absolute, `./`, `../`, or existing directories are used as-is.
-2. **Offline mode**: If `HF_HUB_OFFLINE` or `TRANSFORMERS_OFFLINE` is set, names are used as-is.
-3. **Direct lookup**: `model_info()` API call. Returns canonical `model.id` if found.
+2. **Cached locally**: If the model directory exists in the HF cache, the name is used as-is (no network).
+3. **Offline mode**: If `HF_HUB_OFFLINE` or `TRANSFORMERS_OFFLINE` is set, names are used as-is.
+4. **Direct lookup**: `model_info()` API call. Returns canonical `model.id` if found.
 4. **Search fallback**: If direct lookup fails (`RepositoryNotFoundError` or `HfHubHTTPError`), searches with `list_models(search=name, limit=50)`:
    - **Exact match**: Result ID matches input (case-insensitive).
    - **Suffix match**: Result ends with `/<name>`, picks highest downloads.
@@ -103,7 +118,7 @@ If a tokenizer fails during service initialization, AIPerf walks the `__cause__`
 
 | Option | Description |
 |---|---|
-| `--tokenizer <name-or-path>` | Explicit tokenizer name or local path. If omitted, model names are used. |
+| `--tokenizer <name-or-path>` | Explicit tokenizer name, local path, or `builtin` for tiktoken. If omitted, model names are used. |
 | `--tokenizer-revision <rev>` | Git revision for the tokenizer repo. Default: `main`. |
 | `--tokenizer-trust-remote-code` | Allow execution of custom tokenizer code from the repo. |
 | `--use-server-token-count` | Skip client-side tokenization. Skips pre-flight validation with non-synthetic data. |

--- a/docs/reference/tokenizer-auto-detection.md
+++ b/docs/reference/tokenizer-auto-detection.md
@@ -24,7 +24,7 @@ Pass `--tokenizer builtin` to use a zero-network-access tokenizer backed by [tik
 Use this when you don't need a model-specific tokenizer and just want token counts for performance metrics. The encoding data is downloaded once on first use and cached locally by tiktoken -- subsequent runs require no network access.
 
 ```bash
-aiperf run --tokenizer builtin ...
+aiperf profile --tokenizer builtin ...
 ```
 
 ## Automatic Cache Detection

--- a/docs/reference/tokenizer-auto-detection.md
+++ b/docs/reference/tokenizer-auto-detection.md
@@ -37,7 +37,7 @@ When a HuggingFace tokenizer has been previously downloaded, AIPerf detects it i
 2. **Cached locally**: If the model directory exists in the HF cache, the name is used as-is (no network).
 3. **Offline mode**: If `HF_HUB_OFFLINE` or `TRANSFORMERS_OFFLINE` is set, names are used as-is.
 4. **Direct lookup**: `model_info()` API call. Returns canonical `model.id` if found.
-4. **Search fallback**: If direct lookup fails (`RepositoryNotFoundError` or `HfHubHTTPError`), searches with `list_models(search=name, limit=50)`:
+5. **Search fallback**: If direct lookup fails (`RepositoryNotFoundError` or `HfHubHTTPError`), searches with `list_models(search=name, limit=50)`:
    - **Exact match**: Result ID matches input (case-insensitive).
    - **Suffix match**: Result ends with `/<name>`, picks highest downloads.
    - **Ambiguous**: No match found, returns top 5 suggestions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
   "soundfile~=0.13.1",
   "starlette-compress>=1.0.1",
   "textual~=5.3.0",
+  "tiktoken>=0.7.0,<1",
   "tqdm>=4.67.1",
   "transformers>=4.56.0", # Lowest compatible version for dynamo backends
   "uvicorn[standard]>=0.34,<1",

--- a/src/aiperf/common/config/tokenizer_config.py
+++ b/src/aiperf/common/config/tokenizer_config.py
@@ -21,8 +21,9 @@ class TokenizerConfig(BaseConfig):
     name: Annotated[
         str | None,
         Field(
-            description="HuggingFace tokenizer identifier or local path for token counting in prompts and responses. "
-            "Accepts model names (e.g., `meta-llama/Llama-2-7b-hf`) or filesystem paths to tokenizer files. "
+            description="HuggingFace tokenizer identifier, local path, or `builtin` for token counting in prompts and responses. "
+            "Accepts model names (e.g., `meta-llama/Llama-2-7b-hf`), filesystem paths to tokenizer files, "
+            "or `builtin` for a zero-network-access tokenizer backed by tiktoken (o200k_base encoding). "
             "If not specified, defaults to the value of `--model-names`. Essential for accurate token-based metrics "
             "(input/output token counts, token throughput).",
         ),

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""HuggingFace tokenizer wrapper with sensible defaults."""
+"""HuggingFace tokenizer wrapper with sensible defaults and built-in tiktoken backend."""
 
 import contextlib
 import inspect
@@ -16,9 +16,55 @@ from typing import TYPE_CHECKING
 from aiperf.common.exceptions import NotInitializedError, TokenizerError
 
 if TYPE_CHECKING:
+    import tiktoken
     from transformers import BatchEncoding
 
 _logger = logging.getLogger(__name__)
+
+BUILTIN_TOKENIZER_NAME = "builtin"
+_BUILTIN_ENCODING = "o200k_base"
+# tiktoken encoding names that should be routed through tiktoken, not HF.
+# "gpt2" is excluded because it's also a valid HF model name.
+_TIKTOKEN_ENCODING_NAMES = frozenset(
+    {
+        "cl100k_base",
+        "o200k_base",
+        "o200k_harmony",
+        "p50k_base",
+        "p50k_edit",
+        "r50k_base",
+    }
+)
+
+
+class _TiktokenAdapter:
+    """Adapts tiktoken.Encoding to the interface expected by Tokenizer._tokenizer."""
+
+    def __init__(self, encoding: "tiktoken.Encoding") -> None:
+        self._encoding = encoding
+
+    @property
+    def bos_token_id(self) -> int | None:
+        return None
+
+    @property
+    def eos_token_id(self) -> int:
+        return self._encoding.eot_token
+
+    def encode(self, text: str, **kwargs) -> list[int]:
+        return self._encoding.encode(text, allowed_special="all")
+
+    def decode(self, token_ids: list[int], **kwargs) -> str:
+        return self._encoding.decode(token_ids)
+
+    def __call__(self, text: str, **kwargs) -> dict:
+        return {"input_ids": self.encode(text)}
+
+    def __repr__(self) -> str:
+        return f"TiktokenAdapter({self._encoding.name})"
+
+    def __str__(self) -> str:
+        return repr(self)
 
 
 @dataclass(slots=True)
@@ -66,6 +112,34 @@ def _is_offline_mode() -> bool:
     )
 
 
+def _is_hf_cached(name: str) -> bool:
+    """Check if a HuggingFace model is available in the local cache.
+
+    Looks for ``models--<name>/`` (with ``/`` replaced by ``--``) inside the
+    HF hub cache directory.  Also handles alias-style short names by scanning
+    for directories whose suffix matches ``--<name>``.
+    """
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    cache_dir = Path(HF_HUB_CACHE)
+    if not cache_dir.is_dir():
+        return False
+
+    # Exact match: "meta-llama/Llama-2-7b-hf" -> "models--meta-llama--Llama-2-7b-hf"
+    exact = cache_dir / f"models--{name.replace('/', '--')}"
+    if exact.is_dir():
+        return True
+
+    # Alias match: "gpt2" -> any "models--*--gpt2"
+    suffix = f"--{name.lower()}"
+    return any(
+        entry.is_dir()
+        and entry.name.startswith("models--")
+        and entry.name.lower().endswith(suffix)
+        for entry in cache_dir.iterdir()
+    )
+
+
 def resolve_alias(name: str) -> AliasResolutionResult:
     """Resolve a tokenizer name alias to its canonical repository ID.
 
@@ -88,7 +162,7 @@ def resolve_alias(name: str) -> AliasResolutionResult:
         or path.is_dir()
     )
 
-    if is_local_path or _is_offline_mode():
+    if is_local_path or _is_offline_mode() or _is_hf_cached(name):
         return AliasResolutionResult(resolved_name=name)
 
     # Lazy import HuggingFace Hub
@@ -195,6 +269,8 @@ class Tokenizer:
         """Load a tokenizer for the given pretrained model name.
 
         Uses HF_TOKEN environment variable for authentication.
+        Pass ``"builtin"`` as *name* for a zero-network-access tokenizer
+        backed by tiktoken's ``o200k_base`` encoding.
 
         Args:
             name: The name or path of the pretrained tokenizer model.
@@ -206,6 +282,11 @@ class Tokenizer:
             AmbiguousTokenizerNameError: If the name is ambiguous.
             TokenizerError: If the tokenizer cannot be loaded.
         """
+        if name == BUILTIN_TOKENIZER_NAME or name in _TIKTOKEN_ENCODING_NAMES:
+            return cls._from_tiktoken(
+                _BUILTIN_ENCODING if name == BUILTIN_TOKENIZER_NAME else name
+            )
+
         try:
             # Silence tokenizer warning on import and first use
             with (
@@ -214,8 +295,8 @@ class Tokenizer:
             ):
                 from transformers import AutoTokenizer
 
-                # Offline mode: skip alias resolution, load from local cache
-                if _is_offline_mode():
+                # Offline mode or cached: skip network, load from local cache
+                if _is_offline_mode() or _is_hf_cached(name):
                     tokenizer_instance = cls._from_pretrained_local(
                         AutoTokenizer.from_pretrained,
                         name,
@@ -225,7 +306,7 @@ class Tokenizer:
                     tokenizer_instance._resolved_name = name
                     return tokenizer_instance
 
-                # Online mode: resolve alias then load
+                # Online mode (not cached): resolve alias then load
                 resolved_name = name
                 if resolve_alias:
                     result = cls.resolve_alias(name)
@@ -322,6 +403,27 @@ class Tokenizer:
             return tokenizer_cls
         finally:
             huggingface_hub.model_info = _original_model_info
+
+    @classmethod
+    def _from_tiktoken(cls, encoding_name: str = _BUILTIN_ENCODING) -> "Tokenizer":
+        """Load a tokenizer backed by tiktoken (no HuggingFace, no network after first cache)."""
+        try:
+            import tiktoken
+        except ImportError as e:
+            raise TokenizerError(
+                f"tiktoken is required for --tokenizer {encoding_name}",
+                tokenizer_name=encoding_name,
+            ) from e
+
+        tokenizer_cls = cls()
+        tokenizer_cls._tokenizer = _TiktokenAdapter(
+            tiktoken.get_encoding(encoding_name)
+        )
+        tokenizer_cls._resolved_name = encoding_name
+        tokenizer_cls._call_args = {}
+        tokenizer_cls._encode_args = {}
+        tokenizer_cls._decode_args = {}
+        return tokenizer_cls
 
     def __call__(self, text, **kwargs) -> "BatchEncoding":
         """

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -112,12 +112,37 @@ def _is_offline_mode() -> bool:
     )
 
 
+def _find_hf_cache_aliases(name: str) -> list[Path]:
+    """Find HF cache directories matching a model name alias.
+
+    Scans the HF hub cache for ``models--*--<name>`` directories
+    (case-insensitive suffix match).
+
+    Returns:
+        List of matching cache directory paths.
+    """
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    cache_dir = Path(HF_HUB_CACHE)
+    if not cache_dir.is_dir():
+        return []
+
+    suffix = f"--{name.lower()}"
+    return [
+        entry
+        for entry in cache_dir.iterdir()
+        if entry.is_dir()
+        and entry.name.startswith("models--")
+        and entry.name.lower().endswith(suffix)
+    ]
+
+
 def _is_hf_cached(name: str) -> bool:
     """Check if a HuggingFace model is available in the local cache.
 
     Looks for ``models--<name>/`` (with ``/`` replaced by ``--``) inside the
-    HF hub cache directory.  Also handles alias-style short names by scanning
-    for directories whose suffix matches ``--<name>``.
+    HF hub cache directory.  Also handles alias-style short names, returning
+    True only when a single unambiguous match exists.
     """
     from huggingface_hub.constants import HF_HUB_CACHE
 
@@ -130,16 +155,7 @@ def _is_hf_cached(name: str) -> bool:
     if exact.is_dir():
         return True
 
-    # Alias match: "gpt2" -> unique "models--*--gpt2"
-    suffix = f"--{name.lower()}"
-    matches = [
-        entry
-        for entry in cache_dir.iterdir()
-        if entry.is_dir()
-        and entry.name.startswith("models--")
-        and entry.name.lower().endswith(suffix)
-    ]
-    return len(matches) == 1
+    return len(_find_hf_cache_aliases(name)) == 1
 
 
 def resolve_alias(name: str) -> AliasResolutionResult:
@@ -342,24 +358,12 @@ class Tokenizer:
         Returns:
             The full model ID (e.g. "openai-community/gpt2") or None.
         """
-        from huggingface_hub.constants import HF_HUB_CACHE
-
-        cache_dir = Path(HF_HUB_CACHE)
-        if not cache_dir.is_dir():
+        matches = _find_hf_cache_aliases(name)
+        if len(matches) != 1:
             return None
-
-        suffix = f"--{name.lower()}"
-        for entry in cache_dir.iterdir():
-            if (
-                entry.is_dir()
-                and entry.name.startswith("models--")
-                and entry.name.lower().endswith(suffix)
-            ):
-                # Convert "models--openai-community--gpt2" -> "openai-community/gpt2"
-                model_id = entry.name[len("models--") :].replace("--", "/")
-                _logger.debug(f"Found cached model for alias '{name}': {model_id}")
-                return model_id
-        return None
+        model_id = matches[0].name[len("models--") :].replace("--", "/")
+        _logger.debug(f"Found cached model for alias '{name}': {model_id}")
+        return model_id
 
     @classmethod
     def _from_pretrained_local(

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -130,14 +130,16 @@ def _is_hf_cached(name: str) -> bool:
     if exact.is_dir():
         return True
 
-    # Alias match: "gpt2" -> any "models--*--gpt2"
+    # Alias match: "gpt2" -> unique "models--*--gpt2"
     suffix = f"--{name.lower()}"
-    return any(
-        entry.is_dir()
+    matches = [
+        entry
+        for entry in cache_dir.iterdir()
+        if entry.is_dir()
         and entry.name.startswith("models--")
         and entry.name.lower().endswith(suffix)
-        for entry in cache_dir.iterdir()
-    )
+    ]
+    return len(matches) == 1
 
 
 def resolve_alias(name: str) -> AliasResolutionResult:

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -25,7 +25,7 @@ BUILTIN_TOKENIZER_NAME = "builtin"
 _BUILTIN_ENCODING = "o200k_base"
 # tiktoken encoding names that should be routed through tiktoken, not HF.
 # "gpt2" is excluded because it's also a valid HF model name.
-_TIKTOKEN_ENCODING_NAMES = frozenset(
+TIKTOKEN_ENCODING_NAMES = frozenset(
     {
         "cl100k_base",
         "o200k_base",
@@ -282,7 +282,7 @@ class Tokenizer:
             AmbiguousTokenizerNameError: If the name is ambiguous.
             TokenizerError: If the tokenizer cannot be loaded.
         """
-        if name == BUILTIN_TOKENIZER_NAME or name in _TIKTOKEN_ENCODING_NAMES:
+        if name == BUILTIN_TOKENIZER_NAME or name in TIKTOKEN_ENCODING_NAMES:
             return cls._from_tiktoken(
                 _BUILTIN_ENCODING if name == BUILTIN_TOKENIZER_NAME else name
             )

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -33,7 +33,11 @@ def validate_tokenizer_early(
     """
     from rich.console import Console
 
-    from aiperf.common.tokenizer import Tokenizer
+    from aiperf.common.tokenizer import (
+        _TIKTOKEN_ENCODING_NAMES,
+        BUILTIN_TOKENIZER_NAME,
+        Tokenizer,
+    )
     from aiperf.common.tokenizer_display import (
         TokenizerDisplayEntry,
         display_tokenizer_ambiguous_name,
@@ -62,6 +66,14 @@ def validate_tokenizer_early(
     tokenizer_cfg = user_config.tokenizer
     model_names = user_config.endpoint.model_names
     names = [tokenizer_cfg.name] if tokenizer_cfg.name else list(model_names)
+
+    # tiktoken-backed tokenizers need no HF resolution
+    if (
+        tokenizer_cfg.name == BUILTIN_TOKENIZER_NAME
+        or tokenizer_cfg.name in _TIKTOKEN_ENCODING_NAMES
+    ):
+        logger.debug("Using tiktoken tokenizer, skipping HF alias resolution")
+        return {model: tokenizer_cfg.name for model in model_names}
 
     # Validate and resolve aliases
     console = Console()

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -34,8 +34,8 @@ def validate_tokenizer_early(
     from rich.console import Console
 
     from aiperf.common.tokenizer import (
-        _TIKTOKEN_ENCODING_NAMES,
         BUILTIN_TOKENIZER_NAME,
+        TIKTOKEN_ENCODING_NAMES,
         Tokenizer,
     )
     from aiperf.common.tokenizer_display import (
@@ -70,7 +70,7 @@ def validate_tokenizer_early(
     # tiktoken-backed tokenizers need no HF resolution
     if (
         tokenizer_cfg.name == BUILTIN_TOKENIZER_NAME
-        or tokenizer_cfg.name in _TIKTOKEN_ENCODING_NAMES
+        or tokenizer_cfg.name in TIKTOKEN_ENCODING_NAMES
     ):
         logger.debug("Using tiktoken tokenizer, skipping HF alias resolution")
         return {model: tokenizer_cfg.name for model in model_names}

--- a/tests/unit/common/test_tokenizer.py
+++ b/tests/unit/common/test_tokenizer.py
@@ -5,7 +5,7 @@
 import pytest
 
 from aiperf.common.exceptions import NotInitializedError
-from aiperf.common.tokenizer import Tokenizer
+from aiperf.common.tokenizer import BUILTIN_TOKENIZER_NAME, Tokenizer
 
 
 class TestTokenizer:
@@ -21,3 +21,59 @@ class TestTokenizer:
             tokenizer.decode([1])
         with pytest.raises(NotInitializedError):
             _ = tokenizer.bos_token_id
+
+
+class TestBuiltinTokenizer:
+    @pytest.fixture
+    def tokenizer(self) -> Tokenizer:
+        return Tokenizer.from_pretrained(BUILTIN_TOKENIZER_NAME)
+
+    def test_from_pretrained_returns_tokenizer(self, tokenizer: Tokenizer) -> None:
+        assert tokenizer._tokenizer is not None
+
+    def test_resolved_name(self, tokenizer: Tokenizer) -> None:
+        assert tokenizer.resolved_name == "o200k_base"
+
+    def test_encode_returns_token_ids(self, tokenizer: Tokenizer) -> None:
+        tokens = tokenizer.encode("hello world")
+        assert isinstance(tokens, list)
+        assert all(isinstance(t, int) for t in tokens)
+        assert len(tokens) > 0
+
+    def test_decode_returns_string(self, tokenizer: Tokenizer) -> None:
+        decoded = tokenizer.decode([15339, 1917])
+        assert isinstance(decoded, str)
+        assert len(decoded) > 0
+
+    def test_encode_decode_roundtrip(self, tokenizer: Tokenizer) -> None:
+        text = "The quick brown fox jumps over the lazy dog."
+        assert tokenizer.decode(tokenizer.encode(text)) == text
+
+    def test_bos_token_id_is_none(self, tokenizer: Tokenizer) -> None:
+        assert tokenizer.bos_token_id is None
+
+    def test_eos_token_id_is_set(self, tokenizer: Tokenizer) -> None:
+        assert isinstance(tokenizer.eos_token_id, int)
+
+    def test_block_separation_token_id_falls_back_to_eos(
+        self, tokenizer: Tokenizer
+    ) -> None:
+        assert tokenizer.block_separation_token_id == tokenizer.eos_token_id
+
+    def test_call_returns_input_ids(self, tokenizer: Tokenizer) -> None:
+        result = tokenizer("hello")
+        assert "input_ids" in result
+
+    def test_no_hf_imports_required(self) -> None:
+        """Builtin tokenizer must not trigger HuggingFace imports."""
+        import sys
+
+        hf_modules = {
+            k for k in sys.modules if k.startswith(("transformers", "huggingface_hub"))
+        }
+        tokenizer = Tokenizer.from_pretrained(BUILTIN_TOKENIZER_NAME)
+        new_hf_modules = {
+            k for k in sys.modules if k.startswith(("transformers", "huggingface_hub"))
+        }
+        assert new_hf_modules == hf_modules
+        assert tokenizer.encode("test") is not None

--- a/tests/unit/common/test_tokenizer.py
+++ b/tests/unit/common/test_tokenizer.py
@@ -2,10 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from unittest.mock import patch
+
 import pytest
 
-from aiperf.common.exceptions import NotInitializedError
-from aiperf.common.tokenizer import BUILTIN_TOKENIZER_NAME, Tokenizer
+from aiperf.common.exceptions import NotInitializedError, TokenizerError
+from aiperf.common.tokenizer import (
+    BUILTIN_TOKENIZER_NAME,
+    TIKTOKEN_ENCODING_NAMES,
+    Tokenizer,
+)
 
 
 class TestTokenizer:
@@ -77,3 +83,27 @@ class TestBuiltinTokenizer:
         }
         assert new_hf_modules == hf_modules
         assert tokenizer.encode("test") is not None
+
+
+class TestTiktokenEncodingNames:
+    @pytest.mark.parametrize("encoding_name", sorted(TIKTOKEN_ENCODING_NAMES))
+    def test_from_pretrained_with_encoding_name(self, encoding_name: str) -> None:
+        tokenizer = Tokenizer.from_pretrained(encoding_name)
+        assert tokenizer.resolved_name == encoding_name
+        assert tokenizer.encode("hello") is not None
+
+    def test_o200k_base_direct(self) -> None:
+        tokenizer = Tokenizer.from_pretrained("o200k_base")
+        assert tokenizer.resolved_name == "o200k_base"
+        assert tokenizer.encode("test") == Tokenizer.from_pretrained("builtin").encode(
+            "test"
+        )
+
+
+class TestTiktokenImportError:
+    def test_raises_tokenizer_error_when_tiktoken_missing(self) -> None:
+        with (
+            patch.dict("sys.modules", {"tiktoken": None}),
+            pytest.raises(TokenizerError, match="tiktoken is required"),
+        ):
+            Tokenizer.from_pretrained(BUILTIN_TOKENIZER_NAME)

--- a/tests/unit/common/test_tokenizer_alias_resolution.py
+++ b/tests/unit/common/test_tokenizer_alias_resolution.py
@@ -18,6 +18,13 @@ def _create_mock_response(status_code: int = 404) -> MagicMock:
     return mock_response
 
 
+@pytest.fixture(autouse=True)
+def _no_cache_shortcut():
+    """Disable cache-based shortcut so tests exercise the network path."""
+    with patch("aiperf.common.tokenizer._is_hf_cached", return_value=False):
+        yield
+
+
 @pytest.fixture
 def mock_model_info():
     """Mock huggingface_hub.model_info."""

--- a/tests/unit/common/test_tokenizer_alias_resolution.py
+++ b/tests/unit/common/test_tokenizer_alias_resolution.py
@@ -3,6 +3,7 @@
 
 """Tests for HuggingFace Hub alias resolution in Tokenizer class."""
 
+from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,7 +20,7 @@ def _create_mock_response(status_code: int = 404) -> MagicMock:
 
 
 @pytest.fixture(autouse=True)
-def _no_cache_shortcut():
+def _no_cache_shortcut() -> Iterator[None]:
     """Disable cache-based shortcut so tests exercise the network path."""
     with patch("aiperf.common.tokenizer._is_hf_cached", return_value=False):
         yield

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -3,13 +3,15 @@
 
 """Tests for HuggingFace cache detection in the tokenizer module."""
 
+from pathlib import Path
+
 import pytest
 
 from aiperf.common.tokenizer import Tokenizer, _is_hf_cached
 
 
 @pytest.fixture
-def hf_cache(tmp_path, monkeypatch):
+def hf_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point HF_HUB_CACHE at a temporary directory."""
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
     return tmp_path
@@ -40,6 +42,11 @@ class TestIsHfCached:
 
     def test_empty_cache_dir(self, hf_cache) -> None:
         assert _is_hf_cached("anything") is False
+
+    def test_ambiguous_alias_returns_false(self, hf_cache) -> None:
+        (hf_cache / "models--org-a--gpt2").mkdir()
+        (hf_cache / "models--org-b--gpt2").mkdir()
+        assert _is_hf_cached("gpt2") is False
 
 
 class TestFindCachedModelForAlias:

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for HuggingFace cache detection in the tokenizer module."""
+
+import pytest
+
+from aiperf.common.tokenizer import Tokenizer, _is_hf_cached
+
+
+@pytest.fixture
+def hf_cache(tmp_path, monkeypatch):
+    """Point HF_HUB_CACHE at a temporary directory."""
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
+    return tmp_path
+
+
+class TestIsHfCached:
+    def test_returns_false_when_cache_dir_missing(self, tmp_path, monkeypatch) -> None:
+        nonexistent = tmp_path / "does_not_exist"
+        monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(nonexistent))
+        assert _is_hf_cached("some-model") is False
+
+    def test_exact_match(self, hf_cache) -> None:
+        (hf_cache / "models--meta-llama--Llama-2-7b-hf").mkdir()
+        assert _is_hf_cached("meta-llama/Llama-2-7b-hf") is True
+
+    def test_alias_match_case_insensitive(self, hf_cache) -> None:
+        (hf_cache / "models--openai-community--GPT2").mkdir()
+        assert _is_hf_cached("gpt2") is True
+
+    def test_no_match(self, hf_cache) -> None:
+        (hf_cache / "models--some-org--other-model").mkdir()
+        assert _is_hf_cached("nonexistent") is False
+
+    def test_ignores_non_model_directories(self, hf_cache) -> None:
+        (hf_cache / "refs").mkdir()
+        (hf_cache / "blobs").mkdir()
+        assert _is_hf_cached("refs") is False
+
+    def test_empty_cache_dir(self, hf_cache) -> None:
+        assert _is_hf_cached("anything") is False
+
+
+class TestFindCachedModelForAlias:
+    def test_finds_cached_alias(self, hf_cache) -> None:
+        (hf_cache / "models--openai-community--gpt2").mkdir()
+        result = Tokenizer._find_cached_model_for_alias("gpt2")
+        assert result == "openai-community/gpt2"
+
+    def test_returns_none_when_no_match(self, hf_cache) -> None:
+        (hf_cache / "models--some-org--other-model").mkdir()
+        assert Tokenizer._find_cached_model_for_alias("gpt2") is None
+
+    def test_returns_none_when_cache_missing(self, tmp_path, monkeypatch) -> None:
+        nonexistent = tmp_path / "does_not_exist"
+        monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(nonexistent))
+        assert Tokenizer._find_cached_model_for_alias("gpt2") is None
+
+    def test_case_insensitive_match(self, hf_cache) -> None:
+        (hf_cache / "models--OpenAI-Community--GPT2").mkdir()
+        result = Tokenizer._find_cached_model_for_alias("gpt2")
+        assert result == "OpenAI-Community/GPT2"

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -68,3 +68,8 @@ class TestFindCachedModelForAlias:
         (hf_cache / "models--OpenAI-Community--GPT2").mkdir()
         result = Tokenizer._find_cached_model_for_alias("gpt2")
         assert result == "OpenAI-Community/GPT2"
+
+    def test_ambiguous_alias_returns_none(self, hf_cache) -> None:
+        (hf_cache / "models--org-a--gpt2").mkdir()
+        (hf_cache / "models--org-b--gpt2").mkdir()
+        assert Tokenizer._find_cached_model_for_alias("gpt2") is None

--- a/tests/unit/common/test_tokenizer_validator.py
+++ b/tests/unit/common/test_tokenizer_validator.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for early tokenizer validation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aiperf.common.tokenizer import (
+    BUILTIN_TOKENIZER_NAME,
+    TIKTOKEN_ENCODING_NAMES,
+    Tokenizer,
+)
+from aiperf.common.tokenizer_validator import validate_tokenizer_early
+
+
+@pytest.fixture
+def mock_user_config():
+    """Create a mock UserConfig with tokenizer requiring endpoints."""
+    config = MagicMock()
+    config.endpoint.type = "openai_chat"
+    config.endpoint.model_names = ["gpt-4o", "gpt-4o-mini"]
+    config.endpoint.use_server_token_count = False
+    config.input.public_dataset = None
+    config.input.custom_dataset_type = None
+    config.input.file = None
+    config.tokenizer.name = None
+    config.tokenizer.trust_remote_code = False
+    config.tokenizer.revision = "main"
+    return config
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def _mock_endpoint_meta():
+    """Mock plugins.get_endpoint_metadata to return token-producing endpoint."""
+    meta = MagicMock()
+    meta.produces_tokens = True
+    meta.tokenizes_input = True
+    with patch(
+        "aiperf.plugin.plugins.get_endpoint_metadata",
+        return_value=meta,
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("_mock_endpoint_meta")
+class TestValidatorTiktokenShortCircuit:
+    def test_builtin_skips_alias_resolution(
+        self, mock_user_config, mock_logger
+    ) -> None:
+        mock_user_config.tokenizer.name = BUILTIN_TOKENIZER_NAME
+
+        with patch.object(Tokenizer, "resolve_alias") as mock_resolve:
+            result = validate_tokenizer_early(mock_user_config, mock_logger)
+
+        mock_resolve.assert_not_called()
+        assert result == {
+            "gpt-4o": BUILTIN_TOKENIZER_NAME,
+            "gpt-4o-mini": BUILTIN_TOKENIZER_NAME,
+        }
+
+    @pytest.mark.parametrize("encoding_name", sorted(TIKTOKEN_ENCODING_NAMES))
+    def test_tiktoken_encoding_names_skip_alias_resolution(
+        self, mock_user_config, mock_logger, encoding_name: str
+    ) -> None:
+        mock_user_config.tokenizer.name = encoding_name
+
+        with patch.object(Tokenizer, "resolve_alias") as mock_resolve:
+            result = validate_tokenizer_early(mock_user_config, mock_logger)
+
+        mock_resolve.assert_not_called()
+        assert result == {
+            "gpt-4o": encoding_name,
+            "gpt-4o-mini": encoding_name,
+        }

--- a/tests/unit/common/test_tokenizer_validator.py
+++ b/tests/unit/common/test_tokenizer_validator.py
@@ -3,6 +3,7 @@
 
 """Tests for early tokenizer validation."""
 
+from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,7 +17,7 @@ from aiperf.common.tokenizer_validator import validate_tokenizer_early
 
 
 @pytest.fixture
-def mock_user_config():
+def mock_user_config() -> MagicMock:
     """Create a mock UserConfig with tokenizer requiring endpoints."""
     config = MagicMock()
     config.endpoint.type = "openai_chat"
@@ -32,12 +33,12 @@ def mock_user_config():
 
 
 @pytest.fixture
-def mock_logger():
+def mock_logger() -> MagicMock:
     return MagicMock()
 
 
 @pytest.fixture
-def _mock_endpoint_meta():
+def _mock_endpoint_meta() -> Iterator[None]:
     """Mock plugins.get_endpoint_metadata to return token-producing endpoint."""
     meta = MagicMock()
     meta.produces_tokens = True


### PR DESCRIPTION
# Builtin tiktoken tokenizer support

## Origin

Bulk of the implementation cherry-picked from [`ajc/tokenizer-cache`](https://github.com/ai-dynamo/aiperf/commits/ajc/tokenizer-cache/) (commit [`346fbf3f`](https://github.com/ai-dynamo/aiperf/commit/346fbf3f8e343446cd543bc72ee80126d525ec9a) by @ajcasagrande).

## Summary

Add `--tokenizer builtin` option backed by tiktoken's `o200k_base` encoding for zero-network-access token counting. Also adds automatic HF cache detection to skip unnecessary network calls. Includes code review fixes and comprehensive test coverage for the new functionality.

## Plan

### Commit 1: Cherry-pick from ajc/tokenizer-cache (@ajcasagrande)

Core implementation:

- [x] Add `tiktoken>=0.7.0,<1` dependency to `pyproject.toml`
- [x] `_TiktokenAdapter` class bridging tiktoken's API to `Tokenizer` interface (`tokenizer.py`)
- [x] `_is_hf_cached()` to detect locally cached HF tokenizers and skip network calls (`tokenizer.py`)
- [x] `_find_cached_model_for_alias()` to scan HF cache for alias-style short names (`tokenizer.py`)
- [x] `_from_tiktoken()` factory method on `Tokenizer` with `"builtin"` and encoding name routing (`tokenizer.py`)
- [x] `BUILTIN_TOKENIZER_NAME` and `TIKTOKEN_ENCODING_NAMES` constants for routing decisions (`tokenizer.py`)
- [x] Short-circuit HF alias resolution for tiktoken-backed tokenizers (`tokenizer_validator.py`)
- [x] Update `--tokenizer` CLI description to mention `builtin` option (`tokenizer_config.py`)
- [x] Pre-cache `o200k_base` encoding in Docker image, set `TIKTOKEN_CACHE_DIR` (`Dockerfile`)
- [x] MIT license attribution for OpenAI tiktoken encoding data (`ATTRIBUTIONS.md`)
- [x] Docs for builtin tokenizer, cache detection, updated alias resolution numbering (`tokenizer-auto-detection.md`)
- [x] `TestBuiltinTokenizer` tests and `_no_cache_shortcut` fixture (`test_tokenizer.py`, `test_tokenizer_alias_resolution.py`)

### Commit 2: Self-review fixes and additional tests (@matthewkotila)

Code review fixes:

- [x] Rename `_TIKTOKEN_ENCODING_NAMES` -> `TIKTOKEN_ENCODING_NAMES` (was private but imported cross-module in `tokenizer_validator.py`)
- [x] Fix duplicate "4." numbering in alias resolution docs (`tokenizer-auto-detection.md`)

New test coverage:

- [x] `test_tokenizer_cache.py` (new, 10 tests)
  - `TestIsHfCached`: cache dir missing, exact match, alias match (case-insensitive), no match, non-model dirs ignored, empty cache
  - `TestFindCachedModelForAlias`: finds alias, no match, cache missing, case-insensitive
- [x] `test_tokenizer.py` (extended, 9 new tests)
  - `TestTiktokenEncodingNames`: parametrized over all 6 encoding names + direct `o200k_base` equivalence with `builtin`
  - `TestTiktokenImportError`: verifies `TokenizerError` when tiktoken isn't installed
- [x] `test_tokenizer_validator.py` (new, 7 tests)
  - `TestValidatorTiktokenShortCircuit`: `"builtin"` + parametrized over all 6 encoding names, verifying `resolve_alias` is never called

## Files changed

| File | Change |
|---|---|
| `pyproject.toml` | Add `tiktoken>=0.7.0,<1` dependency |
| `src/aiperf/common/tokenizer.py` | `_TiktokenAdapter`, `_is_hf_cached()`, `_find_cached_model_for_alias()`, builtin/tiktoken routing, `TIKTOKEN_ENCODING_NAMES` |
| `src/aiperf/common/tokenizer_validator.py` | Short-circuit HF resolution for tiktoken tokenizers |
| `src/aiperf/common/config/tokenizer_config.py` | Update `--tokenizer` description to mention `builtin` |
| `Dockerfile` | Pre-cache `o200k_base` encoding, set `TIKTOKEN_CACHE_DIR` |
| `ATTRIBUTIONS.md` | MIT license attribution for OpenAI tiktoken encoding data |
| `docs/cli-options.md` | Auto-generated CLI docs update |
| `docs/reference/tokenizer-auto-detection.md` | Builtin tokenizer docs, cache detection docs, fix numbering |
| `tests/unit/common/test_tokenizer.py` | `TestBuiltinTokenizer`, `TestTiktokenEncodingNames`, `TestTiktokenImportError` |
| `tests/unit/common/test_tokenizer_alias_resolution.py` | `_no_cache_shortcut` autouse fixture |
| `tests/unit/common/test_tokenizer_cache.py` | `TestIsHfCached`, `TestFindCachedModelForAlias` |
| `tests/unit/common/test_tokenizer_validator.py` | `TestValidatorTiktokenShortCircuit` |

## Verification

- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] All 133 tokenizer-related unit tests pass
- [x] Full unit test suite passes (`uv run pytest tests/unit/ -n auto`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--tokenizer builtin` for a zero-network-access tokenizer (o200k_base) and support for loading tokenizers from a local cache.

* **Documentation**
  * Updated CLI and tokenizer reference docs to describe builtin mode and automatic local-cache detection.
  * Added attribution noting included MIT-licensed tokenizer data.

* **Tests**
  * Added tests covering builtin tokenizer behavior, cache detection, and validation logic.

* **Chores**
  * Added tiktoken as a project dependency and pre-cache support for images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->