### PR TITLE
fix(ci): prevent Fern Docs preview from overwriting install instructions comment

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -263,13 +263,39 @@ jobs:
 
       - name: Comment preview URL on PR
         if: steps.ctx.outputs.is_main != 'true' && steps.preview.outputs.url != '' && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --edit-last --create-if-none \
-            --body "**Fern Docs Preview:** ${{ steps.preview.outputs.url }}/dev"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const commentIdentifier = '<!-- fern-docs-preview -->';
+            const body = `${commentIdentifier}\n**Fern Docs Preview:** ${{ steps.preview.outputs.url }}/dev`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes(commentIdentifier)
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }
 
       ##########################################################################
       # PUSH AND PUBLISH - push changes to docs-website branch and publish docs


### PR DESCRIPTION
* The "Comment with install instructions" GitHub Action silently fails to persist its comment on any PR that touches `docs/` or `fern/` files.
* The workflow runs successfully and logs "Created new comment with commit SHA", but the comment is immediately overwritten.

### Root cause

Two workflows post PR comments as `github-actions[bot]`:

| Workflow | Trigger | Comment method |
|---|---|---|
| `pr-install-instructions.yaml` | `pull_request_target` (all PRs) | Marker-based (`<!-- aiperf-pr-install-instructions -->`) |
| `fern-docs.yml` | `pull_request` (PRs touching `docs/**` or `fern/**`) | `gh pr comment --edit-last --create-if-none` |

`--edit-last` finds the most recent comment from the authenticated user (`github-actions[bot]`) and replaces its body — regardless of which workflow created it. When both workflows fire on the same PR, the Fern Docs preview overwrites the install instructions.

**Evidence:** Perfect correlation across PRs 821-830 — every PR with `docs/` changes is missing the install comment; every PR without `docs/` changes has it.

### Fix

Replace the `--edit-last` shell command in `fern-docs.yml` with the same marker-based approach used by the install instructions workflow:

- Add a `<!-- fern-docs-preview -->` HTML comment identifier
- Use `actions/github-script@v7` to find-or-create only the Fern preview comment
- Leave all other `github-actions[bot]` comments untouched

### Files changed

- `.github/workflows/fern-docs.yml` — "Comment preview URL on PR" step

### Verification

- Push to a PR that touches `docs/` files
- Confirm both the install instructions comment and the Fern Docs preview comment appear as separate comments