### PR TITLE
fix(ci): skip venv-dependent hooks in pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+ci:
+  skip:
+    - add-license
+    - generate-cli-docs
+    - generate-env-vars-docs
+    - generate-plugin-artifacts
+    - validate-plugin-schemas
+    - test-imports
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0  # Use the latest stable version


### PR DESCRIPTION
The pre-commit.ci GitHub App was installed on [ai-dynamo/aiperf](https://github.com/ai-dynamo/aiperf) on 2026-04-15. All 6 local hooks fail because pre-commit.ci's sandboxed environment has no `.venv`. This blocks the entire pre-commit.ci job, including the auto-push feature (i.e. the reason pre-commit.ci was installed). These hooks are already covered by the GitHub Actions `Pre-commit` job which has the full environment.

🟢 **Review: trivial** — single config addition, no code changes.

### Files modified

- `.pre-commit-config.yaml` (single edit)

### Verification

- `pre-commit run --all-files` passes locally (confirms no local regression)
- After push, confirm pre-commit.ci check passes on the PR (portable hooks run, local hooks skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit configuration to skip specific validation checks during continuous integration runs, allowing the CI pipeline to execute more efficiently while maintaining all checks for local development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->