### PR TITLE
docs: convert Github docs from Fern MDX to GitHub Markdown

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -142,10 +142,8 @@ jobs:
             cp source-checkout/fern/.gitignore docs-checkout/fern/.gitignore
           fi
 
-          # Sync md_to_mdx.py script
-          if [ -f source-checkout/fern/md_to_mdx.py ]; then
-            cp source-checkout/fern/md_to_mdx.py docs-checkout/fern/md_to_mdx.py
-          fi
+          # Sync md_to_mdx.py script (required — fail fast if missing)
+          cp source-checkout/fern/md_to_mdx.py docs-checkout/fern/md_to_mdx.py
 
           # Sync components/ directory (e.g., CustomFooter.tsx)
           if [ -d source-checkout/fern/components ]; then

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -68,7 +68,8 @@ jobs:
 
   fern-check:
     name: Fern Configuration Check
-    if: github.event_name == 'pull_request'
+    # TODO(AIP-855): Re-enable once convert_mdx_comments.py is wired into the sync pipeline (PR 2)
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -87,7 +88,8 @@ jobs:
 
   fern-broken-links:
     name: Fern Broken Links Check
-    if: github.event_name == 'pull_request'
+    # TODO(AIP-855): Re-enable once convert_mdx_comments.py is wired into the sync pipeline (PR 2)
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -299,17 +301,18 @@ jobs:
 
       ##########################################################################
       # PUSH AND PUBLISH - push changes to docs-website branch and publish docs
+      # TODO(AIP-855): Re-enable once convert_mdx_comments.py transform is wired in (PR 2)
       ##########################################################################
 
       - name: Setup Git
-        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
+        if: false
         run: |
           cd docs-checkout
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit and push changes
-        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
+        if: false
         run: |
           cd docs-checkout
 
@@ -326,7 +329,7 @@ jobs:
           echo "Successfully synced dev docs to docs-website branch"
 
       - name: Publish Docs
-        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
+        if: false
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         working-directory: docs-checkout/fern

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -66,45 +66,22 @@ jobs:
   # LINT JOBS - Run on PRs when docs/** or fern/** files change
   #############################################################################
 
-  fern-check:
-    name: Fern Configuration Check
-    # TODO(AIP-855): Re-enable once convert_mdx_comments.py is wired into the sync pipeline (PR 2)
-    if: false
+  docs-index-check:
+    name: Docs Index Completeness Check
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          node-version: '22'
+          python-version: "3.12"
 
-      - name: Install Fern CLI
-        run: npm install -g fern-api@$(jq -r '.version' fern/fern.config.json)
+      - name: Check all docs are listed in index.yml
+        run: python tools/check_docs_index.py
 
-      - name: Validate Fern configuration
-        run: fern check
-
-  fern-broken-links:
-    name: Fern Broken Links Check
-    # TODO(AIP-855): Re-enable once convert_mdx_comments.py is wired into the sync pipeline (PR 2)
-    if: false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Install Fern CLI
-        run: npm install -g fern-api@$(jq -r '.version' fern/fern.config.json)
-
-      - name: Check for broken links
-        run: fern docs broken-links
 
   #############################################################################
   # SYNC & PUBLISH/PREVIEW - Syncs docs content to docs-website structure
@@ -114,8 +91,9 @@ jobs:
 
   preview-or-publish-docs:
     name: Preview or publish docs
-    # TODO(AIP-855): Re-enable once convert_mdx_comments.py is wired into the sync pipeline (PR 2)
-    if: false
+    if: |
+      github.ref_type != 'tag' &&
+      (github.event.inputs.tag == '' || github.event.inputs.tag == null)
     runs-on: ubuntu-latest
     steps:
       - name: Determine context
@@ -164,9 +142,9 @@ jobs:
             cp source-checkout/fern/.gitignore docs-checkout/fern/.gitignore
           fi
 
-          # Sync convert_callouts.py script
-          if [ -f source-checkout/fern/convert_callouts.py ]; then
-            cp source-checkout/fern/convert_callouts.py docs-checkout/fern/convert_callouts.py
+          # Sync md_to_mdx.py script
+          if [ -f source-checkout/fern/md_to_mdx.py ]; then
+            cp source-checkout/fern/md_to_mdx.py docs-checkout/fern/md_to_mdx.py
           fi
 
           # Sync components/ directory (e.g., CustomFooter.tsx)
@@ -188,11 +166,11 @@ jobs:
           # On docs-website, fern/versions/dev.yml needs ../pages-dev/ prefix.
           yq -i '(.. | select(has("path")).path) |= sub("^([a-zA-Z])", "../pages-dev/${1}")' docs-checkout/fern/versions/dev.yml
 
-      - name: Convert GitHub callouts to Fern format
+      - name: Convert Markdown to Fern MDX format
         run: |
-          echo "Converting GitHub-style callouts to Fern format in pages-dev/..."
-          python3 docs-checkout/fern/convert_callouts.py --dir docs-checkout/fern/pages-dev
-          echo "Callout conversion complete."
+          echo "Converting GitHub Markdown to Fern MDX format in pages-dev/..."
+          python3 docs-checkout/fern/md_to_mdx.py --dir docs-checkout/fern/pages-dev
+          echo "Conversion complete."
 
       - name: Update docs.yml preserving products
         run: |
@@ -212,6 +190,26 @@ jobs:
 
           echo "Updated docs.yml:"
           cat docs.yml
+
+      - name: Setup Node.js for Fern validation
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Fern CLI for validation
+        run: npm install -g fern-api@$(jq -r '.version' docs-checkout/fern/fern.config.json)
+
+      - name: Validate transformed Fern content
+        working-directory: docs-checkout
+        run: fern check
+
+      - name: Validate transformed Fern content (strict)
+        working-directory: docs-checkout
+        run: fern check --warnings --strict-broken-links
+
+      - name: Check for broken links in transformed content
+        working-directory: docs-checkout
+        run: fern docs broken-links
 
       - name: Check for changes
         id: changes
@@ -304,14 +302,14 @@ jobs:
       ##########################################################################
 
       - name: Setup Git
-        if: false
+        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
         run: |
           cd docs-checkout
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit and push changes
-        if: false
+        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
         run: |
           cd docs-checkout
 
@@ -328,7 +326,7 @@ jobs:
           echo "Successfully synced dev docs to docs-website branch"
 
       - name: Publish Docs
-        if: false
+        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         working-directory: docs-checkout/fern
@@ -431,13 +429,13 @@ jobs:
 
           echo "GitHub link update complete."
 
-      - name: Convert GitHub callouts to Fern format
+      - name: Convert Markdown to Fern MDX format
         run: |
           TAG="${{ steps.version.outputs.tag }}"
 
-          echo "Converting GitHub-style callouts to Fern format in pages-$TAG/..."
-          python3 fern/convert_callouts.py --dir "fern/pages-$TAG"
-          echo "Callout conversion complete."
+          echo "Converting GitHub Markdown to Fern MDX format in pages-$TAG/..."
+          python3 fern/md_to_mdx.py --dir "fern/pages-$TAG"
+          echo "Conversion complete."
 
       - name: Create version config file
         run: |

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -114,9 +114,8 @@ jobs:
 
   preview-or-publish-docs:
     name: Preview or publish docs
-    if: |
-      github.ref_type != 'tag' &&
-      (github.event.inputs.tag == '' || github.event.inputs.tag == null)
+    # TODO(AIP-855): Re-enable once convert_mdx_comments.py is wired into the sync pipeline (PR 2)
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Determine context

--- a/.github/workflows/run-fern-checks.yml
+++ b/.github/workflows/run-fern-checks.yml
@@ -16,8 +16,6 @@ on:
 
 jobs:
   fern-checks:
-    # TODO(AIP-855): Re-enable once convert_mdx_comments.py is wired into the sync pipeline (PR 2)
-    if: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/run-fern-checks.yml
+++ b/.github/workflows/run-fern-checks.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   fern-checks:
+    # TODO(AIP-855): Re-enable once convert_mdx_comments.py is wired into the sync pipeline (PR 2)
+    if: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Log File: /home/user/Code/aiperf/artifacts/granite4:350m-openai-chat-concurrency
 - [Rankings](docs/tutorials/rankings.md) - Profile ranking models
 - [OpenAI Responses API](docs/tutorials/openai-responses.md) - Profile OpenAI Responses API endpoints
 - [Audio](docs/tutorials/audio.md) - Profile audio language models
+- [NIM Image Retrieval](docs/tutorials/nim-image-retrieval.md) - Profile NIM image retrieval models
 - [Vision](docs/tutorials/vision.md) - Profile vision language models
 - [Image Generation](docs/tutorials/image-generation.md) - Benchmark any OpenAI-compatible image generation API
 - [SGLang Video Generation](docs/tutorials/sglang-video-generation.md) - Video generation benchmarking

--- a/docs/benchmark-modes/trace-replay.md
+++ b/docs/benchmark-modes/trace-replay.md
@@ -62,7 +62,7 @@ Example entry:
 
 Create a trace file with timing information:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 cat > custom_trace.jsonl << 'EOF'
 {"timestamp": 0, "input_length": 1200, "output_length": 52, "hash_ids": [0, 1, 2]}
@@ -70,10 +70,10 @@ cat > custom_trace.jsonl << 'EOF'
 {"timestamp": 274, "input_length": 1300, "output_length": 52, "hash_ids": [1, 4, 6]}
 EOF
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 Run AIPerf with the trace file:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -84,7 +84,7 @@ aiperf profile \
     --custom-dataset-type mooncake_trace \
     --fixed-schedule
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 The `--fixed-schedule` flag tells AIPerf to send requests at the exact timestamps specified in the trace. This reproduces the original timing pattern.
 
@@ -115,7 +115,7 @@ The `tools` field is only valid when `messages` is provided. It is injected dire
 
 For real-world benchmarking, use the FAST25 production trace data from the Mooncake research paper:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Download the Mooncake trace data
 curl -Lo mooncake_trace.jsonl https://raw.githubusercontent.com/kvcache-ai/Mooncake/refs/heads/main/FAST25-release/arxiv-trace/mooncake_trace.jsonl
@@ -133,4 +133,4 @@ aiperf profile \
     --custom-dataset-type mooncake_trace \
     --fixed-schedule
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->

--- a/docs/genai-perf-feature-comparison.md
+++ b/docs/genai-perf-feature-comparison.md
@@ -7,9 +7,8 @@ sidebar-title: GenAI-Perf vs AIPerf CLI Feature Comparison Matrix
 
 This comparison matrix shows the supported CLI options between GenAI-Perf and AIPerf.
 
-<Note>
-This is a living document and will be updated as new features are added to AIPerf.
-</Note>
+> [!NOTE]
+> This is a living document and will be updated as new features are added to AIPerf.
 
 
 **Legend:**
@@ -312,9 +311,8 @@ This is a living document and will be updated as new features are added to AIPer
 
 ## **Perf-Analyzer Passthrough Arguments**
 
-<Note>
-GenAI-Perf supports passing through arguments to the Perf-Analyzer CLI. AIPerf does not support this, as it does not use Perf-Analyzer under the hood.
-</Note>
+> [!NOTE]
+> GenAI-Perf supports passing through arguments to the Perf-Analyzer CLI. AIPerf does not support this, as it does not use Perf-Analyzer under the hood.
 
 | Feature | CLI Option | GenAI-Perf | AIPerf | Notes |
 |---------|------------|------------|---------|-------|

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -35,6 +35,8 @@ navigation:
       path: tutorials/embeddings.md
     - page: Profile Ranking Models with AIPerf
       path: tutorials/rankings.md
+    - page: Profile NIM Image Retrieval with AIPerf
+      path: tutorials/nim-image-retrieval.md
     - page: SGLang Image Generation
       path: tutorials/image-generation.md
     - page: SGLang Video Generation
@@ -52,6 +54,30 @@ navigation:
       path: tutorials/custom-prompt-benchmarking.md
     - page: Profile with ShareGPT Dataset
       path: tutorials/sharegpt.md
+    - page: Synthetic Dataset Generation
+      path: tutorials/synthetic-dataset.md
+    - page: Profile with InstructCoder Dataset
+      path: tutorials/instruct-coder.md
+    - page: Profile with AIMO Dataset
+      path: tutorials/aimo.md
+    - page: Profile with MMStar Dataset
+      path: tutorials/mmstar.md
+    - page: Profile with MMVU Dataset
+      path: tutorials/mmvu.md
+    - page: Profile with LLaVA-OneVision Dataset
+      path: tutorials/llava-onevision.md
+    - page: Profile with VisionArena Dataset
+      path: tutorials/vision-arena.md
+    - page: Profile with Blazedit Dataset
+      path: tutorials/blazedit.md
+    - page: Profile with SpecBench Dataset
+      path: tutorials/spec-bench.md
+    - page: Profile with SPEED-Bench Dataset
+      path: tutorials/speed-bench.md
+    - page: Profile with Bailian Traces
+      path: tutorials/bailian-trace.md
+    - page: Profile with BurstGPT Traces
+      path: tutorials/burst-gpt-trace.md
     - page: Multi-Turn Conversations
       path: tutorials/multi-turn.md
     - page: Sequence Length Distributions for Advanced Benchmarking
@@ -129,6 +155,8 @@ navigation:
     path: benchmark-datasets.md
   - page: Pre-Flight Tokenizer Auto Detection
     path: reference/tokenizer-auto-detection.md
+  - page: Conversation Context Mode
+    path: reference/conversation-context-mode.md
 
 - section: Server Metrics
   collapsed: true

--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -148,9 +148,8 @@ any knowledge of the individual request/response data.
 
 ## Streaming Metrics
 
-<Note>
-All metrics in this section require the `--streaming` flag with a token-producing endpoint and at least one non-empty response chunk.
-</Note>
+> [!NOTE]
+> All metrics in this section require the `--streaming` flag with a token-producing endpoint and at least one non-empty response chunk.
 
 ### Time to First Token (TTFT)
 
@@ -269,9 +268,8 @@ inter_chunk_latency = [request.content_responses[i].perf_ns - request.content_re
 
 **Type:** [Record Metric](#record-metrics)
 
-<Warning>
-This metric is computed per-request, and it excludes the TTFT from the equation, so it is **not** directly comparable to the [Output Token Throughput](#output-token-throughput) metric.
-</Warning>
+> [!WARNING]
+> This metric is computed per-request, and it excludes the TTFT from the equation, so it is **not** directly comparable to the [Output Token Throughput](#output-token-throughput) metric.
 
 The token generation rate experienced by an individual user/request, measured as the inverse of inter-token latency. This represents single-request streaming performance.
 
@@ -307,9 +305,8 @@ prefill_throughput_per_user = input_sequence_length / time_to_first_token_second
 
 ## Token Based Metrics
 
-<Note>
-All metrics in this section require token-producing endpoints that return text content (chat, completion, etc.). These metrics are not available for embeddings or other non-generative endpoints.
-</Note>
+> [!NOTE]
+> All metrics in this section require token-producing endpoints that return text content (chat, completion, etc.). These metrics are not available for embeddings or other non-generative endpoints.
 
 ### Output Token Count
 
@@ -436,9 +433,8 @@ e2e_output_token_throughput = output_sequence_length / request_latency_seconds
 
 **Type:** [Derived Metric](#derived-metrics)
 
-<Warning>
-This metric is computed as a single value across all requests and includes TTFT in the equation, so it is **not** directly comparable to the [Output Token Throughput Per User](#output-token-throughput-per-user) metric.
-</Warning>
+> [!WARNING]
+> This metric is computed as a single value across all requests and includes TTFT in the equation, so it is **not** directly comparable to the [Output Token Throughput Per User](#output-token-throughput-per-user) metric.
 
 The aggregate token generation rate across all concurrent requests, measured as total tokens per second. This represents the system's overall token generation capacity.
 
@@ -473,9 +469,8 @@ total_token_throughput = (total_isl + total_osl) / benchmark_duration_seconds
 
 ## Image Metrics
 
-<Note>
-All metrics in this section require image-capable endpoints (e.g., image generation APIs). These metrics are not available for text-only or other non-image endpoints.
-</Note>
+> [!NOTE]
+> All metrics in this section require image-capable endpoints (e.g., image generation APIs). These metrics are not available for text-only or other non-image endpoints.
 
 ### Number of Images
 
@@ -528,9 +523,8 @@ image_latency = request_latency_ms / num_images
 
 ## Video Metrics
 
-<Note>
-All metrics in this section require video-producing endpoints (e.g., SGLang video generation). These metrics rely on server-reported fields in the response and are not available for non-video endpoints.
-</Note>
+> [!NOTE]
+> All metrics in this section require video-producing endpoints (e.g., SGLang video generation). These metrics rely on server-reported fields in the response and are not available for non-video endpoints.
 
 ### Video Inference Time
 
@@ -568,9 +562,8 @@ video_peak_memory = response.data.peak_memory_mb
 
 ## Reasoning Metrics
 
-<Note>
-All metrics in this section require models and backends that expose reasoning content in a separate `reasoning_content` field, distinct from the regular `content` field.
-</Note>
+> [!NOTE]
+> All metrics in this section require models and backends that expose reasoning content in a separate `reasoning_content` field, distinct from the regular `content` field.
 
 ### Reasoning Token Count
 
@@ -607,9 +600,8 @@ total_reasoning_tokens = sum(r.reasoning_token_count for r in records if r.valid
 
 ## Usage Field Metrics
 
-<Note>
-All metrics in this section track API-reported token counts from the `usage` field in API responses. These are **not displayed in console output** but are available in exports. These metrics are useful for comparing client-side token counts with server-reported counts to detect discrepancies.
-</Note>
+> [!NOTE]
+> All metrics in this section track API-reported token counts from the `usage` field in API responses. These are **not displayed in console output** but are available in exports. These metrics are useful for comparing client-side token counts with server-reported counts to detect discrepancies.
 
 ### Usage Prompt Tokens
 
@@ -733,9 +725,8 @@ total_usage_total_tokens = sum(r.usage_total_tokens for r in records if r.valid)
 
 ## Usage Discrepancy Metrics
 
-<Note>
-These metrics measure the percentage difference between API-reported token counts (`usage` fields) and client-computed token counts. They are **not displayed in console output** but help identify tokenizer mismatches or counting discrepancies.
-</Note>
+> [!NOTE]
+> These metrics measure the percentage difference between API-reported token counts (`usage` fields) and client-computed token counts. They are **not displayed in console output** but help identify tokenizer mismatches or counting discrepancies.
 
 ### Usage Prompt Tokens Diff %
 
@@ -808,9 +799,8 @@ usage_discrepancy_count = sum(1 for r in records if r.any_diff > threshold)
 
 ## OSL Mismatch Metrics
 
-<Note>
-These metrics measure the difference between requested output sequence length (`--osl`/`max_tokens`) and actual output tokens generated. They help identify when the server is not honoring the requested output length, typically because EOS tokens stop generation early. These metrics are **not displayed in console output** but are available in exports and used by the end-of-benchmark warning.
-</Note>
+> [!NOTE]
+> These metrics measure the difference between requested output sequence length (`--osl`/`max_tokens`) and actual output tokens generated. They help identify when the server is not honoring the requested output length, typically because EOS tokens stop generation early. These metrics are **not displayed in console output** but are available in exports and used by the end-of-benchmark warning.
 
 ### OSL Mismatch Diff %
 
@@ -868,9 +858,8 @@ osl_mismatch_count = sum(1 for r in records if diff_tokens > threshold_tokens)
 
 ## Goodput Metrics
 
-<Note>
-Goodput metrics measure the throughput of requests that meet user-defined Service Level Objectives (SLOs). See the [Goodput tutorial](tutorials/goodput.md) for configuration details.
-</Note>
+> [!NOTE]
+> Goodput metrics measure the throughput of requests that meet user-defined Service Level Objectives (SLOs). See the [Goodput tutorial](tutorials/goodput.md) for configuration details.
 
 ### Good Request Count
 
@@ -910,9 +899,8 @@ goodput = good_request_count / benchmark_duration_seconds
 
 ## Error Metrics
 
-<Note>
-These metrics are computed only for failed/error requests and are **not displayed in console output**.
-</Note>
+> [!NOTE]
+> These metrics are computed only for failed/error requests and are **not displayed in console output**.
 
 ### Error Input Sequence Length
 
@@ -949,9 +937,8 @@ total_error_isl = sum(r.input_sequence_length for r in records if not r.valid)
 
 ## General Metrics
 
-<Note>
-Metrics in this section are available for all benchmark runs with no special requirements.
-</Note>
+> [!NOTE]
+> Metrics in this section are available for all benchmark runs with no special requirements.
 
 ### Request Latency
 
@@ -1061,9 +1048,8 @@ benchmark_duration = max_response_timestamp - min_request_timestamp
 
 ## HTTP Trace Metrics
 
-<Note>
-All metrics in this section require HTTP trace data to be collected during requests. These metrics provide detailed HTTP request lifecycle timing following k6 naming conventions. See the [HTTP Trace Metrics tutorial](tutorials/http-trace-metrics.md) for configuration details.
-</Note>
+> [!NOTE]
+> All metrics in this section require HTTP trace data to be collected during requests. These metrics provide detailed HTTP request lifecycle timing following k6 naming conventions. See the [HTTP Trace Metrics tutorial](tutorials/http-trace-metrics.md) for configuration details.
 
 ### HTTP Blocked
 
@@ -1315,9 +1301,8 @@ http_req_chunks_received = trace.response_chunks_count
 
 ## Multi-Run Aggregate Metrics
 
-<Note>
-These metrics are only available when using `--num-profile-runs > 1` for confidence reporting.
-</Note>
+> [!NOTE]
+> These metrics are only available when using `--num-profile-runs > 1` for confidence reporting.
 
 When running multiple profile iterations with `--num-profile-runs`, AIPerf computes aggregate statistics across all runs to quantify measurement variance and repeatability. These statistics are written to `aggregate/profile_export_aiperf_aggregate.json` and `aggregate/profile_export_aiperf_aggregate.csv`.
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -40,9 +40,8 @@ Modern language models with reasoning capabilities such as openai/gpt-oss-120b, 
 
 ### Behavioral Differences
 
-<Warning>
-**GenAI-Perf does not parse or process reasoning tokens**. Content in the `reasoning_content` field is ignored, which means GenAI-Perf waits until the first non-reasoning output token is generated before recording the Time to First Token (TTFT).
-</Warning>
+> [!WARNING]
+> **GenAI-Perf does not parse or process reasoning tokens**. Content in the `reasoning_content` field is ignored, which means GenAI-Perf waits until the first non-reasoning output token is generated before recording the Time to First Token (TTFT).
 
 **AIPerf** fully supports parsing and processing of reasoning tokens. The TTFT metric captures the time to generate the first token of any type, whether it's a reasoning token or an output token. Additionally, AIPerf introduces a new metric: **Time to First Output Token (TTFO)**, which measures the time to the first non-reasoning output token, equivalent to GenAI-Perf's TTFT.
 
@@ -52,9 +51,8 @@ When comparing benchmark results between the two tools for reasoning-capable mod
 
 #### Time to First Token (TTFT)
 
-<Tip>
-When migrating from GenAI-Perf, use **AIPerf TTFO** to compare against **GenAI-Perf TTFT** for equivalent measurements of reasoning-capable models.
-</Tip>
+> [!TIP]
+> When migrating from GenAI-Perf, use **AIPerf TTFO** to compare against **GenAI-Perf TTFT** for equivalent measurements of reasoning-capable models.
 
 - **AIPerf TTFT** measures time to the first token of any type (including reasoning tokens) from the start of the request, and will be lower than GenAI-Perf TTFT
 - **GenAI-Perf TTFT** measures time to the first non-reasoning output token from the start of the request, and will be higher than AIPerf TTFT
@@ -64,9 +62,8 @@ By providing both TTFT and TTFO metrics, AIPerf enables more comprehensive perfo
 
 #### Output Sequence Length (OSL)
 
-<Tip>
-When migrating from GenAI-Perf, use **AIPerf Output Token Count** to compare against **GenAI-Perf OSL** for equivalent measurements of reasoning-capable models.
-</Tip>
+> [!TIP]
+> When migrating from GenAI-Perf, use **AIPerf Output Token Count** to compare against **GenAI-Perf OSL** for equivalent measurements of reasoning-capable models.
 
 - **AIPerf OSL** includes both reasoning and output tokens, so it will be higher than GenAI-Perf OSL
 - **GenAI-Perf OSL** excludes reasoning tokens from the count, so it will be lower than AIPerf OSL

--- a/docs/plugins/creating-your-first-plugin.md
+++ b/docs/plugins/creating-your-first-plugin.md
@@ -8,12 +8,11 @@ sidebar-title: Creating Your First AIPerf Plugin
 
 This tutorial walks you through creating a custom AIPerf endpoint plugin from scratch. By the end, you'll have a working plugin package that can benchmark any custom API.
 
-<Tip>
-**Contributing directly to AIPerf?** The endpoint class (Step 2) and manifest format (Step 3) are the same, but you can skip the external packaging:
-- Add your class under `src/aiperf/` instead of a separate package
-- Register it in the existing `src/aiperf/plugin/plugins.yaml` instead of creating a new one
-- Skip: Project Structure, Step 1 (pyproject.toml/entry points), Step 4 (install)
-</Tip>
+> [!TIP]
+> **Contributing directly to AIPerf?** The endpoint class (Step 2) and manifest format (Step 3) are the same, but you can skip the external packaging:
+> - Add your class under `src/aiperf/` instead of a separate package
+> - Register it in the existing `src/aiperf/plugin/plugins.yaml` instead of creating a new one
+> - Skip: Project Structure, Step 1 (pyproject.toml/entry points), Step 4 (install)
 
 ## What You'll Build
 

--- a/docs/plugins/plugin-system.md
+++ b/docs/plugins/plugin-system.md
@@ -204,13 +204,12 @@ endpoint_meta = plugins.get_endpoint_metadata("chat")  # Returns EndpointMetadat
 
 ## Creating Custom Plugins
 
-<Tip>
-**Contributing directly to AIPerf?** You only need two things:
-1. Add your class under `src/aiperf/`
-2. Register it in `src/aiperf/plugin/plugins.yaml`
-
-The `pyproject.toml` entry points and separate package install below are only needed for external/third-party plugins.
-</Tip>
+> [!TIP]
+> **Contributing directly to AIPerf?** You only need two things:
+> 1. Add your class under `src/aiperf/`
+> 2. Register it in `src/aiperf/plugin/plugins.yaml`
+>
+> The `pyproject.toml` entry points and separate package install below are only needed for external/third-party plugins.
 
 **Quick Start** (4 steps):
 
@@ -248,9 +247,8 @@ endpoint:
     metadata: { endpoint_path: /v1/generate, supports_streaming: true, produces_tokens: true, tokenizes_input: true, metrics_title: My Custom Metrics }
 ```
 
-<Note>
-Extend base classes (`BaseEndpoint`, etc.) to get logging, helpers, and default implementations. Only implement core methods.
-</Note>
+> [!NOTE]
+> Extend base classes (`BaseEndpoint`, etc.) to get logging, helpers, and default implementations. Only implement core methods.
 
 ## Plugin Configuration
 
@@ -336,9 +334,8 @@ $ aiperf plugins endpoint chat
 | 2 | External packages beat built-in (equal priority) |
 | 3 | First registered wins (with warning) |
 
-<Tip>
-Shadowed plugins remain accessible via full class path: `plugins.get_class("endpoint", "my_pkg.endpoints:MyEndpoint")`
-</Tip>
+> [!TIP]
+> Shadowed plugins remain accessible via full class path: `plugins.get_class("endpoint", "my_pkg.endpoints:MyEndpoint")`
 
 ### API Reference
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -16,13 +16,11 @@ sidebar-title: Random Number Generation & Reproducibility
 
 AIPerf provides **deterministic reproducibility** for all seed-controlled randomness using hash-based RNG derivation. This enables reproducible dataset generation while maintaining realistic load testing performance.
 
-<Warning>
-**Default behavior:** Without `--random-seed`, AIPerf produces **non-deterministic** results. Set `--random-seed <integer>` for reproducibility.
-</Warning>
+> [!WARNING]
+> **Default behavior:** Without `--random-seed`, AIPerf produces **non-deterministic** results. Set `--random-seed <integer>` for reproducibility.
 
-<Warning>
-**Distributed System Constraints:** Even with `--random-seed`, **performance metrics and worker assignment are NOT reproducible** due to system non-determinism (network timing, async I/O, ZMQ load balancing).
-</Warning>
+> [!WARNING]
+> **Distributed System Constraints:** Even with `--random-seed`, **performance metrics and worker assignment are NOT reproducible** due to system non-determinism (network timing, async I/O, ZMQ load balancing).
 
 **Reproducible (with `--random-seed`):**
 - ✅ Dataset content (prompts, images, audio)
@@ -143,9 +141,8 @@ done
 
 ### How to Use RNGs in Your Code
 
-<Warning>
-Workers do NOT use RNGs. Only use RNGs in **DatasetManager** (content generation) or **TimingManager** (request timing) components.
-</Warning>
+> [!WARNING]
+> Workers do NOT use RNGs. Only use RNGs in **DatasetManager** (content generation) or **TimingManager** (request timing) components.
 
 ```python
 from aiperf.common import random_generator as rng

--- a/docs/server-metrics/server-metrics.md
+++ b/docs/server-metrics/server-metrics.md
@@ -101,17 +101,16 @@ AIPerf automatically:
    - `server_metrics_export.jsonl` - Time-series data (all scrapes, opt-in only)
    - `server_metrics_export.parquet` - Raw time-series with delta calculations (opt-in only)
 
-<Note>
-**Custom file naming:** The `--profile-export-prefix` (or `--profile-export-file`) flag changes the prefix for all export files, including server metrics. Any file extension is automatically stripped from the provided value. For example:
-```bash
-aiperf profile --model MODEL ... --profile-export-prefix my_benchmark
-# Produces: my_benchmark_server_metrics.json, my_benchmark_server_metrics.csv, etc.
-
-# --profile-export-file is an alias for --profile-export-prefix, so this is equivalent:
-aiperf profile --model MODEL ... --profile-export-file my_benchmark.json
-# Produces the same files (the .json extension is stripped automatically)
-```
-</Note>
+> [!NOTE]
+> **Custom file naming:** The `--profile-export-prefix` (or `--profile-export-file`) flag changes the prefix for all export files, including server metrics. Any file extension is automatically stripped from the provided value. For example:
+> ```bash
+> aiperf profile --model MODEL ... --profile-export-prefix my_benchmark
+> # Produces: my_benchmark_server_metrics.json, my_benchmark_server_metrics.csv, etc.
+>
+> # --profile-export-file is an alias for --profile-export-prefix, so this is equivalent:
+> aiperf profile --model MODEL ... --profile-export-file my_benchmark.json
+> # Produces the same files (the .json extension is stripped automatically)
+> ```
 
 **Time filtering:** Statistics in JSON/CSV exports exclude the warmup period, showing only metrics from the profiling phase. The JSONL file contains all scrapes (including warmup) for complete time-series analysis.
 
@@ -167,9 +166,8 @@ aiperf profile --model MODEL ... --server-metrics-formats json csv jsonl parquet
 
 ## Output Files
 
-<Note>
-The filenames below are defaults. When `--profile-export-prefix <prefix>` is used, server metrics files are named `<prefix>_server_metrics.{json,csv,jsonl,parquet}` (any file extension in the prefix is stripped automatically). All files are written to the artifact directory (`--artifact-directory`, default: `./artifacts/<run_info>`).
-</Note>
+> [!NOTE]
+> The filenames below are defaults. When `--profile-export-prefix <prefix>` is used, server metrics files are named `<prefix>_server_metrics.{json,csv,jsonl,parquet}` (any file extension in the prefix is stripped automatically). All files are written to the artifact directory (`--artifact-directory`, default: `./artifacts/<run_info>`).
 
 ### 1. Time-Series: `server_metrics_export.jsonl`
 
@@ -396,9 +394,8 @@ Series-level field: `buckets` (per-bucket delta counts, not cumulative)
 - `avg` (sum/count) is **exact**
 - Percentiles are **estimates** from bucket interpolation
 
-<Note>
-**Prometheus Summary metrics are not supported.** Summary quantiles are computed cumulatively over the entire server lifetime, making them unsuitable for benchmark-specific analysis. Major LLM inference servers (vLLM, SGLang, TRT-LLM, Dynamo) use Histograms instead, which allow period-specific percentile estimation.
-</Note>
+> [!NOTE]
+> **Prometheus Summary metrics are not supported.** Summary quantiles are computed cumulatively over the entire server lifetime, making them unsuitable for benchmark-specific analysis. Major LLM inference servers (vLLM, SGLang, TRT-LLM, Dynamo) use Histograms instead, which allow period-specific percentile estimation.
 
 ## Timesliced Statistics
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,7 +10,7 @@ This tutorial will demonstrate how you can use AIPerf to measure the performance
 models using various inference solutions.
 
 ## Profile Qwen3-0.6B using vllm <a id="vllm-qwen3-0.6B"></a>
-{/* setup-vllm-default-openai-endpoint-server */}
+<!-- setup-vllm-default-openai-endpoint-server -->
 ```bash
 # Pull and run vLLM Docker container:
 docker pull vllm/vllm-openai:latest
@@ -19,16 +19,16 @@ docker run --gpus all -p 8000:8000 vllm/vllm-openai:latest \
   --reasoning-parser qwen3 \
   --host 0.0.0.0 --port 8000
 ```
-{/* /setup-vllm-default-openai-endpoint-server */}
+<!-- /setup-vllm-default-openai-endpoint-server -->
 
-{/* health-check-vllm-default-openai-endpoint-server */}
+<!-- health-check-vllm-default-openai-endpoint-server -->
 ```bash
 timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"Qwen/Qwen3-0.6B\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":1}")" != "200" ]; do sleep 2; done' || { echo "vLLM not ready after 15min"; exit 1; }
 ```
-{/* /health-check-vllm-default-openai-endpoint-server */}
+<!-- /health-check-vllm-default-openai-endpoint-server -->
 
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Profile the model
 aiperf profile \
@@ -40,7 +40,7 @@ aiperf profile \
     --request-count 64 \
     --url localhost:8000
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/docs/tutorials/aimo.md
+++ b/docs/tutorials/aimo.md
@@ -50,7 +50,7 @@ AIPerf loads the AIMO dataset from HuggingFace and uses each problem as a single
 AIMO problems elicit long chain-of-thought responses. Use `--prompt-output-tokens-mean` to cap
 output length and reduce benchmark duration:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -62,7 +62,7 @@ aiperf profile \
     --concurrency 4 \
     --prompt-output-tokens-mean 512
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 

--- a/docs/tutorials/audio.md
+++ b/docs/tutorials/audio.md
@@ -16,7 +16,7 @@ This guide covers profiling audio models using OpenAI-compatible chat completion
 
 Launch the vLLM server with Qwen2-Audio-7B-Instruct. Audio support requires the `vllm[audio]` extras to be installed:
 
-{/* setup-vllm-audio-openai-endpoint-server */}
+<!-- setup-vllm-audio-openai-endpoint-server -->
 ```bash
 # Build vLLM image with audio support
 docker build -t vllm-audio - << 'EOF'
@@ -29,16 +29,16 @@ docker run --gpus all -p 8000:8000 vllm-audio \
   --model Qwen/Qwen2-Audio-7B-Instruct \
   --trust-remote-code
 ```
-{/* /setup-vllm-audio-openai-endpoint-server */}
+<!-- /setup-vllm-audio-openai-endpoint-server -->
 
 
 Verify the server is ready:
 
-{/* health-check-vllm-audio-openai-endpoint-server */}
+<!-- health-check-vllm-audio-openai-endpoint-server -->
 ```bash
 timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"Qwen/Qwen2-Audio-7B-Instruct\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":1}")" != "200" ]; do sleep 2; done' || { echo "vLLM not ready after 15min"; exit 1; }
 ```
-{/* /health-check-vllm-audio-openai-endpoint-server */}
+<!-- /health-check-vllm-audio-openai-endpoint-server -->
 
 ---
 
@@ -46,7 +46,7 @@ timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost
 
 AIPerf can generate synthetic audio for benchmarking:
 
-{/* aiperf-run-vllm-audio-openai-endpoint-server */}
+<!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-Audio-7B-Instruct \
@@ -59,7 +59,7 @@ aiperf profile \
     --request-count 20 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-audio-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-audio-openai-endpoint-server -->
 
 **Output:**
 
@@ -99,11 +99,10 @@ To add text prompts alongside audio, include `--synthetic-input-tokens-mean 100`
 
 AIPerf can automatically load and encode audio files from local paths.
 
-<Note>
-The example below uses paths from the AIPerf test fixtures directory. Replace these with paths to your own audio files.
-</Note>
+> [!NOTE]
+> The example below uses paths from the AIPerf test fixtures directory. Replace these with paths to your own audio files.
 
-{/* aiperf-run-vllm-audio-openai-endpoint-server */}
+<!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 cat <<EOF > inputs.jsonl
 {"texts": ["Transcribe this."], "audios": ["/fixtures/audio/test_audio_1s.wav"]}
@@ -120,7 +119,7 @@ aiperf profile \
     --url localhost:8000 \
     --request-count 3
 ```
-{/* /aiperf-run-vllm-audio-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-audio-openai-endpoint-server -->
 
 AIPerf will automatically:
 - Load the audio files from the specified paths

--- a/docs/tutorials/bailian-trace.md
+++ b/docs/tutorials/bailian-trace.md
@@ -85,7 +85,7 @@ aiperf profile \
 
 ## Related Tutorials
 
-- [Trace Benchmarking with Mooncake](../benchmark_modes/trace_replay.md) - Mooncake FAST'25 trace replay
+- [Trace Benchmarking with Mooncake](../benchmark-modes/trace-replay.md) - Mooncake FAST'25 trace replay
 - [Fixed Schedule](fixed-schedule.md) - Precise timestamp-based execution for any dataset
 - [Prefix Synthesis](prefix-synthesis.md) - KV cache testing with hash-based prefix data
 - [Multi-Turn Conversations](multi-turn.md) - Multi-turn conversation benchmarking

--- a/docs/tutorials/blazedit.md
+++ b/docs/tutorials/blazedit.md
@@ -51,7 +51,7 @@ entire modified file, producing thousands of output tokens per request.
 
 **5k character variant:**
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -63,7 +63,7 @@ aiperf profile \
     --concurrency 4 \
     --prompt-output-tokens-mean 512
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 
@@ -104,7 +104,7 @@ aiperf profile \
 
 **10k character variant:**
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -116,4 +116,4 @@ aiperf profile \
     --concurrency 4 \
     --prompt-output-tokens-mean 512
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->

--- a/docs/tutorials/custom-dataset.md
+++ b/docs/tutorials/custom-dataset.md
@@ -66,7 +66,7 @@ Use single_turn when you need **deterministic, sequential execution** where requ
 
 ### Basic Text Example
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 cat > prompts.jsonl << 'EOF'
 {"text": "What is machine learning?"}
@@ -85,7 +85,7 @@ aiperf profile \
     --url localhost:8000 \
     --concurrency 2
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Output:**
 ```
@@ -176,7 +176,7 @@ Use multi_turn when you need **conversations with context** where each turn buil
 
 ### Basic Conversation
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 cat > conversations.jsonl << 'EOF'
 {"session_id": "chat_1", "turns": [{"text": "What is machine learning?"}, {"text": "Can you give me an example?"}]}
@@ -192,7 +192,7 @@ aiperf profile \
     --url localhost:8000 \
     --concurrency 2
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Output:**
 ```
@@ -262,7 +262,7 @@ Use random_pool when you need **random sampling with replacement** for unpredict
 
 ### Basic Single-File Sampling
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 cat > pool.jsonl << 'EOF'
 {"text": "What is machine learning?"}
@@ -286,7 +286,7 @@ aiperf profile \
     --random-seed 42 \
     --url localhost:8000
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Output:**
 ```

--- a/docs/tutorials/custom-prompt-benchmarking.md
+++ b/docs/tutorials/custom-prompt-benchmarking.md
@@ -39,7 +39,7 @@ timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost
 
 ### Running the Benchmark
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 # Create an input file with specific text inputs
 ```bash
 # Create an input file to use for benchmarking
@@ -64,7 +64,7 @@ aiperf profile \
     --concurrency 2 \
     --warmup-request-count 1
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/docs/tutorials/embeddings.md
+++ b/docs/tutorials/embeddings.md
@@ -35,7 +35,7 @@ curl -s http://localhost:8000/v1/embeddings \
 
 Run AIPerf against the embeddings endpoint using synthetic inputs:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model BAAI/bge-small-en-v1.5 \
@@ -47,7 +47,7 @@ aiperf profile \
     --request-count 20 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -77,7 +77,7 @@ Embeddings endpoints return metrics focused on request latency and throughput. N
 
 Create a JSONL embeddings input file:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 cat <<EOF > inputs.jsonl
 {"texts": ["What is artificial intelligence?"]}
@@ -99,7 +99,7 @@ aiperf profile \
     --url localhost:8000 \
     --request-count 5
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/docs/tutorials/fixed-schedule.md
+++ b/docs/tutorials/fixed-schedule.md
@@ -55,7 +55,7 @@ timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost
 
 ### Running Basic Fixed Schedule
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Create a fixed schedule with precise timing
 cat > precise_schedule.jsonl << 'EOF'
@@ -82,7 +82,7 @@ aiperf profile \
     --fixed-schedule \
     --fixed-schedule-auto-offset
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -119,7 +119,7 @@ JSON Export: artifacts/Qwen_Qwen3-0.6B-chat-fixed-schedule/profile_export_aiperf
 
 Execute only a portion of the schedule using start and end offsets:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Execute schedule from 2s to 6s window
 aiperf profile \
@@ -134,7 +134,7 @@ aiperf profile \
     --fixed-schedule-start-offset 2000 \
     --fixed-schedule-end-offset 4000
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -170,15 +170,14 @@ JSON Export: artifacts/Qwen_Qwen3-0.6B-chat-fixed-schedule/profile_export_aiperf
 
 ## Use Cases
 
-<Warning>
-**When to Use Fixed Schedule Benchmarking:**
-- **Traffic Replay**: Reproduce exact timing patterns from production logs
-- **Temporal Analysis**: Study how performance varies with request timing
-- **Peak Load Testing**: Test system behavior during known high-traffic periods
-- **SLA Validation**: Verify performance under specific timing constraints
-- **Capacity Planning**: Model future load based on projected growth patterns
-- **Regression Testing**: Ensure temporal performance characteristics remain stable
-</Warning>
+> [!WARNING]
+> **When to Use Fixed Schedule Benchmarking:**
+> - **Traffic Replay**: Reproduce exact timing patterns from production logs
+> - **Temporal Analysis**: Study how performance varies with request timing
+> - **Peak Load Testing**: Test system behavior during known high-traffic periods
+> - **SLA Validation**: Verify performance under specific timing constraints
+> - **Capacity Planning**: Model future load based on projected growth patterns
+> - **Regression Testing**: Ensure temporal performance characteristics remain stable
 
 ## Related Tutorials
 

--- a/docs/tutorials/goodput.md
+++ b/docs/tutorials/goodput.md
@@ -40,7 +40,7 @@ timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost
 
 #### Run AIPerf with Goodput Constraints
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     -m Qwen/Qwen3-0.6B \
@@ -50,7 +50,7 @@ aiperf profile \
     --request-count 20 \
     --goodput "time_to_first_token:100 inter_token_latency:3.40"
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 Example output:
 

--- a/docs/tutorials/gpu-telemetry.md
+++ b/docs/tutorials/gpu-telemetry.md
@@ -44,21 +44,18 @@ AIPerf provides GPU telemetry collection with the `--gpu-telemetry` flag. Here's
 | **pynvml + dashboard** | `aiperf profile --model MODEL ... --gpu-telemetry pynvml dashboard` | Local GPUs via pynvml library | ✅ Yes | ✅ Yes ([see dashboard](#real-time-dashboard-view)) | ✅ Yes |
 | **Disabled** | `aiperf profile --model MODEL ... --no-gpu-telemetry` | None | ❌ No | ❌ No | ❌ No |
 
-<Warning>
-**DCGM mode (default):** The default endpoints `http://localhost:9400/metrics` and `http://localhost:9401/metrics` are always attempted for telemetry collection, regardless of whether the `--gpu-telemetry` flag is used. The flag primarily controls whether metrics are displayed on the console and allows you to specify additional custom DCGM exporter endpoints.
+> [!WARNING]
+> **DCGM mode (default):** The default endpoints `http://localhost:9400/metrics` and `http://localhost:9401/metrics` are always attempted for telemetry collection, regardless of whether the `--gpu-telemetry` flag is used. The flag primarily controls whether metrics are displayed on the console and allows you to specify additional custom DCGM exporter endpoints.
+>
+> **pynvml mode:** When using `--gpu-telemetry pynvml`, DCGM endpoints are NOT used. Metrics are collected directly from local GPUs via the nvidia-ml-py library.
+>
+> To completely disable GPU telemetry collection, use `--no-gpu-telemetry`.
 
-**pynvml mode:** When using `--gpu-telemetry pynvml`, DCGM endpoints are NOT used. Metrics are collected directly from local GPUs via the nvidia-ml-py library.
+> [!NOTE]
+> When specifying custom DCGM exporter URLs, the `http://` prefix is optional. URLs like `localhost:9400` will automatically be treated as `http://localhost:9400`. Both formats work identically.
 
-To completely disable GPU telemetry collection, use `--no-gpu-telemetry`.
-</Warning>
-
-<Note>
-When specifying custom DCGM exporter URLs, the `http://` prefix is optional. URLs like `localhost:9400` will automatically be treated as `http://localhost:9400`. Both formats work identically.
-</Note>
-
-<Tip>
-For simple local GPU monitoring without DCGM setup, use `--gpu-telemetry pynvml`. This collects metrics directly from the NVIDIA driver using the nvidia-ml-py library. See [Path 3: pynvml](#3-using-pynvml-local-gpu-monitoring) for details.
-</Tip>
+> [!TIP]
+> For simple local GPU monitoring without DCGM setup, use `--gpu-telemetry pynvml`. This collects metrics directly from the NVIDIA driver using the nvidia-ml-py library. See [Path 3: pynvml](#3-using-pynvml-local-gpu-monitoring) for details.
 
 ### Real-Time Dashboard View
 
@@ -200,9 +197,8 @@ GPU Telemetry: artifacts/Qwen_Qwen3-0.6B-chat-concurrency4/gpu_telemetry_export.
 
 The GPU telemetry table displays real-time metrics collected from DCGM during the benchmark. Each GPU is shown with its metrics aggregated across the benchmark duration.
 
-<Tip>
-The `dashboard` keyword enables a live terminal UI for real-time GPU telemetry visualization. Press `5` to maximize the GPU Telemetry panel during the benchmark run.
-</Tip>
+> [!TIP]
+> The `dashboard` keyword enables a live terminal UI for real-time GPU telemetry visualization. Press `5` to maximize the GPU Telemetry panel during the benchmark run.
 
 ---
 
@@ -278,9 +274,8 @@ docker run -d --name vllm-server \
   --port 8000
 ```
 
-<Tip>
-You can customize the `custom_gpu_metrics.csv` file by commenting out metrics you don't need. Lines starting with `#` are ignored.
-</Tip>
+> [!TIP]
+> You can customize the `custom_gpu_metrics.csv` file by commenting out metrics you don't need. Lines starting with `#` are ignored.
 
 **Key Configuration:**
 - `-p 9401:9400` - Forward container's port 9400 to host's port 9401 (AIPerf's default)
@@ -315,9 +310,8 @@ git clone -b ${AIPERF_REPO_TAG} --depth 1 https://github.com/ai-dynamo/aiperf.gi
 uv pip install ./aiperf
 ```
 
-<Note>
-Replace the vLLM command above with your preferred backend (SGLang, TRT-LLM, etc.). The DCGM setup works with any server.
-</Note>
+> [!NOTE]
+> Replace the vLLM command above with your preferred backend (SGLang, TRT-LLM, etc.). The DCGM setup works with any server.
 
 ## Verify Everything is Running
 
@@ -354,9 +348,8 @@ aiperf profile \
     --gpu-telemetry
 ```
 
-<Tip>
-The `dashboard` keyword enables a live terminal UI for real-time GPU telemetry visualization. Press `5` to maximize the GPU Telemetry panel during the benchmark run.
-</Tip>
+> [!TIP]
+> The `dashboard` keyword enables a live terminal UI for real-time GPU telemetry visualization. Press `5` to maximize the GPU Telemetry panel during the benchmark run.
 
 ---
 
@@ -402,9 +395,8 @@ aiperf profile \
     --gpu-telemetry pynvml
 ```
 
-<Tip>
-Add `dashboard` after `pynvml` for the real-time terminal UI: `--gpu-telemetry pynvml dashboard`
-</Tip>
+> [!TIP]
+> Add `dashboard` after `pynvml` for the real-time terminal UI: `--gpu-telemetry pynvml dashboard`
 
 ## Metrics Collected via pynvml
 
@@ -424,9 +416,8 @@ The nvidia-ml-py library (pynvml) collects the following metrics directly from t
 | JPEG Utilization | JPEG decoder utilization | % |
 | Power Violation | Throttling duration due to power limits | µs |
 
-<Note>
-Not all metrics are available on all GPU models. AIPerf gracefully handles missing metrics and reports only what the hardware supports.
-</Note>
+> [!NOTE]
+> Not all metrics are available on all GPU models. AIPerf gracefully handles missing metrics and reports only what the hardware supports.
 
 ## Comparing DCGM vs pynvml
 
@@ -501,13 +492,11 @@ The CSV format is identical to DCGM exporter configuration. See the **vLLM setup
 - XID Errors
 - Power Violation
 
-<Note>
-The file path can be absolute or relative. Use `.csv` extension so AIPerf can distinguish it from DCGM endpoint URLs.
-</Note>
+> [!NOTE]
+> The file path can be absolute or relative. Use `.csv` extension so AIPerf can distinguish it from DCGM endpoint URLs.
 
-<Tip>
-You can start with the example CSV from the vLLM setup section and customize it by commenting out metrics you don't need or adding new DCGM metrics.
-</Tip>
+> [!TIP]
+> You can start with the example CSV from the vLLM setup section and customize it by commenting out metrics you don't need or adding new DCGM metrics.
 
 ## Example Console Display:
 

--- a/docs/tutorials/http-trace-metrics.md
+++ b/docs/tutorials/http-trace-metrics.md
@@ -109,13 +109,12 @@ http_req_total = http_req_blocked + http_req_dns_lookup + http_req_connecting
                + http_req_sending + http_req_waiting + http_req_receiving
 ```
 
-<Note>
-`http_req_total` and `http_req_duration` may differ slightly because:
-- `http_req_duration` is a single end-to-end measurement (`response_receive_end - request_send_start`)
-- `http_req_total` sums 6 individual phase measurements, which may have small unmeasured gaps between phases
-
-Use `http_req_total` when you need the breakdown to add up exactly. Use `http_req_duration` when you want the most accurate single measurement of request/response exchange time.
-</Note>
+> [!NOTE]
+> `http_req_total` and `http_req_duration` may differ slightly because:
+> - `http_req_duration` is a single end-to-end measurement (`response_receive_end - request_send_start`)
+> - `http_req_total` sums 6 individual phase measurements, which may have small unmeasured gaps between phases
+>
+> Use `http_req_total` when you need the breakdown to add up exactly. Use `http_req_duration` when you want the most accurate single measurement of request/response exchange time.
 
 ### Important Distinctions
 
@@ -232,9 +231,8 @@ When exported to `profile_export.jsonl`, trace data uses **wall-clock timestamps
 }
 ```
 
-<Note>
-Computed duration fields (`blocked_ns`, `dns_lookup_ns`, `connecting_ns`) are **omitted** from `trace_data` when the underlying event did not occur. The corresponding metrics (e.g., `http_req_blocked`) will report `0` for aggregation purposes, but the trace field itself is absent.
-</Note>
+> [!NOTE]
+> Computed duration fields (`blocked_ns`, `dns_lookup_ns`, `connecting_ns`) are **omitted** from `trace_data` when the underlying event did not occur. The corresponding metrics (e.g., `http_req_blocked`) will report `0` for aggregation purposes, but the trace field itself is absent.
 
 ### Trace Data Fields
 

--- a/docs/tutorials/image-generation.md
+++ b/docs/tutorials/image-generation.md
@@ -42,20 +42,18 @@ docker run --gpus all \
     lmsysorg/sglang:dev
 ```
 
-<Note>
-> The following steps are to be performed _inside_ the Docker container.
-</Note>
+> [!NOTE]
+> > The following steps are to be performed _inside_ the Docker container.
 **Install the dependencies:**
 ```bash
 pip install yunchang remote_pdb imageio diffusers diffusion
 ```
 
 **Set the server arguments:**
-<Warning>
-> The following arguments will setup the server to use the FLUX.1-dev model on a single GPU, on port 30000.
-> You can modify these arguments to use a different model, different number of GPUs, different port, etc.
-> See the [SGLang Image Generation CLI](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/cli.md) for more details.
-</Warning>
+> [!WARNING]
+> > The following arguments will setup the server to use the FLUX.1-dev model on a single GPU, on port 30000.
+> > You can modify these arguments to use a different model, different number of GPUs, different port, etc.
+> > See the [SGLang Image Generation CLI](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/cli.md) for more details.
 ```bash
 SERVER_ARGS=(   --model-path black-forest-labs/FLUX.1-dev   --text-encoder-cpu-offload   --pin-cpu-memory   --num-gpus 1   --port 30000 --host 0.0.0.0 )
 ```
@@ -72,9 +70,8 @@ Uvicorn running on http://0.0.0.0:30000 (Press CTRL+C to quit)
 
 ## Running the benchmark (basic usage)
 
-<Note>
-> The following steps are to be performed on your local machine. (_outside_ the Docker container.)
-</Note>
+> [!NOTE]
+> > The following steps are to be performed on your local machine. (_outside_ the Docker container.)
 
 ### Text-to-Image Generation Using Input File
 **Create an input file:**
@@ -176,9 +173,8 @@ EOF
 
 **Run the benchmark:**
 
-<Warning>
-Use `--export-level raw` to get the raw input/output payloads.
-</Warning>
+> [!WARNING]
+> Use `--export-level raw` to get the raw input/output payloads.
 
 ```bash
 aiperf profile \
@@ -239,11 +235,10 @@ with open(input_file, 'r') as f:
 ```
 
 **Run the script:**
-<Tip>
-The script is setup to use the default directory and file names for the input and output files, but can be modified to use different files.<br/>
-
-Usage: `python extract_images.py <input_file> <output_dir>`
-</Tip>
+> [!TIP]
+> The script is setup to use the default directory and file names for the input and output files, but can be modified to use different files.<br/>
+>
+> Usage: `python extract_images.py <input_file> <output_dir>`
 
 ```bash
 python extract_images.py

--- a/docs/tutorials/instruct-coder.md
+++ b/docs/tutorials/instruct-coder.md
@@ -39,7 +39,7 @@ curl -s localhost:8000/v1/chat/completions \
 AIPerf loads the InstructCoder dataset from HuggingFace and uses each instruction as a
 single-turn prompt.
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -50,7 +50,7 @@ aiperf profile \
     --request-count 10 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 

--- a/docs/tutorials/llava-onevision.md
+++ b/docs/tutorials/llava-onevision.md
@@ -40,7 +40,7 @@ curl -s 127.0.0.1:8000/v1/chat/completions \
 AIPerf loads the `sharegpt4o` subset from HuggingFace, extracts the first user message and image
 from each row, and sends each as a single-turn vision request.
 
-{/* aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- aiperf-run-vllm-vision-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -51,7 +51,7 @@ aiperf profile \
     --request-count 10 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-vision-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 

--- a/docs/tutorials/mmstar.md
+++ b/docs/tutorials/mmstar.md
@@ -39,7 +39,7 @@ curl -s localhost:8000/v1/chat/completions \
 AIPerf loads the MMStar dataset from HuggingFace, attaches the image from each row to the
 question, and sends each pair as a single-turn vision request.
 
-{/* aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- aiperf-run-vllm-vision-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -50,7 +50,7 @@ aiperf profile \
     --request-count 10 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-vision-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 

--- a/docs/tutorials/mmvu.md
+++ b/docs/tutorials/mmvu.md
@@ -20,18 +20,21 @@ dataset.
 
 Launch a vLLM server with a video-capable vision language model:
 
+<!-- setup-vllm-video-openai-endpoint-server -->
 ```bash
 docker pull vllm/vllm-openai:latest
 docker run --gpus all -p 8000:8000 vllm/vllm-openai:latest \
   --model Qwen/Qwen2-VL-2B-Instruct
 ```
+<!-- /setup-vllm-video-openai-endpoint-server -->
 
 Verify the server is ready:
+
+<!-- health-check-vllm-video-openai-endpoint-server -->
 ```bash
-curl -s localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model":"Qwen/Qwen2-VL-2B-Instruct","messages":[{"role":"user","content":"test"}],"max_tokens":1}'
+timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"Qwen/Qwen2-VL-2B-Instruct\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":1}")" != "200" ]; do sleep 2; done' || { echo "vLLM not ready after 15min"; exit 1; }
 ```
+<!-- /health-check-vllm-video-openai-endpoint-server -->
 
 ---
 

--- a/docs/tutorials/mmvu.md
+++ b/docs/tutorials/mmvu.md
@@ -41,7 +41,7 @@ AIPerf loads the MMVU dataset from HuggingFace, combines each question with its
 multiple-choice options, attaches the video URL, and sends each pair as a single-turn
 video request. The prompt format matches vLLM's own MMVU benchmark format.
 
-{/* aiperf-run-vllm-video-openai-endpoint-server */}
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -53,7 +53,7 @@ aiperf profile \
     --concurrency 2 \
     --output-tokens-mean 128
 ```
-{/* /aiperf-run-vllm-video-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-video-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 

--- a/docs/tutorials/multi-turn.md
+++ b/docs/tutorials/multi-turn.md
@@ -18,28 +18,26 @@ Multi-turn benchmarking provides several advantages:
 - **Memory and State Management**: Identify issues with conversation state handling
 - **Conversation Flow Analysis**: Measure performance degradation over multiple turns
 
-<Warning>
-**Understanding Request Control Options**
+> [!WARNING]
+> **Understanding Request Control Options**
+>
+> AIPerf provides different options for controlling the number of requests depending on whether you're running single-turn or multi-turn benchmarks:
+>
+> - **`--request-count`**: Controls the total number of **single-turn requests** to send. Use this for traditional single-turn benchmarks.
+> - **`--conversation-num`**: Controls the total number of **conversations (sessions)** to send in multi-turn scenarios. Each conversation may contain multiple turns (requests).
+>
+> These options are mutually exclusive in their intent - use `--request-count` for single-turn benchmarking and `--conversation-num` for multi-turn benchmarking to avoid confusion.
 
-AIPerf provides different options for controlling the number of requests depending on whether you're running single-turn or multi-turn benchmarks:
-
-- **`--request-count`**: Controls the total number of **single-turn requests** to send. Use this for traditional single-turn benchmarks.
-- **`--conversation-num`**: Controls the total number of **conversations (sessions)** to send in multi-turn scenarios. Each conversation may contain multiple turns (requests).
-
-These options are mutually exclusive in their intent - use `--request-count` for single-turn benchmarking and `--conversation-num` for multi-turn benchmarking to avoid confusion.
-</Warning>
-
-<Note>
-**Dataset Generation vs Request Execution**
-
-The `--num-dataset-entries` option controls how many **unique prompts** are generated in the dataset. This is separate from the number of requests or conversations:
-
-- `--num-dataset-entries`: Number of unique prompt entries to generate in the dataset
-- `--request-count`: Number of single-turn requests to send (for single-turn benchmarks)
-- `--conversation-num`: Number of conversations to send (for multi-turn benchmarks)
-
-The dataset entries are reused/sampled as needed to fulfill the total request or conversation count. For example, you might generate 100 unique prompts (`--num-dataset-entries 100`) but send 1000 requests that sample from those prompts. `--dataset-sampling-strategy` determines how the pool of prompts is sampled when building payloads.
-</Note>
+> [!NOTE]
+> **Dataset Generation vs Request Execution**
+>
+> The `--num-dataset-entries` option controls how many **unique prompts** are generated in the dataset. This is separate from the number of requests or conversations:
+>
+> - `--num-dataset-entries`: Number of unique prompt entries to generate in the dataset
+> - `--request-count`: Number of single-turn requests to send (for single-turn benchmarks)
+> - `--conversation-num`: Number of conversations to send (for multi-turn benchmarks)
+>
+> The dataset entries are reused/sampled as needed to fulfill the total request or conversation count. For example, you might generate 100 unique prompts (`--num-dataset-entries 100`) but send 1000 requests that sample from those prompts. `--dataset-sampling-strategy` determines how the pool of prompts is sampled when building payloads.
 
 ## Core Parameters
 
@@ -88,7 +86,7 @@ docker run --gpus all -p 8000:8000 vllm/vllm-openai:latest \
 
 Run a simple multi-turn benchmark with a fixed number of turns per conversation:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Run 10 conversations, each with exactly 3 turns
 aiperf profile \
@@ -105,7 +103,7 @@ aiperf profile \
     --concurrency 2 \
     --random-seed 42
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -141,7 +139,7 @@ This command will:
 
 Add variance to the number of turns per conversation for more realistic patterns:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Run conversations with variable lengths (mean: 5, stddev: 2)
 aiperf profile \
@@ -158,7 +156,7 @@ aiperf profile \
     --concurrency 4 \
     --random-seed 42
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 This creates conversations with varying lengths (typically 3-7 turns), simulating natural conversation patterns where some users ask quick questions and others engage in deeper discussions.
 
@@ -168,7 +166,7 @@ This creates conversations with varying lengths (typically 3-7 turns), simulatin
 
 Simulate real user "think time" between turns to model actual human interaction patterns:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Add realistic delays between turns (mean: 2000ms, stddev: 500ms)
 aiperf profile \
@@ -187,7 +185,7 @@ aiperf profile \
     --concurrency 3 \
     --random-seed 42
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 The turn delays simulate realistic pauses as users read responses and formulate follow-up questions. This is critical for:
 - Testing connection keep-alive mechanisms
@@ -198,7 +196,7 @@ The turn delays simulate realistic pauses as users read responses and formulate 
 
 Test how your server handles many simultaneous multi-turn conversations:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Run 50 concurrent conversations with variable lengths
 aiperf profile \
@@ -215,7 +213,7 @@ aiperf profile \
     --concurrency 50 \
     --random-seed 42
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 This benchmark:
 - Maintains 50 active conversations simultaneously
@@ -226,7 +224,7 @@ This benchmark:
 
 Combine request rate control with multi-turn conversations for controlled, sustained load:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Start new conversations at 5 conversations/second
 aiperf profile \
@@ -243,7 +241,7 @@ aiperf profile \
     --output-tokens-mean 150 \
     --random-seed 42
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 This approach is ideal for:
 - Modeling steady conversation arrival patterns
@@ -256,7 +254,7 @@ This approach is ideal for:
 
 Simulate realistic customer support interactions with varying conversation lengths:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Model customer support conversations:
 # - Average 6-8 turns per conversation
@@ -281,13 +279,13 @@ aiperf profile \
     --concurrency 10 \
     --random-seed 42
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 ### Context Window Stress Testing
 
 Test model performance with long conversations that accumulate substantial context:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Test long conversations with growing context
 aiperf profile \
@@ -304,7 +302,7 @@ aiperf profile \
     --concurrency 2 \
     --random-seed 42
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 Each turn in a conversation includes the full conversation history, so:
 - Turn 1: ~300 tokens input
@@ -317,7 +315,7 @@ This helps identify performance degradation as context grows.
 
 Simulate sudden spikes in conversation activity:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Simulate burst of conversation starts
 aiperf profile \
@@ -333,7 +331,7 @@ aiperf profile \
     --output-tokens-mean 120 \
     --random-seed 42
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 ## How Multi-Turn Works
 

--- a/docs/tutorials/openai-text-endpoints.md
+++ b/docs/tutorials/openai-text-endpoints.md
@@ -29,7 +29,7 @@ The Chat Completions API uses the `/v1/chat/completions` endpoint.
 ### Profile with synthetic inputs
 
 Run AIPerf against the Chat Completions endpoint using synthetic inputs:
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -43,7 +43,7 @@ aiperf profile \
     --url localhost:8000 \
     --request-count 20
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -71,7 +71,7 @@ JSON Export: artifacts/Qwen_Qwen3-0.6B-chat-concurrency1/profile_export_aiperf.j
 ### Profile with custom input file
 
 Create a JSONL input file:
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 
 ```bash
 cat <<EOF > inputs.jsonl
@@ -92,7 +92,7 @@ aiperf profile \
     --url localhost:8000 \
     --request-count 10
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 ## Profile Completions API
 The Completions API uses the `/v1/completions` endpoint.
@@ -100,7 +100,7 @@ The Completions API uses the `/v1/completions` endpoint.
 ### Profile with synthetic inputs
 
 Run AIPerf against the Completions endpoint using synthetic inputs:
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -113,7 +113,7 @@ aiperf profile \
     --url localhost:8000 \
     --request-count 32
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -142,7 +142,7 @@ JSON Export: artifacts/Qwen_Qwen3-0.6B-completions-concurrency1/profile_export_a
 ### Profile with custom input file
 
 Create a JSONL input file:
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 cat <<EOF > inputs.jsonl
 {"texts": ["How are you?"]}
@@ -162,4 +162,4 @@ aiperf profile \
     --request-count 10
 
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->

--- a/docs/tutorials/plot.md
+++ b/docs/tutorials/plot.md
@@ -18,15 +18,13 @@ The `aiperf plot` command automatically detects whether to generate multi-run co
 - Timeslice support (performance evolution across time windows)
 - Configurable plots via `~/.aiperf/plot_config.yaml`
 
-<Warning>
-**Multi-Run Profile Incompatibility**: The plot CLI is not compatible with the `--num-profile-runs > 1` option. When using multi-run confidence profiling, the directory structure includes `profile_runs/` subdirectories which the plot command does not recognize. To visualize individual profile runs, navigate into the specific run directory (e.g., `artifacts/my_run/profile_runs/run_0001/`) and run the plot command from there.
-</Warning>
+> [!WARNING]
+> **Multi-Run Profile Incompatibility**: The plot CLI is not compatible with the `--num-profile-runs > 1` option. When using multi-run confidence profiling, the directory structure includes `profile_runs/` subdirectories which the plot command does not recognize. To visualize individual profile runs, navigate into the specific run directory (e.g., `artifacts/my_run/profile_runs/run_0001/`) and run the plot command from there.
 
 ## Quick Start
 
-<Warning>
-**Custom export filenames not supported:** The plot command expects default export filenames (`profile_export.jsonl`, `profile_export_aiperf.json`). If you ran `aiperf profile` with `--profile-export-file` or a custom `--profile-export-prefix`, the output files will have different names and will not be detected by `aiperf plot`. To use the plot command, re-run profiling without custom export file options, or rename the files to match the default names.
-</Warning>
+> [!WARNING]
+> **Custom export filenames not supported:** The plot command expects default export filenames (`profile_export.jsonl`, `profile_export_aiperf.json`). If you ran `aiperf profile` with `--profile-export-file` or a custom `--profile-export-prefix`, the output files will have different names and will not be detected by `aiperf plot`. To use the plot command, re-run profiling without custom export file options, or rename the files to match the default names.
 
 ```bash
 # Analyze a single profiling run
@@ -132,9 +130,8 @@ artifacts/sweep_qwen/
 2. **Token Throughput per GPU vs Latency** - GPU efficiency vs latency (requires GPU telemetry)
 3. **Token Throughput per GPU vs Interactivity** - GPU efficiency vs TTFT (requires GPU telemetry)
 
-<Tip>
-Use [Experiment Classification](#experiment-classification) to assign semantic colors (grey for baselines, green for treatments) for clearer visual distinction.
-</Tip>
+> [!TIP]
+> Use [Experiment Classification](#experiment-classification) to assign semantic colors (grey for baselines, green for treatments) for clearer visual distinction.
 
 #### Example Visualizations
 
@@ -255,13 +252,11 @@ multi_run_plots:
     groups: [run_name]
 ```
 
-<Note>
-When experiment classification is enabled, all multi-run plots automatically group by `experiment_group` to preserve treatment variants with semantic colors.
-</Note>
+> [!NOTE]
+> When experiment classification is enabled, all multi-run plots automatically group by `experiment_group` to preserve treatment variants with semantic colors.
 
-<Tip>
-See the CONFIGURATION GUIDE section in `~/.aiperf/plot_config.yaml` for detailed customization options.
-</Tip>
+> [!TIP]
+> See the CONFIGURATION GUIDE section in `~/.aiperf/plot_config.yaml` for detailed customization options.
 
 ### Experiment Classification
 
@@ -284,9 +279,8 @@ experiment_classification:
 - **Treatments**: NVIDIA green shades, listed after baselines
 - **Use case**: Clear visual distinction for A/B testing
 
-<Warning>
-When enabled, **all multi-run plots automatically group by experiment_group** (directory name) to preserve individual treatment variants with semantic baseline/treatment colors.
-</Warning>
+> [!WARNING]
+> When enabled, **all multi-run plots automatically group by experiment_group** (directory name) to preserve individual treatment variants with semantic baseline/treatment colors.
 
 **Pattern notes**: Uses glob syntax (`*` = wildcard), case-sensitive, first match wins.
 
@@ -313,9 +307,8 @@ artifacts/
 group_extraction_pattern: "^(treatment_\d+)"  # Groups treatment_1_varA + treatment_1_varB → "treatment_1"
 ```
 
-<Tip>
-See `src/aiperf/plot/default_plot_config.yaml` for all configuration options.
-</Tip>
+> [!TIP]
+> See `src/aiperf/plot/default_plot_config.yaml` for all configuration options.
 
 ![Pareto Curve with Experiment Classification](../diagrams/plot-examples/multi-run/config-experiment-classification/pareto-curve-throughput-per-gpu-vs-interactivity.png)
 
@@ -378,13 +371,11 @@ aiperf plot path/to/runs --dashboard
 
 The dashboard automatically detects visualization mode (multi-run comparison or single-run analysis) and displays appropriate tabs and controls. Press Ctrl+C in the terminal to stop the server.
 
-<Tip>
-The dashboard runs on localhost only and requires no authentication. For remote access via SSH, use port forwarding: `ssh -L 8080:localhost:8080 user@remote-host`
-</Tip>
+> [!TIP]
+> The dashboard runs on localhost only and requires no authentication. For remote access via SSH, use port forwarding: `ssh -L 8080:localhost:8080 user@remote-host`
 
-<Note>
-Dashboard mode and PNG mode are separate. To generate both static PNGs and launch the dashboard, run the commands separately.
-</Note>
+> [!NOTE]
+> Dashboard mode and PNG mode are separate. To generate both static PNGs and launch the dashboard, run the commands separately.
 
 ## Advanced Features
 
@@ -404,9 +395,8 @@ Dashboard mode and PNG mode are separate. To generate both static PNGs and launc
 
 **Correlates compute resources with token generation performance**. High GPU utilization with low throughput may suggest compute-bound workloads (consider optimizing model/batch size). Low utilization with low throughput can indicate bottlenecks elsewhere (KV cache, memory bandwidth, CPU scheduling). Potentially useful for targeting >80% GPU utilization for efficient hardware usage.
 
-<Tip>
-See the [GPU Telemetry Tutorial](gpu-telemetry.md) for setup and detailed analysis.
-</Tip>
+> [!TIP]
+> See the [GPU Telemetry Tutorial](gpu-telemetry.md) for setup and detailed analysis.
 
 ### Timeslice Integration
 
@@ -428,9 +418,8 @@ When timeslice data is available (via `--slice-duration` during profiling), plot
 
 ![Latency Across Timeslices](../diagrams/plot-examples/single-run/timeslices/timeslices-latency.png)
 
-<Tip>
-See the [Timeslices Tutorial](timeslices.md) for configuration and analysis.
-</Tip>
+> [!TIP]
+> See the [Timeslices Tutorial](timeslices.md) for configuration and analysis.
 
 ## Output Files
 
@@ -449,25 +438,20 @@ plots/
 
 ## Best Practices
 
-<Tip>
-**Consistent Configurations**: When comparing runs, vary only one parameter (e.g., concurrency) while keeping others constant. This isolates the impact of that specific parameter.
-</Tip>
+> [!TIP]
+> **Consistent Configurations**: When comparing runs, vary only one parameter (e.g., concurrency) while keeping others constant. This isolates the impact of that specific parameter.
 
-<Tip>
-**Use Experiment Classification**: Configure [experiment classification](#experiment-classification) to distinguish baselines from treatments with semantic colors.
-</Tip>
+> [!TIP]
+> **Use Experiment Classification**: Configure [experiment classification](#experiment-classification) to distinguish baselines from treatments with semantic colors.
 
-<Tip>
-**Include Warmup**: Use `--warmup-request-count` to ensure steady state before measurement, reducing noise in visualizations.
-</Tip>
+> [!TIP]
+> **Include Warmup**: Use `--warmup-request-count` to ensure steady state before measurement, reducing noise in visualizations.
 
-<Warning>
-**Directory Structure**: Ensure consistent naming - runs to compare must be in subdirectories of a common parent.
-</Warning>
+> [!WARNING]
+> **Directory Structure**: Ensure consistent naming - runs to compare must be in subdirectories of a common parent.
 
-<Note>
-**GPU Metrics**: GPU telemetry plots only appear when telemetry data is available. Ensure DCGM is running during profiling. See [GPU Telemetry Tutorial](gpu-telemetry.md).
-</Note>
+> [!NOTE]
+> **GPU Metrics**: GPU telemetry plots only appear when telemetry data is available. Ensure DCGM is running during profiling. See [GPU Telemetry Tutorial](gpu-telemetry.md).
 
 ## Troubleshooting
 

--- a/docs/tutorials/prefill-concurrency.md
+++ b/docs/tutorials/prefill-concurrency.md
@@ -54,13 +54,11 @@ With --prefill-concurrency 3:
 
 Once a request receives its first token, it releases its prefill slot and moves to decode—allowing the next request to start prefilling.
 
-<Warning>
-Requires `--streaming` to be enabled. Without streaming, AIPerf can't detect when the first token arrives.
-</Warning>
+> [!WARNING]
+> Requires `--streaming` to be enabled. Without streaming, AIPerf can't detect when the first token arrives.
 
-<Warning>
-**Coordinated omission trade-off:** When requests wait for prefill slots, the benchmark operates as a closed loop, throttling itself to match server capacity. This is [coordinated omission](https://www.scylladb.com/2021/04/22/on-coordinated-omission/)—your measured latencies will be **lower** than what users would experience if traffic kept arriving at the original rate. For accurate latency measurement, use open-loop benchmarking (request rate without prefill limits).
-</Warning>
+> [!WARNING]
+> **Coordinated omission trade-off:** When requests wait for prefill slots, the benchmark operates as a closed loop, throttling itself to match server capacity. This is [coordinated omission](https://www.scylladb.com/2021/04/22/on-coordinated-omission/)—your measured latencies will be **lower** than what users would experience if traffic kept arriving at the original rate. For accurate latency measurement, use open-loop benchmarking (request rate without prefill limits).
 
 ## Two Concurrency Limits
 

--- a/docs/tutorials/prefill-concurrency.md
+++ b/docs/tutorials/prefill-concurrency.md
@@ -56,8 +56,7 @@ Once a request receives its first token, it releases its prefill slot and moves 
 
 > [!WARNING]
 > Requires `--streaming` to be enabled. Without streaming, AIPerf can't detect when the first token arrives.
-
-> [!WARNING]
+>
 > **Coordinated omission trade-off:** When requests wait for prefill slots, the benchmark operates as a closed loop, throttling itself to match server capacity. This is [coordinated omission](https://www.scylladb.com/2021/04/22/on-coordinated-omission/)—your measured latencies will be **lower** than what users would experience if traffic kept arriving at the original rate. For accurate latency measurement, use open-loop benchmarking (request rate without prefill limits).
 
 ## Two Concurrency Limits

--- a/docs/tutorials/ramping.md
+++ b/docs/tutorials/ramping.md
@@ -148,9 +148,8 @@ Request Rate (QPS)
           15s   30s   45s   60s              Time
 ```
 
-<Note>
-The starting rate is calculated proportionally: `start = target * (update_interval / duration)`. With default settings (0.1s updates), ramping to 100 QPS over 60 seconds starts at ~0.17 QPS (not zero).
-</Note>
+> [!NOTE]
+> The starting rate is calculated proportionally: `start = target * (update_interval / duration)`. With default settings (0.1s updates), ramping to 100 QPS over 60 seconds starts at ~0.17 QPS (not zero).
 
 ### Combining Rate and Concurrency Ramping
 

--- a/docs/tutorials/rankings.md
+++ b/docs/tutorials/rankings.md
@@ -71,9 +71,8 @@ INFO     Results saved to: artifacts/BAAI_bge-reranker-base-rankings/
 JSON Export: artifacts/BAAI_bge-reranker-base-rankings/profile_export_aiperf.json
 ```
 
-<Note>
-The rankings-specific token options cannot be used together with `--prompt-input-tokens-mean` or `--prompt-input-tokens-stddev`. Use the rankings-specific options for controlling token counts in rankings queries and passages.
-</Note>
+> [!NOTE]
+> The rankings-specific token options cannot be used together with `--prompt-input-tokens-mean` or `--prompt-input-tokens-stddev`. Use the rankings-specific options for controlling token counts in rankings queries and passages.
 
 ### Profile using Custom Inputs
 

--- a/docs/tutorials/request-cancellation.md
+++ b/docs/tutorials/request-cancellation.md
@@ -36,9 +36,8 @@ The cancellation timer starts at **T2** ("request fully sent") for two reasons:
 
 2. **Reproducibility**: The delay is measured from a fixed point (request fully sent) rather than being affected by variable queue times or connection setup. This means running the same benchmark twice with `--request-cancellation-delay 0.5` will cancel requests at the same point in their lifecycle, regardless of system load.
 
-<Note>
-If the server responds before the delay expires, the request completes normally and is **not** cancelled. Only requests still waiting for a response when the timer expires are cancelled.
-</Note>
+> [!NOTE]
+> If the server responds before the delay expires, the request completes normally and is **not** cancelled. Only requests still waiting for a response when the timer expires are cancelled.
 
 ### Understanding the Delay Parameter
 
@@ -48,9 +47,8 @@ If the server responds before the delay expires, the request completes normally 
 | `0.5` | Wait 0.5 seconds after sending, then disconnect |
 | `5` | Wait 5 seconds after sending, then disconnect |
 
-<Tip>
-A delay of **0 means "send the full request, then immediately disconnect"**. The server receives the complete request but the client closes the connection before receiving any response. Longer delays allow partial responses to be received before disconnection.
-</Tip>
+> [!TIP]
+> A delay of **0 means "send the full request, then immediately disconnect"**. The server receives the complete request but the client closes the connection before receiving any response. Longer delays allow partial responses to be received before disconnection.
 
 ### Testing Disaggregated Inference Systems
 
@@ -82,7 +80,7 @@ timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost
 
 Test with a small percentage of cancelled requests:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Profile with 10% request cancellation
 aiperf profile \
@@ -101,7 +99,7 @@ aiperf profile \
     --request-count 50 \
     --warmup-request-count 5
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -142,7 +140,7 @@ JSON Export: artifacts/Qwen_Qwen3-0.6B-chat-concurrency8/profile_export_aiperf.j
 
 Test service resilience under frequent cancellations:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Profile with 50% request cancellation
 aiperf profile \
@@ -158,7 +156,7 @@ aiperf profile \
     --concurrency 10 \
     --request-count 40
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -190,7 +188,7 @@ JSON Export: artifacts/Qwen_Qwen3-0.6B-chat-concurrency10/profile_export_aiperf.
 
 Test immediate disconnection where the client closes the connection right after sending the request:
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Profile with immediate cancellation (0 delay)
 aiperf profile \
@@ -206,7 +204,7 @@ aiperf profile \
     --concurrency 15 \
     --request-count 60
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/docs/tutorials/request-rate-concurrency.md
+++ b/docs/tutorials/request-rate-concurrency.md
@@ -25,37 +25,33 @@ When both parameters are specified, AIPerf uses a **sleep-then-gate** pattern fo
 
 The sleep controls **when** requests attempt to launch (the rate), while the semaphore controls **whether** they can proceed (the concurrency ceiling).
 
-<Warning>
-**No catch-up behavior**: When the concurrency limit is reached, the system does not attempt to "catch up" by issuing requests faster once slots free up. The schedule continues at the configured rate.
-</Warning>
+> [!WARNING]
+> **No catch-up behavior**: When the concurrency limit is reached, the system does not attempt to "catch up" by issuing requests faster once slots free up. The schedule continues at the configured rate.
 
-<Tip>
-**Sustaining max concurrency**: If your request rate is faster than your server's average response time, the system will naturally reach and sustain max concurrency. For example, at 100 req/s with 1 second average response time, new requests arrive every 10ms but each takes 1 second to complete—so slots are always waiting to be filled, keeping the system at the concurrency ceiling. Conversely, if the request rate is slower than response time, slots free up faster than new requests arrive, so concurrency may never reach the maximum.
-</Tip>
+> [!TIP]
+> **Sustaining max concurrency**: If your request rate is faster than your server's average response time, the system will naturally reach and sustain max concurrency. For example, at 100 req/s with 1 second average response time, new requests arrive every 10ms but each takes 1 second to complete—so slots are always waiting to be filled, keeping the system at the concurrency ceiling. Conversely, if the request rate is slower than response time, slots free up faster than new requests arrive, so concurrency may never reach the maximum.
 
-<Note>
-**Ramp-up time formula**: `ramp_up_time = concurrency / request_rate`
-
-| Concurrency | Request Rate | Ramp-up Time |
-|-------------|--------------|--------------|
-| 100         | 200 req/s    | ~0.5 seconds |
-| 50          | 50 req/s     | ~1.0 second  |
-| 100         | 20 req/s     | ~5.0 seconds |
-</Note>
+> [!NOTE]
+> **Ramp-up time formula**: `ramp_up_time = concurrency / request_rate`
+>
+> | Concurrency | Request Rate | Ramp-up Time |
+> |-------------|--------------|--------------|
+> | 100         | 200 req/s    | ~0.5 seconds |
+> | 50          | 50 req/s     | ~1.0 second  |
+> | 100         | 20 req/s     | ~5.0 seconds |
 
 ## Choosing Your Arrival Pattern
 
 The sleep intervals in step 1 are determined by your chosen arrival pattern (`--arrival-pattern` or `--request-rate-mode`). AIPerf supports four distribution patterns:
 
-<Tip>
-**`poisson` (default)** — Uses exponentially-distributed inter-arrival times to mimic natural traffic with randomized spacing. Ideal for realistic load testing and capacity planning. Add `--random-seed` for reproducible random patterns.
-
-**`constant`** — Requests arrive at precisely evenly-spaced intervals for deterministic, predictable load. Ideal for reproducible benchmarks and regression testing.
-
-**`gamma`** — Uses gamma-distributed inter-arrival times with tunable smoothness via `--arrival-smoothness`. Values &lt;1.0 create bursty traffic, >1.0 creates smoother traffic, and 1.0 is equivalent to Poisson. Compatible with vLLM's `--burstiness` parameter.
-
-**`concurrency_burst`** — Issues requests as fast as possible (zero interval), useful for stress testing or when concurrency is the only rate limiter. Often used internally for warmup phases.
-</Tip>
+> [!TIP]
+> **`poisson` (default)** — Uses exponentially-distributed inter-arrival times to mimic natural traffic with randomized spacing. Ideal for realistic load testing and capacity planning. Add `--random-seed` for reproducible random patterns.
+>
+> **`constant`** — Requests arrive at precisely evenly-spaced intervals for deterministic, predictable load. Ideal for reproducible benchmarks and regression testing.
+>
+> **`gamma`** — Uses gamma-distributed inter-arrival times with tunable smoothness via `--arrival-smoothness`. Values &lt;1.0 create bursty traffic, >1.0 creates smoother traffic, and 1.0 is equivalent to Poisson. Compatible with vLLM's `--burstiness` parameter.
+>
+> **`concurrency_burst`** — Issues requests as fast as possible (zero interval), useful for stress testing or when concurrency is the only rate limiter. Often used internally for warmup phases.
 
 ## Setting Up the Server
 
@@ -80,7 +76,7 @@ The following examples demonstrate both request rate modes in action. Make sure 
 
 This example demonstrates realistic traffic simulation with a fast ramp-up (0.5 seconds). The Poisson distribution creates natural variance in request timing while maintaining an average rate of 200 req/s, capped at 100 concurrent requests.
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -96,7 +92,7 @@ aiperf profile \
     --synthetic-input-tokens-mean 500 \
     --output-tokens-mean 200
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -125,7 +121,7 @@ The Poisson distribution creates natural request spacing. You'll notice requests
 
 This example uses evenly-spaced requests with a moderate ramp-up (1 second). Requests arrive at exactly 20ms intervals (50 req/s), making results highly reproducible for benchmarking and regression testing.
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -140,7 +136,7 @@ aiperf profile \
     --synthetic-input-tokens-mean 800 \
     --output-tokens-mean 400
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/docs/tutorials/sequence-distributions.md
+++ b/docs/tutorials/sequence-distributions.md
@@ -84,7 +84,7 @@ Values are automatically clamped to be at least 1.
 
 ### Example Case: Chatbot Workload Simulation
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Simulate typical chatbot traffic:
 # - 70% short queries (quick questions)
@@ -99,7 +99,7 @@ aiperf profile \
     --url localhost:8000 \
     --sequence-distribution "64|10,32|8:70;256|40,128|20:20;1024|100,512|50:10"
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/docs/tutorials/sglang-video-generation.md
+++ b/docs/tutorials/sglang-video-generation.md
@@ -57,9 +57,8 @@ docker run --gpus all \
     lmsysorg/sglang:dev
 ```
 
-<Note>
-The following steps are to be performed _inside_ the SGLang Docker container.
-</Note>
+> [!NOTE]
+> The following steps are to be performed _inside_ the SGLang Docker container.
 
 **Install the diffusion dependencies:**
 ```bash
@@ -68,10 +67,9 @@ uv pip install "sglang[diffusion]" --prerelease=allow --system
 
 **Set the server arguments:**
 
-<Warning>
-The following arguments set up the SGLang server to use Wan2.1-T2V-1.3B on port 30010.
-Adjust `--num-gpus`, `--ulysses-degree`, and `--ring-degree` based on your GPU configuration.
-</Warning>
+> [!WARNING]
+> The following arguments set up the SGLang server to use Wan2.1-T2V-1.3B on port 30010.
+> Adjust `--num-gpus`, `--ulysses-degree`, and `--ring-degree` based on your GPU configuration.
 
 **Single GPU setup:**
 ```bash
@@ -131,9 +129,8 @@ sglang serve \
 
 ## Running the Benchmark
 
-<Note>
-The following steps are to be performed on your local machine (_outside_ the SGLang Docker container).
-</Note>
+> [!NOTE]
+> The following steps are to be performed on your local machine (_outside_ the SGLang Docker container).
 
 ### Basic Usage: Text-to-Video with Input File
 

--- a/docs/tutorials/sharegpt.md
+++ b/docs/tutorials/sharegpt.md
@@ -35,7 +35,7 @@ curl -s localhost:8000/v1/chat/completions \
 
 AIPerf automatically downloads and caches the ShareGPT dataset from HuggingFace.
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -46,7 +46,7 @@ aiperf profile \
     --request-count 20 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/docs/tutorials/spec-bench.md
+++ b/docs/tutorials/spec-bench.md
@@ -39,7 +39,7 @@ curl -s localhost:8000/v1/chat/completions \
 AIPerf downloads the SpecBench JSONL file from GitHub and uses the first turn of each
 question as a single-turn prompt.
 
-{/* aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -50,7 +50,7 @@ aiperf profile \
     --request-count 10 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-default-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/docs/tutorials/time-based-benchmarking.md
+++ b/docs/tutorials/time-based-benchmarking.md
@@ -38,9 +38,8 @@ Requests are sent continuously until the duration expires. AIPerf then waits for
 - **Grace period default**: 30 seconds (use `inf` to wait forever, `0` for immediate completion)
 - Responses received within grace period are included in metrics; responses still pending when grace expires are not
 
-<Warning>
-`--benchmark-grace-period` requires `--benchmark-duration` to be set.
-</Warning>
+> [!WARNING]
+> `--benchmark-grace-period` requires `--benchmark-duration` to be set.
 
 ## Combining with Request Count
 

--- a/docs/tutorials/timeslices.md
+++ b/docs/tutorials/timeslices.md
@@ -192,18 +192,16 @@ To be announced...
 
 ## Best Practices
 
-<Warning>
-**Timeslice Boundaries:**
-- Timeslices are calculated based on absolute wall clock time divisions
-- The first timeslice may be shorter if requests don't start exactly at a timeslice boundary
-- The last timeslice may be shorter if the benchmark ends mid-slice
-</Warning>
+> [!WARNING]
+> **Timeslice Boundaries:**
+> - Timeslices are calculated based on absolute wall clock time divisions
+> - The first timeslice may be shorter if requests don't start exactly at a timeslice boundary
+> - The last timeslice may be shorter if the benchmark ends mid-slice
 
-<Warning>
-**Statistical Considerations:**
-- Very short slices may have high variance and unstable metrics
-- Low-concurrency benchmarks need longer slices for adequate sample size
-</Warning>
+> [!WARNING]
+> **Statistical Considerations:**
+> - Very short slices may have high variance and unstable metrics
+> - Low-concurrency benchmarks need longer slices for adequate sample size
 
 ## Troubleshooting
 

--- a/docs/tutorials/vision-arena.md
+++ b/docs/tutorials/vision-arena.md
@@ -41,7 +41,7 @@ curl -s 127.0.0.1:8000/v1/chat/completions \
 
 ## Profile with VisionArena Dataset
 
-{/* aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- aiperf-run-vllm-vision-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -52,7 +52,7 @@ aiperf profile \
     --request-count 10 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-vision-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 

--- a/docs/tutorials/vision.md
+++ b/docs/tutorials/vision.md
@@ -16,21 +16,21 @@ This guide covers profiling vision models using OpenAI-compatible chat completio
 
 Launch a vLLM server with a vision language model:
 
-{/* setup-vllm-vision-openai-endpoint-server */}
+<!-- setup-vllm-vision-openai-endpoint-server -->
 ```bash
 docker pull vllm/vllm-openai:latest
 docker run --gpus all -p 8000:8000 vllm/vllm-openai:latest \
   --model Qwen/Qwen2-VL-2B-Instruct
 ```
-{/* /setup-vllm-vision-openai-endpoint-server */}
+<!-- /setup-vllm-vision-openai-endpoint-server -->
 
 Verify the server is ready:
 
-{/* health-check-vllm-vision-openai-endpoint-server */}
+<!-- health-check-vllm-vision-openai-endpoint-server -->
 ```bash
 timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"Qwen/Qwen2-VL-2B-Instruct\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":1}")" != "200" ]; do sleep 2; done' || { echo "vLLM not ready after 15min"; exit 1; }
 ```
-{/* /health-check-vllm-vision-openai-endpoint-server */}
+<!-- /health-check-vllm-vision-openai-endpoint-server -->
 
 ---
 
@@ -38,7 +38,7 @@ timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost
 
 AIPerf can generate synthetic images for benchmarking.
 
-{/* aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- aiperf-run-vllm-vision-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -51,7 +51,7 @@ aiperf profile \
     --request-count 20 \
     --concurrency 4
 ```
-{/* /aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-vision-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```
@@ -84,7 +84,7 @@ JSON Export: artifacts/Qwen_Qwen2-VL-2B-Instruct-chat-concurrency4/profile_expor
 
 Create a JSONL file with text prompts and image URLs:
 
-{/* aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- aiperf-run-vllm-vision-openai-endpoint-server -->
 ```bash
 cat <<EOF > inputs.jsonl
 {"texts": ["Describe this image in detail."], "images": ["https://picsum.photos/512/512?random=1"], "output_length": 200}
@@ -94,11 +94,11 @@ cat <<EOF > inputs.jsonl
 {"texts": ["Provide a caption for this image."], "images": ["https://picsum.photos/512/512?random=5"], "output_length": 50}
 EOF
 ```
-{/* /aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-vision-openai-endpoint-server -->
 
 Run AIPerf using the custom input file:
 
-{/* aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- aiperf-run-vllm-vision-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -109,7 +109,7 @@ aiperf profile \
     --url localhost:8000 \
     --request-count 5
 ```
-{/* /aiperf-run-vllm-vision-openai-endpoint-server */}
+<!-- /aiperf-run-vllm-vision-openai-endpoint-server -->
 
 **Sample Output (Successful Run):**
 ```

--- a/fern/md_to_mdx.py
+++ b/fern/md_to_mdx.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Convert standard GitHub Markdown to Fern MDX format.
+
+Two transformations are applied in a single pass:
+
+1. HTML comments -> MDX comments
+       <!-- tag-name -->   ->  {/* tag-name */}
+       <!-- /tag-name -->  ->  {/* /tag-name */}
+
+2. GitHub callouts -> Fern admonitions
+       > [!NOTE]           ->  <Note>...</Note>
+       > [!TIP]            ->  <Tip>...</Tip>
+       > [!IMPORTANT]      ->  <Info>...</Info>
+       > [!WARNING]        ->  <Warning>...</Warning>
+       > [!CAUTION]        ->  <Error>...</Error>
+
+Run as part of the docs-website sync pipeline on every merge to main.
+Designed to be reusable across repos — teams opt in by including this file.
+
+Usage:
+    # Convert all markdown files in a directory (in-place)
+    python fern/md_to_mdx.py --dir fern/pages-dev
+
+    # Convert a single file in-place
+    python fern/md_to_mdx.py fern/pages-dev/tutorials/example.md
+
+    # Preview changes without writing
+    python fern/md_to_mdx.py --dir fern/pages-dev --dry-run
+
+    # Run tests
+    python fern/md_to_mdx.py --test
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ── Code fence awareness ─────────────────────────────────────────────────────
+
+# Splits text into alternating non-fence / fence segments.
+# Odd-indexed segments are inside fenced code blocks and must not be transformed.
+_FENCE_SPLIT = re.compile(r"(^```.*?^```)", re.MULTILINE | re.DOTALL)
+
+
+def _apply_outside_fences(text: str, fn) -> str:
+    """Apply fn only to text outside fenced code blocks."""
+    parts = _FENCE_SPLIT.split(text)
+    return "".join(fn(p) if i % 2 == 0 else p for i, p in enumerate(parts))
+
+
+# ── HTML comment -> MDX comment ──────────────────────────────────────────────
+
+# re.DOTALL so . matches newlines, handling multiline HTML comments
+HTML_COMMENT_PATTERN = re.compile(r"<!--\s*(.*?)\s*-->", re.DOTALL)
+
+
+def _convert_comments(text: str) -> str:
+    """Replace <!-- ... --> with {/* ... */}, skipping fenced code blocks."""
+    return _apply_outside_fences(
+        text,
+        lambda s: HTML_COMMENT_PATTERN.sub(lambda m: f"{{/* {m.group(1)} */}}", s),
+    )
+
+
+# ── GitHub callouts -> Fern admonitions ──────────────────────────────────────
+
+GITHUB_TO_FERN = {
+    "NOTE": "Note",
+    "TIP": "Tip",
+    "IMPORTANT": "Info",
+    "WARNING": "Warning",
+    "CAUTION": "Error",
+}
+
+GITHUB_ADMONITION_PATTERN = re.compile(
+    r"^(?P<indent>[ \t]*)>[ \t]*\[!(?P<type>NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*\n"
+    r"(?P<content>(?:(?P=indent)>[ \t]*.*\n?)+)",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def _extract_blockquote_content(content: str, indent: str) -> str:
+    lines = content.split("\n")
+    extracted = []
+    for line in lines:
+        if line.startswith(indent + ">"):
+            stripped = line[len(indent) + 1 :]
+            if stripped.startswith(" "):
+                stripped = stripped[1:]
+            extracted.append(stripped)
+        elif line.strip() == "":
+            break
+        else:
+            break
+    return "\n".join(extracted).rstrip()
+
+
+def _convert_admonition(match: re.Match) -> str:
+    indent = match.group("indent")
+    alert_type = match.group("type").upper()
+    fern_tag = GITHUB_TO_FERN.get(alert_type, "Note")
+    content = _extract_blockquote_content(match.group("content"), indent)
+    content_lines = content.split("\n")
+    if len(content_lines) == 1 and len(content) < 100:
+        return f"{indent}<{fern_tag}>{content}</{fern_tag}>\n"
+    formatted = "\n".join(content_lines)
+    return f"{indent}<{fern_tag}>\n{formatted}\n{indent}</{fern_tag}>\n"
+
+
+def _convert_admonitions(text: str) -> str:
+    """Replace GitHub > [!TYPE] callouts with Fern <Tag> admonitions, skipping fenced code blocks."""
+    return _apply_outside_fences(
+        text,
+        lambda s: GITHUB_ADMONITION_PATTERN.sub(_convert_admonition, s),
+    )
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def convert(text: str) -> str:
+    """Apply all transformations to convert GitHub Markdown to Fern MDX."""
+    text = _convert_comments(text)
+    text = _convert_admonitions(text)
+    return text
+
+
+def process_file(path: Path, dry_run: bool = False) -> bool:
+    """Convert a single file. Returns True if the file was (or would be) changed."""
+    original = path.read_text(encoding="utf-8")
+    converted = convert(original)
+    if converted == original:
+        return False
+    if not dry_run:
+        path.write_text(converted, encoding="utf-8")
+    return True
+
+
+def process_directory(dir_path: Path, dry_run: bool = False) -> int:
+    """Convert all markdown files in a directory. Returns count of changed files."""
+    changed = 0
+    for file_path in sorted(dir_path.rglob("*.md")):
+        if process_file(file_path, dry_run=dry_run):
+            action = "Would convert" if dry_run else "Converted"
+            print(f"  {action}: {file_path}")
+            changed += 1
+    return changed
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def run_tests() -> bool:
+    passed = 0
+    failed = 0
+
+    def test(name: str, input_text: str, expected: str) -> None:
+        nonlocal passed, failed
+        result = convert(input_text)
+        if result == expected:
+            print(f"  PASS: {name}")
+            passed += 1
+        else:
+            print(f"  FAIL: {name}")
+            print(f"    Input:    {repr(input_text)}")
+            print(f"    Expected: {repr(expected)}")
+            print(f"    Got:      {repr(result)}")
+            failed += 1
+
+    print("Running tests...\n")
+
+    # HTML comment -> MDX comment
+    test(
+        "Opening HTML comment tag",
+        "<!-- aiperf-run-vllm-default-openai-endpoint-server -->\n",
+        "{/* aiperf-run-vllm-default-openai-endpoint-server */}\n",
+    )
+    test(
+        "Closing HTML comment tag",
+        "<!-- /aiperf-run-vllm-default-openai-endpoint-server -->\n",
+        "{/* /aiperf-run-vllm-default-openai-endpoint-server */}\n",
+    )
+    test(
+        "Tag surrounded by content",
+        "Some text\n<!-- my-tag -->\n```bash\necho hi\n```\n<!-- /my-tag -->\nMore text\n",
+        "Some text\n{/* my-tag */}\n```bash\necho hi\n```\n{/* /my-tag */}\nMore text\n",
+    )
+    test(
+        "Multiline HTML comment",
+        "<!--\nCopyright 2026 NVIDIA\n-->\n\n# Title\n",
+        "{/* Copyright 2026 NVIDIA */}\n\n# Title\n",
+    )
+
+    # GitHub callouts -> Fern admonitions
+    test(
+        "NOTE callout",
+        "> [!NOTE]\n> This is a note.\n",
+        "<Note>This is a note.</Note>\n",
+    )
+    test(
+        "TIP callout",
+        "> [!TIP]\n> Helpful tip.\n",
+        "<Tip>Helpful tip.</Tip>\n",
+    )
+    test(
+        "IMPORTANT -> Info",
+        "> [!IMPORTANT]\n> Key info.\n",
+        "<Info>Key info.</Info>\n",
+    )
+    test(
+        "WARNING callout",
+        "> [!WARNING]\n> Watch out.\n",
+        "<Warning>Watch out.</Warning>\n",
+    )
+    test(
+        "CAUTION -> Error",
+        "> [!CAUTION]\n> Dangerous.\n",
+        "<Error>Dangerous.</Error>\n",
+    )
+    test(
+        "Multiline callout",
+        "> [!NOTE]\n> Line one.\n> Line two.\n",
+        "<Note>\nLine one.\nLine two.\n</Note>\n",
+    )
+    test(
+        "Admonition in document",
+        "# Header\n\n> [!WARNING]\n> Be careful.\n\nMore text.\n",
+        "# Header\n\n<Warning>Be careful.</Warning>\n\nMore text.\n",
+    )
+
+    # Code-fence awareness — content inside fences must not be transformed
+    test(
+        "HTML comment inside code fence unchanged",
+        "```bash\n<!-- tag-name -->\n```\n",
+        "```bash\n<!-- tag-name -->\n```\n",
+    )
+    test(
+        "Callout inside code fence unchanged",
+        "```\n> [!NOTE]\n> This is inside a fence.\n```\n",
+        "```\n> [!NOTE]\n> This is inside a fence.\n```\n",
+    )
+    test(
+        "Comment outside fence converted, inside unchanged",
+        "<!-- before -->\n```bash\n<!-- inside -->\n```\n<!-- after -->\n",
+        "{/* before */}\n```bash\n<!-- inside -->\n```\n{/* after */}\n",
+    )
+
+    # No change
+    test(
+        "Plain markdown unchanged",
+        "# Just a header\n\nSome text.\n",
+        "# Just a header\n\nSome text.\n",
+    )
+
+    print(f"\n{'=' * 40}")
+    print(f"Results: {passed} passed, {failed} failed")
+    return failed == 0
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert GitHub Markdown to Fern MDX format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("input", nargs="?", help="Single file to convert in-place")
+    parser.add_argument(
+        "--dir", "-d", type=Path, help="Directory of markdown files to convert"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print what would change without writing"
+    )
+    parser.add_argument("--test", "-t", action="store_true", help="Run test cases")
+    args = parser.parse_args()
+
+    if args.test:
+        sys.exit(0 if run_tests() else 1)
+
+    if args.dir:
+        if not args.dir.is_dir():
+            print(f"Error: {args.dir} is not a directory", file=sys.stderr)
+            sys.exit(1)
+        count = process_directory(args.dir, dry_run=args.dry_run)
+        action = "Would convert" if args.dry_run else "Converted"
+        print(f"\n{action} {count} file(s)")
+    elif args.input:
+        path = Path(args.input)
+        if not path.is_file():
+            print(f"Error: {path} is not a file", file=sys.stderr)
+            sys.exit(1)
+        changed = process_file(path, dry_run=args.dry_run)
+        if changed:
+            action = "Would convert" if args.dry_run else "Converted"
+            print(f"{action}: {path}")
+        else:
+            print(f"No changes: {path}")
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/test_docs_end_to_end/parser.py
+++ b/tests/ci/test_docs_end_to_end/parser.py
@@ -53,11 +53,9 @@ class MarkdownParser:
         while i < len(lines):
             line = lines[i].strip()
 
-            # Look for MDX comment tags: {/* tag-name */}
-            if line.startswith("{/*") and line.endswith("*/}"):
-                # Use [^*\s]\S* instead of [^*\s]+.*? to avoid ReDoS
-                # (both quantifiers can match the same chars, causing O(n²) backtracking)
-                tag_match = re.match(r"\{/\*\s*([^*\s]\S*)\s*\*/\}", line)
+            # Look for HTML comment tags: <!-- tag-name -->
+            if line.startswith("<!--") and line.endswith("-->"):
+                tag_match = re.match(r"<!--\s*(\S+)\s*-->", line)
                 if tag_match:
                     tag_name = tag_match.group(1).strip()
 

--- a/tests/unit/fern/test_fern_docs.py
+++ b/tests/unit/fern/test_fern_docs.py
@@ -53,20 +53,6 @@ def test_fern_check() -> None:
     )
 
 
-def test_fern_check_strict() -> None:
-    """Validate the Fern definition with strict broken-link checking."""
-    result = subprocess.run(
-        ["fern", "check", "--warnings", "--strict-broken-links"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-    assert result.returncode == 0, (
-        f"fern check --strict-broken-links failed (exit {result.returncode}):\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-
-
 def test_fern_docs_dev_starts() -> None:
     """Verify fern docs dev builds and starts without errors.
 

--- a/tools/check_docs_index.py
+++ b/tools/check_docs_index.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Check that every markdown file in docs/ is listed in docs/index.yml.
+
+Fails with a non-zero exit code if any file is missing, so this can be
+used as a CI gate to prevent docs from being silently excluded from the
+Fern documentation site.
+
+Files listed in ALLOWLIST are intentionally excluded and will not cause
+a failure.
+
+Usage:
+    python tools/check_docs_index.py
+    python tools/check_docs_index.py --docs-dir docs --index docs/index.yml
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Files intentionally excluded from the index (relative to docs/)
+ALLOWLIST = {
+    "accuracy/accuracy_stubs.md",
+}
+
+
+def get_indexed_paths(index_path: Path) -> set[str]:
+    """Extract all path: values from index.yml."""
+    content = index_path.read_text(encoding="utf-8")
+    return set(re.findall(r"^\s*path:\s*(.+)$", content, re.MULTILINE))
+
+
+def get_all_docs(docs_dir: Path) -> set[str]:
+    """Return all .md files in docs/ relative to docs_dir, excluding index.md."""
+    return {
+        str(f.relative_to(docs_dir))
+        for f in docs_dir.rglob("*.md")
+        if f.name != "index.md"
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check docs/index.yml is complete")
+    parser.add_argument(
+        "--docs-dir", type=Path, default=Path("docs"), help="Path to docs directory"
+    )
+    parser.add_argument(
+        "--index", type=Path, default=Path("docs/index.yml"), help="Path to index.yml"
+    )
+    args = parser.parse_args()
+
+    if not args.docs_dir.is_dir():
+        print(f"Error: docs directory not found: {args.docs_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.index.is_file():
+        print(f"Error: index file not found: {args.index}", file=sys.stderr)
+        sys.exit(1)
+
+    all_docs = get_all_docs(args.docs_dir)
+    indexed = get_indexed_paths(args.index)
+    missing = sorted(all_docs - indexed - ALLOWLIST)
+
+    if missing:
+        print(
+            f"ERROR: {len(missing)} file(s) in docs/ are not listed in {args.index}:\n"
+        )
+        for f in missing:
+            print(f"  - {f}")
+        print(
+            f"\nAdd the missing file(s) to {args.index} or to the ALLOWLIST in this script."
+        )
+        sys.exit(1)
+
+    print(
+        f"OK: all {len(all_docs) - len(ALLOWLIST)} docs files are listed in {args.index}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Automatic docs sync to `docs-website` is disabled for now.
I also have a `docs-wesbite` snapshot in another branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized many admonitions and snippet markers to consistent Markdown/HTML comment formats and updated the docs navigation with new tutorial and reference entries.

* **New Features**
  * Added a docs index completeness check script to validate that markdown pages are listed in the docs navigation.

* **Workflow**
  * Switched docs linting to run the new Python-based index check and updated the docs transformation step; publishing remains temporarily gated with a TODO to re-enable.

* **Tests**
  * Adjusted docs tests and updated the parser to recognize the new comment format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->