### PR TITLE
fix(dataset): accept input as alias for text in JSONL loaders

### DIFF
--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -10,7 +10,7 @@ from aiperf.plugin.enums import CustomDatasetType
 
 
 def _coalesce_input_to_text(data: Any) -> Any:
-    """Map JSONL ``input`` onto ``text`` when ``text`` is unset (OpenAI-style exports)."""
+    """Map JSONL ``input`` onto ``text`` when ``text`` is absent or identical (OpenAI-style exports)."""
     if not isinstance(data, dict):
         return data
     raw_input = data.get("input")
@@ -18,9 +18,7 @@ def _coalesce_input_to_text(data: Any) -> Any:
     if raw_input is None:
         return data
     if text is not None and text != raw_input:
-        raise ValueError(
-            "Cannot specify both 'input' and 'text' with different values"
-        )
+        raise ValueError("Cannot specify both 'input' and 'text' with different values")
     out = dict(data)
     if text is None:
         out["text"] = raw_input

--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -9,6 +9,25 @@ from aiperf.common.models import AIPerfBaseModel, Audio, Image, Text, Video
 from aiperf.plugin.enums import CustomDatasetType
 
 
+def _coalesce_input_to_text(data: Any) -> Any:
+    """Map JSONL ``input`` onto ``text`` when ``text`` is unset (OpenAI-style exports)."""
+    if not isinstance(data, dict):
+        return data
+    raw_input = data.get("input")
+    text = data.get("text")
+    if raw_input is None:
+        return data
+    if text is not None and text != raw_input:
+        raise ValueError(
+            "Cannot specify both 'input' and 'text' with different values"
+        )
+    out = dict(data)
+    if text is None:
+        out["text"] = raw_input
+    out.pop("input", None)
+    return out
+
+
 class SingleTurn(AIPerfBaseModel):
     """Defines the schema for single-turn data.
 
@@ -56,6 +75,11 @@ class SingleTurn(AIPerfBaseModel):
         description="Amount of milliseconds to wait before sending the turn. Supports floating point, but scheduling accuracy is at the millisecond level.",
     )
     role: str | None = Field(default=None, description="Role of the turn.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def coalesce_input_key(cls, data: Any) -> Any:
+        return _coalesce_input_to_text(data)
 
     @model_validator(mode="after")
     def validate_mutually_exclusive_fields(self) -> "SingleTurn":
@@ -152,6 +176,11 @@ class RandomPool(AIPerfBaseModel):
         None,
         description="List of video strings or Video objects format",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def coalesce_input_key(cls, data: Any) -> Any:
+        return _coalesce_input_to_text(data)
 
     @model_validator(mode="after")
     def validate_mutually_exclusive_fields(self) -> "RandomPool":

--- a/tests/unit/dataset/loader/test_random_pool.py
+++ b/tests/unit/dataset/loader/test_random_pool.py
@@ -22,6 +22,18 @@ from aiperf.plugin.enums import CustomDatasetType
 class TestRandomPool:
     """Tests for RandomPool model validation and functionality."""
 
+    def test_create_with_input_alias_for_text(self):
+        data = RandomPool.model_validate(
+            {"type": "random_pool", "input": "What is machine learning?"}
+        )
+        assert data.text == "What is machine learning?"
+
+    def test_input_and_text_conflict_raises(self):
+        with pytest.raises(ValueError, match="input.*text"):
+            RandomPool.model_validate(
+                {"type": "random_pool", "input": "a", "text": "b"}
+            )
+
     def test_create_with_text_only(self):
         """Test creating RandomPool with simple text."""
         data = RandomPool(text="What is machine learning?")

--- a/tests/unit/dataset/loader/test_random_pool.py
+++ b/tests/unit/dataset/loader/test_random_pool.py
@@ -23,16 +23,25 @@ class TestRandomPool:
     """Tests for RandomPool model validation and functionality."""
 
     def test_create_with_input_alias_for_text(self):
+        """RandomPool must map 'input' to 'text' for compatibility with OpenAI-style JSONL exports."""
         data = RandomPool.model_validate(
             {"type": "random_pool", "input": "What is machine learning?"}
         )
         assert data.text == "What is machine learning?"
 
     def test_input_and_text_conflict_raises(self):
+        """Providing 'input' and 'text' with different values must raise a ValidationError."""
         with pytest.raises(ValueError, match="input.*text"):
             RandomPool.model_validate(
                 {"type": "random_pool", "input": "a", "text": "b"}
             )
+
+    def test_input_and_text_same_value_accepted(self):
+        """When input and text carry the same value, coalescing should succeed silently."""
+        data = RandomPool.model_validate(
+            {"type": "random_pool", "input": "hello", "text": "hello"}
+        )
+        assert data.text == "hello"
 
     def test_create_with_text_only(self):
         """Test creating RandomPool with simple text."""

--- a/tests/unit/dataset/loader/test_single_turn.py
+++ b/tests/unit/dataset/loader/test_single_turn.py
@@ -23,6 +23,7 @@ class TestSingleTurn:
         assert data.text == "What is deep learning?"
 
     def test_input_and_text_conflict_raises(self):
+        """Providing 'input' and 'text' with different values must raise a ValidationError."""
         with pytest.raises(ValueError, match="input.*text"):
             SingleTurn.model_validate(
                 {
@@ -31,6 +32,13 @@ class TestSingleTurn:
                     "text": "b",
                 }
             )
+
+    def test_input_and_text_same_value_accepted(self):
+        """When input and text carry the same value, coalescing should succeed silently."""
+        data = SingleTurn.model_validate(
+            {"type": "single_turn", "input": "hello", "text": "hello"}
+        )
+        assert data.text == "hello"
 
     def test_create_with_text_only(self):
         """Test creating SingleTurn with text."""
@@ -152,6 +160,26 @@ class TestSingleTurn:
 
 class TestSingleTurnDatasetLoader:
     """Basic functionality tests for SingleTurnDatasetLoader."""
+
+    def test_load_dataset_with_input_alias(
+        self, create_jsonl_file, default_user_config
+    ):
+        """The 'input' key in JSONL must be respected end-to-end through load_dataset()."""
+        content = [
+            '{"input": "What is deep learning?"}',
+            '{"input": "Explain neural networks"}',
+        ]
+        filename = create_jsonl_file(content)
+
+        loader = SingleTurnDatasetLoader(
+            filename=filename, user_config=default_user_config
+        )
+        dataset = loader.load_dataset()
+
+        assert len(dataset) == 2
+        turn1, turn2 = list(dataset.values())
+        assert turn1[0].text == "What is deep learning?"
+        assert turn2[0].text == "Explain neural networks"
 
     def test_load_dataset_basic_functionality(
         self, create_jsonl_file, default_user_config

--- a/tests/unit/dataset/loader/test_single_turn.py
+++ b/tests/unit/dataset/loader/test_single_turn.py
@@ -15,6 +15,23 @@ from aiperf.plugin.enums import CustomDatasetType
 class TestSingleTurn:
     """Basic functionality tests for SingleTurn model."""
 
+    def test_create_with_input_alias_for_text(self):
+        """JSONL may use ``input``; it must populate ``text`` for modality validation."""
+        data = SingleTurn.model_validate(
+            {"type": "single_turn", "input": "What is deep learning?"}
+        )
+        assert data.text == "What is deep learning?"
+
+    def test_input_and_text_conflict_raises(self):
+        with pytest.raises(ValueError, match="input.*text"):
+            SingleTurn.model_validate(
+                {
+                    "type": "single_turn",
+                    "input": "a",
+                    "text": "b",
+                }
+            )
+
     def test_create_with_text_only(self):
         """Test creating SingleTurn with text."""
         data = SingleTurn(text="What is deep learning?")


### PR DESCRIPTION
## Summary
- Allow JSONL input field as an alias for text where applicable (single_turn / random_pool) for broader dataset compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `input` as an alternative field name for `text` in dataset files. Data is automatically normalized during loading, improving compatibility with OpenAI-style formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->