### PR TITLE
feat(dataset): add per-request output_length to single_turn and multi_turn input files

### DIFF
--- a/docs/tutorials/custom-dataset.md
+++ b/docs/tutorials/custom-dataset.md
@@ -131,6 +131,32 @@ artifacts/Qwen_Qwen3-0.6B-openai-chat-concurrency2/profile_export_aiperf.json
 Log File: artifacts/Qwen_Qwen3-0.6B-openai-chat-concurrency2/logs/aiperf.log
 ```
 
+### Per-Request Output Length
+
+Control the maximum output tokens per request using the `output_length` field:
+
+```bash
+cat > prompts_with_osl.jsonl << 'EOF'
+{"text": "Write a haiku about mountains.", "output_length": 50}
+{"text": "Explain quantum computing in detail.", "output_length": 500}
+{"text": "What is 2+2?", "output_length": 10}
+{"text": "Summarize machine learning."}
+EOF
+
+aiperf profile \
+    --model Qwen/Qwen3-0.6B \
+    --endpoint-type chat \
+    --input-file prompts_with_osl.jsonl \
+    --custom-dataset-type single_turn \
+    --streaming \
+    --url localhost:8000 \
+    --osl 200
+```
+
+**Precedence:** Per-line `output_length` takes priority over the global `--osl` flag. Lines without `output_length` fall back to `--osl` if set (200 in this example), or let the server decide the output length.
+
+The `output_length` field also works per-turn in multi_turn datasets.
+
 ---
 
 ## Multi-Turn Datasets

--- a/docs/tutorials/vision.md
+++ b/docs/tutorials/vision.md
@@ -87,11 +87,11 @@ Create a JSONL file with text prompts and image URLs:
 {/* aiperf-run-vllm-vision-openai-endpoint-server */}
 ```bash
 cat <<EOF > inputs.jsonl
-{"texts": ["Describe this image in detail."], "images": ["https://picsum.photos/512/512?random=1"]}
+{"texts": ["Describe this image in detail."], "images": ["https://picsum.photos/512/512?random=1"], "output_length": 200}
 {"texts": ["What objects are visible in this image?"], "images": ["https://picsum.photos/512/512?random=2"]}
-{"texts": ["Analyze the composition of this photo."], "images": ["https://picsum.photos/512/512?random=3"]}
+{"texts": ["Analyze the composition of this photo."], "images": ["https://picsum.photos/512/512?random=3"], "output_length": 300}
 {"texts": ["What is the main subject of this image?"], "images": ["https://picsum.photos/512/512?random=4"]}
-{"texts": ["Provide a caption for this image."], "images": ["https://picsum.photos/512/512?random=5"]}
+{"texts": ["Provide a caption for this image."], "images": ["https://picsum.photos/512/512?random=5"], "output_length": 50}
 EOF
 ```
 {/* /aiperf-run-vllm-vision-openai-endpoint-server */}

--- a/src/aiperf/dataset/composer/base.py
+++ b/src/aiperf/dataset/composer/base.py
@@ -119,9 +119,16 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
     def _set_max_tokens(self, turn: Turn) -> None:
         """Set max_tokens for the turn based on the sequence distribution or output configuration.
 
+        If the turn already has max_tokens set (e.g., from per-line input data),
+        the existing value is preserved. Per-line values take precedence over
+        global --osl and --seq-dist settings.
+
         Args:
             turn: The turn object to finalize.
         """
+        if turn.max_tokens is not None:
+            return
+
         if self._seq_distribution is not None:
             # Use cached sequence distribution to get OSL (ensures ISL/OSL pairing consistency)
             turn_id = id(turn)

--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -61,6 +61,11 @@ class SingleTurn(AIPerfBaseModel):
         description="Session ID for causal ordering. Entries sharing a session_id "
         "are sent sequentially. Each entry is self-contained (no history accumulation).",
     )
+    output_length: int | None = Field(
+        default=None,
+        gt=0,
+        description="Maximum number of output tokens to generate for this request. Overrides the global --osl setting when specified.",
+    )
 
     @model_validator(mode="after")
     def validate_mutually_exclusive_fields(self) -> "SingleTurn":

--- a/src/aiperf/dataset/loader/multi_turn.py
+++ b/src/aiperf/dataset/loader/multi_turn.py
@@ -168,6 +168,7 @@ class MultiTurnDatasetLoader(BaseFileLoader, MediaConversionMixin):
                             timestamp=single_turn.timestamp,
                             delay=single_turn.delay,
                             role=single_turn.role,
+                            max_tokens=single_turn.output_length,
                         )
                     )
             conversations.append(conversation)

--- a/src/aiperf/dataset/loader/single_turn.py
+++ b/src/aiperf/dataset/loader/single_turn.py
@@ -146,6 +146,7 @@ class SingleTurnDatasetLoader(BaseFileLoader, MediaConversionMixin):
                         timestamp=single_turn.timestamp,
                         delay=single_turn.delay,
                         role=single_turn.role,
+                        max_tokens=single_turn.output_length,
                     )
                 )
             conversations.append(conversation)

--- a/tests/unit/dataset/composer/test_base_composer.py
+++ b/tests/unit/dataset/composer/test_base_composer.py
@@ -213,6 +213,29 @@ class TestBaseDatasetComposer:
         # max_tokens should remain None when no distribution and no output_tokens.mean
         assert turn.max_tokens is None
 
+    def test_set_max_tokens_preserves_existing_value(self, base_config, mock_tokenizer):
+        """Test that per-line max_tokens is not overwritten by global --osl config."""
+        composer = ConcreteBaseComposer(base_config, mock_tokenizer)
+        turn = Turn(max_tokens=42)
+
+        composer._set_max_tokens(turn)
+
+        assert turn.max_tokens == 42
+
+    def test_set_max_tokens_preserves_existing_with_distribution(
+        self, sequence_dist_config, mock_tokenizer
+    ):
+        """Test that per-line max_tokens is not overwritten by sequence distribution."""
+        composer = ConcreteBaseComposer(sequence_dist_config, mock_tokenizer)
+        turn = Turn(max_tokens=42)
+
+        turn_id = id(turn)
+        composer._turn_sequence_cache[turn_id] = (150, 75)
+
+        composer._set_max_tokens(turn)
+
+        assert turn.max_tokens == 42
+
     def test_finalize_turn(self, sequence_dist_config, mock_tokenizer):
         """Test turn finalization."""
         composer = ConcreteBaseComposer(sequence_dist_config, mock_tokenizer)

--- a/tests/unit/dataset/composer/test_custom_composer.py
+++ b/tests/unit/dataset/composer/test_custom_composer.py
@@ -37,6 +37,14 @@ class TestInitialization:
         assert input_config.custom_dataset_type == CustomDatasetType.SINGLE_TURN
 
 
+MOCK_SINGLE_TURN_CONTENT = """{"text": "Write a haiku.", "output_length": 50}
+{"text": "Explain quantum computing.", "output_length": 500}
+{"text": "Summarize machine learning."}
+"""
+
+MOCK_MULTI_TURN_CONTENT = """{"session_id": "s1", "turns": [{"text": "Summarize.", "output_length": 100}, {"text": "Key points only."}, {"text": "Expand on point 2.", "output_length": 300}]}
+"""
+
 MOCK_TRACE_CONTENT = """{"timestamp": 0, "input_length": 655, "output_length": 52, "hash_ids": [46, 47]}
 {"timestamp": 10535, "input_length": 672, "output_length": 52, "hash_ids": [46, 47]}
 {"timestamp": 27482, "input_length": 655, "output_length": 52, "hash_ids": [46, 47]}
@@ -94,15 +102,49 @@ class TestCoreFunctionality:
         conversations = composer.create_dataset()
 
         assert len(conversations) > 0
-        # With global RNG, verify max_tokens is set to a positive integer
-        # around the mean of 120
+        # Per-line output_length (52) takes precedence over global --osl (120)
         for conversation in conversations:
             for turn in conversation.turns:
-                assert turn.max_tokens is not None
-                assert turn.max_tokens > 0
-                assert isinstance(turn.max_tokens, int)
-                # Should be roughly around the mean of 120 (within 3 stddev)
-                assert 96 < turn.max_tokens < 144
+                assert turn.max_tokens == 52
+
+    @patch("aiperf.dataset.composer.custom.check_file_exists")
+    @patch("builtins.open", mock_open(read_data=MOCK_SINGLE_TURN_CONTENT))
+    def test_single_turn_output_length_precedence(
+        self, mock_check_file, custom_config, mock_tokenizer
+    ):
+        """Test that per-line output_length takes precedence over global --osl in single_turn."""
+        custom_config.input.prompt.output_tokens.mean = 200
+        custom_config.input.prompt.output_tokens.stddev = 0.0
+
+        composer = CustomDatasetComposer(custom_config, mock_tokenizer)
+        conversations = composer.create_dataset()
+
+        assert len(conversations) == 3
+        # First two lines have output_length, third falls back to global --osl (200)
+        assert conversations[0].turns[0].max_tokens == 50
+        assert conversations[1].turns[0].max_tokens == 500
+        assert conversations[2].turns[0].max_tokens == 200
+
+    @patch("aiperf.dataset.composer.custom.check_file_exists")
+    @patch("builtins.open", mock_open(read_data=MOCK_MULTI_TURN_CONTENT))
+    def test_multi_turn_output_length_precedence(
+        self, mock_check_file, custom_config, mock_tokenizer
+    ):
+        """Test per-turn output_length precedence over global --osl in multi_turn."""
+        custom_config.input.custom_dataset_type = CustomDatasetType.MULTI_TURN
+        custom_config.input.prompt.output_tokens.mean = 200
+        custom_config.input.prompt.output_tokens.stddev = 0.0
+
+        composer = CustomDatasetComposer(custom_config, mock_tokenizer)
+        conversations = composer.create_dataset()
+
+        assert len(conversations) == 1
+        turns = conversations[0].turns
+        assert len(turns) == 3
+        # Turn 1 and 3 have output_length, turn 2 falls back to global --osl (200)
+        assert turns[0].max_tokens == 100
+        assert turns[1].max_tokens == 200
+        assert turns[2].max_tokens == 300
 
     @patch("aiperf.dataset.loader.base_trace_loader.parallel_decode")
     @patch("aiperf.dataset.composer.custom.check_file_exists")

--- a/tests/unit/dataset/loader/test_multi_turn.py
+++ b/tests/unit/dataset/loader/test_multi_turn.py
@@ -113,6 +113,19 @@ class TestMultiTurn:
         assert data.turns[0].texts[0].name == "question"
         assert data.turns[0].images[0].name == "main_image"
 
+    def test_create_with_per_turn_output_length(self):
+        """Test creating conversation with per-turn output_length."""
+        data = MultiTurn(
+            session_id="test_session",
+            turns=[
+                SingleTurn(text="Write briefly.", output_length=50),
+                SingleTurn(text="Explain in detail.", output_length=500),
+            ],
+        )
+
+        assert data.turns[0].output_length == 50
+        assert data.turns[1].output_length == 500
+
     def test_validation_empty_turns_raises_error(self):
         """Test that empty turns list raises validation error."""
         with pytest.raises(ValueError, match="At least one turn must be provided"):
@@ -552,6 +565,52 @@ class TestMultiTurnDatasetLoaderConvertToConversations:
         assert turn.texts[0].contents == ["What is this?"]
         assert turn.texts[1].name == "context"
         assert turn.texts[1].contents == ["Some context"]
+
+    def test_convert_with_per_turn_output_length(self, default_user_config):
+        """Test converting multi-turn data with output_length sets Turn.max_tokens."""
+        data = {
+            "session_1": [
+                MultiTurn(
+                    session_id="session_1",
+                    turns=[
+                        SingleTurn(text="Write briefly.", output_length=50),
+                        SingleTurn(text="Explain in detail.", output_length=500),
+                    ],
+                )
+            ]
+        }
+
+        loader = MultiTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        conversations = loader.convert_to_conversations(data)
+
+        assert len(conversations) == 1
+        assert conversations[0].turns[0].max_tokens == 50
+        assert conversations[0].turns[1].max_tokens == 500
+
+    def test_convert_mixed_output_length(self, default_user_config):
+        """Test converting data where some turns have output_length and others do not."""
+        data = {
+            "session_1": [
+                MultiTurn(
+                    session_id="session_1",
+                    turns=[
+                        SingleTurn(text="Specific length.", output_length=100),
+                        SingleTurn(text="No length specified."),
+                    ],
+                )
+            ]
+        }
+
+        loader = MultiTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        conversations = loader.convert_to_conversations(data)
+
+        assert len(conversations) == 1
+        assert conversations[0].turns[0].max_tokens == 100
+        assert conversations[0].turns[1].max_tokens is None
 
     def test_convert_multiple_sessions(self, default_user_config):
         """Test converting multiple sessions."""

--- a/tests/unit/dataset/loader/test_single_turn.py
+++ b/tests/unit/dataset/loader/test_single_turn.py
@@ -61,6 +61,29 @@ class TestSingleTurn:
         assert data.timestamp == 1000
         assert data.delay is None
 
+    def test_create_with_output_length(self):
+        """Test creating SingleTurn with output_length."""
+        data = SingleTurn(text="Write a haiku.", output_length=50)
+
+        assert data.text == "Write a haiku."
+        assert data.output_length == 50
+
+    def test_create_with_output_length_default_is_none(self):
+        """Test that output_length defaults to None."""
+        data = SingleTurn(text="Hello")
+
+        assert data.output_length is None
+
+    def test_create_with_output_length_zero_raises(self):
+        """Test that output_length=0 raises validation error."""
+        with pytest.raises(ValueError):
+            SingleTurn(text="Hello", output_length=0)
+
+    def test_create_with_output_length_negative_raises(self):
+        """Test that negative output_length raises validation error."""
+        with pytest.raises(ValueError):
+            SingleTurn(text="Hello", output_length=-1)
+
     def test_create_with_delay(self):
         """Test creating SingleTurn with delay."""
         data = SingleTurn(text="Who are you?", delay=1234)
@@ -267,6 +290,27 @@ class TestSingleTurnDatasetLoader:
         assert turn2[0].delay == 1234
         assert turn2[0].timestamp is None
 
+    def test_load_dataset_with_output_length(
+        self, create_jsonl_file, default_user_config
+    ):
+        """Test loading dataset with output_length field."""
+        content = [
+            '{"text": "Write a haiku.", "output_length": 50}',
+            '{"text": "Explain quantum computing.", "output_length": 500}',
+        ]
+        filename = create_jsonl_file(content)
+
+        loader = SingleTurnDatasetLoader(
+            filename=filename, user_config=default_user_config
+        )
+        dataset = loader.load_dataset()
+
+        assert len(dataset) == 2
+
+        turn1, turn2 = list(dataset.values())
+        assert turn1[0].output_length == 50
+        assert turn2[0].output_length == 500
+
     def test_load_dataset_with_full_featured_version(
         self, create_jsonl_file, default_user_config
     ):
@@ -424,6 +468,56 @@ class TestSingleTurnDatasetLoaderConvertToConversations:
         assert second_turn.timestamp is None
         assert second_turn.delay == 500
         assert second_turn.role == "user"
+
+    def test_convert_with_output_length(self, default_user_config):
+        """Test converting data with output_length sets Turn.max_tokens."""
+        loader = SingleTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        data = {
+            "session_1": [SingleTurn(text="Write a haiku.", output_length=50)],
+        }
+
+        conversations = loader.convert_to_conversations(data)
+
+        assert len(conversations) == 1
+        assert conversations[0].turns[0].max_tokens == 50
+
+    def test_convert_without_output_length_is_none(self, default_user_config):
+        """Test converting data without output_length leaves Turn.max_tokens as None."""
+        loader = SingleTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        data = {
+            "session_1": [SingleTurn(text="Hello")],
+        }
+
+        conversations = loader.convert_to_conversations(data)
+
+        assert len(conversations) == 1
+        assert conversations[0].turns[0].max_tokens is None
+
+    def test_convert_multimodal_with_output_length(self, default_user_config):
+        """Test converting multimodal data with output_length sets Turn.max_tokens."""
+        loader = SingleTurnDatasetLoader(
+            filename="dummy.jsonl", user_config=default_user_config
+        )
+        data = {
+            "session_1": [
+                SingleTurn(
+                    text="Describe this image.",
+                    image="https://example.com/image.png",
+                    output_length=200,
+                )
+            ],
+        }
+
+        conversations = loader.convert_to_conversations(data)
+
+        turn = conversations[0].turns[0]
+        assert turn.max_tokens == 200
+        assert len(turn.texts) == 1
+        assert len(turn.images) == 1
 
     def test_convert_structured_text_objects(self, default_user_config):
         """Test converting data with structured Text objects."""


### PR DESCRIPTION
When using `--input-file` with custom JSONL datasets, there is no way to control the output sequence length (OSL) per request. Users can only set OSL globally via `--osl`, which applies uniformly to all requests. Trace formats (mooncake_trace, bailian_trace) already support per-line `output_length`, but the simpler single_turn and multi_turn formats do not.

## Solution

Add an `output_length` field to the `SingleTurn` JSONL schema. Since `MultiTurn` reuses `SingleTurn` for its turns, this enables per-turn output length in both formats with a single model change. The loader maps `output_length` to `Turn.max_tokens` internally, matching the existing trace loader pattern.

A guard in the composer's `_set_max_tokens()` ensures per-line values are never overwritten by global config. This also fixes a latent bug where trace datasets' `output_length` was overwritten when `--osl` was simultaneously specified.

### Precedence

1. Per-line `output_length` from input file (highest)
2. Global `--osl` / `--seq-dist` (fallback for lines without `output_length`)
3. Neither set: `max_tokens` remains `None` (server decides)

### Example

```jsonl
{"text": "Write a haiku.", "output_length": 50}
{"text": "Explain quantum computing.", "output_length": 500}
{"text": "Summarize machine learning."}
```

```bash
aiperf profile \
    --model my-model \
    --endpoint-type chat \
    --input-file prompts.jsonl \
    --url localhost:8000 \
    --osl 200
```

Requests 1 and 2 use their per-line values (50, 500). Request 3 falls back to `--osl 200`.

## Changes

### Production code

| File | Change |
|------|--------|
| `src/aiperf/dataset/loader/models.py` | Add `output_length: int \| None` field to `SingleTurn` with `gt=0` validation |
| `src/aiperf/dataset/loader/single_turn.py` | Pass `single_turn.output_length` to `Turn(max_tokens=...)` during conversion |
| `src/aiperf/dataset/loader/multi_turn.py` | Same passthrough for multi-turn turns |
| `src/aiperf/dataset/composer/base.py` | Guard in `_set_max_tokens()`: skip if `turn.max_tokens` is already set |

### Tests

| File | Change |
|------|--------|
| `tests/unit/dataset/loader/test_single_turn.py` | Model validation (happy path, zero, negative), JSONL loading, conversion with/without `output_length`, multimodal + `output_length` |
| `tests/unit/dataset/loader/test_multi_turn.py` | Per-turn model storage, conversion, mixed (some turns with, some without) |
| `tests/unit/dataset/composer/test_base_composer.py` | Guard preserves existing `max_tokens` with both global config and sequence distribution |
| `tests/unit/dataset/composer/test_custom_composer.py` | Updated trace test for new precedence; end-to-end single_turn and multi_turn precedence through full `CustomDatasetComposer` pipeline |

### Documentation

| File | Change |
|------|--------|
| `docs/tutorials/custom-dataset.md` | New "Per-Request Output Length" section with example and precedence explanation |
| `docs/tutorials/vision.md` | Added `output_length` to some example lines to show the field is available for multimodal inputs |

## Verification

- `uv run ruff format . && uv run ruff check --fix .` -- all clean
- `uv run pytest tests/unit/ -n auto` -- 7951 passed, 0 failed
- `uv run pre-commit run --all-files` -- all hooks passed
- Runtime reproduction with mock server confirmed correct `max_tokens` values in HTTP payloads for all three precedence cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request output-length control: individual prompts can cap generated tokens and override global output-length settings.

* **Documentation**
  * Tutorials updated with examples and precedence rules for per-request and global output-length configuration in single-turn and multi-turn datasets.

* **Bug Fixes**
  * Ensured per-request output-length values are honored and not overwritten by global sampling behavior.

* **Tests**
  * Added unit tests covering per-request output-length parsing, precedence, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->