### PR TITLE
fix: pass system_message and user_context_message to RequestInfo

### DIFF
--- a/src/aiperf/dataset/dataset_manager.py
+++ b/src/aiperf/dataset/dataset_manager.py
@@ -300,6 +300,8 @@ class DatasetManager(ReplyClientMixin, BaseComponentService):
                     x_request_id="",
                     x_correlation_id="",
                     conversation_id=conversation.session_id,
+                    system_message=conversation.system_message,
+                    user_context_message=conversation.user_context_message,
                 )
                 request_info.endpoint_headers = endpoint.get_endpoint_headers(
                     request_info

--- a/tests/unit/dataset/test_dataset_manager_inputs_json.py
+++ b/tests/unit/dataset/test_dataset_manager_inputs_json.py
@@ -214,6 +214,54 @@ class TestDatasetManagerInputsJsonGeneration:
             )
 
     @pytest.mark.asyncio
+    async def test_generate_inputs_json_includes_system_message(
+        self,
+        populated_dataset_manager,
+        capture_file_writes,
+    ):
+        """Test that system_message from conversation is included in payloads."""
+        # Set system_message on first conversation
+        populated_dataset_manager.dataset[
+            "session_1"
+        ].system_message = "You are a helpful assistant."
+
+        await populated_dataset_manager._generate_inputs_json_file()
+
+        written_json = json.loads(capture_file_writes.written_content)
+        session_1 = next(
+            s for s in written_json["data"] if s["session_id"] == "session_1"
+        )
+
+        # System message should appear as the first message with role "system"
+        first_payload_messages = session_1["payloads"][0]["messages"]
+        assert first_payload_messages[0]["role"] == "system"
+        assert first_payload_messages[0]["content"] == "You are a helpful assistant."
+
+    @pytest.mark.asyncio
+    async def test_generate_inputs_json_includes_user_context_message(
+        self,
+        populated_dataset_manager,
+        capture_file_writes,
+    ):
+        """Test that user_context_message from conversation is included in payloads."""
+        populated_dataset_manager.dataset[
+            "session_2"
+        ].user_context_message = "Context about this user session."
+
+        await populated_dataset_manager._generate_inputs_json_file()
+
+        written_json = json.loads(capture_file_writes.written_content)
+        session_2 = next(
+            s for s in written_json["data"] if s["session_id"] == "session_2"
+        )
+
+        # User context message should appear in the messages
+        messages = session_2["payloads"][0]["messages"]
+        assert any(
+            msg["content"] == "Context about this user session." for msg in messages
+        )
+
+    @pytest.mark.asyncio
     async def test_generate_inputs_json_logging(
         self,
         populated_dataset_manager,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset manager now populates system and user context messages from conversation data in payload requests.

* **Tests**
  * Added unit tests verifying proper serialization of system and user context messages in generated payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->