### PR TITLE
feat: Add request-id header to correlate with Dynamo router logs

### DIFF
--- a/src/aiperf/transports/base_transports.py
+++ b/src/aiperf/transports/base_transports.py
@@ -114,6 +114,7 @@ class BaseTransport(AIPerfLifecycleMixin, ABC):
 
         if request_info.x_request_id:
             headers["X-Request-ID"] = request_info.x_request_id
+            headers["request-id"] = request_info.x_request_id
         if request_info.x_correlation_id:
             headers["X-Correlation-ID"] = request_info.x_correlation_id
 

--- a/tests/unit/transports/test_base_transport.py
+++ b/tests/unit/transports/test_base_transport.py
@@ -113,7 +113,11 @@ class TestBaseTransport:
             (
                 "req-123456",
                 None,
-                {"User-Agent": AIPERF_USER_AGENT, "X-Request-ID": "req-123456"},
+                {
+                    "User-Agent": AIPERF_USER_AGENT,
+                    "X-Request-ID": "req-123456",
+                    "request-id": "req-123456",
+                },
             ),
             (
                 None,
@@ -126,6 +130,7 @@ class TestBaseTransport:
                 {
                     "User-Agent": AIPERF_USER_AGENT,
                     "X-Request-ID": "req-123",
+                    "request-id": "req-123",
                     "X-Correlation-ID": "corr-456",
                 },
             ),


### PR DESCRIPTION
For evaluating KV aware routing (overlap scores, choice of worker, etc), want to be able to correlate request ID from AIPerf raw records to Dynamo router debug logs. Dynamo router logs output:

`2026-04-16T21:48:12.765113Z DEBUG http-request:kv_router.select_worker: dynamo_llm::kv_router::push_router: [ROUTING] Best: worker_<worker_id> dp_rank=<rank> with X/Y blocks overlap request_id=<request_id> worker_id=<worker_id> dp_rank=0 overlap_blocks=X total_blocks=Y method=POST uri=/v1/chat/completions version=HTTP/1.1 ...`

Where request_id is taken from request-id HTTP header. Without it, the default is to generate a UUID. 

This PR adds the request-id header to `src/aiperf/transports/base_transports.py` to enable per-request tracking between logs and AIPerf raw records. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request identifier header handling to support an additional lowercase format variant alongside the standard request identifier for enhanced system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->