### PR TITLE
fix(dataset): ShareGPT multi-turn handling

### DIFF
--- a/src/aiperf/dataset/composer/public.py
+++ b/src/aiperf/dataset/composer/public.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any
 
 from aiperf.common.models import Conversation
@@ -43,7 +44,7 @@ class PublicDatasetComposer(BaseDatasetComposer):
 
         LoaderClass = plugins.get_class(PluginType.PUBLIC_DATASET_LOADER, dataset_type)
 
-        loader_kwargs = self._build_loader_kwargs(dataset_type)
+        loader_kwargs = self._build_loader_kwargs(dataset_type, LoaderClass)
         loader = LoaderClass(
             run=self.run,
             tokenizer=self.tokenizer,
@@ -60,7 +61,9 @@ class PublicDatasetComposer(BaseDatasetComposer):
         self._finalize_conversations(conversations)
         return conversations
 
-    def _build_loader_kwargs(self, dataset_type: PublicDatasetType) -> dict[str, Any]:
+    def _build_loader_kwargs(
+        self, dataset_type: PublicDatasetType, loader_class: type
+    ) -> dict[str, Any]:
         """Build loader constructor kwargs from plugin metadata.
 
         Reads HF-specific fields from the plugin metadata and returns only the
@@ -69,6 +72,11 @@ class PublicDatasetComposer(BaseDatasetComposer):
 
         Args:
             dataset_type: The public dataset plugin name.
+            loader_class: The loader class about to be instantiated. Used to
+                validate that opt-in metadata fields (e.g. ``multi_turn``) are
+                actually declared on the constructor before forwarding them,
+                so users learn about misconfigurations instead of silently
+                getting the default behavior.
 
         Returns:
             dict of kwargs to pass to the loader constructor.
@@ -99,9 +107,42 @@ class PublicDatasetComposer(BaseDatasetComposer):
             kwargs["message_content_key"] = loader_metadata.message_content_key
 
         if loader_metadata.multi_turn:
+            if not self._loader_accepts_kwarg(loader_class, "multi_turn"):
+                raise ValueError(
+                    f"Loader {loader_class.__name__} for dataset {dataset_type!r} "
+                    "does not support the 'multi_turn' metadata flag. Remove "
+                    "'multi_turn: true' from this loader's plugin metadata, or "
+                    "use a loader that declares 'multi_turn' on its constructor "
+                    "(e.g. HFConversationDatasetLoader, SpeedBenchLoader, "
+                    "SpecBenchLoader)."
+                )
             kwargs["multi_turn"] = True
 
         if loader_metadata.streaming:
             kwargs["streaming"] = loader_metadata.streaming
 
         return kwargs
+
+    @staticmethod
+    def _loader_accepts_kwarg(loader_class: type, name: str) -> bool:
+        """Return True when ``name`` is an explicitly declared parameter of
+        ``loader_class.__init__`` (or any class in its MRO before ``BaseMixin``).
+
+        ``**kwargs`` does not count as acceptance — the silent-swallow chain
+        through ``BaseMixin.__init__`` is exactly what this check exists to
+        catch.
+        """
+        for klass in loader_class.__mro__:
+            if klass.__name__ == "BaseMixin":
+                break
+            try:
+                params = inspect.signature(klass.__init__).parameters
+            except (TypeError, ValueError):
+                continue
+            param = params.get(name)
+            if param is not None and param.kind in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            ):
+                return True
+        return False

--- a/src/aiperf/dataset/composer/public.py
+++ b/src/aiperf/dataset/composer/public.py
@@ -98,6 +98,9 @@ class PublicDatasetComposer(BaseDatasetComposer):
             kwargs["conversation_column"] = loader_metadata.conversation_column
             kwargs["message_content_key"] = loader_metadata.message_content_key
 
+        if loader_metadata.multi_turn:
+            kwargs["multi_turn"] = True
+
         if loader_metadata.streaming:
             kwargs["streaming"] = loader_metadata.streaming
 

--- a/src/aiperf/dataset/loader/hf_conversation.py
+++ b/src/aiperf/dataset/loader/hf_conversation.py
@@ -209,6 +209,13 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
         conversations = []
         skipped = 0
         max_conversations = self._max_conversations()
+        if self.multi_turn and self.tokenizer is None:
+            self.warning(
+                "multi_turn=True but no tokenizer is configured; sequence-length "
+                "validation will be skipped and Turn.max_tokens will be None for "
+                "every turn. Configure a tokenizer to enable prompt/output-length "
+                "filtering and max_tokens propagation."
+            )
 
         for row in dataset:
             if (

--- a/src/aiperf/dataset/loader/hf_conversation.py
+++ b/src/aiperf/dataset/loader/hf_conversation.py
@@ -186,9 +186,11 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
             return sg
         return self._openai_style_pairs(normalized)
 
-    def _pairs_pass_validation(self, pairs: list[tuple[str, str]]) -> bool:
+    def _pairs_pass_validation(self, pairs: list[tuple[str, str]]) -> list[int] | None:
+        """Validate pairs and return completion token lengths, or None if invalid."""
         if self.tokenizer is None:
-            return True
+            return [0] * len(pairs)
+        completion_lengths: list[int] = []
         for prompt, completion in pairs:
             prompt_length = len(self.tokenizer.encode(prompt))
             completion_length = len(self.tokenizer.encode(completion))
@@ -197,8 +199,9 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
                 output_len=completion_length,
                 skip_min_output_len_check=self.output_tokens_mean is not None,
             ):
-                return False
-        return True
+                return None
+            completion_lengths.append(completion_length)
+        return completion_lengths
 
     async def convert_to_conversations(
         self, data: dict[str, Any]
@@ -226,18 +229,20 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
 
             if self.multi_turn:
                 pairs = self._prompt_completion_pairs(messages)
-                if not pairs or not self._pairs_pass_validation(pairs):
+                if not pairs:
+                    skipped += 1
+                    continue
+                completion_lengths = self._pairs_pass_validation(pairs)
+                if completion_lengths is None:
                     skipped += 1
                     continue
                 turns = [
                     Turn(
                         texts=[Text(contents=[prompt])],
                         images=images if idx == 0 else [],
-                        max_tokens=len(self.tokenizer.encode(completion))
-                        if self.tokenizer
-                        else None,
+                        max_tokens=completion_lengths[idx] if self.tokenizer else None,
                     )
-                    for idx, (prompt, completion) in enumerate(pairs)
+                    for idx, (prompt, _) in enumerate(pairs)
                 ]
                 conversations.append(
                     Conversation(

--- a/src/aiperf/dataset/loader/hf_conversation.py
+++ b/src/aiperf/dataset/loader/hf_conversation.py
@@ -97,14 +97,12 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
 
     def _normalize_messages(self, messages: list[Any]) -> list[dict[str, Any]]:
         """Flatten list-of-lists (VisionArena) to a list of message dicts."""
-        out: list[dict[str, Any]] = []
-        for raw in messages:
-            m = raw
-            if isinstance(m, list):
-                m = m[0] if m else None
-            if m and isinstance(m, dict):
-                out.append(m)
-        return out
+        normalized: list[dict[str, Any]] = []
+        for item in messages:
+            msg = item[0] if isinstance(item, list) and item else item
+            if isinstance(msg, dict) and msg:
+                normalized.append(msg)
+        return normalized
 
     def _extract_first_message(self, messages: list[Any]) -> str | None:
         """Extract the text of the first message, handling dataset-specific quirks.
@@ -145,34 +143,23 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
         self, messages: list[dict[str, Any]]
     ) -> list[tuple[str, str]]:
         """Pair consecutive user→assistant messages (OpenAI-style roles)."""
+        chat_messages = [
+            msg for msg in messages if (msg.get("role") or "").lower() != "system"
+        ]
         pairs: list[tuple[str, str]] = []
-        i = 0
-        while i < len(messages):
-            role = (messages[i].get("role") or "").lower()
-            if role == "system":
-                i += 1
-                continue
-            if role != "user":
-                i += 1
-                continue
-            prompt = self._text_from_message_dict(messages[i])
-            if not prompt:
-                i += 1
-                continue
-            j = i + 1
-            while j < len(messages) and (messages[j].get("role") or "").lower() in (
-                "system",
-            ):
-                j += 1
-            if j < len(messages) and (messages[j].get("role") or "").lower() == (
-                "assistant"
-            ):
-                completion = self._text_from_message_dict(messages[j])
-                if completion:
+        idx = 0
+        while idx < len(chat_messages) - 1:
+            current, next_msg = chat_messages[idx], chat_messages[idx + 1]
+            current_role = (current.get("role") or "").lower()
+            next_role = (next_msg.get("role") or "").lower()
+            if current_role == "user" and next_role == "assistant":
+                prompt = self._text_from_message_dict(current)
+                completion = self._text_from_message_dict(next_msg)
+                if prompt and completion:
                     pairs.append((prompt, completion))
-                i = j + 1
+                idx += 2
             else:
-                i += 1
+                idx += 1
         return pairs
 
     def _prompt_completion_pairs(self, messages: list[Any]) -> list[tuple[str, str]]:

--- a/src/aiperf/dataset/loader/hf_conversation.py
+++ b/src/aiperf/dataset/loader/hf_conversation.py
@@ -105,14 +105,20 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
         return normalized
 
     def _extract_first_message(self, messages: list[Any]) -> str | None:
-        """Extract the text of the first message, handling dataset-specific quirks.
+        """Extract the text of the first user message, handling dataset-specific quirks.
 
-        Unwraps list-of-lists turns (VisionArena) and strips ``<image>``
-        placeholder tokens (LLaVA) that are meaningless for benchmarking.
+        Prefers the first message with a ``user`` or ``human`` role. Falls back
+        to the literal first message when no role fields are present (backward
+        compatible with untagged datasets). Unwraps list-of-lists turns
+        (VisionArena) and strips ``<image>`` placeholder tokens (LLaVA).
         """
         normalized = self._normalize_messages(messages)
         if not normalized:
             return None
+        for msg in normalized:
+            role = (msg.get("role") or msg.get("from") or "").lower()
+            if role in ("user", "human"):
+                return self._text_from_message_dict(msg)
         return self._text_from_message_dict(normalized[0])
 
     def _sharegpt_style_pairs(
@@ -169,14 +175,19 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
             return []
 
         sg = self._sharegpt_style_pairs(normalized)
-        if sg is not None:
+        if sg:
             return sg
         return self._openai_style_pairs(normalized)
 
     def _pairs_pass_validation(self, pairs: list[tuple[str, str]]) -> list[int] | None:
-        """Validate pairs and return completion token lengths, or None if invalid."""
+        """Validate pairs and return completion token lengths, or None if invalid.
+
+        Returns ``None`` when any pair fails validation. When no tokenizer is
+        configured, validation is skipped and an empty list is returned so the
+        caller falls back to ``max_tokens=None``.
+        """
         if self.tokenizer is None:
-            return [0] * len(pairs)
+            return []
         completion_lengths: list[int] = []
         for prompt, completion in pairs:
             prompt_length = len(self.tokenizer.encode(prompt))
@@ -227,7 +238,9 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
                     Turn(
                         texts=[Text(contents=[prompt])],
                         images=images if idx == 0 else [],
-                        max_tokens=completion_lengths[idx] if self.tokenizer else None,
+                        max_tokens=completion_lengths[idx]
+                        if completion_lengths
+                        else None,
                     )
                     for idx, (prompt, _) in enumerate(pairs)
                 ]

--- a/src/aiperf/dataset/loader/hf_conversation.py
+++ b/src/aiperf/dataset/loader/hf_conversation.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from aiperf.common.models import Conversation, Text, Turn
+from aiperf.common.tokenizer import Tokenizer
 from aiperf.dataset.loader.base_hf_dataset import BaseHFDatasetLoader
 
 if TYPE_CHECKING:
@@ -16,8 +17,14 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
     """HuggingFace dataset loader for conversation-array datasets.
 
     Handles datasets where each row stores messages as a list of dicts.
-    Extracts the first message as the prompt, producing single-turn Conversations.
-    Optionally attaches an image per row when image_column is configured.
+    By default extracts only the first user message as the prompt (single-turn).
+    With ``multi_turn=True``, builds one Conversation per row with multiple
+    turns from consecutive user→assistant (or human→gpt) pairs—aligned with
+    :class:`~aiperf.dataset.loader.sharegpt.ShareGPTLoader` semantics for HF
+    conversation columns.
+
+    Optionally attaches an image per row when image_column is configured (same
+    image on every turn in multi-turn mode, matching single-turn behavior).
 
     Normalises two common dataset quirks automatically:
     - List-of-lists wrapping (VisionArena): each turn is wrapped in its own list
@@ -43,6 +50,15 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
             conversation_column: conversations
             message_content_key: value
             image_column: image
+
+        my_multi_turn_hf:
+          class: aiperf.dataset.loader.hf_conversation:HFConversationDatasetLoader
+          metadata:
+            hf_dataset_name: org/chat-dataset
+            hf_split: train
+            conversation_column: messages
+            message_content_key: content
+            multi_turn: true
     """
 
     def __init__(
@@ -52,12 +68,43 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
         conversation_column: str,
         message_content_key: str = "content",
         image_column: str | None = None,
+        multi_turn: bool = False,
+        tokenizer: Tokenizer | None = None,
         **kwargs,
     ) -> None:
         self.conversation_column = conversation_column
         self.message_content_key = message_content_key
         self.image_column = image_column
+        self.multi_turn = multi_turn
+        self.tokenizer = tokenizer
+        from aiperf.dataset.loader.base_loader import _default_test_run
+
+        active_run = run or _default_test_run()
+        dataset = active_run.cfg.get_default_dataset()
+        prompts = getattr(dataset, "prompts", None)
+        osl = getattr(prompts, "osl", None) if prompts else None
+        if isinstance(osl, dict):
+            self.output_tokens_mean = osl.get("mean")
+        else:
+            self.output_tokens_mean = getattr(osl, "mean", None) if osl else None
         super().__init__(run=run, **kwargs)
+
+    def _text_from_message_dict(self, message: dict[str, Any]) -> str | None:
+        value = message.get(self.message_content_key)
+        if not isinstance(value, str):
+            return None
+        return value.replace("<image>", "").strip() or None
+
+    def _normalize_messages(self, messages: list[Any]) -> list[dict[str, Any]]:
+        """Flatten list-of-lists (VisionArena) to a list of message dicts."""
+        out: list[dict[str, Any]] = []
+        for raw in messages:
+            m = raw
+            if isinstance(m, list):
+                m = m[0] if m else None
+            if m and isinstance(m, dict):
+                out.append(m)
+        return out
 
     def _extract_first_message(self, messages: list[Any]) -> str | None:
         """Extract the text of the first message, handling dataset-specific quirks.
@@ -65,22 +112,98 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
         Unwraps list-of-lists turns (VisionArena) and strips ``<image>``
         placeholder tokens (LLaVA) that are meaningless for benchmarking.
         """
-        if not messages:
+        normalized = self._normalize_messages(messages)
+        if not normalized:
             return None
-        message = messages[0]
-        if isinstance(message, list):
-            message = message[0] if message else None
-        if not message or not isinstance(message, dict):
+        return self._text_from_message_dict(normalized[0])
+
+    def _sharegpt_style_pairs(
+        self, messages: list[dict[str, Any]]
+    ) -> list[tuple[str, str]] | None:
+        """Return human→gpt pairs if messages use ShareGPT ``from`` roles."""
+        uses_roles = any(c.get("from") in ("human", "gpt") for c in messages)
+        if not uses_roles:
             return None
-        value = message.get(self.message_content_key)
-        if not isinstance(value, str):
-            return None
-        return value.replace("<image>", "").strip() or None
+        role_msgs = [c for c in messages if c.get("from") in ("human", "gpt")]
+        pairs: list[tuple[str, str]] = []
+        i = 0
+        while i < len(role_msgs) - 1:
+            if (
+                role_msgs[i].get("from") == "human"
+                and role_msgs[i + 1].get("from") == "gpt"
+            ):
+                pa = self._text_from_message_dict(role_msgs[i])
+                pb = self._text_from_message_dict(role_msgs[i + 1])
+                if pa and pb:
+                    pairs.append((pa, pb))
+                i += 2
+            else:
+                i += 1
+        return pairs
+
+    def _openai_style_pairs(
+        self, messages: list[dict[str, Any]]
+    ) -> list[tuple[str, str]]:
+        """Pair consecutive user→assistant messages (OpenAI-style roles)."""
+        pairs: list[tuple[str, str]] = []
+        i = 0
+        while i < len(messages):
+            role = (messages[i].get("role") or "").lower()
+            if role == "system":
+                i += 1
+                continue
+            if role != "user":
+                i += 1
+                continue
+            prompt = self._text_from_message_dict(messages[i])
+            if not prompt:
+                i += 1
+                continue
+            j = i + 1
+            while j < len(messages) and (messages[j].get("role") or "").lower() in (
+                "system",
+            ):
+                j += 1
+            if j < len(messages) and (messages[j].get("role") or "").lower() == (
+                "assistant"
+            ):
+                completion = self._text_from_message_dict(messages[j])
+                if completion:
+                    pairs.append((prompt, completion))
+                i = j + 1
+            else:
+                i += 1
+        return pairs
+
+    def _prompt_completion_pairs(self, messages: list[Any]) -> list[tuple[str, str]]:
+        """Match ShareGPTLoader pairing: ShareGPT ``from`` roles, else OpenAI roles."""
+        normalized = self._normalize_messages(messages)
+        if len(normalized) < 2:
+            return []
+
+        sg = self._sharegpt_style_pairs(normalized)
+        if sg is not None:
+            return sg
+        return self._openai_style_pairs(normalized)
+
+    def _pairs_pass_validation(self, pairs: list[tuple[str, str]]) -> bool:
+        if self.tokenizer is None:
+            return True
+        for prompt, completion in pairs:
+            prompt_length = len(self.tokenizer.encode(prompt))
+            completion_length = len(self.tokenizer.encode(completion))
+            if not self.is_valid_sequence(
+                prompt_len=prompt_length,
+                output_len=completion_length,
+                skip_min_output_len_check=self.output_tokens_mean is not None,
+            ):
+                return False
+        return True
 
     async def convert_to_conversations(
         self, data: dict[str, Any]
     ) -> list[Conversation]:
-        """Convert each dataset row into a single-turn Conversation."""
+        """Convert each dataset row into one Conversation (single- or multi-turn)."""
         dataset = data["dataset"]
         conversations = []
         skipped = 0
@@ -94,16 +217,40 @@ class HFConversationDatasetLoader(BaseHFDatasetLoader):
                 break
 
             messages = row.get(self.conversation_column) or []
-            prompt = self._extract_first_message(messages)
-            if not prompt:
-                skipped += 1
-                continue
 
             images = (
                 self._extract_images(row, self.image_column)
                 if self.image_column
                 else []
             )
+
+            if self.multi_turn:
+                pairs = self._prompt_completion_pairs(messages)
+                if not pairs or not self._pairs_pass_validation(pairs):
+                    skipped += 1
+                    continue
+                turns = [
+                    Turn(
+                        texts=[Text(contents=[prompt])],
+                        images=images if idx == 0 else [],
+                        max_tokens=len(self.tokenizer.encode(completion))
+                        if self.tokenizer
+                        else None,
+                    )
+                    for idx, (prompt, completion) in enumerate(pairs)
+                ]
+                conversations.append(
+                    Conversation(
+                        session_id=self.session_id_generator.next(),
+                        turns=turns,
+                    )
+                )
+                continue
+
+            prompt = self._extract_first_message(messages)
+            if not prompt:
+                skipped += 1
+                continue
 
             conversations.append(
                 Conversation(

--- a/src/aiperf/dataset/loader/sharegpt.py
+++ b/src/aiperf/dataset/loader/sharegpt.py
@@ -115,7 +115,7 @@ class ShareGPTLoader(BasePublicDatasetLoader):
                 skipped_entries += 1
                 continue
 
-            turns: list[Turn] = []
+            validated: list[tuple[str, int]] = []
             rejected = False
             for prompt, completion in pairs:
                 prompt_length = len(self.tokenizer.encode(prompt))
@@ -127,17 +127,19 @@ class ShareGPTLoader(BasePublicDatasetLoader):
                 ):
                     rejected = True
                     break
-                turns.append(
-                    Turn(
-                        model=self._select_model_name(),
-                        texts=[Text(contents=[prompt])],
-                        max_tokens=completion_length,
-                    )
-                )
-            if rejected or not turns:
+                validated.append((prompt, completion_length))
+            if rejected or not validated:
                 skipped_entries += 1
                 continue
 
+            turns = [
+                Turn(
+                    model=self._select_model_name(),
+                    texts=[Text(contents=[prompt])],
+                    max_tokens=completion_length,
+                )
+                for prompt, completion_length in validated
+            ]
             filtered_dataset.append(
                 Conversation(
                     session_id=self.session_id_generator.next(),

--- a/src/aiperf/dataset/loader/sharegpt.py
+++ b/src/aiperf/dataset/loader/sharegpt.py
@@ -110,28 +110,38 @@ class ShareGPTLoader(BasePublicDatasetLoader):
                 skipped_entries += 1
                 continue
 
-            prompt, completion = conversations[0]["value"], conversations[1]["value"]
-            prompt_length = len(self.tokenizer.encode(prompt))
-            completion_length = len(self.tokenizer.encode(completion))
+            pairs = self._sharegpt_prompt_completion_pairs(conversations)
+            if not pairs:
+                skipped_entries += 1
+                continue
 
-            if not self.is_valid_sequence(
-                prompt_len=prompt_length,
-                output_len=completion_length,
-                skip_min_output_len_check=self.output_tokens_mean is not None,
-            ):
+            turns: list[Turn] = []
+            rejected = False
+            for prompt, completion in pairs:
+                prompt_length = len(self.tokenizer.encode(prompt))
+                completion_length = len(self.tokenizer.encode(completion))
+                if not self.is_valid_sequence(
+                    prompt_len=prompt_length,
+                    output_len=completion_length,
+                    skip_min_output_len_check=self.output_tokens_mean is not None,
+                ):
+                    rejected = True
+                    break
+                turns.append(
+                    Turn(
+                        model=self._select_model_name(),
+                        texts=[Text(contents=[prompt])],
+                        max_tokens=completion_length,
+                    )
+                )
+            if rejected or not turns:
                 skipped_entries += 1
                 continue
 
             filtered_dataset.append(
                 Conversation(
                     session_id=self.session_id_generator.next(),
-                    turns=[
-                        Turn(
-                            model=self._select_model_name(),
-                            texts=[Text(contents=[prompt])],
-                            max_tokens=completion_length,
-                        )
-                    ],
+                    turns=turns,
                 )
             )
 
@@ -139,6 +149,36 @@ class ShareGPTLoader(BasePublicDatasetLoader):
             lambda: f"Filtered to {len(filtered_dataset)} dataset entries out of {len(dataset)} (skipped {skipped_entries})"
         )
         return filtered_dataset
+
+    @staticmethod
+    def _sharegpt_prompt_completion_pairs(
+        conversations: list[dict[str, Any]],
+    ) -> list[tuple[str, str]]:
+        """Pair prompts with completions from ShareGPT ``conversations`` entries.
+
+        When messages include ``from: human`` / ``from: gpt`` (typical ShareGPT
+        JSON), every adjacent human→gpt pair becomes one turn. Otherwise the
+        first two ``value`` fields are treated as a single pair (minimal JSON
+        and unit tests without role fields).
+        """
+        uses_roles = any(c.get("from") in ("human", "gpt") for c in conversations)
+        if not uses_roles:
+            return [
+                (conversations[0]["value"], conversations[1]["value"]),
+            ]
+
+        role_msgs = [c for c in conversations if c.get("from") in ("human", "gpt")]
+        pairs: list[tuple[str, str]] = []
+        i = 0
+        while i < len(role_msgs) - 1:
+            if role_msgs[i].get("from") == "human" and role_msgs[i + 1].get(
+                "from"
+            ) == "gpt":
+                pairs.append((role_msgs[i]["value"], role_msgs[i + 1]["value"]))
+                i += 2
+            else:
+                i += 1
+        return pairs
 
     def _select_model_name(self) -> str:
         models_cfg = self.run.cfg.models

--- a/src/aiperf/dataset/loader/sharegpt.py
+++ b/src/aiperf/dataset/loader/sharegpt.py
@@ -163,18 +163,24 @@ class ShareGPTLoader(BasePublicDatasetLoader):
         """
         uses_roles = any(c.get("from") in ("human", "gpt") for c in conversations)
         if not uses_roles:
-            return [
-                (conversations[0]["value"], conversations[1]["value"]),
-            ]
+            prompt = conversations[0].get("value")
+            completion = conversations[1].get("value")
+            if not prompt or not completion:
+                return []
+            return [(prompt, completion)]
 
         role_msgs = [c for c in conversations if c.get("from") in ("human", "gpt")]
         pairs: list[tuple[str, str]] = []
         i = 0
         while i < len(role_msgs) - 1:
-            if role_msgs[i].get("from") == "human" and role_msgs[i + 1].get(
-                "from"
-            ) == "gpt":
-                pairs.append((role_msgs[i]["value"], role_msgs[i + 1]["value"]))
+            if (
+                role_msgs[i].get("from") == "human"
+                and role_msgs[i + 1].get("from") == "gpt"
+            ):
+                prompt = role_msgs[i].get("value")
+                completion = role_msgs[i + 1].get("value")
+                if prompt and completion:
+                    pairs.append((prompt, completion))
                 i += 2
             else:
                 i += 1

--- a/src/aiperf/dataset/loader/sharegpt.py
+++ b/src/aiperf/dataset/loader/sharegpt.py
@@ -154,7 +154,7 @@ class ShareGPTLoader(BasePublicDatasetLoader):
 
     @staticmethod
     def _sharegpt_prompt_completion_pairs(
-        conversations: list[dict[str, Any]],
+        conversations: list[Any],
     ) -> list[tuple[str, str]]:
         """Pair prompts with completions from ShareGPT ``conversations`` entries.
 
@@ -163,15 +163,18 @@ class ShareGPTLoader(BasePublicDatasetLoader):
         first two ``value`` fields are treated as a single pair (minimal JSON
         and unit tests without role fields).
         """
-        uses_roles = any(c.get("from") in ("human", "gpt") for c in conversations)
+        message_dicts = [c for c in conversations if isinstance(c, dict)]
+        if len(message_dicts) < 2:
+            return []
+        uses_roles = any(c.get("from") in ("human", "gpt") for c in message_dicts)
         if not uses_roles:
-            prompt = conversations[0].get("value")
-            completion = conversations[1].get("value")
+            prompt = message_dicts[0].get("value")
+            completion = message_dicts[1].get("value")
             if not prompt or not completion:
                 return []
             return [(prompt, completion)]
 
-        role_msgs = [c for c in conversations if c.get("from") in ("human", "gpt")]
+        role_msgs = [c for c in message_dicts if c.get("from") in ("human", "gpt")]
         pairs: list[tuple[str, str]] = []
         i = 0
         while i < len(role_msgs) - 1:

--- a/src/aiperf/dataset/loader/spec_bench.py
+++ b/src/aiperf/dataset/loader/spec_bench.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import orjson
 
+from aiperf.common.config.user_config import UserConfig
 from aiperf.common.models import Conversation, Text, Turn
 from aiperf.dataset.loader.base_public_dataset import BasePublicDatasetLoader
 from aiperf.plugin.enums import DatasetSamplingStrategy
@@ -15,11 +16,22 @@ class SpecBenchLoader(BasePublicDatasetLoader):
 
     Downloads the SpecBench JSONL file from GitHub and converts each entry
     into a single-turn AIPerf Conversation using the first turn of each question.
+    With ``multi_turn=True``, all turns in each entry are used.
     """
 
     tag = "SpecBench"
     url = "https://raw.githubusercontent.com/hemingkx/Spec-Bench/fd2c1cd7d2201ef71db4c5f4e455008f017967bf/data/spec_bench/question.jsonl"
     filename = "spec_bench.jsonl"
+
+    def __init__(
+        self,
+        user_config: UserConfig,
+        *,
+        multi_turn: bool = False,
+        **kwargs,
+    ) -> None:
+        self.multi_turn = multi_turn
+        super().__init__(user_config=user_config, **kwargs)
 
     async def load_dataset(self) -> dict[str, Any]:
         """Load the SpecBench JSONL file from cache or download it."""
@@ -30,27 +42,41 @@ class SpecBenchLoader(BasePublicDatasetLoader):
     async def convert_to_conversations(
         self, data: dict[str, Any]
     ) -> list[Conversation]:
-        """Convert each SpecBench entry into a single-turn Conversation."""
+        """Convert each SpecBench entry into a Conversation (single- or multi-turn)."""
         dataset = data["dataset"]
         conversations = []
         skipped = 0
 
         for row in dataset:
-            turns = row.get("turns", [])
-            if not turns or not str(turns[0]).strip():
+            turns_raw = row.get("turns", [])
+            if not turns_raw or not str(turns_raw[0]).strip():
                 skipped += 1
                 continue
 
-            conversations.append(
-                Conversation(
-                    session_id=self.session_id_generator.next(),
-                    turns=[
-                        Turn(
-                            texts=[Text(contents=[str(turns[0])])],
-                        )
-                    ],
+            if self.multi_turn:
+                conv_turns: list[Turn] = []
+                for t in turns_raw:
+                    text = str(t).strip() if t else ""
+                    if text:
+                        conv_turns.append(Turn(texts=[Text(contents=[text])]))
+                if not conv_turns:
+                    skipped += 1
+                    continue
+                conversations.append(
+                    Conversation(
+                        session_id=self.session_id_generator.next(),
+                        turns=conv_turns,
+                    )
                 )
-            )
+            else:
+                conversations.append(
+                    Conversation(
+                        session_id=self.session_id_generator.next(),
+                        turns=[
+                            Turn(texts=[Text(contents=[str(turns_raw[0])])]),
+                        ],
+                    )
+                )
 
         self.debug(
             lambda: f"Converted {len(conversations)} rows (skipped {skipped} empty)"

--- a/src/aiperf/dataset/loader/spec_bench.py
+++ b/src/aiperf/dataset/loader/spec_bench.py
@@ -49,7 +49,7 @@ class SpecBenchLoader(BasePublicDatasetLoader):
 
         for row in dataset:
             turns_raw = row.get("turns", [])
-            if not turns_raw or not str(turns_raw[0]).strip():
+            if not turns_raw:
                 skipped += 1
                 continue
 
@@ -69,11 +69,15 @@ class SpecBenchLoader(BasePublicDatasetLoader):
                     )
                 )
             else:
+                prompt = str(turns_raw[0]).strip()
+                if not prompt:
+                    skipped += 1
+                    continue
                 conversations.append(
                     Conversation(
                         session_id=self.session_id_generator.next(),
                         turns=[
-                            Turn(texts=[Text(contents=[str(turns_raw[0])])]),
+                            Turn(texts=[Text(contents=[prompt])]),
                         ],
                     )
                 )

--- a/src/aiperf/dataset/loader/spec_bench.py
+++ b/src/aiperf/dataset/loader/spec_bench.py
@@ -48,8 +48,8 @@ class SpecBenchLoader(BasePublicDatasetLoader):
         skipped = 0
 
         for row in dataset:
-            turns_raw = row.get("turns", [])
-            if not turns_raw:
+            turns_raw = row.get("turns")
+            if not isinstance(turns_raw, list) or not turns_raw:
                 skipped += 1
                 continue
 
@@ -69,7 +69,7 @@ class SpecBenchLoader(BasePublicDatasetLoader):
                     )
                 )
             else:
-                prompt = str(turns_raw[0]).strip()
+                prompt = str(turns_raw[0]).strip() if turns_raw[0] else ""
                 if not prompt:
                     skipped += 1
                     continue

--- a/src/aiperf/dataset/loader/spec_bench.py
+++ b/src/aiperf/dataset/loader/spec_bench.py
@@ -1,14 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import orjson
 
-from aiperf.common.config.user_config import UserConfig
 from aiperf.common.models import Conversation, Text, Turn
 from aiperf.dataset.loader.base_public_dataset import BasePublicDatasetLoader
 from aiperf.plugin.enums import DatasetSamplingStrategy
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
 
 
 class SpecBenchLoader(BasePublicDatasetLoader):
@@ -25,13 +29,13 @@ class SpecBenchLoader(BasePublicDatasetLoader):
 
     def __init__(
         self,
-        user_config: UserConfig,
+        run: BenchmarkRun | None = None,
         *,
         multi_turn: bool = False,
         **kwargs,
     ) -> None:
         self.multi_turn = multi_turn
-        super().__init__(user_config=user_config, **kwargs)
+        super().__init__(run=run, **kwargs)
 
     async def load_dataset(self) -> dict[str, Any]:
         """Load the SpecBench JSONL file from cache or download it."""

--- a/src/aiperf/dataset/loader/speed_bench.py
+++ b/src/aiperf/dataset/loader/speed_bench.py
@@ -85,7 +85,7 @@ class SpeedBenchLoader(BaseHFDatasetLoader):
                 continue
 
             turns_raw = row.get("turns")
-            if not turns_raw or not isinstance(turns_raw, list) or not turns_raw[0]:
+            if not turns_raw or not isinstance(turns_raw, list):
                 skipped += 1
                 continue
 
@@ -105,6 +105,9 @@ class SpeedBenchLoader(BaseHFDatasetLoader):
                     )
                 )
             else:
+                if not turns_raw[0]:
+                    skipped += 1
+                    continue
                 prompt = str(turns_raw[0]).strip()
                 if not prompt:
                     skipped += 1

--- a/src/aiperf/dataset/loader/speed_bench.py
+++ b/src/aiperf/dataset/loader/speed_bench.py
@@ -105,10 +105,7 @@ class SpeedBenchLoader(BaseHFDatasetLoader):
                     )
                 )
             else:
-                if not turns_raw[0]:
-                    skipped += 1
-                    continue
-                prompt = str(turns_raw[0]).strip()
+                prompt = str(turns_raw[0]).strip() if turns_raw[0] else ""
                 if not prompt:
                     skipped += 1
                     continue

--- a/src/aiperf/dataset/loader/speed_bench.py
+++ b/src/aiperf/dataset/loader/speed_bench.py
@@ -19,8 +19,9 @@ class SpeedBenchLoader(BaseHFDatasetLoader):
     benchmarking speculative decoding across diverse semantic domains and
     input sequence lengths. Each row contains a ``turns`` column with a
     list of plain strings and a ``category`` column identifying the
-    semantic domain or entropy tier. Only the first turn is used as the
-    benchmark prompt; subsequent turns are discarded.
+    semantic domain or entropy tier. By default only the first turn is used
+    as the benchmark prompt; with ``multi_turn=True`` every non-empty turn
+    in the row becomes its own Turn in one Conversation.
 
     When ``category`` is set in plugin metadata, only rows matching that
     category are loaded. This enables per-category acceptance rate
@@ -56,15 +57,18 @@ class SpeedBenchLoader(BaseHFDatasetLoader):
         self,
         run: BenchmarkRun | None = None,
         category: str | None = None,
+        *,
+        multi_turn: bool = False,
         **kwargs,
     ) -> None:
         self.category = category
+        self.multi_turn = multi_turn
         super().__init__(run=run, **kwargs)
 
     async def convert_to_conversations(
         self, data: dict[str, Any]
     ) -> list[Conversation]:
-        """Convert each dataset row into a single-turn Conversation."""
+        """Convert each dataset row into a Conversation (single- or multi-turn)."""
         dataset = data["dataset"]
         conversations: list[Conversation] = []
         skipped = 0
@@ -80,24 +84,37 @@ class SpeedBenchLoader(BaseHFDatasetLoader):
             if self.category and row.get("category") != self.category:
                 continue
 
-            turns = row.get("turns")
-            if not turns or not isinstance(turns, list) or not turns[0]:
+            turns_raw = row.get("turns")
+            if not turns_raw or not isinstance(turns_raw, list) or not turns_raw[0]:
                 skipped += 1
                 continue
 
-            prompt = str(turns[0]).strip()
-            if not prompt:
-                skipped += 1
-                continue
-
-            conversations.append(
-                Conversation(
-                    session_id=self.session_id_generator.next(),
-                    turns=[
-                        Turn(texts=[Text(contents=[prompt])]),
-                    ],
+            if self.multi_turn:
+                conv_turns: list[Turn] = []
+                for t in turns_raw:
+                    text = str(t).strip() if t else ""
+                    if text:
+                        conv_turns.append(Turn(texts=[Text(contents=[text])]))
+                if not conv_turns:
+                    skipped += 1
+                    continue
+                conversations.append(
+                    Conversation(
+                        session_id=self.session_id_generator.next(),
+                        turns=conv_turns,
+                    )
                 )
-            )
+            else:
+                prompt = str(turns_raw[0]).strip()
+                if not prompt:
+                    skipped += 1
+                    continue
+                conversations.append(
+                    Conversation(
+                        session_id=self.session_id_generator.next(),
+                        turns=[Turn(texts=[Text(contents=[prompt])])],
+                    )
+                )
 
         self.debug(
             lambda: (

--- a/src/aiperf/plugin/schema/plugins.schema.json
+++ b/src/aiperf/plugin/schema/plugins.schema.json
@@ -786,6 +786,12 @@
               "title": "Message Content Key",
               "type": "string"
             },
+            "multi_turn": {
+              "default": false,
+              "description": "When true, each row becomes one Conversation with multiple Turn objects. For HFConversationDatasetLoader: user\u2192assistant (OpenAI roles) or human\u2192gpt (ShareGPT-style ``from`` fields) pairs. For SpeedBenchLoader and SpecBenchLoader: all entries in the ``turns`` array. Default false preserves single-turn behavior.",
+              "title": "Multi Turn",
+              "type": "boolean"
+            },
             "streaming": {
               "default": false,
               "description": "Whether to load the HuggingFace dataset in streaming mode. Use true for large datasets (>10 GB) to avoid downloading the full dataset. Use false (default) for small datasets to leverage HF caching and len() support.",

--- a/src/aiperf/plugin/schema/schemas.py
+++ b/src/aiperf/plugin/schema/schemas.py
@@ -406,6 +406,15 @@ class PublicDatasetLoaderMetadata(BaseModel):
         default="content",
         description="Key inside each message dict for the text content. Used with conversation_column (e.g. 'content', 'value').",
     )
+    multi_turn: bool = Field(
+        default=False,
+        description=(
+            "When true, each row becomes one Conversation with multiple Turn objects. "
+            "For HFConversationDatasetLoader: user→assistant (OpenAI roles) or human→gpt "
+            "(ShareGPT-style ``from`` fields) pairs. For SpeedBenchLoader and SpecBenchLoader: "
+            "all entries in the ``turns`` array. Default false preserves single-turn behavior."
+        ),
+    )
     streaming: bool = Field(
         default=False,
         description=(

--- a/tests/unit/dataset/composer/test_public_composer.py
+++ b/tests/unit/dataset/composer/test_public_composer.py
@@ -8,6 +8,11 @@ import pytest
 from aiperf.common.models import Conversation, Text, Turn
 from aiperf.config.flags.cli_config import CLIConfig
 from aiperf.dataset.composer.public import PublicDatasetComposer
+from aiperf.dataset.loader.hf_conversation import HFConversationDatasetLoader
+from aiperf.dataset.loader.hf_instruction_response import (
+    HFInstructionResponseDatasetLoader,
+)
+from aiperf.dataset.loader.sharegpt import ShareGPTLoader
 from aiperf.plugin.enums import DatasetSamplingStrategy, PublicDatasetType
 from tests.unit.dataset.composer.conftest import make_run
 
@@ -54,7 +59,9 @@ class TestPublicDatasetComposerInit:
 class TestBuildLoaderKwargs:
     def test_hf_kwargs_populated_from_metadata(self, aimo_config):
         composer = PublicDatasetComposer(run=make_run(aimo_config), tokenizer=None)
-        kwargs = composer._build_loader_kwargs(PublicDatasetType.AIMO)
+        kwargs = composer._build_loader_kwargs(
+            PublicDatasetType.AIMO, HFInstructionResponseDatasetLoader
+        )
 
         assert kwargs["hf_dataset_name"] == "AI-MO/NuminaMath-TIR"
         assert kwargs["hf_split"] == "train"
@@ -62,7 +69,9 @@ class TestBuildLoaderKwargs:
 
     def test_no_subset_when_metadata_lacks_it(self, aimo_config):
         composer = PublicDatasetComposer(run=make_run(aimo_config), tokenizer=None)
-        kwargs = composer._build_loader_kwargs(PublicDatasetType.AIMO)
+        kwargs = composer._build_loader_kwargs(
+            PublicDatasetType.AIMO, HFInstructionResponseDatasetLoader
+        )
         assert "hf_subset" not in kwargs
 
     def test_no_kwargs_when_no_hf_metadata(self, aimo_config):
@@ -74,7 +83,9 @@ class TestBuildLoaderKwargs:
             "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
             return_value=PublicDatasetLoaderMetadata(),
         ):
-            kwargs = composer._build_loader_kwargs(PublicDatasetType.AIMO)
+            kwargs = composer._build_loader_kwargs(
+                PublicDatasetType.AIMO, HFInstructionResponseDatasetLoader
+            )
         assert kwargs == {}
 
     def test_category_forwarded_when_set(self, aimo_config):
@@ -90,7 +101,9 @@ class TestBuildLoaderKwargs:
                 category="coding",
             ),
         ):
-            kwargs = composer._build_loader_kwargs(PublicDatasetType.AIMO)
+            kwargs = composer._build_loader_kwargs(
+                PublicDatasetType.AIMO, HFInstructionResponseDatasetLoader
+            )
         assert kwargs["category"] == "coding"
 
     def test_no_category_in_kwargs_when_none(self, aimo_config):
@@ -104,8 +117,57 @@ class TestBuildLoaderKwargs:
                 hf_split="test",
             ),
         ):
-            kwargs = composer._build_loader_kwargs(PublicDatasetType.AIMO)
+            kwargs = composer._build_loader_kwargs(
+                PublicDatasetType.AIMO, HFInstructionResponseDatasetLoader
+            )
         assert "category" not in kwargs
+
+    def test_multi_turn_forwarded_to_supporting_loader(self, aimo_config):
+        from aiperf.plugin.schema.schemas import PublicDatasetLoaderMetadata
+
+        composer = PublicDatasetComposer(run=make_run(aimo_config), tokenizer=None)
+        with patch(
+            "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
+            return_value=PublicDatasetLoaderMetadata(
+                hf_dataset_name="test/data",
+                hf_split="train",
+                conversation_column="conversation",
+                multi_turn=True,
+            ),
+        ):
+            kwargs = composer._build_loader_kwargs(
+                PublicDatasetType.AIMO, HFConversationDatasetLoader
+            )
+        assert kwargs["multi_turn"] is True
+
+    def test_multi_turn_raises_for_unsupported_loader(self, aimo_config):
+        """A loader that doesn't declare multi_turn on its __init__ must not
+        silently swallow the kwarg via **kwargs — composer should refuse."""
+        from aiperf.plugin.schema.schemas import PublicDatasetLoaderMetadata
+
+        composer = PublicDatasetComposer(run=make_run(aimo_config), tokenizer=None)
+        with (
+            patch(
+                "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
+                return_value=PublicDatasetLoaderMetadata(multi_turn=True),
+            ),
+            pytest.raises(ValueError, match="does not support the 'multi_turn'"),
+        ):
+            composer._build_loader_kwargs(PublicDatasetType.AIMO, ShareGPTLoader)
+
+    def test_multi_turn_false_does_not_validate_loader_support(self, aimo_config):
+        """multi_turn=False is the default; no need to gate it on loader support."""
+        from aiperf.plugin.schema.schemas import PublicDatasetLoaderMetadata
+
+        composer = PublicDatasetComposer(run=make_run(aimo_config), tokenizer=None)
+        with patch(
+            "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
+            return_value=PublicDatasetLoaderMetadata(multi_turn=False),
+        ):
+            kwargs = composer._build_loader_kwargs(
+                PublicDatasetType.AIMO, ShareGPTLoader
+            )
+        assert "multi_turn" not in kwargs
 
 
 @pytest.mark.asyncio
@@ -135,6 +197,8 @@ class TestCreateDatasetAsync:
                     hf_split="train",
                     hf_subset=None,
                     prompt_column="problem",
+                    multi_turn=False,
+                    streaming=False,
                 ),
             ),
         ):
@@ -176,6 +240,8 @@ class TestCreateDatasetAsync:
                     hf_split="train",
                     hf_subset=None,
                     prompt_column="problem",
+                    multi_turn=False,
+                    streaming=False,
                 ),
             ),
         ):

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import io
+from unittest.mock import MagicMock
 
 import pytest
 from PIL import Image as PILImage
@@ -490,3 +491,228 @@ class TestHFConversationDatasetLoader:
             streaming=True,
         )
         assert loader.streaming is True
+
+    async def test_multi_turn_openai_user_assistant_pairs(self, cli_config):
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversation",
+            message_content_key="content",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "user", "content": "First?"},
+                        {"role": "assistant", "content": "First reply."},
+                        {"role": "user", "content": "Second?"},
+                        {"role": "assistant", "content": "Second reply."},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 2
+        assert conversations[0].turns[0].texts[0].contents[0] == "First?"
+        assert conversations[0].turns[1].texts[0].contents[0] == "Second?"
+
+    async def test_multi_turn_sharegpt_human_gpt_pairs(self, cli_config):
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversations",
+            message_content_key="value",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversations": [
+                        {"from": "human", "value": "Hi"},
+                        {"from": "gpt", "value": "Hello"},
+                        {"from": "human", "value": "Bye"},
+                        {"from": "gpt", "value": "Goodbye"},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 2
+        assert conversations[0].turns[0].texts[0].contents[0] == "Hi"
+        assert conversations[0].turns[1].texts[0].contents[0] == "Bye"
+
+    async def test_multi_turn_skips_row_when_no_pairs(self, cli_config):
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversation",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "user", "content": "Only user, no assistant"},
+                    ]
+                },
+                {
+                    "conversation": [
+                        {"role": "user", "content": "Q"},
+                        {"role": "assistant", "content": "A"},
+                    ]
+                },
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 1
+
+    async def test_multi_turn_sets_max_tokens_when_tokenizer_provided(
+        self, cli_config
+    ):
+        tok = MagicMock()
+        tok.encode.side_effect = lambda s: list(range(max(1, len(s))))
+
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversation",
+            multi_turn=True,
+            tokenizer=tok,
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "user", "content": "What is four plus four?"},
+                        {"role": "assistant", "content": "The answer is eight."},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations[0].turns) == 1
+        assert conversations[0].turns[0].max_tokens == len("The answer is eight.")
+
+    async def test_multi_turn_skips_system_messages_between_pairs(self, cli_config):
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversation",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "system", "content": "You are helpful"},
+                        {"role": "user", "content": "Q1"},
+                        {"role": "system", "content": "reminder"},
+                        {"role": "assistant", "content": "A1"},
+                        {"role": "user", "content": "Q2"},
+                        {"role": "assistant", "content": "A2"},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 2
+        assert conversations[0].turns[0].texts[0].contents[0] == "Q1"
+        assert conversations[0].turns[1].texts[0].contents[0] == "Q2"
+
+    async def test_multi_turn_skips_row_with_empty_assistant(self, cli_config):
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversation",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "user", "content": "Q"},
+                        {"role": "assistant", "content": ""},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 0
+
+    async def test_multi_turn_image_only_on_first_turn(self, cli_config):
+        pil_img = _make_pil_image()
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversation",
+            image_column="image",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "user", "content": "Describe this"},
+                        {"role": "assistant", "content": "It is a red square"},
+                        {"role": "user", "content": "What color?"},
+                        {"role": "assistant", "content": "Red"},
+                    ],
+                    "image": pil_img,
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations[0].turns) == 2
+        assert len(conversations[0].turns[0].images) == 1
+        assert conversations[0].turns[1].images == []
+
+    async def test_multi_turn_validation_rejection_drops_entire_row(self, cli_config):
+        tok = MagicMock()
+        tok.encode.side_effect = lambda s: list(range(len(s)))
+
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversation",
+            multi_turn=True,
+            tokenizer=tok,
+        )
+
+        orig_is_valid = loader.is_valid_sequence
+        call_count = {"n": 0}
+
+        def reject_second_pair(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                return False
+            return orig_is_valid(**kwargs)
+
+        loader.is_valid_sequence = reject_second_pair
+
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "user", "content": "First question here"},
+                        {"role": "assistant", "content": "First answer here"},
+                        {"role": "user", "content": "Second question here"},
+                        {"role": "assistant", "content": "Second answer here"},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 0

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -622,9 +622,7 @@ class TestHFConversationDatasetLoader:
         assert len(conversations) == 1
         assert len(conversations[0].turns) == 1
 
-    async def test_multi_turn_sets_max_tokens_when_tokenizer_provided(
-        self, cli_config
-    ):
+    async def test_multi_turn_sets_max_tokens_when_tokenizer_provided(self, cli_config):
         tok = MagicMock()
         tok.encode.side_effect = lambda s: list(range(max(1, len(s))))
 

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -763,3 +763,37 @@ class TestHFConversationDatasetLoader:
         }
         conversations = await loader.convert_to_conversations(data)
         assert len(conversations) == 0
+
+    async def test_multi_turn_warns_when_no_tokenizer(self, cli_config, caplog):
+        """When multi_turn=True but no tokenizer is configured, validation is
+        silently disabled and Turn.max_tokens=None for every turn. Surface this
+        as a warning so users learn their filter settings are being skipped."""
+        import logging
+
+        loader = HFConversationDatasetLoader(
+            run=make_run_from_cli(cli_config),
+            hf_dataset_name="test/data",
+            hf_split="train",
+            conversation_column="conversation",
+            multi_turn=True,
+            tokenizer=None,
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "user", "content": "Q"},
+                        {"role": "assistant", "content": "A"},
+                    ]
+                }
+            ]
+        }
+        with caplog.at_level(logging.WARNING):
+            conversations = await loader.convert_to_conversations(data)
+
+        assert any(
+            "multi_turn=True but no tokenizer" in record.message
+            for record in caplog.records
+        ), f"expected warning, got records: {[r.message for r in caplog.records]}"
+        assert len(conversations) == 1
+        assert conversations[0].turns[0].max_tokens is None

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -95,6 +95,55 @@ class TestHFConversationDatasetLoader:
         assert len(conversations[0].turns) == 1
         assert conversations[0].turns[0].texts[0].contents[0] == "First message"
 
+    async def test_single_turn_skips_system_message(self, loader):
+        """Single-turn extraction should prefer the first user message, not a system preamble."""
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "system", "content": "You are helpful"},
+                        {"role": "user", "content": "What is 2+2?"},
+                        {"role": "assistant", "content": "4"},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert conversations[0].turns[0].texts[0].contents[0] == "What is 2+2?"
+
+    async def test_single_turn_skips_assistant_first_message(self, loader):
+        """Single-turn extraction should skip a leading assistant message."""
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"role": "assistant", "content": "Hello!"},
+                        {"role": "user", "content": "Tell me a joke"},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert conversations[0].turns[0].texts[0].contents[0] == "Tell me a joke"
+
+    async def test_single_turn_fallback_when_no_roles(self, loader):
+        """When messages have no role tags, fall back to the literal first message."""
+        data = {
+            "dataset": [
+                {
+                    "conversation": [
+                        {"content": "What is AI?"},
+                        {"content": "Artificial intelligence"},
+                    ]
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert conversations[0].turns[0].texts[0].contents[0] == "What is AI?"
+
     async def test_each_row_becomes_one_conversation(self, loader):
         data = {
             "dataset": [

--- a/tests/unit/dataset/loader/test_hf_dataset_loader.py
+++ b/tests/unit/dataset/loader/test_hf_dataset_loader.py
@@ -435,7 +435,9 @@ class TestPublicDatasetComposerHFSubsetOverride:
             "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
             return_value=metadata,
         ):
-            kwargs = composer._build_loader_kwargs("aimo")
+            kwargs = composer._build_loader_kwargs(
+                "aimo", HFInstructionResponseDatasetLoader
+            )
 
         assert kwargs["hf_subset"] == "cli-subset"
 
@@ -448,7 +450,9 @@ class TestPublicDatasetComposerHFSubsetOverride:
             "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
             return_value=metadata,
         ):
-            kwargs = composer._build_loader_kwargs("aimo")
+            kwargs = composer._build_loader_kwargs(
+                "aimo", HFInstructionResponseDatasetLoader
+            )
 
         assert kwargs["hf_subset"] == "plugin-subset"
 
@@ -461,7 +465,9 @@ class TestPublicDatasetComposerHFSubsetOverride:
             "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
             return_value=metadata,
         ):
-            kwargs = composer._build_loader_kwargs("aimo")
+            kwargs = composer._build_loader_kwargs(
+                "aimo", HFInstructionResponseDatasetLoader
+            )
 
         assert "hf_subset" not in kwargs
 
@@ -478,7 +484,9 @@ class TestPublicDatasetComposerHFSubsetOverride:
             "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
             return_value=metadata,
         ):
-            kwargs = composer._build_loader_kwargs("librispeech")
+            kwargs = composer._build_loader_kwargs(
+                "librispeech", HFInstructionResponseDatasetLoader
+            )
 
         assert kwargs["audio_column"] == "audio"
 
@@ -491,6 +499,8 @@ class TestPublicDatasetComposerHFSubsetOverride:
             "aiperf.dataset.composer.public.plugins.get_public_dataset_loader_metadata",
             return_value=metadata,
         ):
-            kwargs = composer._build_loader_kwargs("aimo")
+            kwargs = composer._build_loader_kwargs(
+                "aimo", HFInstructionResponseDatasetLoader
+            )
 
         assert "audio_column" not in kwargs

--- a/tests/unit/dataset/loader/test_sharegpt.py
+++ b/tests/unit/dataset/loader/test_sharegpt.py
@@ -88,6 +88,32 @@ class TestShareGPTLoader:
         assert turn.max_tokens == len(["This", "is", "test", "output"])
         assert turn.model == "test-model"
 
+    async def test_convert_multi_turn_sharegpt_roles(
+        self, sharegpt_loader: ShareGPTLoader
+    ):
+        """Entries with human/gpt roles beyond the first pair become extra turns."""
+        dataset = [
+            {
+                "conversations": [
+                    {"from": "human", "value": "Hello how are you"},
+                    {"from": "gpt", "value": "This is test output"},
+                    {"from": "human", "value": "Follow up question here"},
+                    {"from": "gpt", "value": "Second assistant reply text"},
+                ]
+            }
+        ]
+        conversations = await sharegpt_loader.convert_to_conversations(dataset)
+
+        assert len(conversations) == 1
+        conv = conversations[0]
+        assert len(conv.turns) == 2
+        assert conv.turns[0].texts[0].contents[0] == "Hello how are you"
+        assert conv.turns[0].max_tokens == len(["This", "is", "test", "output"])
+        assert conv.turns[1].texts[0].contents[0] == "Follow up question here"
+        assert conv.turns[1].max_tokens == len(
+            ["Second", "assistant", "reply", "text"]
+        )
+
     async def test_get_preferred_sampling_strategy(
         self, sharegpt_loader: ShareGPTLoader
     ):

--- a/tests/unit/dataset/loader/test_sharegpt.py
+++ b/tests/unit/dataset/loader/test_sharegpt.py
@@ -110,9 +110,7 @@ class TestShareGPTLoader:
         assert conv.turns[0].texts[0].contents[0] == "Hello how are you"
         assert conv.turns[0].max_tokens == len(["This", "is", "test", "output"])
         assert conv.turns[1].texts[0].contents[0] == "Follow up question here"
-        assert conv.turns[1].max_tokens == len(
-            ["Second", "assistant", "reply", "text"]
-        )
+        assert conv.turns[1].max_tokens == len(["Second", "assistant", "reply", "text"])
 
     async def test_get_preferred_sampling_strategy(
         self, sharegpt_loader: ShareGPTLoader

--- a/tests/unit/dataset/loader/test_sharegpt.py
+++ b/tests/unit/dataset/loader/test_sharegpt.py
@@ -139,3 +139,27 @@ class TestShareGPTLoader:
         """Test that ShareGPTLoader returns the correct preferred sampling strategy."""
         strategy = ShareGPTLoader.get_preferred_sampling_strategy()
         assert strategy == DatasetSamplingStrategy.SEQUENTIAL
+
+    async def test_skips_row_with_non_dict_messages_without_crashing(
+        self, sharegpt_loader: ShareGPTLoader
+    ):
+        """A malformed row whose 'conversations' list contains non-dict items
+        (strings, None, ints) must be skipped — not abort the whole load via
+        AttributeError on the next .get() call. Also covers the case where a
+        row has one valid dict + non-dict noise (fewer than two usable dicts)."""
+        dataset = [
+            {"conversations": ["raw_string", None, 42]},
+            {"conversations": [None, {"from": "gpt", "value": "orphan reply text"}]},
+            {
+                "conversations": [
+                    {"from": "human", "value": "Hello can you help me with a question"},
+                    {"from": "gpt", "value": "Yes I can help you with that question"},
+                ]
+            },
+        ]
+        conversations = await sharegpt_loader.convert_to_conversations(dataset)
+        assert len(conversations) == 1
+        assert (
+            conversations[0].turns[0].texts[0].contents[0]
+            == "Hello can you help me with a question"
+        )

--- a/tests/unit/dataset/loader/test_sharegpt.py
+++ b/tests/unit/dataset/loader/test_sharegpt.py
@@ -112,6 +112,27 @@ class TestShareGPTLoader:
         assert conv.turns[1].texts[0].contents[0] == "Follow up question here"
         assert conv.turns[1].max_tokens == len(["Second", "assistant", "reply", "text"])
 
+    async def test_skips_pair_with_missing_value_key(
+        self, sharegpt_loader: ShareGPTLoader
+    ):
+        """Pairs where a message lacks the 'value' key are silently skipped."""
+        dataset = [
+            {
+                "conversations": [
+                    {"from": "human", "value": "Hello how are you"},
+                    {"from": "gpt"},
+                    {"from": "human", "value": "Follow up question here"},
+                    {"from": "gpt", "value": "Second assistant reply text"},
+                ]
+            }
+        ]
+        conversations = await sharegpt_loader.convert_to_conversations(dataset)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 1
+        assert (
+            conversations[0].turns[0].texts[0].contents[0] == "Follow up question here"
+        )
+
     async def test_get_preferred_sampling_strategy(
         self, sharegpt_loader: ShareGPTLoader
     ):

--- a/tests/unit/dataset/loader/test_spec_bench_loader.py
+++ b/tests/unit/dataset/loader/test_spec_bench_loader.py
@@ -133,8 +133,8 @@ class TestSpecBenchLoader:
 
 @pytest.mark.asyncio
 class TestSpecBenchLoaderMultiTurn:
-    async def test_multi_turn_produces_all_turns(self, user_config):
-        loader = SpecBenchLoader(user_config=user_config, multi_turn=True)
+    async def test_multi_turn_produces_all_turns(self, cli_config):
+        loader = SpecBenchLoader(run=make_run_from_cli(cli_config), multi_turn=True)
         data = {
             "dataset": [{"turns": ["First turn prompt.", "Second follow-up turn."]}]
         }
@@ -155,8 +155,8 @@ class TestSpecBenchLoaderMultiTurn:
         assert len(conversations[0].turns) == 1
         assert conversations[0].turns[0].texts[0].contents[0] == "First turn prompt."
 
-    async def test_multi_turn_skips_empty_entries(self, user_config):
-        loader = SpecBenchLoader(user_config=user_config, multi_turn=True)
+    async def test_multi_turn_skips_empty_entries(self, cli_config):
+        loader = SpecBenchLoader(run=make_run_from_cli(cli_config), multi_turn=True)
         data = {"dataset": [{"turns": ["Valid", "", "Also valid"]}]}
         conversations = await loader.convert_to_conversations(data)
         assert len(conversations) == 1
@@ -164,14 +164,14 @@ class TestSpecBenchLoaderMultiTurn:
         assert conversations[0].turns[0].texts[0].contents[0] == "Valid"
         assert conversations[0].turns[1].texts[0].contents[0] == "Also valid"
 
-    async def test_multi_turn_empty_turns_skipped(self, user_config):
-        loader = SpecBenchLoader(user_config=user_config, multi_turn=True)
+    async def test_multi_turn_empty_turns_skipped(self, cli_config):
+        loader = SpecBenchLoader(run=make_run_from_cli(cli_config), multi_turn=True)
         data = {"dataset": [{"turns": [""]}]}
         conversations = await loader.convert_to_conversations(data)
         assert len(conversations) == 0
 
-    async def test_multi_turn_null_values_in_turns(self, user_config):
-        loader = SpecBenchLoader(user_config=user_config, multi_turn=True)
+    async def test_multi_turn_null_values_in_turns(self, cli_config):
+        loader = SpecBenchLoader(run=make_run_from_cli(cli_config), multi_turn=True)
         data = {"dataset": [{"turns": [None, "Valid turn", None]}]}
         conversations = await loader.convert_to_conversations(data)
         assert len(conversations) == 1

--- a/tests/unit/dataset/loader/test_spec_bench_loader.py
+++ b/tests/unit/dataset/loader/test_spec_bench_loader.py
@@ -109,6 +109,16 @@ class TestSpecBenchLoader:
         conversations = await loader.convert_to_conversations(data)
         assert len(conversations) == 1
 
+    async def test_skips_non_list_turns(self, loader):
+        data = {
+            "dataset": [
+                {"turns": "not a list"},
+                {"turns": ["Valid prompt"]},
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+
     async def test_empty_dataset_returns_empty_list(self, loader):
         data = {"dataset": []}
         conversations = await loader.convert_to_conversations(data)
@@ -159,3 +169,11 @@ class TestSpecBenchLoaderMultiTurn:
         data = {"dataset": [{"turns": [""]}]}
         conversations = await loader.convert_to_conversations(data)
         assert len(conversations) == 0
+
+    async def test_multi_turn_null_values_in_turns(self, user_config):
+        loader = SpecBenchLoader(user_config=user_config, multi_turn=True)
+        data = {"dataset": [{"turns": [None, "Valid turn", None]}]}
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 1
+        assert conversations[0].turns[0].texts[0].contents[0] == "Valid turn"

--- a/tests/unit/dataset/loader/test_spec_bench_loader.py
+++ b/tests/unit/dataset/loader/test_spec_bench_loader.py
@@ -119,3 +119,43 @@ class TestSpecBenchLoader:
         conversations = await loader.convert_to_conversations(data)
         session_ids = [c.session_id for c in conversations]
         assert len(set(session_ids)) == 5
+
+
+@pytest.mark.asyncio
+class TestSpecBenchLoaderMultiTurn:
+    async def test_multi_turn_produces_all_turns(self, user_config):
+        loader = SpecBenchLoader(user_config=user_config, multi_turn=True)
+        data = {
+            "dataset": [{"turns": ["First turn prompt.", "Second follow-up turn."]}]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 2
+        assert conversations[0].turns[0].texts[0].contents[0] == "First turn prompt."
+        assert (
+            conversations[0].turns[1].texts[0].contents[0] == "Second follow-up turn."
+        )
+
+    async def test_default_single_turn_unchanged(self, loader):
+        data = {
+            "dataset": [{"turns": ["First turn prompt.", "Second follow-up turn."]}]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 1
+        assert conversations[0].turns[0].texts[0].contents[0] == "First turn prompt."
+
+    async def test_multi_turn_skips_empty_entries(self, user_config):
+        loader = SpecBenchLoader(user_config=user_config, multi_turn=True)
+        data = {"dataset": [{"turns": ["Valid", "", "Also valid"]}]}
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 2
+        assert conversations[0].turns[0].texts[0].contents[0] == "Valid"
+        assert conversations[0].turns[1].texts[0].contents[0] == "Also valid"
+
+    async def test_multi_turn_empty_turns_skipped(self, user_config):
+        loader = SpecBenchLoader(user_config=user_config, multi_turn=True)
+        data = {"dataset": [{"turns": [""]}]}
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 0

--- a/tests/unit/dataset/loader/test_speed_bench.py
+++ b/tests/unit/dataset/loader/test_speed_bench.py
@@ -293,9 +293,9 @@ class TestSpeedBenchLoaderStreaming:
 
 @pytest.mark.asyncio
 class TestSpeedBenchLoaderMultiTurn:
-    async def test_multi_turn_produces_all_turns(self, user_config):
+    async def test_multi_turn_produces_all_turns(self, cli_config):
         loader = SpeedBenchLoader(
-            user_config=user_config,
+            run=make_run_from_cli(cli_config),
             hf_dataset_name="nvidia/SPEED-Bench",
             hf_split="test",
             hf_subset="qualitative",
@@ -324,9 +324,9 @@ class TestSpeedBenchLoaderMultiTurn:
         assert len(conversations[0].turns) == 1
         assert conversations[0].turns[0].texts[0].contents[0] == "First turn"
 
-    async def test_multi_turn_skips_empty_turns_in_array(self, user_config):
+    async def test_multi_turn_skips_empty_turns_in_array(self, cli_config):
         loader = SpeedBenchLoader(
-            user_config=user_config,
+            run=make_run_from_cli(cli_config),
             hf_dataset_name="nvidia/SPEED-Bench",
             hf_split="test",
             hf_subset="qualitative",
@@ -343,9 +343,9 @@ class TestSpeedBenchLoaderMultiTurn:
         assert conversations[0].turns[0].texts[0].contents[0] == "Valid"
         assert conversations[0].turns[1].texts[0].contents[0] == "Also valid"
 
-    async def test_multi_turn_with_category_filter(self, user_config):
+    async def test_multi_turn_with_category_filter(self, cli_config):
         loader = SpeedBenchLoader(
-            user_config=user_config,
+            run=make_run_from_cli(cli_config),
             hf_dataset_name="nvidia/SPEED-Bench",
             hf_split="test",
             hf_subset="qualitative",

--- a/tests/unit/dataset/loader/test_speed_bench.py
+++ b/tests/unit/dataset/loader/test_speed_bench.py
@@ -289,3 +289,75 @@ class TestSpeedBenchLoaderStreaming:
         assert len(conversations) == 2
         assert conversations[0].turns[0].texts[0].contents[0] == "Code 0"
         assert conversations[1].turns[0].texts[0].contents[0] == "Code 1"
+
+
+@pytest.mark.asyncio
+class TestSpeedBenchLoaderMultiTurn:
+    async def test_multi_turn_produces_all_turns(self, user_config):
+        loader = SpeedBenchLoader(
+            user_config=user_config,
+            hf_dataset_name="nvidia/SPEED-Bench",
+            hf_split="test",
+            hf_subset="qualitative",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                _make_speed_bench_row(["First turn", "Second turn", "Third turn"]),
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 3
+        assert conversations[0].turns[0].texts[0].contents[0] == "First turn"
+        assert conversations[0].turns[1].texts[0].contents[0] == "Second turn"
+        assert conversations[0].turns[2].texts[0].contents[0] == "Third turn"
+
+    async def test_default_single_turn_unchanged(self, loader):
+        data = {
+            "dataset": [
+                _make_speed_bench_row(["First turn", "Second turn", "Third turn"]),
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 1
+        assert conversations[0].turns[0].texts[0].contents[0] == "First turn"
+
+    async def test_multi_turn_skips_empty_turns_in_array(self, user_config):
+        loader = SpeedBenchLoader(
+            user_config=user_config,
+            hf_dataset_name="nvidia/SPEED-Bench",
+            hf_split="test",
+            hf_subset="qualitative",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                _make_speed_bench_row(["Valid", "", "Also valid"]),
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 2
+        assert conversations[0].turns[0].texts[0].contents[0] == "Valid"
+        assert conversations[0].turns[1].texts[0].contents[0] == "Also valid"
+
+    async def test_multi_turn_with_category_filter(self, user_config):
+        loader = SpeedBenchLoader(
+            user_config=user_config,
+            hf_dataset_name="nvidia/SPEED-Bench",
+            hf_split="test",
+            hf_subset="qualitative",
+            category="coding",
+            multi_turn=True,
+        )
+        data = {
+            "dataset": [
+                _make_speed_bench_row(["Code Q1", "Code Q2"], category="coding"),
+                _make_speed_bench_row(["Math Q1"], category="math"),
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 1
+        assert len(conversations[0].turns) == 2


### PR DESCRIPTION
## Summary
- Improves ShareGPT multi-turn dataset behavior.

Fixes #798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-turn conversation support across dataset loaders with single-turn as default.
  * Public `multi_turn` configuration option to enable multi-turn behavior.
  * Role-aware pairing (human/user → assistant); images attached only to the first turn.
  * Optional per-turn token-length validation when a tokenizer is provided; invalid or incomplete pairs are skipped.

* **Tests**
  * Added unit tests covering multi-turn conversion, image handling, skipping invalid/empty pairs, and token-length validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->