### PR TITLE
feat(cli): add --wait-for-model pre-flight readiness probe

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -169,7 +169,7 @@ API authentication key for the endpoint. When provided, automatically included i
 
 #### `--wait-for-model`
 
-When enabled, aiperf polls `{url}/v1/models` before profiling starts and waits for the target `--model` id to appear in the response. Falls back to a single GET on the base URL if `/v1/models` returns 404. Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.
+When enabled, aiperf runs a pre-flight readiness probe before profiling starts and waits for the target endpoint to accept requests. The probe strategy is controlled by `--wait-for-model-mode`, which defaults to sending a 1-token inference request (strongest signal). Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.
 <br/>_Flag (no value required)_
 
 #### `--wait-for-model-timeout` `<float>`
@@ -183,6 +183,11 @@ Maximum time in seconds to wait for the model to become ready before aborting wi
 Seconds between readiness probe attempts while waiting for the model. Only applies when `--wait-for-model` is enabled.
 <br/>_Constraints: > 0.0_
 <br/>_Default: `5.0`_
+
+#### `--wait-for-model-mode` `<str>`
+
+Strategy for the readiness probe. 'inference' (default): POST a 1-token inference request to the configured endpoint; this is the strongest signal — it proves the full stack (frontend, scheduler, worker, forward pass) is live. Any HTTP status &lt; 500 counts as ready. 'models': GET `/v1/models` and verify the model id appears in `data[]` (cheaper, no tokens consumed; falls back to a plain GET on the base URL on 404). 'both': run 'models' first, then 'inference'. Only applies when `--wait-for-model` is enabled.
+<br/>_Default: `inference`_
 
 #### `--transport`, `--transport-type` `<str>`
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -167,6 +167,21 @@ Maximum time in seconds to wait for each HTTP request to complete, including con
 
 API authentication key for the endpoint. When provided, automatically included in request headers as `Authorization: Bearer <api_key>`.
 
+#### `--wait-for-model`
+
+When enabled, aiperf polls `{url}/v1/models` before profiling starts and waits for the target `--model` id to appear in the response. Falls back to a single GET on the base URL if `/v1/models` returns 404. Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.
+<br/>_Flag (no value required)_
+
+#### `--wait-for-model-timeout` `<float>`
+
+Maximum time in seconds to wait for the model to become ready before aborting with a non-zero exit. Only applies when `--wait-for-model` is enabled.
+<br/>_Default: `1800.0`_
+
+#### `--wait-for-model-interval` `<float>`
+
+Seconds between readiness probe attempts while waiting for the model. Only applies when `--wait-for-model` is enabled.
+<br/>_Default: `5.0`_
+
 #### `--transport`, `--transport-type` `<str>`
 
 Transport protocol to use for API requests. If not specified, auto-detected from the URL scheme (`http`/`https` → `TransportType.HTTP`). Currently supports `http` transport using aiohttp with connection pooling, TCP optimization, and Server-Sent Events (SSE) for streaming. Explicit override rarely needed.

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -169,7 +169,7 @@ API authentication key for the endpoint. When provided, automatically included i
 
 #### `--wait-for-model-timeout` `<float>`
 
-Enable a pre-flight readiness probe by setting this to a positive value (seconds). aiperf will then wait up to this long for the target endpoint to accept requests before starting the benchmark, aborting with a non-zero exit on timeout. The probe strategy is controlled by `--wait-for-model-mode`, which defaults to sending a 1-token inference request. 0 (default) disables the probe. Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.
+Enable a pre-flight readiness probe by setting this to a positive value (seconds). aiperf applies this timeout to each URL/model probe before starting the benchmark, aborting with a non-zero exit if any probe times out. For multiple URLs or models, worst-case wall-clock time can be roughly this timeout multiplied by the number of URL/model probes. The probe strategy is controlled by `--wait-for-model-mode`, which defaults to sending a 1-token inference request. 0 (default) disables the probe. Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.
 <br/>_Constraints: ≥ 0.0_
 <br/>_Default: `0.0`_
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -175,11 +175,13 @@ When enabled, aiperf polls `{url}/v1/models` before profiling starts and waits f
 #### `--wait-for-model-timeout` `<float>`
 
 Maximum time in seconds to wait for the model to become ready before aborting with a non-zero exit. Only applies when `--wait-for-model` is enabled.
+<br/>_Constraints: > 0.0_
 <br/>_Default: `1800.0`_
 
 #### `--wait-for-model-interval` `<float>`
 
 Seconds between readiness probe attempts while waiting for the model. Only applies when `--wait-for-model` is enabled.
+<br/>_Constraints: > 0.0_
 <br/>_Default: `5.0`_
 
 #### `--transport`, `--transport-type` `<str>`

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -167,26 +167,21 @@ Maximum time in seconds to wait for each HTTP request to complete, including con
 
 API authentication key for the endpoint. When provided, automatically included in request headers as `Authorization: Bearer <api_key>`.
 
-#### `--wait-for-model`
-
-When enabled, aiperf runs a pre-flight readiness probe before profiling starts and waits for the target endpoint to accept requests. The probe strategy is controlled by `--wait-for-model-mode`, which defaults to sending a 1-token inference request (strongest signal). Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.
-<br/>_Flag (no value required)_
-
 #### `--wait-for-model-timeout` `<float>`
 
-Maximum time in seconds to wait for the model to become ready before aborting with a non-zero exit. Only applies when `--wait-for-model` is enabled.
-<br/>_Constraints: > 0.0_
-<br/>_Default: `1800.0`_
+Enable a pre-flight readiness probe by setting this to a positive value (seconds). aiperf will then wait up to this long for the target endpoint to accept requests before starting the benchmark, aborting with a non-zero exit on timeout. The probe strategy is controlled by `--wait-for-model-mode`, which defaults to sending a 1-token inference request. 0 (default) disables the probe. Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `0.0`_
 
 #### `--wait-for-model-interval` `<float>`
 
-Seconds between readiness probe attempts while waiting for the model. Only applies when `--wait-for-model` is enabled.
+Seconds between readiness probe attempts. Only consulted when `--wait-for-model-timeout` is positive.
 <br/>_Constraints: > 0.0_
 <br/>_Default: `5.0`_
 
 #### `--wait-for-model-mode` `<str>`
 
-Strategy for the readiness probe. 'inference' (default): POST a 1-token inference request to the configured endpoint; this is the strongest signal — it proves the full stack (frontend, scheduler, worker, forward pass) is live. Any HTTP status &lt; 500 counts as ready. 'models': GET `/v1/models` and verify the model id appears in `data[]` (cheaper, no tokens consumed; falls back to a plain GET on the base URL on 404). 'both': run 'models' first, then 'inference'. Only applies when `--wait-for-model` is enabled.
+Strategy for the readiness probe. 'inference' (default): POST a 1-token inference request to the configured endpoint; this is the strongest signal — it proves the full stack (frontend, scheduler, worker, forward pass) is live. Any HTTP status &lt; 500 counts as ready. 'models': GET `/v1/models` and verify the model id appears in `data[]` (cheaper, no tokens consumed; falls back to a plain GET on the base URL on 404). 'both': run 'models' first, then 'inference'. Only consulted when `--wait-for-model-timeout` is positive.
 <br/>_Default: `inference`_
 
 #### `--transport`, `--transport-type` `<str>`

--- a/src/aiperf/cli_commands/profile.py
+++ b/src/aiperf/cli_commands/profile.py
@@ -57,7 +57,7 @@ def profile(
             import asyncio
             import logging
 
-            from aiperf.common.readiness_probe import wait_for_models_ready
+            from aiperf.common.readiness_probe import wait_for_endpoint
 
             # The probe runs before `run_system_controller` (which installs
             # rich logging), so there are no handlers attached yet. Install
@@ -74,9 +74,12 @@ def profile(
                 headers["Authorization"] = f"Bearer {user_config.endpoint.api_key}"
 
             asyncio.run(
-                wait_for_models_ready(
+                wait_for_endpoint(
                     urls=user_config.endpoint.urls,
                     model_names=user_config.endpoint.model_names,
+                    mode=user_config.endpoint.wait_for_model_mode,
+                    endpoint_type=str(user_config.endpoint.type),
+                    custom_endpoint=user_config.endpoint.custom_endpoint,
                     timeout_s=user_config.endpoint.wait_for_model_timeout,
                     interval_s=user_config.endpoint.wait_for_model_interval,
                     headers=headers,

--- a/src/aiperf/cli_commands/profile.py
+++ b/src/aiperf/cli_commands/profile.py
@@ -53,7 +53,7 @@ def profile(
 
         service_config = service_config or load_service_config()
 
-        if user_config.endpoint.wait_for_model:
+        if user_config.endpoint.wait_for_model_timeout > 0:
             import asyncio
             import logging
 

--- a/src/aiperf/cli_commands/profile.py
+++ b/src/aiperf/cli_commands/profile.py
@@ -52,4 +52,35 @@ def profile(
         from aiperf.common.config.loader import load_service_config
 
         service_config = service_config or load_service_config()
+
+        if user_config.endpoint.wait_for_model:
+            import asyncio
+            import logging
+
+            from aiperf.common.readiness_probe import wait_for_models_ready
+
+            # The probe runs before `run_system_controller` (which installs
+            # rich logging), so there are no handlers attached yet. Install
+            # a basic stderr handler so probe log messages are visible.
+            if not logging.getLogger().handlers:
+                logging.basicConfig(
+                    level=logging.INFO,
+                    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                )
+
+            raw_headers = user_config.input.headers or []
+            headers = {str(k): str(v) for k, v in raw_headers}
+            if user_config.endpoint.api_key:
+                headers["Authorization"] = f"Bearer {user_config.endpoint.api_key}"
+
+            asyncio.run(
+                wait_for_models_ready(
+                    urls=user_config.endpoint.urls,
+                    model_name=user_config.endpoint.model_names[0],
+                    timeout_s=user_config.endpoint.wait_for_model_timeout,
+                    interval_s=user_config.endpoint.wait_for_model_interval,
+                    headers=headers,
+                )
+            )
+
         run_system_controller(user_config, service_config)

--- a/src/aiperf/cli_commands/profile.py
+++ b/src/aiperf/cli_commands/profile.py
@@ -76,7 +76,7 @@ def profile(
             asyncio.run(
                 wait_for_models_ready(
                     urls=user_config.endpoint.urls,
-                    model_name=user_config.endpoint.model_names[0],
+                    model_names=user_config.endpoint.model_names,
                     timeout_s=user_config.endpoint.wait_for_model_timeout,
                     interval_s=user_config.endpoint.wait_for_model_interval,
                     headers=headers,

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -48,6 +48,9 @@ class EndpointDefaults:
     CONNECTION_REUSE_STRATEGY = ConnectionReuseStrategy.POOLED
     DOWNLOAD_VIDEO_CONTENT = False
     REQUEST_CONTENT_TYPE = None
+    WAIT_FOR_MODEL = False
+    WAIT_FOR_MODEL_TIMEOUT = 1800.0
+    WAIT_FOR_MODEL_INTERVAL = 5.0
 
 
 @dataclass(frozen=True)

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -51,6 +51,7 @@ class EndpointDefaults:
     WAIT_FOR_MODEL = False
     WAIT_FOR_MODEL_TIMEOUT = 1800.0
     WAIT_FOR_MODEL_INTERVAL = 5.0
+    WAIT_FOR_MODEL_MODE = "inference"
 
 
 @dataclass(frozen=True)

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -48,8 +48,11 @@ class EndpointDefaults:
     CONNECTION_REUSE_STRATEGY = ConnectionReuseStrategy.POOLED
     DOWNLOAD_VIDEO_CONTENT = False
     REQUEST_CONTENT_TYPE = None
-    WAIT_FOR_MODEL = False
-    WAIT_FOR_MODEL_TIMEOUT = 1800.0
+    # Readiness probe defaults. Timeout 0 disables the probe (the default);
+    # any positive value enables it. Interval is only consulted when the
+    # probe is enabled but is validated positive so mis-configuration
+    # (e.g. --wait-for-model-interval 0) is rejected at config-load time.
+    WAIT_FOR_MODEL_TIMEOUT = 0.0
     WAIT_FOR_MODEL_INTERVAL = 5.0
     WAIT_FOR_MODEL_MODE = "inference"
 

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -224,10 +224,11 @@ class EndpointConfig(BaseConfig):
         float,
         Field(
             description="Enable a pre-flight readiness probe by setting this to a positive value (seconds). "
-            "aiperf will then wait up to this long for the target endpoint to accept requests before "
-            "starting the benchmark, aborting with a non-zero exit on timeout. The probe strategy is "
-            "controlled by `--wait-for-model-mode`, which defaults to sending a 1-token inference request. "
-            "0 (default) disables the probe. "
+            "aiperf applies this timeout to each URL/model probe before starting the benchmark, "
+            "aborting with a non-zero exit if any probe times out. For multiple URLs or models, "
+            "worst-case wall-clock time can be roughly this timeout multiplied by the number of "
+            "URL/model probes. The probe strategy is controlled by `--wait-for-model-mode`, which "
+            "defaults to sending a 1-token inference request. 0 (default) disables the probe. "
             "Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.",
             ge=0.0,
         ),

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import (
     BeforeValidator,
@@ -200,8 +200,9 @@ class EndpointConfig(BaseConfig):
     wait_for_model: Annotated[
         bool,
         Field(
-            description="When enabled, aiperf polls `{url}/v1/models` before profiling starts and waits for the target "
-            "`--model` id to appear in the response. Falls back to a single GET on the base URL if `/v1/models` returns 404. "
+            description="When enabled, aiperf runs a pre-flight readiness probe before profiling starts and waits for "
+            "the target endpoint to accept requests. The probe strategy is controlled by `--wait-for-model-mode`, which "
+            "defaults to sending a 1-token inference request (strongest signal). "
             "Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.",
         ),
         CLIParameter(
@@ -235,6 +236,24 @@ class EndpointConfig(BaseConfig):
             group=_CLI_GROUP,
         ),
     ] = EndpointDefaults.WAIT_FOR_MODEL_INTERVAL
+
+    wait_for_model_mode: Annotated[
+        Literal["models", "inference", "both"],
+        Field(
+            description="Strategy for the readiness probe. "
+            "'inference' (default): POST a 1-token inference request to the configured endpoint; "
+            "this is the strongest signal — it proves the full stack (frontend, scheduler, worker, "
+            "forward pass) is live. Any HTTP status < 500 counts as ready. "
+            "'models': GET `/v1/models` and verify the model id appears in `data[]` "
+            "(cheaper, no tokens consumed; falls back to a plain GET on the base URL on 404). "
+            "'both': run 'models' first, then 'inference'. "
+            "Only applies when `--wait-for-model` is enabled.",
+        ),
+        CLIParameter(
+            name=("--wait-for-model-mode",),
+            group=_CLI_GROUP,
+        ),
+    ] = EndpointDefaults.WAIT_FOR_MODEL_MODE
 
     transport: Annotated[
         TransportType | None,

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -197,6 +197,43 @@ class EndpointConfig(BaseConfig):
         ),
     ] = EndpointDefaults.API_KEY
 
+    wait_for_model: Annotated[
+        bool,
+        Field(
+            description="When enabled, aiperf polls `{url}/v1/models` before profiling starts and waits for the target "
+            "`--model` id to appear in the response. Falls back to a single GET on the base URL if `/v1/models` returns 404. "
+            "Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.",
+        ),
+        CLIParameter(
+            name=("--wait-for-model",),
+            group=_CLI_GROUP,
+        ),
+    ] = EndpointDefaults.WAIT_FOR_MODEL
+
+    wait_for_model_timeout: Annotated[
+        float,
+        Field(
+            description="Maximum time in seconds to wait for the model to become ready before aborting with a non-zero exit. "
+            "Only applies when `--wait-for-model` is enabled.",
+        ),
+        CLIParameter(
+            name=("--wait-for-model-timeout",),
+            group=_CLI_GROUP,
+        ),
+    ] = EndpointDefaults.WAIT_FOR_MODEL_TIMEOUT
+
+    wait_for_model_interval: Annotated[
+        float,
+        Field(
+            description="Seconds between readiness probe attempts while waiting for the model. "
+            "Only applies when `--wait-for-model` is enabled.",
+        ),
+        CLIParameter(
+            name=("--wait-for-model-interval",),
+            group=_CLI_GROUP,
+        ),
+    ] = EndpointDefaults.WAIT_FOR_MODEL_INTERVAL
+
     transport: Annotated[
         TransportType | None,
         Field(

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -215,6 +215,7 @@ class EndpointConfig(BaseConfig):
         Field(
             description="Maximum time in seconds to wait for the model to become ready before aborting with a non-zero exit. "
             "Only applies when `--wait-for-model` is enabled.",
+            gt=0.0,
         ),
         CLIParameter(
             name=("--wait-for-model-timeout",),
@@ -227,6 +228,7 @@ class EndpointConfig(BaseConfig):
         Field(
             description="Seconds between readiness probe attempts while waiting for the model. "
             "Only applies when `--wait-for-model` is enabled.",
+            gt=0.0,
         ),
         CLIParameter(
             name=("--wait-for-model-interval",),

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -57,6 +57,29 @@ class EndpointConfig(BaseConfig):
             self.streaming = False
         return self
 
+    @model_validator(mode="after")
+    def validate_wait_for_model_coherent(self) -> Self:
+        """Reject configurations where probe sub-options are set without
+        enabling the probe itself (timeout > 0). Catches typos like
+        `--wait-for-model-interval 1` without a timeout value.
+        """
+        if self.wait_for_model_timeout > 0:
+            return self
+        dependent = {"wait_for_model_interval", "wait_for_model_mode"}
+        set_without_enable = sorted(dependent & self.model_fields_set)
+        if set_without_enable:
+            flag_names = {
+                "wait_for_model_interval": "--wait-for-model-interval",
+                "wait_for_model_mode": "--wait-for-model-mode",
+            }
+            shown = ", ".join(flag_names[f] for f in set_without_enable)
+            raise ValueError(
+                f"{shown} has no effect unless --wait-for-model-timeout is set "
+                f"to a positive value. Set --wait-for-model-timeout to enable "
+                f"the readiness probe."
+            )
+        return self
+
     model_names: Annotated[
         list[str],
         Field(
@@ -197,26 +220,16 @@ class EndpointConfig(BaseConfig):
         ),
     ] = EndpointDefaults.API_KEY
 
-    wait_for_model: Annotated[
-        bool,
-        Field(
-            description="When enabled, aiperf runs a pre-flight readiness probe before profiling starts and waits for "
-            "the target endpoint to accept requests. The probe strategy is controlled by `--wait-for-model-mode`, which "
-            "defaults to sending a 1-token inference request (strongest signal). "
-            "Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.",
-        ),
-        CLIParameter(
-            name=("--wait-for-model",),
-            group=_CLI_GROUP,
-        ),
-    ] = EndpointDefaults.WAIT_FOR_MODEL
-
     wait_for_model_timeout: Annotated[
         float,
         Field(
-            description="Maximum time in seconds to wait for the model to become ready before aborting with a non-zero exit. "
-            "Only applies when `--wait-for-model` is enabled.",
-            gt=0.0,
+            description="Enable a pre-flight readiness probe by setting this to a positive value (seconds). "
+            "aiperf will then wait up to this long for the target endpoint to accept requests before "
+            "starting the benchmark, aborting with a non-zero exit on timeout. The probe strategy is "
+            "controlled by `--wait-for-model-mode`, which defaults to sending a 1-token inference request. "
+            "0 (default) disables the probe. "
+            "Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.",
+            ge=0.0,
         ),
         CLIParameter(
             name=("--wait-for-model-timeout",),
@@ -227,8 +240,8 @@ class EndpointConfig(BaseConfig):
     wait_for_model_interval: Annotated[
         float,
         Field(
-            description="Seconds between readiness probe attempts while waiting for the model. "
-            "Only applies when `--wait-for-model` is enabled.",
+            description="Seconds between readiness probe attempts. "
+            "Only consulted when `--wait-for-model-timeout` is positive.",
             gt=0.0,
         ),
         CLIParameter(
@@ -247,7 +260,7 @@ class EndpointConfig(BaseConfig):
             "'models': GET `/v1/models` and verify the model id appears in `data[]` "
             "(cheaper, no tokens consumed; falls back to a plain GET on the base URL on 404). "
             "'both': run 'models' first, then 'inference'. "
-            "Only applies when `--wait-for-model` is enabled.",
+            "Only consulted when `--wait-for-model-timeout` is positive.",
         ),
         CLIParameter(
             name=("--wait-for-model-mode",),

--- a/src/aiperf/common/readiness_probe.py
+++ b/src/aiperf/common/readiness_probe.py
@@ -1,19 +1,30 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Pre-flight readiness probe for the target inference server(s).
+"""Pre-flight endpoint readiness probe.
 
-Polls `{url}/v1/models` on each URL until the requested model id appears in
-the response, or raises `TimeoutError` when the deadline elapses. If
-`/v1/models` returns 404, falls back to a single GET on the base URL so
-servers that don't expose a model list (or only expose a healthcheck) still
-pass the probe when they respond at all.
+Probes every configured (URL, model) pair before benchmarking starts. Three
+probe strategies, selected via ``endpoint.wait_for_model_mode``:
+
+- ``inference`` (default) — POST a canned 1-token inference request to the
+  configured endpoint. Strongest signal: proves the full serving stack
+  (frontend, scheduler, worker, forward pass) is live. Any HTTP status
+  below 500 counts as ready — 4xx surfaces the same way on the first real
+  benchmark request and doesn't warrant hanging the probe.
+- ``models`` — GET ``{url}/v1/models`` and verify the model id appears in
+  ``data[]``. Cheap, no tokens consumed. Falls back to a plain GET on the
+  base URL if ``/v1/models`` returns 404 so servers without a model list
+  still pass when they're responsive. Note: some frontends (including
+  Dynamo) can return 200 from ``/v1/models`` before the backend workers
+  are actually able to serve — ``inference`` is the more trustworthy
+  signal there.
+- ``both`` — run ``models`` first on each URL, then ``inference``.
 """
 
 from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import aiohttp
 import orjson
@@ -25,10 +36,37 @@ if TYPE_CHECKING:
 
 _logger = AIPerfLogger(__name__)
 
-# Minimum per-request timeout for the probe. `interval_s` can be very small
-# (e.g. 0.5s for fast-retrying tests); using it directly as a request timeout
-# would cause spurious failures on networks with any real latency.
+# "Lo" — the first message ever sent over a network. On Oct 29, 1969, UCLA
+# tried to transmit "login" over the ARPANET but the system crashed after
+# two characters. A one-byte prompt keeps token cost and KV-cache impact
+# minimal on paid / metered backends.
+_READINESS_PROMPT = "Lo"
+
+_CANNED_PAYLOADS: dict[str, dict] = {
+    "chat": {
+        "messages": [{"role": "user", "content": _READINESS_PROMPT}],
+        "max_tokens": 1,
+    },
+    "completions": {
+        "prompt": _READINESS_PROMPT,
+        "max_tokens": 1,
+    },
+    "embeddings": {
+        "input": _READINESS_PROMPT,
+    },
+}
+
+_DEFAULT_PATHS: dict[str, str] = {
+    "chat": "/v1/chat/completions",
+    "completions": "/v1/completions",
+    "embeddings": "/v1/embeddings",
+}
+
+# Floor on per-request HTTP timeout. Retry interval can be small for tests
+# but network round trips need breathing room.
 _MIN_REQUEST_TIMEOUT_S = 5.0
+
+ReadyCheckMode = Literal["models", "inference", "both"]
 
 
 def _model_in_payload(payload_text: str, model_name: str) -> bool:
@@ -45,7 +83,7 @@ def _model_in_payload(payload_text: str, model_name: str) -> bool:
     )
 
 
-async def _wait_for_single_url(
+async def _wait_models(
     client: AioHttpClient,
     url: str,
     model_name: str,
@@ -53,7 +91,12 @@ async def _wait_for_single_url(
     interval_s: float,
     headers: dict[str, str],
 ) -> None:
-    """Poll one URL until model is ready or deadline elapses."""
+    """Poll ``{url}/v1/models`` until ``model_name`` appears in ``data[]``.
+
+    Falls back to a single GET on the base URL if ``/v1/models`` returns 404
+    on any attempt — so servers that don't expose a model list still pass
+    when they respond at all.
+    """
     deadline = time.monotonic() + timeout_s
     models_url = url.rstrip("/") + "/v1/models"
     request_timeout_base = max(interval_s, _MIN_REQUEST_TIMEOUT_S)
@@ -137,36 +180,150 @@ async def _wait_for_single_url(
         await asyncio.sleep(sleep_for)
 
 
-async def wait_for_models_ready(
-    urls: list[str],
-    model_names: list[str],
+async def _wait_inference(
+    client: AioHttpClient,
+    url: str,
+    model_name: str,
+    endpoint_type: str,
+    custom_endpoint: str | None,
     timeout_s: float,
     interval_s: float,
     headers: dict[str, str],
 ) -> None:
-    """Block until every model in `model_names` is ready on every URL, or raise TimeoutError.
+    """POST a canned 1-token request to the inference endpoint until it works.
 
-    URLs and models are checked sequentially — at typical fleet sizes (1-4 URLs,
-    1-2 models) this keeps log output legible, and the caller's timeout is
-    per-URL-per-model.
+    Any response with ``status < 500`` counts as ready — 4xx means the
+    server is live but our payload was rejected (bad auth / bad model /
+    bad path), which surfaces the same way on the first real benchmark
+    request. Only 5xx and connection errors trigger retries.
+    """
+    from urllib.parse import urlparse
+
+    # Respect a caller-supplied path (e.g. --custom-endpoint), otherwise if
+    # the URL already carries a non-root path use that, otherwise append
+    # the OpenAI default for the endpoint type.
+    parsed = urlparse(url)
+    if custom_endpoint:
+        request_url = url.rstrip("/") + "/" + custom_endpoint.lstrip("/")
+    elif parsed.path and parsed.path != "/":
+        request_url = url.rstrip("/")
+    else:
+        endpoint_path = _DEFAULT_PATHS.get(endpoint_type, _DEFAULT_PATHS["chat"])
+        request_url = url.rstrip("/") + endpoint_path
+
+    payload = dict(_CANNED_PAYLOADS.get(endpoint_type, _CANNED_PAYLOADS["chat"]))
+    payload["model"] = model_name
+    body = orjson.dumps(payload)
+
+    # Inference requests need more breathing room than a trivial models GET:
+    # model load can push even a 1-token forward pass into the seconds range
+    # on first request. Floor higher than the models probe.
+    request_timeout_base = max(interval_s, 30.0)
+    deadline = time.monotonic() + timeout_s
+    attempt = 0
+
+    request_headers = {"Content-Type": "application/json", **headers}
+
+    while True:
+        attempt += 1
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Timed out after {timeout_s:.1f}s probing {request_url} "
+                f"with model '{model_name}' (checked {attempt - 1} time(s))"
+            )
+        request_timeout = aiohttp.ClientTimeout(
+            total=min(request_timeout_base, remaining)
+        )
+        record = await client.post_request(
+            request_url,
+            payload=body,
+            headers=request_headers,
+            timeout=request_timeout,
+        )
+
+        status = record.status
+        if status is not None and status < 500:
+            _logger.info(
+                f"Inference probe ready at {request_url} "
+                f"(status={status}, attempt {attempt})"
+            )
+            return
+
+        status_repr = status if status is not None else "connection error"
+        error_repr = record.error.message if record.error else ""
+        _logger.info(
+            f"Inference probe to {request_url} returned {status_repr} "
+            f"{('(' + error_repr + ') ') if error_repr else ''}"
+            f"(attempt {attempt}), retrying in {interval_s}s"
+        )
+
+        sleep_for = min(interval_s, max(0.0, deadline - time.monotonic()))
+        await asyncio.sleep(sleep_for)
+
+
+async def wait_for_endpoint(
+    urls: list[str],
+    model_names: list[str],
+    mode: ReadyCheckMode,
+    endpoint_type: str,
+    custom_endpoint: str | None,
+    timeout_s: float,
+    interval_s: float,
+    headers: dict[str, str],
+) -> None:
+    """Block until every configured (URL, model) pair passes the probe.
+
+    URLs and models are checked sequentially so log output stays legible at
+    typical fleet sizes (1-4 URLs, 1-2 models). The caller's ``timeout_s``
+    is applied per probe invocation, so the worst-case total wall-clock is
+    roughly ``timeout_s * len(urls) * len(models)`` — pick a generous value.
     """
     # Imported lazily to avoid a circular import: aiperf.common is imported
     # before aiperf.transports, and AioHttpClient pulls in a mixin that
     # back-imports from aiperf.transports.aiohttp_client.
     from aiperf.transports.aiohttp_client import AioHttpClient
 
+    if mode in ("models", "both") and not model_names:
+        raise ValueError(
+            f"wait-for-model mode={mode!r} requires at least one model name"
+        )
+    if not urls:
+        return
+
     _logger.info(
-        f"Waiting for model(s) {model_names} to be ready at: {', '.join(urls)} "
-        f"(timeout={timeout_s}s, interval={interval_s}s)"
+        f"Waiting for endpoint readiness (mode={mode}, timeout={timeout_s}s, "
+        f"interval={interval_s}s) across {len(urls)} URL(s) x "
+        f"{len(model_names)} model(s)"
     )
-    client = AioHttpClient(timeout=max(interval_s, 5.0))
+
+    client = AioHttpClient(timeout=max(interval_s, _MIN_REQUEST_TIMEOUT_S))
     try:
         for url in urls:
-            for model_name in model_names:
-                await _wait_for_single_url(
+            if mode in ("models", "both"):
+                for model_name in model_names:
+                    await _wait_models(
+                        client=client,
+                        url=url,
+                        model_name=model_name,
+                        timeout_s=timeout_s,
+                        interval_s=interval_s,
+                        headers=headers,
+                    )
+            if mode in ("inference", "both"):
+                # For the inference probe, any successful generation proves
+                # the stack is live — we don't need to loop across every
+                # model name. Use the first configured model (or fall back
+                # to "default" so the probe still works when model_names is
+                # empty, which the validator above permits only in pure
+                # inference mode).
+                probe_model = model_names[0] if model_names else "default"
+                await _wait_inference(
                     client=client,
                     url=url,
-                    model_name=model_name,
+                    model_name=probe_model,
+                    endpoint_type=endpoint_type,
+                    custom_endpoint=custom_endpoint,
                     timeout_s=timeout_s,
                     interval_s=interval_s,
                     headers=headers,

--- a/src/aiperf/common/readiness_probe.py
+++ b/src/aiperf/common/readiness_probe.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pre-flight readiness probe for the target inference server(s).
+
+Polls `{url}/v1/models` on each URL until the requested model id appears in
+the response, or raises `TimeoutError` when the deadline elapses. If
+`/v1/models` returns 404, falls back to a single GET on the base URL so
+servers that don't expose a model list (or only expose a healthcheck) still
+pass the probe when they respond at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+import orjson
+
+from aiperf.common.aiperf_logger import AIPerfLogger
+
+if TYPE_CHECKING:
+    from aiperf.transports.aiohttp_client import AioHttpClient
+
+_logger = AIPerfLogger(__name__)
+
+
+def _model_in_payload(payload_text: str, model_name: str) -> bool:
+    """Return True if `model_name` appears as a `data[].id` entry in the JSON body."""
+    try:
+        payload = orjson.loads(payload_text)
+    except (orjson.JSONDecodeError, ValueError):
+        return False
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return False
+    return any(
+        isinstance(entry, dict) and entry.get("id") == model_name for entry in data
+    )
+
+
+async def _wait_for_single_url(
+    client: AioHttpClient,
+    url: str,
+    model_name: str,
+    timeout_s: float,
+    interval_s: float,
+    headers: dict[str, str],
+) -> None:
+    """Poll one URL until model is ready or deadline elapses."""
+    deadline = time.monotonic() + timeout_s
+    models_url = url.rstrip("/") + "/v1/models"
+    attempt = 0
+
+    while True:
+        attempt += 1
+        record = await client.get_request(models_url, headers=headers)
+
+        if record.status == 200 and record.responses:
+            body = (
+                record.responses[0].text if hasattr(record.responses[0], "text") else ""
+            )
+            if _model_in_payload(body, model_name):
+                _logger.info(
+                    f"Model '{model_name}' ready at {url} after {attempt} attempt(s)"
+                )
+                return
+            _logger.info(
+                f"Model '{model_name}' not yet in {models_url} (attempt {attempt}), "
+                f"retrying in {interval_s}s"
+            )
+        elif record.status == 404:
+            # Fallback: server doesn't expose /v1/models. Try the base URL; if
+            # it answers 2xx we accept it as "server up" and move on.
+            fallback = await client.get_request(url, headers=headers)
+            if fallback.status is not None and 200 <= fallback.status < 300:
+                _logger.info(
+                    f"/v1/models not available at {url}; base URL responded "
+                    f"{fallback.status} — accepting as ready"
+                )
+                return
+            _logger.info(
+                f"/v1/models returned 404 and base URL returned "
+                f"{fallback.status or 'error'} at {url} (attempt {attempt}), "
+                f"retrying in {interval_s}s"
+            )
+        else:
+            status_repr = (
+                record.status if record.status is not None else "connection error"
+            )
+            error_repr = record.error.message if record.error else ""
+            _logger.info(
+                f"Probe to {models_url} returned {status_repr} "
+                f"{('(' + error_repr + ') ') if error_repr else ''}"
+                f"(attempt {attempt}), retrying in {interval_s}s"
+            )
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            elapsed = timeout_s - remaining
+            raise TimeoutError(
+                f"Timed out after {elapsed:.1f}s waiting for model "
+                f"'{model_name}' to become ready at {url} "
+                f"(checked {attempt} time(s))"
+            )
+        await asyncio.sleep(min(interval_s, remaining))
+
+
+async def wait_for_models_ready(
+    urls: list[str],
+    model_name: str,
+    timeout_s: float,
+    interval_s: float,
+    headers: dict[str, str],
+) -> None:
+    """Block until `model_name` is ready on every URL, or raise TimeoutError.
+
+    URLs are checked sequentially — at typical fleet sizes (1-4 URLs) this
+    keeps log output legible, and the caller's timeout is per-URL.
+    """
+    # Imported lazily to avoid a circular import: aiperf.common is imported
+    # before aiperf.transports, and AioHttpClient pulls in a mixin that
+    # back-imports from aiperf.transports.aiohttp_client.
+    from aiperf.transports.aiohttp_client import AioHttpClient
+
+    _logger.info(
+        f"Waiting for model '{model_name}' to be ready at: {', '.join(urls)} "
+        f"(timeout={timeout_s}s, interval={interval_s}s)"
+    )
+    client = AioHttpClient(timeout=max(interval_s, 5.0))
+    try:
+        for url in urls:
+            await _wait_for_single_url(
+                client=client,
+                url=url,
+                model_name=model_name,
+                timeout_s=timeout_s,
+                interval_s=interval_s,
+                headers=headers,
+            )
+    finally:
+        await client.close()

--- a/src/aiperf/common/readiness_probe.py
+++ b/src/aiperf/common/readiness_probe.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import aiohttp
 import orjson
@@ -83,125 +83,118 @@ def _model_in_payload(payload_text: str, model_name: str) -> bool:
     )
 
 
-async def _wait_models(
+def _models_timeout(
+    *,
+    deadline: float,
+    request_timeout_base: float,
+    timeout_s: float,
+    model_name: str,
+    url: str,
+    checked_attempts: int,
+) -> aiohttp.ClientTimeout:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError(
+            f"Timed out after {timeout_s:.1f}s waiting for model "
+            f"'{model_name}' to become ready at {url} "
+            f"(checked {checked_attempts} time(s))"
+        )
+    return aiohttp.ClientTimeout(total=min(request_timeout_base, remaining))
+
+
+def _inference_timeout(
+    *,
+    deadline: float,
+    request_timeout_base: float,
+    timeout_s: float,
+    request_url: str,
+    model_name: str,
+    checked_attempts: int,
+) -> aiohttp.ClientTimeout:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError(
+            f"Timed out after {timeout_s:.1f}s probing {request_url} "
+            f"with model '{model_name}' (checked {checked_attempts} time(s))"
+        )
+    return aiohttp.ClientTimeout(total=min(request_timeout_base, remaining))
+
+
+async def _sleep_until_next_attempt(*, deadline: float, interval_s: float) -> None:
+    sleep_for = min(interval_s, max(0.0, deadline - time.monotonic()))
+    await asyncio.sleep(sleep_for)
+
+
+def _response_status_and_error(record: Any) -> tuple[int | str, str]:
+    status_repr = record.status if record.status is not None else "connection error"
+    error_repr = record.error.message if record.error else ""
+    return status_repr, error_repr
+
+
+def _models_response_ready(
+    *,
+    record: Any,
+    model_name: str,
+    url: str,
+    models_url: str,
+    attempt: int,
+    interval_s: float,
+) -> bool:
+    body = record.responses[0].text if hasattr(record.responses[0], "text") else ""
+    if _model_in_payload(body, model_name):
+        _logger.info(f"Model '{model_name}' ready at {url} after {attempt} attempt(s)")
+        return True
+    _logger.info(
+        f"Model '{model_name}' not yet in {models_url} (attempt {attempt}), "
+        f"retrying in {interval_s}s"
+    )
+    return False
+
+
+async def _base_url_ready_after_models_404(
+    *,
     client: AioHttpClient,
     url: str,
     model_name: str,
+    deadline: float,
     timeout_s: float,
+    request_timeout_base: float,
+    attempt: int,
     interval_s: float,
     headers: dict[str, str],
-) -> None:
-    """Poll ``{url}/v1/models`` until ``model_name`` appears in ``data[]``.
-
-    Falls back to a single GET on the base URL if ``/v1/models`` returns 404
-    on any attempt — so servers that don't expose a model list still pass
-    when they respond at all.
-    """
-    deadline = time.monotonic() + timeout_s
-    models_url = url.rstrip("/") + "/v1/models"
-    request_timeout_base = max(interval_s, _MIN_REQUEST_TIMEOUT_S)
-    attempt = 0
-
-    while True:
-        attempt += 1
-
-        # Cap the per-request timeout by the remaining budget so a slow or
-        # hung response can never run past the global deadline.
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise TimeoutError(
-                f"Timed out after {timeout_s:.1f}s waiting for model "
-                f"'{model_name}' to become ready at {url} "
-                f"(checked {attempt - 1} time(s))"
-            )
-        request_timeout = aiohttp.ClientTimeout(
-            total=min(request_timeout_base, remaining)
+) -> bool:
+    fallback_timeout = _models_timeout(
+        deadline=deadline,
+        request_timeout_base=request_timeout_base,
+        timeout_s=timeout_s,
+        model_name=model_name,
+        url=url,
+        checked_attempts=attempt,
+    )
+    fallback = await client.get_request(url, headers=headers, timeout=fallback_timeout)
+    if fallback.status is not None and 200 <= fallback.status < 300:
+        _logger.info(
+            f"/v1/models not available at {url}; base URL responded "
+            f"{fallback.status} — accepting as ready"
         )
-        record = await client.get_request(
-            models_url, headers=headers, timeout=request_timeout
-        )
-
-        if record.status == 200 and record.responses:
-            body = (
-                record.responses[0].text if hasattr(record.responses[0], "text") else ""
-            )
-            if _model_in_payload(body, model_name):
-                _logger.info(
-                    f"Model '{model_name}' ready at {url} after {attempt} attempt(s)"
-                )
-                return
-            _logger.info(
-                f"Model '{model_name}' not yet in {models_url} (attempt {attempt}), "
-                f"retrying in {interval_s}s"
-            )
-        elif record.status == 404:
-            # Fallback: server doesn't expose /v1/models. Try the base URL; if
-            # it answers 2xx we accept it as "server up" and move on. Cap the
-            # fallback request by the same per-request budget.
-            fallback_remaining = deadline - time.monotonic()
-            if fallback_remaining <= 0:
-                raise TimeoutError(
-                    f"Timed out after {timeout_s:.1f}s waiting for model "
-                    f"'{model_name}' to become ready at {url} "
-                    f"(checked {attempt} time(s))"
-                )
-            fallback_timeout = aiohttp.ClientTimeout(
-                total=min(request_timeout_base, fallback_remaining)
-            )
-            fallback = await client.get_request(
-                url, headers=headers, timeout=fallback_timeout
-            )
-            if fallback.status is not None and 200 <= fallback.status < 300:
-                _logger.info(
-                    f"/v1/models not available at {url}; base URL responded "
-                    f"{fallback.status} — accepting as ready"
-                )
-                return
-            _logger.info(
-                f"/v1/models returned 404 and base URL returned "
-                f"{fallback.status or 'error'} at {url} (attempt {attempt}), "
-                f"retrying in {interval_s}s"
-            )
-        else:
-            status_repr = (
-                record.status if record.status is not None else "connection error"
-            )
-            error_repr = record.error.message if record.error else ""
-            _logger.info(
-                f"Probe to {models_url} returned {status_repr} "
-                f"{('(' + error_repr + ') ') if error_repr else ''}"
-                f"(attempt {attempt}), retrying in {interval_s}s"
-            )
-
-        # Pre-check at the top of the loop raises on deadline; here we only
-        # need to sleep before the next attempt, capped so we never sleep
-        # past the deadline.
-        sleep_for = min(interval_s, max(0.0, deadline - time.monotonic()))
-        await asyncio.sleep(sleep_for)
+        return True
+    _logger.info(
+        f"/v1/models returned 404 and base URL returned "
+        f"{fallback.status or 'error'} at {url} (attempt {attempt}), "
+        f"retrying in {interval_s}s"
+    )
+    return False
 
 
-async def _wait_inference(
-    client: AioHttpClient,
+def _build_inference_probe_request(
+    *,
     url: str,
     model_name: str,
     endpoint_type: str,
     custom_endpoint: str | None,
-    timeout_s: float,
-    interval_s: float,
-    headers: dict[str, str],
-) -> None:
-    """POST a canned 1-token request to the inference endpoint until it works.
-
-    Any response with ``status < 500`` counts as ready — 4xx means the
-    server is live but our payload was rejected (bad auth / bad model /
-    bad path), which surfaces the same way on the first real benchmark
-    request. Only 5xx and connection errors trigger retries.
-    """
+) -> tuple[str, bytes]:
     from urllib.parse import urlparse
 
-    # Respect a caller-supplied path (e.g. --custom-endpoint), otherwise if
-    # the URL already carries a non-root path use that, otherwise append
-    # the OpenAI default for the endpoint type.
     parsed = urlparse(url)
     endpoint_path = _DEFAULT_PATHS.get(endpoint_type)
     payload_template = _CANNED_PAYLOADS.get(endpoint_type)
@@ -222,8 +215,101 @@ async def _wait_inference(
 
     payload = dict(payload_template or _CANNED_PAYLOADS["chat"])
     payload["model"] = model_name
-    body = orjson.dumps(payload)
+    return request_url, orjson.dumps(payload)
 
+
+async def _wait_models(
+    *,
+    client: AioHttpClient,
+    url: str,
+    model_name: str,
+    timeout_s: float,
+    interval_s: float,
+    headers: dict[str, str],
+) -> None:
+    """Poll ``{url}/v1/models`` until ``model_name`` appears in ``data[]``.
+
+    Falls back to a single GET on the base URL if ``/v1/models`` returns 404
+    on any attempt — so servers that don't expose a model list still pass
+    when they respond at all.
+    """
+    deadline = time.monotonic() + timeout_s
+    models_url = url.rstrip("/") + "/v1/models"
+    request_timeout_base = max(interval_s, _MIN_REQUEST_TIMEOUT_S)
+    attempt = 0
+
+    while True:
+        attempt += 1
+        request_timeout = _models_timeout(
+            deadline=deadline,
+            request_timeout_base=request_timeout_base,
+            timeout_s=timeout_s,
+            model_name=model_name,
+            url=url,
+            checked_attempts=attempt - 1,
+        )
+        record = await client.get_request(
+            models_url, headers=headers, timeout=request_timeout
+        )
+
+        if record.status == 200 and record.responses:
+            if _models_response_ready(
+                record=record,
+                model_name=model_name,
+                url=url,
+                models_url=models_url,
+                attempt=attempt,
+                interval_s=interval_s,
+            ):
+                return
+        elif record.status == 404:
+            if await _base_url_ready_after_models_404(
+                client=client,
+                url=url,
+                model_name=model_name,
+                deadline=deadline,
+                timeout_s=timeout_s,
+                request_timeout_base=request_timeout_base,
+                attempt=attempt,
+                interval_s=interval_s,
+                headers=headers,
+            ):
+                return
+        else:
+            status_repr, error_repr = _response_status_and_error(record)
+            _logger.info(
+                f"Probe to {models_url} returned {status_repr} "
+                f"{('(' + error_repr + ') ') if error_repr else ''}"
+                f"(attempt {attempt}), retrying in {interval_s}s"
+            )
+
+        await _sleep_until_next_attempt(deadline=deadline, interval_s=interval_s)
+
+
+async def _wait_inference(
+    *,
+    client: AioHttpClient,
+    url: str,
+    model_name: str,
+    endpoint_type: str,
+    custom_endpoint: str | None,
+    timeout_s: float,
+    interval_s: float,
+    headers: dict[str, str],
+) -> None:
+    """POST a canned 1-token request to the inference endpoint until it works.
+
+    Any response with ``status < 500`` counts as ready — 4xx means the
+    server is live but our payload was rejected (bad auth / bad model /
+    bad path), which surfaces the same way on the first real benchmark
+    request. Only 5xx and connection errors trigger retries.
+    """
+    request_url, body = _build_inference_probe_request(
+        url=url,
+        model_name=model_name,
+        endpoint_type=endpoint_type,
+        custom_endpoint=custom_endpoint,
+    )
     # Inference requests need more breathing room than a trivial models GET:
     # model load can push even a 1-token forward pass into the seconds range
     # on first request. Floor higher than the models probe.
@@ -235,14 +321,13 @@ async def _wait_inference(
 
     while True:
         attempt += 1
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise TimeoutError(
-                f"Timed out after {timeout_s:.1f}s probing {request_url} "
-                f"with model '{model_name}' (checked {attempt - 1} time(s))"
-            )
-        request_timeout = aiohttp.ClientTimeout(
-            total=min(request_timeout_base, remaining)
+        request_timeout = _inference_timeout(
+            deadline=deadline,
+            request_timeout_base=request_timeout_base,
+            timeout_s=timeout_s,
+            request_url=request_url,
+            model_name=model_name,
+            checked_attempts=attempt - 1,
         )
         record = await client.post_request(
             request_url,
@@ -259,19 +344,18 @@ async def _wait_inference(
             )
             return
 
-        status_repr = status if status is not None else "connection error"
-        error_repr = record.error.message if record.error else ""
+        status_repr, error_repr = _response_status_and_error(record)
         _logger.info(
             f"Inference probe to {request_url} returned {status_repr} "
             f"{('(' + error_repr + ') ') if error_repr else ''}"
             f"(attempt {attempt}), retrying in {interval_s}s"
         )
 
-        sleep_for = min(interval_s, max(0.0, deadline - time.monotonic()))
-        await asyncio.sleep(sleep_for)
+        await _sleep_until_next_attempt(deadline=deadline, interval_s=interval_s)
 
 
 async def wait_for_endpoint(
+    *,
     urls: list[str],
     model_names: list[str],
     mode: ReadyCheckMode,

--- a/src/aiperf/common/readiness_probe.py
+++ b/src/aiperf/common/readiness_probe.py
@@ -15,6 +15,7 @@ import asyncio
 import time
 from typing import TYPE_CHECKING
 
+import aiohttp
 import orjson
 
 from aiperf.common.aiperf_logger import AIPerfLogger
@@ -23,6 +24,11 @@ if TYPE_CHECKING:
     from aiperf.transports.aiohttp_client import AioHttpClient
 
 _logger = AIPerfLogger(__name__)
+
+# Minimum per-request timeout for the probe. `interval_s` can be very small
+# (e.g. 0.5s for fast-retrying tests); using it directly as a request timeout
+# would cause spurious failures on networks with any real latency.
+_MIN_REQUEST_TIMEOUT_S = 5.0
 
 
 def _model_in_payload(payload_text: str, model_name: str) -> bool:
@@ -50,11 +56,27 @@ async def _wait_for_single_url(
     """Poll one URL until model is ready or deadline elapses."""
     deadline = time.monotonic() + timeout_s
     models_url = url.rstrip("/") + "/v1/models"
+    request_timeout_base = max(interval_s, _MIN_REQUEST_TIMEOUT_S)
     attempt = 0
 
     while True:
         attempt += 1
-        record = await client.get_request(models_url, headers=headers)
+
+        # Cap the per-request timeout by the remaining budget so a slow or
+        # hung response can never run past the global deadline.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Timed out after {timeout_s:.1f}s waiting for model "
+                f"'{model_name}' to become ready at {url} "
+                f"(checked {attempt - 1} time(s))"
+            )
+        request_timeout = aiohttp.ClientTimeout(
+            total=min(request_timeout_base, remaining)
+        )
+        record = await client.get_request(
+            models_url, headers=headers, timeout=request_timeout
+        )
 
         if record.status == 200 and record.responses:
             body = (
@@ -71,8 +93,21 @@ async def _wait_for_single_url(
             )
         elif record.status == 404:
             # Fallback: server doesn't expose /v1/models. Try the base URL; if
-            # it answers 2xx we accept it as "server up" and move on.
-            fallback = await client.get_request(url, headers=headers)
+            # it answers 2xx we accept it as "server up" and move on. Cap the
+            # fallback request by the same per-request budget.
+            fallback_remaining = deadline - time.monotonic()
+            if fallback_remaining <= 0:
+                raise TimeoutError(
+                    f"Timed out after {timeout_s:.1f}s waiting for model "
+                    f"'{model_name}' to become ready at {url} "
+                    f"(checked {attempt} time(s))"
+                )
+            fallback_timeout = aiohttp.ClientTimeout(
+                total=min(request_timeout_base, fallback_remaining)
+            )
+            fallback = await client.get_request(
+                url, headers=headers, timeout=fallback_timeout
+            )
             if fallback.status is not None and 200 <= fallback.status < 300:
                 _logger.info(
                     f"/v1/models not available at {url}; base URL responded "
@@ -95,28 +130,25 @@ async def _wait_for_single_url(
                 f"(attempt {attempt}), retrying in {interval_s}s"
             )
 
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            elapsed = timeout_s - remaining
-            raise TimeoutError(
-                f"Timed out after {elapsed:.1f}s waiting for model "
-                f"'{model_name}' to become ready at {url} "
-                f"(checked {attempt} time(s))"
-            )
-        await asyncio.sleep(min(interval_s, remaining))
+        # Pre-check at the top of the loop raises on deadline; here we only
+        # need to sleep before the next attempt, capped so we never sleep
+        # past the deadline.
+        sleep_for = min(interval_s, max(0.0, deadline - time.monotonic()))
+        await asyncio.sleep(sleep_for)
 
 
 async def wait_for_models_ready(
     urls: list[str],
-    model_name: str,
+    model_names: list[str],
     timeout_s: float,
     interval_s: float,
     headers: dict[str, str],
 ) -> None:
-    """Block until `model_name` is ready on every URL, or raise TimeoutError.
+    """Block until every model in `model_names` is ready on every URL, or raise TimeoutError.
 
-    URLs are checked sequentially — at typical fleet sizes (1-4 URLs) this
-    keeps log output legible, and the caller's timeout is per-URL.
+    URLs and models are checked sequentially — at typical fleet sizes (1-4 URLs,
+    1-2 models) this keeps log output legible, and the caller's timeout is
+    per-URL-per-model.
     """
     # Imported lazily to avoid a circular import: aiperf.common is imported
     # before aiperf.transports, and AioHttpClient pulls in a mixin that
@@ -124,19 +156,20 @@ async def wait_for_models_ready(
     from aiperf.transports.aiohttp_client import AioHttpClient
 
     _logger.info(
-        f"Waiting for model '{model_name}' to be ready at: {', '.join(urls)} "
+        f"Waiting for model(s) {model_names} to be ready at: {', '.join(urls)} "
         f"(timeout={timeout_s}s, interval={interval_s}s)"
     )
     client = AioHttpClient(timeout=max(interval_s, 5.0))
     try:
         for url in urls:
-            await _wait_for_single_url(
-                client=client,
-                url=url,
-                model_name=model_name,
-                timeout_s=timeout_s,
-                interval_s=interval_s,
-                headers=headers,
-            )
+            for model_name in model_names:
+                await _wait_for_single_url(
+                    client=client,
+                    url=url,
+                    model_name=model_name,
+                    timeout_s=timeout_s,
+                    interval_s=interval_s,
+                    headers=headers,
+                )
     finally:
         await client.close()

--- a/src/aiperf/common/readiness_probe.py
+++ b/src/aiperf/common/readiness_probe.py
@@ -203,15 +203,24 @@ async def _wait_inference(
     # the URL already carries a non-root path use that, otherwise append
     # the OpenAI default for the endpoint type.
     parsed = urlparse(url)
+    endpoint_path = _DEFAULT_PATHS.get(endpoint_type)
+    payload_template = _CANNED_PAYLOADS.get(endpoint_type)
+    if endpoint_path is None or payload_template is None:
+        _logger.warning(
+            f"Inference readiness probe has no dedicated request template for "
+            f"endpoint type '{endpoint_type}'; using the chat-compatible "
+            f"fallback. This checks server liveness but may not prove model "
+            f"readiness for that endpoint type."
+        )
+
     if custom_endpoint:
         request_url = url.rstrip("/") + "/" + custom_endpoint.lstrip("/")
     elif parsed.path and parsed.path != "/":
         request_url = url.rstrip("/")
     else:
-        endpoint_path = _DEFAULT_PATHS.get(endpoint_type, _DEFAULT_PATHS["chat"])
-        request_url = url.rstrip("/") + endpoint_path
+        request_url = url.rstrip("/") + (endpoint_path or _DEFAULT_PATHS["chat"])
 
-    payload = dict(_CANNED_PAYLOADS.get(endpoint_type, _CANNED_PAYLOADS["chat"]))
+    payload = dict(payload_template or _CANNED_PAYLOADS["chat"])
     payload["model"] = model_name
     body = orjson.dumps(payload)
 

--- a/src/aiperf/common/readiness_probe.py
+++ b/src/aiperf/common/readiness_probe.py
@@ -311,22 +311,23 @@ async def wait_for_endpoint(
                         headers=headers,
                     )
             if mode in ("inference", "both"):
-                # For the inference probe, any successful generation proves
-                # the stack is live — we don't need to loop across every
-                # model name. Use the first configured model (or fall back
-                # to "default" so the probe still works when model_names is
-                # empty, which the validator above permits only in pure
-                # inference mode).
-                probe_model = model_names[0] if model_names else "default"
-                await _wait_inference(
-                    client=client,
-                    url=url,
-                    model_name=probe_model,
-                    endpoint_type=endpoint_type,
-                    custom_endpoint=custom_endpoint,
-                    timeout_s=timeout_s,
-                    interval_s=interval_s,
-                    headers=headers,
-                )
+                # Probe every configured model. In a multi-model deployment
+                # (e.g. --model foo,bar with round_robin selection), `foo`
+                # being ready tells us nothing about `bar` — different
+                # weights, possibly on different workers. Fall back to
+                # ["default"] when model_names is empty, which the
+                # validator above permits only in pure inference mode.
+                probe_models = model_names if model_names else ["default"]
+                for probe_model in probe_models:
+                    await _wait_inference(
+                        client=client,
+                        url=url,
+                        model_name=probe_model,
+                        endpoint_type=endpoint_type,
+                        custom_endpoint=custom_endpoint,
+                        timeout_s=timeout_s,
+                        interval_s=interval_s,
+                        headers=headers,
+                    )
     finally:
         await client.close()

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -802,6 +802,22 @@ async def health():
     return {"status": "healthy", "config": server_config.model_dump()}
 
 
+@app.get("/v1/models")
+async def list_models():
+    """OpenAI-compatible models list. Respects models_ready_delay_seconds and
+    disable_models_endpoint so readiness-probe tests can exercise all branches
+    (immediate success, success after retries, 404 fallback, timeout)."""
+    if server_config.disable_models_endpoint:
+        raise HTTPException(status_code=404, detail="Not Found")
+    elapsed = time.time() - server_start_time if server_start_time > 0 else 0.0
+    if elapsed < server_config.models_ready_delay_seconds:
+        return {"object": "list", "data": []}
+    return {
+        "object": "list",
+        "data": [{"id": server_config.default_model, "object": "model"}],
+    }
+
+
 @app.get("/")
 async def root():
     """Root info."""

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -803,7 +803,7 @@ async def health():
 
 
 @app.get("/v1/models")
-async def list_models():
+async def list_models() -> dict[str, Any]:
     """OpenAI-compatible models list. Respects models_ready_delay_seconds and
     disable_models_endpoint so readiness-probe tests can exercise all branches
     (immediate success, success after retries, 404 fallback, timeout)."""

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -152,8 +152,48 @@ class TimingMiddleware:
         await self.app(scope, receive, send)
 
 
+_INFERENCE_PATHS: frozenset[str] = frozenset(
+    {"/v1/chat/completions", "/v1/completions", "/v1/embeddings"}
+)
+
+
+class InferenceReadinessMiddleware:
+    """Returns HTTP 503 on inference paths while within the configured
+    startup delay. Used by readiness-probe tests to simulate a server
+    whose frontend is up but whose workers haven't loaded weights yet."""
+
+    def __init__(self, inner_app):
+        self.app = inner_app
+
+    async def __call__(self, scope, receive, send):
+        if (
+            scope["type"] == "http"
+            and server_config.inference_ready_delay_seconds > 0
+            and scope.get("path") in _INFERENCE_PATHS
+            and server_start_time > 0
+            and (time.time() - server_start_time)
+            < server_config.inference_ready_delay_seconds
+        ):
+            body = orjson.dumps(
+                {"error": "Model not ready: workers still loading weights"}
+            )
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 503,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"content-length", str(len(body)).encode()),
+                    ],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+        await self.app(scope, receive, send)
+
+
 # Wrap FastAPI with ASGI middleware for earliest possible timing
-asgi_app = TimingMiddleware(app)
+asgi_app = InferenceReadinessMiddleware(TimingMiddleware(app))
 
 
 # ============================================================================

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -62,6 +62,7 @@ from fastapi import FastAPI, HTTPException, Response
 from fastapi.responses import ORJSONResponse, PlainTextResponse, StreamingResponse
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
 from starlette.requests import Request
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 dcgm_fakers: list[DCGMFaker] = []
 server_start_time: float = 0.0
@@ -162,10 +163,10 @@ class InferenceReadinessMiddleware:
     startup delay. Used by readiness-probe tests to simulate a server
     whose frontend is up but whose workers haven't loaded weights yet."""
 
-    def __init__(self, inner_app):
+    def __init__(self, inner_app: ASGIApp) -> None:
         self.app = inner_app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if (
             scope["type"] == "http"
             and server_config.inference_ready_delay_seconds > 0

--- a/tests/aiperf_mock_server/config.py
+++ b/tests/aiperf_mock_server/config.py
@@ -219,6 +219,37 @@ class MockServerConfig(BaseSettings):
         Parameter(name="--no-tokenizer"),
     ] = False
 
+    # /v1/models Options (used by readiness-probe tests)
+    default_model: Annotated[
+        str,
+        Field(
+            description="Model id returned by GET /v1/models once the models "
+            "endpoint is 'ready'. Independent of which model names appear in "
+            "individual inference requests (those are echoed back as-is)."
+        ),
+        Parameter(name="--default-model"),
+    ] = "mock-model"
+
+    models_ready_delay_seconds: Annotated[
+        float,
+        Field(
+            description="Seconds after server start during which GET /v1/models "
+            "returns an empty data list. Simulates a model server that's up "
+            "but hasn't finished loading weights.",
+            ge=0.0,
+        ),
+        Parameter(name="--models-ready-delay-seconds"),
+    ] = 0.0
+
+    disable_models_endpoint: Annotated[
+        bool,
+        Field(
+            description="If set, GET /v1/models returns 404. Used to exercise "
+            "the readiness-probe fallback to a plain base-URL GET."
+        ),
+        Parameter(name="--disable-models-endpoint"),
+    ] = False
+
 
 server_config: MockServerConfig = MockServerConfig()
 

--- a/tests/aiperf_mock_server/config.py
+++ b/tests/aiperf_mock_server/config.py
@@ -250,6 +250,19 @@ class MockServerConfig(BaseSettings):
         Parameter(name="--disable-models-endpoint"),
     ] = False
 
+    inference_ready_delay_seconds: Annotated[
+        float,
+        Field(
+            description="Seconds after server start during which the inference "
+            "endpoints (/v1/chat/completions, /v1/completions, /v1/embeddings) "
+            "return HTTP 503. Simulates a stack that's up on the frontend but "
+            "whose workers haven't loaded weights yet. Used to exercise the "
+            "inference-mode readiness probe's retry loop.",
+            ge=0.0,
+        ),
+        Parameter(name="--inference-ready-delay-seconds"),
+    ] = 0.0
+
 
 server_config: MockServerConfig = MockServerConfig()
 

--- a/tests/integration/test_wait_for_model.py
+++ b/tests/integration/test_wait_for_model.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the `--wait-for-model` readiness probe.
+
+Covers:
+- success immediately (models endpoint ready from t=0)
+- success after N retries (models endpoint returns empty data until delay elapses)
+- timeout failure (requested model never appears)
+- 404 fallback (models endpoint disabled; probe accepts 2xx on base URL)
+"""
+
+import pytest
+
+from tests.harness.utils import AIPerfCLI
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestWaitForModel:
+    """Tests for `aiperf profile --wait-for-model`."""
+
+    async def test_wait_for_model_success_immediate(
+        self, cli: AIPerfCLI, mock_server_factory
+    ):
+        """With no configured delay, /v1/models lists the model from the start
+        and the probe returns on the first attempt."""
+        async with mock_server_factory(
+            fast=True, workers=1, default_model="mock-model"
+        ) as server:
+            result = await cli.run(
+                f"""
+                aiperf profile
+                    --model mock-model
+                    --url {server.url}
+                    --endpoint-type chat
+                    --streaming
+                    --concurrency 1
+                    --request-count 1
+                    --workers-max 1
+                    --ui simple
+                    --wait-for-model
+                    --wait-for-model-timeout 30
+                    --wait-for-model-interval 1
+                """,
+                timeout=120.0,
+            )
+            assert result.exit_code == 0
+            combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
+            assert "Model 'mock-model' ready" in combined
+
+    async def test_wait_for_model_success_after_retries(
+        self, cli: AIPerfCLI, mock_server_factory
+    ):
+        """With models_ready_delay_seconds>0, the probe sees an empty
+        data list on early attempts and must retry until the model appears."""
+        async with mock_server_factory(
+            fast=True,
+            workers=1,
+            default_model="mock-model",
+            models_ready_delay_seconds=2.0,
+        ) as server:
+            result = await cli.run(
+                f"""
+                aiperf profile
+                    --model mock-model
+                    --url {server.url}
+                    --endpoint-type chat
+                    --streaming
+                    --concurrency 1
+                    --request-count 1
+                    --workers-max 1
+                    --ui simple
+                    --wait-for-model
+                    --wait-for-model-timeout 20
+                    --wait-for-model-interval 0.5
+                """,
+                timeout=120.0,
+            )
+            assert result.exit_code == 0
+            # At least one retry log line should have fired before the model appeared.
+            combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
+            assert "not yet in" in combined
+            assert "Model 'mock-model' ready" in combined
+
+    async def test_wait_for_model_timeout(self, cli: AIPerfCLI, mock_server_factory):
+        """If the requested model id never appears in /v1/models, the probe
+        must exit non-zero and the error must reference the model and URL."""
+        async with mock_server_factory(
+            fast=True, workers=1, default_model="mock-model"
+        ) as server:
+            result = await cli.run(
+                f"""
+                aiperf profile
+                    --model this-model-is-never-served
+                    --url {server.url}
+                    --endpoint-type chat
+                    --streaming
+                    --concurrency 1
+                    --request-count 1
+                    --workers-max 1
+                    --ui simple
+                    --wait-for-model
+                    --wait-for-model-timeout 3
+                    --wait-for-model-interval 0.5
+                """,
+                timeout=60.0,
+                assert_success=False,
+            )
+            assert result.exit_code != 0
+            combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
+            assert "this-model-is-never-served" in combined
+            assert server.url in combined
+            assert "Timed out" in combined
+
+    async def test_wait_for_model_404_fallback(
+        self, cli: AIPerfCLI, mock_server_factory
+    ):
+        """When /v1/models returns 404, the probe must fall back to a base-URL
+        GET and accept a 2xx as 'server is up'."""
+        async with mock_server_factory(
+            fast=True,
+            workers=1,
+            default_model="mock-model",
+            disable_models_endpoint=True,
+        ) as server:
+            result = await cli.run(
+                f"""
+                aiperf profile
+                    --model mock-model
+                    --url {server.url}
+                    --endpoint-type chat
+                    --streaming
+                    --concurrency 1
+                    --request-count 1
+                    --workers-max 1
+                    --ui simple
+                    --wait-for-model
+                    --wait-for-model-timeout 15
+                    --wait-for-model-interval 1
+                """,
+                timeout=120.0,
+            )
+            assert result.exit_code == 0
+            combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
+            assert "accepting as ready" in combined

--- a/tests/integration/test_wait_for_model.py
+++ b/tests/integration/test_wait_for_model.py
@@ -2,11 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """Integration tests for the `--wait-for-model` readiness probe.
 
-Covers:
+Covers both probe modes:
+
+Models mode (`--wait-for-model-mode models`):
 - success immediately (models endpoint ready from t=0)
 - success after N retries (models endpoint returns empty data until delay elapses)
 - timeout failure (requested model never appears)
 - 404 fallback (models endpoint disabled; probe accepts 2xx on base URL)
+
+Inference mode (`--wait-for-model-mode inference`, the default):
+- success immediately (inference endpoint ready from t=0)
+- success after N retries (inference endpoint returns 503 until delay elapses)
 """
 
 import pytest
@@ -16,10 +22,13 @@ from tests.harness.utils import AIPerfCLI
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-class TestWaitForModel:
-    """Tests for `aiperf profile --wait-for-model`."""
+class TestWaitForModelModeModels:
+    """Tests for `aiperf profile --wait-for-model --wait-for-model-mode models`.
 
-    async def test_wait_for_model_success_immediate(
+    Exercises the GET /v1/models probe path and its 404 fallback behavior.
+    """
+
+    async def test_models_probe_success_immediate(
         self, cli: AIPerfCLI, mock_server_factory
     ):
         """With no configured delay, /v1/models lists the model from the start
@@ -39,6 +48,7 @@ class TestWaitForModel:
                     --workers-max 1
                     --ui simple
                     --wait-for-model
+                    --wait-for-model-mode models
                     --wait-for-model-timeout 30
                     --wait-for-model-interval 1
                 """,
@@ -48,7 +58,7 @@ class TestWaitForModel:
             combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
             assert "Model 'mock-model' ready" in combined
 
-    async def test_wait_for_model_success_after_retries(
+    async def test_models_probe_success_after_retries(
         self, cli: AIPerfCLI, mock_server_factory
     ):
         """With models_ready_delay_seconds>0, the probe sees an empty
@@ -77,18 +87,18 @@ class TestWaitForModel:
                     --workers-max 1
                     --ui simple
                     --wait-for-model
+                    --wait-for-model-mode models
                     --wait-for-model-timeout 30
                     --wait-for-model-interval 0.5
                 """,
                 timeout=120.0,
             )
             assert result.exit_code == 0
-            # At least one retry log line should have fired before the model appeared.
             combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
             assert "not yet in" in combined
             assert "Model 'mock-model' ready" in combined
 
-    async def test_wait_for_model_timeout(self, cli: AIPerfCLI, mock_server_factory):
+    async def test_models_probe_timeout(self, cli: AIPerfCLI, mock_server_factory):
         """If the requested model id never appears in /v1/models, the probe
         must exit non-zero and the error must reference the model and URL."""
         async with mock_server_factory(
@@ -106,6 +116,7 @@ class TestWaitForModel:
                     --workers-max 1
                     --ui simple
                     --wait-for-model
+                    --wait-for-model-mode models
                     --wait-for-model-timeout 3
                     --wait-for-model-interval 0.5
                 """,
@@ -118,9 +129,7 @@ class TestWaitForModel:
             assert server.url in combined
             assert "Timed out" in combined
 
-    async def test_wait_for_model_404_fallback(
-        self, cli: AIPerfCLI, mock_server_factory
-    ):
+    async def test_models_probe_404_fallback(self, cli: AIPerfCLI, mock_server_factory):
         """When /v1/models returns 404, the probe must fall back to a base-URL
         GET and accept a 2xx as 'server is up'."""
         async with mock_server_factory(
@@ -141,6 +150,7 @@ class TestWaitForModel:
                     --workers-max 1
                     --ui simple
                     --wait-for-model
+                    --wait-for-model-mode models
                     --wait-for-model-timeout 15
                     --wait-for-model-interval 1
                 """,
@@ -149,3 +159,77 @@ class TestWaitForModel:
             assert result.exit_code == 0
             combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
             assert "accepting as ready" in combined
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestWaitForModelModeInference:
+    """Tests for `aiperf profile --wait-for-model --wait-for-model-mode inference`.
+
+    Exercises the POST {path} probe that submits a canned 1-token request
+    and accepts any `status < 500` as ready. `inference` is the default mode,
+    but these tests set it explicitly for clarity.
+    """
+
+    async def test_inference_probe_success_immediate(
+        self, cli: AIPerfCLI, mock_server_factory
+    ):
+        """With no configured delay, /v1/chat/completions responds 200 from t=0
+        and the probe returns on the first attempt."""
+        async with mock_server_factory(fast=True, workers=1) as server:
+            result = await cli.run(
+                f"""
+                aiperf profile
+                    --model mock-model
+                    --url {server.url}
+                    --endpoint-type chat
+                    --streaming
+                    --concurrency 1
+                    --request-count 1
+                    --workers-max 1
+                    --ui simple
+                    --wait-for-model
+                    --wait-for-model-mode inference
+                    --wait-for-model-timeout 30
+                    --wait-for-model-interval 1
+                """,
+                timeout=120.0,
+            )
+            assert result.exit_code == 0
+            combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
+            assert "Inference probe ready" in combined
+
+    async def test_inference_probe_success_after_retries(
+        self, cli: AIPerfCLI, mock_server_factory
+    ):
+        """With inference_ready_delay_seconds>0, the inference endpoint
+        returns 503 on early attempts and the probe must retry until the
+        stack starts responding 2xx."""
+        async with mock_server_factory(
+            fast=True,
+            workers=1,
+            inference_ready_delay_seconds=5.0,
+        ) as server:
+            result = await cli.run(
+                f"""
+                aiperf profile
+                    --model mock-model
+                    --url {server.url}
+                    --endpoint-type chat
+                    --streaming
+                    --concurrency 1
+                    --request-count 1
+                    --workers-max 1
+                    --ui simple
+                    --wait-for-model
+                    --wait-for-model-mode inference
+                    --wait-for-model-timeout 30
+                    --wait-for-model-interval 0.5
+                """,
+                timeout=120.0,
+            )
+            assert result.exit_code == 0
+            combined = f"{result.stdout}\n{result.stderr}\n{result.log}"
+            # 503 retry log line should have fired before the server unblocked.
+            assert "returned 503" in combined
+            assert "Inference probe ready" in combined

--- a/tests/integration/test_wait_for_model.py
+++ b/tests/integration/test_wait_for_model.py
@@ -52,12 +52,18 @@ class TestWaitForModel:
         self, cli: AIPerfCLI, mock_server_factory
     ):
         """With models_ready_delay_seconds>0, the probe sees an empty
-        data list on early attempts and must retry until the model appears."""
+        data list on early attempts and must retry until the model appears.
+
+        Uses a 5.0s server-side delay (vs. a 0.5s probe interval) to give
+        a comfortable margin over subprocess startup time, so the first
+        probe reliably lands before the model becomes ready and we observe
+        at least one retry deterministically.
+        """
         async with mock_server_factory(
             fast=True,
             workers=1,
             default_model="mock-model",
-            models_ready_delay_seconds=2.0,
+            models_ready_delay_seconds=5.0,
         ) as server:
             result = await cli.run(
                 f"""
@@ -71,7 +77,7 @@ class TestWaitForModel:
                     --workers-max 1
                     --ui simple
                     --wait-for-model
-                    --wait-for-model-timeout 20
+                    --wait-for-model-timeout 30
                     --wait-for-model-interval 0.5
                 """,
                 timeout=120.0,

--- a/tests/integration/test_wait_for_model.py
+++ b/tests/integration/test_wait_for_model.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Integration tests for the `--wait-for-model` readiness probe.
+"""Integration tests for the `--wait-for-model-timeout` readiness probe.
 
 Covers both probe modes:
 
@@ -23,7 +23,7 @@ from tests.harness.utils import AIPerfCLI
 @pytest.mark.integration
 @pytest.mark.asyncio
 class TestWaitForModelModeModels:
-    """Tests for `aiperf profile --wait-for-model --wait-for-model-mode models`.
+    """Tests for `aiperf profile --wait-for-model-timeout N --wait-for-model-mode models`.
 
     Exercises the GET /v1/models probe path and its 404 fallback behavior.
     """
@@ -47,7 +47,6 @@ class TestWaitForModelModeModels:
                     --request-count 1
                     --workers-max 1
                     --ui simple
-                    --wait-for-model
                     --wait-for-model-mode models
                     --wait-for-model-timeout 30
                     --wait-for-model-interval 1
@@ -86,7 +85,6 @@ class TestWaitForModelModeModels:
                     --request-count 1
                     --workers-max 1
                     --ui simple
-                    --wait-for-model
                     --wait-for-model-mode models
                     --wait-for-model-timeout 30
                     --wait-for-model-interval 0.5
@@ -115,7 +113,6 @@ class TestWaitForModelModeModels:
                     --request-count 1
                     --workers-max 1
                     --ui simple
-                    --wait-for-model
                     --wait-for-model-mode models
                     --wait-for-model-timeout 3
                     --wait-for-model-interval 0.5
@@ -149,7 +146,6 @@ class TestWaitForModelModeModels:
                     --request-count 1
                     --workers-max 1
                     --ui simple
-                    --wait-for-model
                     --wait-for-model-mode models
                     --wait-for-model-timeout 15
                     --wait-for-model-interval 1
@@ -164,7 +160,7 @@ class TestWaitForModelModeModels:
 @pytest.mark.integration
 @pytest.mark.asyncio
 class TestWaitForModelModeInference:
-    """Tests for `aiperf profile --wait-for-model --wait-for-model-mode inference`.
+    """Tests for `aiperf profile --wait-for-model-timeout N --wait-for-model-mode inference`.
 
     Exercises the POST {path} probe that submits a canned 1-token request
     and accepts any `status < 500` as ready. `inference` is the default mode,
@@ -188,7 +184,6 @@ class TestWaitForModelModeInference:
                     --request-count 1
                     --workers-max 1
                     --ui simple
-                    --wait-for-model
                     --wait-for-model-mode inference
                     --wait-for-model-timeout 30
                     --wait-for-model-interval 1
@@ -221,7 +216,6 @@ class TestWaitForModelModeInference:
                     --request-count 1
                     --workers-max 1
                     --ui simple
-                    --wait-for-model
                     --wait-for-model-mode inference
                     --wait-for-model-timeout 30
                     --wait-for-model-interval 0.5

--- a/tests/unit/common/config/test_endpoint_config.py
+++ b/tests/unit/common/config/test_endpoint_config.py
@@ -134,3 +134,78 @@ class TestMultiURLSupport:
         """URLs list must have at least one entry."""
         with pytest.raises(ValueError):
             EndpointConfig(model_names=["gpt2"], urls=[])
+
+
+class TestWaitForModelValidation:
+    """Tests for the readiness-probe flag coherence + bounds validation.
+
+    The probe is enabled by setting --wait-for-model-timeout to a positive
+    value. Dependent flags (--wait-for-model-interval, --wait-for-model-mode)
+    have no effect when disabled and should be rejected if set alone, so
+    typos like `--wait-for-model-interval 1` (without a timeout) fail fast.
+    """
+
+    def test_default_probe_disabled(self):
+        """With no probe flags set, the probe is disabled (timeout == 0)."""
+        config = EndpointConfig(model_names=["gpt2"])
+        assert config.wait_for_model_timeout == 0.0
+
+    def test_setting_timeout_enables_probe(self):
+        """Setting --wait-for-model-timeout to a positive value is the
+        one-and-only way to enable the probe."""
+        config = EndpointConfig(model_names=["gpt2"], wait_for_model_timeout=60.0)
+        assert config.wait_for_model_timeout == 60.0
+
+    def test_interval_without_timeout_rejected(self):
+        """Setting --wait-for-model-interval without a positive timeout is
+        incoherent (the interval will never be consulted)."""
+        with pytest.raises(ValueError, match="wait-for-model-interval"):
+            EndpointConfig(model_names=["gpt2"], wait_for_model_interval=1.0)
+
+    def test_mode_without_timeout_rejected(self):
+        """Setting --wait-for-model-mode without a positive timeout is
+        incoherent (the mode will never be consulted)."""
+        with pytest.raises(ValueError, match="wait-for-model-mode"):
+            EndpointConfig(model_names=["gpt2"], wait_for_model_mode="inference")
+
+    def test_interval_with_timeout_accepted(self):
+        """With a positive timeout, interval can be customized freely."""
+        config = EndpointConfig(
+            model_names=["gpt2"],
+            wait_for_model_timeout=60.0,
+            wait_for_model_interval=2.5,
+        )
+        assert config.wait_for_model_interval == 2.5
+
+    def test_mode_with_timeout_accepted(self):
+        """With a positive timeout, mode can be customized freely."""
+        config = EndpointConfig(
+            model_names=["gpt2"],
+            wait_for_model_timeout=60.0,
+            wait_for_model_mode="both",
+        )
+        assert config.wait_for_model_mode == "both"
+
+    def test_negative_timeout_rejected(self):
+        """Negative timeout is nonsensical and rejected by ge=0.0 validator."""
+        with pytest.raises(ValueError):
+            EndpointConfig(model_names=["gpt2"], wait_for_model_timeout=-1.0)
+
+    def test_zero_interval_rejected(self):
+        """Zero interval would create a tight retry loop; rejected by gt=0.0
+        validator (this fires even when paired with a positive timeout)."""
+        with pytest.raises(ValueError):
+            EndpointConfig(
+                model_names=["gpt2"],
+                wait_for_model_timeout=60.0,
+                wait_for_model_interval=0.0,
+            )
+
+    def test_invalid_mode_rejected(self):
+        """Mode is a Literal; unknown values rejected by pydantic."""
+        with pytest.raises(ValueError):
+            EndpointConfig(
+                model_names=["gpt2"],
+                wait_for_model_timeout=60.0,
+                wait_for_model_mode="something-else",  # type: ignore[arg-type]
+            )

--- a/tests/unit/common/test_readiness_probe.py
+++ b/tests/unit/common/test_readiness_probe.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, cast
+
+import orjson
+import pytest
+
+from aiperf.common import readiness_probe
+
+
+class _FakeRecord:
+    status: int = 400
+    error: None = None
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.posted_urls: list[str] = []
+        self.payloads: list[dict[str, Any]] = []
+
+    async def post_request(
+        self,
+        request_url: str,
+        payload: bytes,
+        headers: dict[str, str],
+        timeout: object,
+    ) -> _FakeRecord:
+        del headers, timeout
+        decoded_payload = orjson.loads(payload)
+        assert isinstance(decoded_payload, dict)
+        self.posted_urls.append(request_url)
+        self.payloads.append(decoded_payload)
+        return _FakeRecord()
+
+
+def test_wait_inference_warns_on_endpoint_type_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="aiperf.common.readiness_probe")
+    client = _FakeClient()
+
+    asyncio.run(
+        readiness_probe._wait_inference(
+            client=cast(Any, client),
+            url="http://server",
+            model_name="model-a",
+            endpoint_type="responses",
+            custom_endpoint=None,
+            timeout_s=1.0,
+            interval_s=0.1,
+            headers={},
+        )
+    )
+
+    assert "endpoint type 'responses'" in caplog.text
+    assert "may not prove model readiness" in caplog.text
+    assert client.posted_urls == ["http://server/v1/chat/completions"]
+    assert client.payloads[0]["model"] == "model-a"
+    assert "messages" in client.payloads[0]
+
+
+def test_wait_inference_dedicated_template_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="aiperf.common.readiness_probe")
+    client = _FakeClient()
+
+    asyncio.run(
+        readiness_probe._wait_inference(
+            client=cast(Any, client),
+            url="http://server",
+            model_name="embedder",
+            endpoint_type="embeddings",
+            custom_endpoint=None,
+            timeout_s=1.0,
+            interval_s=0.1,
+            headers={},
+        )
+    )
+
+    assert "no dedicated request template" not in caplog.text
+    assert client.posted_urls == ["http://server/v1/embeddings"]
+    assert client.payloads == [{"input": "Lo", "model": "embedder"}]


### PR DESCRIPTION
## Summary

Adds three CLI flags on \`aiperf profile\` — \`--wait-for-model\`, \`--wait-for-model-timeout\`, \`--wait-for-model-interval\` — so the benchmark tool itself can verify the target model server is serving before it starts generating load. Eliminates the need for external shell-based readiness loops (\`curl\` + \`jq\` + \`sleep\`) in containerized deployments, which is the main reason Dynamo's Kubernetes recipes currently need \`curl\`/\`jq\`/\`apt\` in their benchmark images — none of which exist in the published distroless \`aiperf\` container.

When enabled, the probe polls \`{url}/v1/models\` on each configured URL and waits for the requested \`--model\` id to appear in \`data[]\`. If \`/v1/models\` returns 404, it falls back to a single GET on the base URL so servers that don't expose a model list still pass the probe. Honors \`--api-key\` and \`-H\` headers. Exits non-zero with URL + model + elapsed time on timeout.

## Changes

- **New flags on \`EndpointConfig\`** with defaults in \`EndpointDefaults\`. Follows the existing \`CLIParameter\`/\`Annotated\` pattern.
- **New \`aiperf.common.readiness_probe\` module.** Reuses \`AioHttpClient\` for consistent TLS/proxy/header behavior with the load phase. Import is deferred into the function body to avoid a circular import between \`aiperf.common\` and \`aiperf.transports\`.
- **Hook in \`profile()\`** before \`run_system_controller\`. Installs \`basicConfig\` when no handlers exist so probe log lines are visible (rich logging isn't set up yet at this point in the lifecycle).
- **Mock server additions.** New \`/v1/models\` endpoint, plus three new config flags (\`default_model\`, \`models_ready_delay_seconds\`, \`disable_models_endpoint\`) for exercising probe behavior in tests.
- **Docs regenerated** via \`make generate-cli-docs\`.

## Test plan

- [x] 4 new integration tests in \`tests/integration/test_wait_for_model.py\`:
  - success immediately (delay=0)
  - success after N retries (delayed model registration via \`models_ready_delay_seconds\`)
  - timeout failure (requested model never appears; verifies URL + model + \`Timed out\` in error output)
  - 404 fallback (\`disable_models_endpoint=True\`; base-URL GET accepted as ready)
- [x] Adjacent CLI/startup-failure tests pass (no regression from the probe hook)
- [x] Ruff lint and format clean
- [x] \`aiperf profile --help\` shows all three flags
- [x] \`docs/cli-options.md\` auto-regenerated

## Context

Part of a broader effort to migrate Dynamo's Kubernetes benchmark recipes away from \`python:3.12-slim\` + \`pip install aiperf\` + shell preamble toward using the published distroless \`aiperf\` container directly. Tracked in Linear: [DYN-2767](https://linear.app/nvidia/issue/DYN-2767/aiperf-add-wait-for-model-cli-flag) (parent project: [Migrate Dynamo recipes to aiperf container](https://linear.app/nvidia/project/migrate-dynamo-recipes-to-aiperf-container-f75af5b86172)).

## Follow-ups (not in this PR)

- Extract a shared \`build_request_headers(endpoint_config)\` helper — the probe duplicates 2 lines of header-construction logic from \`base_endpoint.py\`.
- Consider parallel URL polling if typical fleet sizes grow beyond a handful; sequential is fine today and keeps logs legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-readiness probing for aiperf profile with selectable strategies (inference, models, both).
  * CLI flags: --wait-for-model, --wait-for-model-timeout (default 1800s), --wait-for-model-interval (default 5s), --wait-for-model-mode (default inference).

* **Documentation**
  * Added CLI docs describing the new readiness options and modes.

* **Tests**
  * Added integration tests covering readiness probe behaviors and edge cases (retries, timeouts, 404 fallback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->