### PR TITLE
feat(tokenizer): preload tokenizer files in main process before spawn.

### DIFF
--- a/src/aiperf/cli_runner.py
+++ b/src/aiperf/cli_runner.py
@@ -59,7 +59,10 @@ def _run_single_benchmark(
 
     from aiperf.common.aiperf_logger import AIPerfLogger
     from aiperf.common.bootstrap import bootstrap_and_run_service
-    from aiperf.common.tokenizer_validator import validate_tokenizer_early
+    from aiperf.common.tokenizer_validator import (
+        preload_tokenizers,
+        validate_tokenizer_early,
+    )
 
     logger = AIPerfLogger(__name__)
 
@@ -98,6 +101,15 @@ def _run_single_benchmark(
 
     # Validate tokenizer early (before spawning services) to fail fast.
     user_config.tokenizer.resolved_names = validate_tokenizer_early(user_config, logger)
+
+    # Preload tokenizer files into HF disk cache so child processes use
+    # local_files_only=True and make zero HF network calls.
+    preload_tokenizers(
+        user_config.tokenizer.resolved_names,
+        trust_remote_code=user_config.tokenizer.trust_remote_code,
+        revision=user_config.tokenizer.revision,
+        logger=logger,
+    )
 
     # Validate custom GPU metrics CSV file
     if user_config.gpu_telemetry_metrics_file:
@@ -175,6 +187,22 @@ def _run_multi_benchmark(
     setup_rich_logging(user_config, service_config)
 
     logger = AIPerfLogger(__name__)
+
+    # Resolve tokenizer aliases and preload files into HF disk cache once,
+    # before any subprocesses spawn. Each subprocess then finds the tokenizer
+    # cached on disk and makes zero HF network calls.
+    from aiperf.common.tokenizer_validator import (
+        preload_tokenizers,
+        validate_tokenizer_early,
+    )
+
+    user_config.tokenizer.resolved_names = validate_tokenizer_early(user_config, logger)
+    preload_tokenizers(
+        user_config.tokenizer.resolved_names,
+        trust_remote_code=user_config.tokenizer.trust_remote_code,
+        revision=user_config.tokenizer.revision,
+        logger=logger,
+    )
 
     # Inform user about UI mode (now that logging is set up)
     if "ui_type" not in service_config.model_fields_set:

--- a/src/aiperf/cli_runner.py
+++ b/src/aiperf/cli_runner.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import contextlib
 import sys
 from typing import TYPE_CHECKING
@@ -104,11 +105,13 @@ def _run_single_benchmark(
 
     # Preload tokenizer files into HF disk cache so child processes use
     # local_files_only=True and make zero HF network calls.
-    preload_tokenizers(
-        user_config.tokenizer.resolved_names,
-        trust_remote_code=user_config.tokenizer.trust_remote_code,
-        revision=user_config.tokenizer.revision,
-        logger=logger,
+    asyncio.run(
+        preload_tokenizers(
+            user_config.tokenizer.resolved_names,
+            trust_remote_code=user_config.tokenizer.trust_remote_code,
+            revision=user_config.tokenizer.revision,
+            logger=logger,
+        )
     )
 
     # Validate custom GPU metrics CSV file
@@ -197,11 +200,13 @@ def _run_multi_benchmark(
     )
 
     user_config.tokenizer.resolved_names = validate_tokenizer_early(user_config, logger)
-    preload_tokenizers(
-        user_config.tokenizer.resolved_names,
-        trust_remote_code=user_config.tokenizer.trust_remote_code,
-        revision=user_config.tokenizer.revision,
-        logger=logger,
+    asyncio.run(
+        preload_tokenizers(
+            user_config.tokenizer.resolved_names,
+            trust_remote_code=user_config.tokenizer.trust_remote_code,
+            revision=user_config.tokenizer.revision,
+            logger=logger,
+        )
     )
 
     # Inform user about UI mode (now that logging is set up)
@@ -353,7 +358,6 @@ def _run_multi_benchmark(
 
         # Export both JSON and CSV in a single async context
         # This avoids multiple asyncio.run() calls and is more efficient
-        import asyncio
 
         # Compute detailed aggregation synchronously before async export
         # (CPU-bound work with no benefit from async offload)

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -137,12 +137,32 @@ def _find_hf_cache_aliases(name: str) -> list[Path]:
     ]
 
 
-def _is_hf_cached(name: str) -> bool:
+def _is_revision_snapshot_cached(model_dir: Path, revision: str) -> bool:
+    """Check if a specific revision snapshot exists in an HF model cache directory.
+
+    Supports both named refs (``main``, ``v1.2``) and direct commit hashes.
+    """
+    snapshots_dir = model_dir / "snapshots"
+    if not snapshots_dir.is_dir():
+        return False
+    # Named ref: refs/<revision> contains the commit hash
+    refs_file = model_dir / "refs" / revision
+    if refs_file.is_file():
+        commit_hash = refs_file.read_text().strip()
+        return (snapshots_dir / commit_hash).is_dir()
+    # Direct commit hash
+    return (snapshots_dir / revision).is_dir()
+
+
+def _is_hf_cached(name: str, revision: str | None = None) -> bool:
     """Check if a HuggingFace model is available in the local cache.
 
     Looks for ``models--<name>/`` (with ``/`` replaced by ``--``) inside the
     HF hub cache directory.  Also handles alias-style short names, returning
     True only when a single unambiguous match exists.
+
+    When *revision* is given, also verifies that the specific revision snapshot
+    is present — a model directory from a different revision is not sufficient.
     """
     from huggingface_hub.constants import HF_HUB_CACHE
 
@@ -153,9 +173,16 @@ def _is_hf_cached(name: str) -> bool:
     # Exact match: "meta-llama/Llama-2-7b-hf" -> "models--meta-llama--Llama-2-7b-hf"
     exact = cache_dir / f"models--{name.replace('/', '--')}"
     if exact.is_dir():
-        return True
+        model_dir = exact
+    else:
+        aliases = _find_hf_cache_aliases(name)
+        if len(aliases) != 1:
+            return False
+        model_dir = aliases[0]
 
-    return len(_find_hf_cache_aliases(name)) == 1
+    if revision is None:
+        return True
+    return _is_revision_snapshot_cached(model_dir, revision)
 
 
 def resolve_alias(name: str) -> AliasResolutionResult:
@@ -314,7 +341,7 @@ class Tokenizer:
                 from transformers import AutoTokenizer
 
                 # Offline mode or cached: skip network, load from local cache
-                if _is_offline_mode() or _is_hf_cached(name):
+                if _is_offline_mode() or _is_hf_cached(name, revision=revision):
                     tokenizer_instance = cls._from_pretrained_local(
                         AutoTokenizer.from_pretrained,
                         name,

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -137,23 +137,39 @@ def preload_tokenizers(
     )
 
     if not resolved_names:
+        if logger:
+            logger.debug("Tokenizer preload skipped: validation was not run")
         return
 
     names_to_load: list[str] = []
     for name in set(resolved_names.values()):
         # tiktoken/builtin: no HF download needed
         if name == BUILTIN_TOKENIZER_NAME or name in TIKTOKEN_ENCODING_NAMES:
+            if logger:
+                logger.debug(
+                    f"Tokenizer preload skipped for '{name}': tiktoken backend"
+                )
             continue
         # Local path: files already on disk
         p = Path(name)
         if p.is_absolute() or name.startswith(("./", "../")) or p.is_dir():
+            if logger:
+                logger.debug(f"Tokenizer preload skipped for '{name}': local path")
             continue
         # Already in HF disk cache
         if _is_hf_cached(name):
+            if logger:
+                logger.debug(
+                    f"Tokenizer preload skipped for '{name}': already in HF cache"
+                )
             continue
         names_to_load.append(name)
 
     if not names_to_load:
+        if logger:
+            logger.debug(
+                "Tokenizer preload: all tokenizers already cached, no download needed"
+            )
         return
 
     if logger:

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -107,3 +107,73 @@ def validate_tokenizer_early(
     if tokenizer_cfg.name:
         return {model: resolved[tokenizer_cfg.name] for model in model_names}
     return resolved
+
+
+def preload_tokenizers(
+    resolved_names: dict[str, str] | None,
+    trust_remote_code: bool = False,
+    revision: str = "main",
+    logger: AIPerfLogger | None = None,
+) -> None:
+    """Preload tokenizer files into HF disk cache before spawning child processes.
+
+    Child processes call _is_hf_cached() inside Tokenizer.from_pretrained().
+    When True, they use local_files_only=True and make zero HF network calls.
+
+    Args:
+        resolved_names: Mapping of model names to resolved tokenizer names.
+                        If None or empty (validation was skipped), this is a no-op.
+        trust_remote_code: Whether to trust remote code when loading.
+        revision: The specific model version to use.
+        logger: Optional logger for progress output.
+    """
+    from pathlib import Path
+
+    from aiperf.common.tokenizer import (
+        BUILTIN_TOKENIZER_NAME,
+        TIKTOKEN_ENCODING_NAMES,
+        Tokenizer,
+        _is_hf_cached,
+    )
+
+    if not resolved_names:
+        return
+
+    names_to_load: list[str] = []
+    for name in set(resolved_names.values()):
+        # tiktoken/builtin: no HF download needed
+        if name == BUILTIN_TOKENIZER_NAME or name in TIKTOKEN_ENCODING_NAMES:
+            continue
+        # Local path: files already on disk
+        p = Path(name)
+        if p.is_absolute() or name.startswith(("./", "../")) or p.is_dir():
+            continue
+        # Already in HF disk cache
+        if _is_hf_cached(name):
+            continue
+        names_to_load.append(name)
+
+    if not names_to_load:
+        return
+
+    if logger:
+        logger.info(f"Preloading {len(names_to_load)} tokenizer(s) into local cache...")
+
+    for name in names_to_load:
+        if logger:
+            logger.info(f"  Caching tokenizer: {name}")
+        try:
+            # Discard result — side effect is populating the HF disk cache so
+            # child processes find it cached and skip all network calls.
+            Tokenizer.from_pretrained(
+                name,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                resolve_alias=False,  # already resolved by validate_tokenizer_early
+            )
+        except Exception as e:
+            if logger:
+                logger.warning(
+                    f"  Failed to preload tokenizer '{name}': {e}. "
+                    "Child processes will attempt to load it themselves."
+                )

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -158,7 +158,7 @@ def preload_tokenizers(
                 logger.debug(f"Tokenizer preload skipped for '{name}': local path")
             continue
         # Already in HF disk cache
-        if _is_hf_cached(name):
+        if _is_hf_cached(name, revision):
             if logger:
                 logger.debug(
                     f"Tokenizer preload skipped for '{name}': already in HF cache"

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Early tokenizer validation before spawning services."""
+"""Early tokenizer validation and preloading before spawning services."""
 
 from __future__ import annotations
 
+import os
 import sys
 import time
 from typing import TYPE_CHECKING
@@ -170,11 +171,13 @@ def preload_tokenizers(
             logger.debug(
                 "Tokenizer preload: all tokenizers already cached, no download needed"
             )
+        _enable_hf_offline_mode(logger)
         return
 
     if logger:
         logger.info(f"Preloading {len(names_to_load)} tokenizer(s) into local cache...")
 
+    all_succeeded = True
     for name in names_to_load:
         if logger:
             logger.info(f"  Caching tokenizer: {name}")
@@ -188,8 +191,20 @@ def preload_tokenizers(
                 resolve_alias=False,  # already resolved by validate_tokenizer_early
             )
         except Exception as e:
+            all_succeeded = False
             if logger:
                 logger.warning(
                     f"  Failed to preload tokenizer '{name}': {e}. "
                     "Child processes will attempt to load it themselves."
                 )
+
+    if all_succeeded:
+        _enable_hf_offline_mode(logger)
+
+
+def _enable_hf_offline_mode(logger: AIPerfLogger | None = None) -> None:
+    """Set HF environment variables so spawned processes never make network calls."""
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    if logger:
+        logger.debug("Enabled HF offline mode for child processes")

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 import time
@@ -110,7 +111,7 @@ def validate_tokenizer_early(
     return resolved
 
 
-def preload_tokenizers(
+async def preload_tokenizers(
     resolved_names: dict[str, str] | None,
     trust_remote_code: bool = False,
     revision: str = "main",
@@ -184,7 +185,8 @@ def preload_tokenizers(
         try:
             # Discard result — side effect is populating the HF disk cache so
             # child processes find it cached and skip all network calls.
-            Tokenizer.from_pretrained(
+            await asyncio.to_thread(
+                Tokenizer.from_pretrained,
                 name,
                 trust_remote_code=trust_remote_code,
                 revision=revision,

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -177,7 +177,7 @@ def preload_tokenizers(
     if logger:
         logger.info(f"Preloading {len(names_to_load)} tokenizer(s) into local cache...")
 
-    all_succeeded = True
+    failed: list[str] = []
     for name in names_to_load:
         if logger:
             logger.info(f"  Caching tokenizer: {name}")
@@ -190,15 +190,17 @@ def preload_tokenizers(
                 revision=revision,
                 resolve_alias=False,  # already resolved by validate_tokenizer_early
             )
-        except Exception as e:
-            all_succeeded = False
-            if logger:
-                logger.warning(
-                    f"  Failed to preload tokenizer '{name}': {e}. "
-                    "Child processes will attempt to load it themselves."
-                )
+        except Exception:  # noqa: BLE001
+            failed.append(name)
 
-    if all_succeeded:
+    if failed:
+        if logger:
+            names_str = ", ".join(f"'{n}'" for n in failed)
+            logger.warning(
+                f"Failed to preload {len(failed)} tokenizer(s): {names_str}. "
+                "Child processes will attempt to load them themselves."
+            )
+    else:
         _enable_hf_offline_mode(logger)
 
 

--- a/src/aiperf/dataset/generator/parallel_decode.py
+++ b/src/aiperf/dataset/generator/parallel_decode.py
@@ -36,7 +36,10 @@ def _init_worker(
     starts. It loads the tokenizer so subsequent decode calls don't need to reload it.
 
     Args:
-        tokenizer_name: Name or path of the pretrained tokenizer to load.
+        tokenizer_name: Pre-resolved model name or local path. Must not be an
+            unresolved alias — callers (e.g. BaseTraceLoader) are expected to
+            resolve aliases before passing this value, because
+            ``resolve_alias=False`` is used to avoid network calls in workers.
         trust_remote_code: Whether to trust remote code when loading.
         revision: The specific model version to use.
     """
@@ -92,7 +95,8 @@ def parallel_decode(
 
     Args:
         token_sequences: List of token ID lists to decode.
-        tokenizer_name: Name or path of the pretrained tokenizer to use in workers.
+        tokenizer_name: Pre-resolved model name or local path (alias resolution
+            is skipped; callers must resolve aliases beforehand).
         max_workers: Number of worker processes. Defaults to min(cpu_count, 8).
         chunksize: Number of items per worker batch for map().
         trust_remote_code: Whether to trust remote code when loading.

--- a/src/aiperf/dataset/generator/parallel_decode.py
+++ b/src/aiperf/dataset/generator/parallel_decode.py
@@ -112,6 +112,7 @@ def parallel_decode(
             tokenizer_name,
             trust_remote_code=trust_remote_code,
             revision=revision,
+            resolve_alias=False,
         )
         return [tokenizer.decode(tokens) for tokens in token_sequences]
 

--- a/src/aiperf/records/inference_result_parser.py
+++ b/src/aiperf/records/inference_result_parser.py
@@ -69,10 +69,11 @@ class InferenceResultParser(CommunicationMixin):
             )
             return
 
-        self.info("Configuring tokenizers for inference result parser")
-        begin = time.perf_counter()
         tokenizer_config = self.user_config.tokenizer
-
+        self.info(
+            f"Configuring tokenizers for inference result parser (resolve_alias: {tokenizer_config.should_resolve_alias})"
+        )
+        begin = time.perf_counter()
         async with self.tokenizer_lock:
             self.tokenizers = {}
             for model in self.model_endpoint.models.models:

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -17,6 +17,13 @@ def hf_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
+def _make_revision_snapshot(model_dir: Path, ref: str, commit_hash: str) -> None:
+    """Create a refs/<ref> file and the corresponding snapshots/<hash>/ directory."""
+    (model_dir / "refs").mkdir(parents=True, exist_ok=True)
+    (model_dir / "refs" / ref).write_text(commit_hash)
+    (model_dir / "snapshots" / commit_hash).mkdir(parents=True, exist_ok=True)
+
+
 class TestIsHfCached:
     def test_returns_false_when_cache_dir_missing(self, tmp_path, monkeypatch) -> None:
         nonexistent = tmp_path / "does_not_exist"
@@ -47,6 +54,47 @@ class TestIsHfCached:
         (hf_cache / "models--org-a--gpt2").mkdir()
         (hf_cache / "models--org-b--gpt2").mkdir()
         assert _is_hf_cached("gpt2") is False
+
+    # --- revision-aware tests ---
+
+    def test_revision_returns_true_when_named_ref_and_snapshot_exist(
+        self, hf_cache
+    ) -> None:
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        _make_revision_snapshot(model_dir, "main", "abc123")
+        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="main") is True
+
+    def test_revision_returns_false_when_refs_file_missing(self, hf_cache) -> None:
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        (model_dir / "snapshots" / "abc123").mkdir(parents=True)
+        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="v1.2") is False
+
+    def test_revision_returns_false_when_snapshot_dir_missing(self, hf_cache) -> None:
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "refs" / "v1.2").write_text("def456")
+        # snapshots/def456/ intentionally not created
+        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="v1.2") is False
+
+    def test_revision_returns_false_when_different_revision_cached(
+        self, hf_cache
+    ) -> None:
+        # "main" is cached; "v1.2" is not
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        _make_revision_snapshot(model_dir, "main", "abc123")
+        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="v1.2") is False
+
+    def test_revision_as_direct_commit_hash_returns_true(self, hf_cache) -> None:
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        (model_dir / "snapshots" / "abc123").mkdir(parents=True)
+        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="abc123") is True
+
+    def test_no_revision_returns_true_when_only_directory_exists(
+        self, hf_cache
+    ) -> None:
+        # Backward-compat: no revision arg → directory-only check
+        (hf_cache / "models--meta-llama--Llama-2-7b-hf").mkdir()
+        assert _is_hf_cached("meta-llama/Llama-2-7b-hf") is True
 
 
 class TestFindCachedModelForAlias:

--- a/tests/unit/common/test_tokenizer_validator.py
+++ b/tests/unit/common/test_tokenizer_validator.py
@@ -13,7 +13,10 @@ from aiperf.common.tokenizer import (
     TIKTOKEN_ENCODING_NAMES,
     Tokenizer,
 )
-from aiperf.common.tokenizer_validator import validate_tokenizer_early
+from aiperf.common.tokenizer_validator import (
+    preload_tokenizers,
+    validate_tokenizer_early,
+)
 
 
 @pytest.fixture
@@ -48,6 +51,106 @@ def _mock_endpoint_meta() -> Iterator[None]:
         return_value=meta,
     ):
         yield
+
+
+class TestPreloadTokenizers:
+    """Tests for preload_tokenizers() — cache-warming step before child processes spawn."""
+
+    def test_skips_when_resolved_names_none(self) -> None:
+        with patch.object(Tokenizer, "from_pretrained") as mock_load:
+            preload_tokenizers(None)
+        mock_load.assert_not_called()
+
+    def test_skips_when_resolved_names_empty(self) -> None:
+        with patch.object(Tokenizer, "from_pretrained") as mock_load:
+            preload_tokenizers({})
+        mock_load.assert_not_called()
+
+    def test_skips_builtin_name(self) -> None:
+        with patch.object(Tokenizer, "from_pretrained") as mock_load:
+            preload_tokenizers({"model": BUILTIN_TOKENIZER_NAME})
+        mock_load.assert_not_called()
+
+    @pytest.mark.parametrize("encoding_name", sorted(TIKTOKEN_ENCODING_NAMES))
+    def test_skips_tiktoken_encoding_names(self, encoding_name: str) -> None:
+        with patch.object(Tokenizer, "from_pretrained") as mock_load:
+            preload_tokenizers({"model": encoding_name})
+        mock_load.assert_not_called()
+
+    def test_skips_already_cached(self) -> None:
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=True),
+            patch.object(Tokenizer, "from_pretrained") as mock_load,
+        ):
+            preload_tokenizers({"model": "meta-llama/Llama-2-7b-hf"})
+        mock_load.assert_not_called()
+
+    def test_skips_local_absolute_path(self, tmp_path) -> None:
+        local_path = str(tmp_path)
+        with patch.object(Tokenizer, "from_pretrained") as mock_load:
+            preload_tokenizers({"model": local_path})
+        mock_load.assert_not_called()
+
+    @pytest.mark.parametrize("local_name", ["./my-tokenizer", "../my-tokenizer"])
+    def test_skips_local_relative_path(self, local_name: str) -> None:
+        with patch.object(Tokenizer, "from_pretrained") as mock_load:
+            preload_tokenizers({"model": local_name})
+        mock_load.assert_not_called()
+
+    def test_deduplicates_same_tokenizer_across_models(self) -> None:
+        resolved = {
+            "model-a": "meta-llama/Llama-2-7b-hf",
+            "model-b": "meta-llama/Llama-2-7b-hf",
+        }
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
+            patch.object(Tokenizer, "from_pretrained") as mock_load,
+        ):
+            preload_tokenizers(resolved)
+        mock_load.assert_called_once()
+
+    def test_calls_from_pretrained_with_correct_params(self) -> None:
+        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
+            patch.object(Tokenizer, "from_pretrained") as mock_load,
+        ):
+            preload_tokenizers(
+                resolved,
+                trust_remote_code=True,
+                revision="v1.0",
+            )
+        mock_load.assert_called_once_with(
+            "meta-llama/Llama-2-7b-hf",
+            trust_remote_code=True,
+            revision="v1.0",
+            resolve_alias=False,
+        )
+
+    def test_swallows_exception_and_warns(self, mock_logger: MagicMock) -> None:
+        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
+            patch.object(
+                Tokenizer, "from_pretrained", side_effect=RuntimeError("network error")
+            ),
+        ):
+            preload_tokenizers(resolved, logger=mock_logger)  # must not raise
+
+        mock_logger.warning.assert_called_once()
+        assert "meta-llama/Llama-2-7b-hf" in mock_logger.warning.call_args[0][0]
+
+    def test_loads_multiple_distinct_tokenizers(self) -> None:
+        resolved = {
+            "model-a": "meta-llama/Llama-2-7b-hf",
+            "model-b": "mistralai/Mistral-7B-v0.1",
+        }
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
+            patch.object(Tokenizer, "from_pretrained") as mock_load,
+        ):
+            preload_tokenizers(resolved)
+        assert mock_load.call_count == 2
 
 
 @pytest.mark.usefixtures("_mock_endpoint_meta")

--- a/tests/unit/common/test_tokenizer_validator.py
+++ b/tests/unit/common/test_tokenizer_validator.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for early tokenizer validation."""
+"""Tests for early tokenizer validation and preloading."""
 
+import os
 from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
@@ -51,6 +52,13 @@ def _mock_endpoint_meta() -> Iterator[None]:
         return_value=meta,
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_hf_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove HF offline env vars before each test so assertions are reliable."""
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
 
 
 class TestPreloadTokenizers:
@@ -151,6 +159,44 @@ class TestPreloadTokenizers:
         ):
             preload_tokenizers(resolved)
         assert mock_load.call_count == 2
+
+    def test_enables_offline_mode_after_successful_preload(self) -> None:
+        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
+            patch.object(Tokenizer, "from_pretrained"),
+        ):
+            preload_tokenizers(resolved)
+        assert os.environ.get("HF_HUB_OFFLINE") == "1"
+        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+
+    def test_enables_offline_mode_when_all_already_cached(self) -> None:
+        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=True),
+            patch.object(Tokenizer, "from_pretrained") as mock_load,
+        ):
+            preload_tokenizers(resolved)
+        mock_load.assert_not_called()
+        assert os.environ.get("HF_HUB_OFFLINE") == "1"
+        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+
+    def test_does_not_enable_offline_mode_on_failure(self) -> None:
+        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
+            patch.object(
+                Tokenizer, "from_pretrained", side_effect=RuntimeError("network error")
+            ),
+        ):
+            preload_tokenizers(resolved)
+        assert os.environ.get("HF_HUB_OFFLINE") is None
+        assert os.environ.get("TRANSFORMERS_OFFLINE") is None
+
+    def test_does_not_enable_offline_mode_when_skipped(self) -> None:
+        preload_tokenizers(None)
+        assert os.environ.get("HF_HUB_OFFLINE") is None
+        assert os.environ.get("TRANSFORMERS_OFFLINE") is None
 
 
 @pytest.mark.usefixtures("_mock_endpoint_meta")

--- a/tests/unit/common/test_tokenizer_validator.py
+++ b/tests/unit/common/test_tokenizer_validator.py
@@ -64,48 +64,56 @@ def _clean_hf_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestPreloadTokenizers:
     """Tests for preload_tokenizers() — cache-warming step before child processes spawn."""
 
-    def test_skips_when_resolved_names_none(self) -> None:
+    @pytest.mark.asyncio
+    async def test_skips_when_resolved_names_none(self) -> None:
         with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            preload_tokenizers(None)
+            await preload_tokenizers(None)
         mock_load.assert_not_called()
 
-    def test_skips_when_resolved_names_empty(self) -> None:
+    @pytest.mark.asyncio
+    async def test_skips_when_resolved_names_empty(self) -> None:
         with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            preload_tokenizers({})
+            await preload_tokenizers({})
         mock_load.assert_not_called()
 
-    def test_skips_builtin_name(self) -> None:
+    @pytest.mark.asyncio
+    async def test_skips_builtin_name(self) -> None:
         with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            preload_tokenizers({"model": BUILTIN_TOKENIZER_NAME})
+            await preload_tokenizers({"model": BUILTIN_TOKENIZER_NAME})
         mock_load.assert_not_called()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("encoding_name", sorted(TIKTOKEN_ENCODING_NAMES))
-    def test_skips_tiktoken_encoding_names(self, encoding_name: str) -> None:
+    async def test_skips_tiktoken_encoding_names(self, encoding_name: str) -> None:
         with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            preload_tokenizers({"model": encoding_name})
+            await preload_tokenizers({"model": encoding_name})
         mock_load.assert_not_called()
 
-    def test_skips_already_cached(self) -> None:
+    @pytest.mark.asyncio
+    async def test_skips_already_cached(self) -> None:
         with (
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=True),
             patch.object(Tokenizer, "from_pretrained") as mock_load,
         ):
-            preload_tokenizers({"model": "meta-llama/Llama-2-7b-hf"})
+            await preload_tokenizers({"model": "meta-llama/Llama-2-7b-hf"})
         mock_load.assert_not_called()
 
-    def test_skips_local_absolute_path(self, tmp_path) -> None:
+    @pytest.mark.asyncio
+    async def test_skips_local_absolute_path(self, tmp_path) -> None:
         local_path = str(tmp_path)
         with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            preload_tokenizers({"model": local_path})
+            await preload_tokenizers({"model": local_path})
         mock_load.assert_not_called()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("local_name", ["./my-tokenizer", "../my-tokenizer"])
-    def test_skips_local_relative_path(self, local_name: str) -> None:
+    async def test_skips_local_relative_path(self, local_name: str) -> None:
         with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            preload_tokenizers({"model": local_name})
+            await preload_tokenizers({"model": local_name})
         mock_load.assert_not_called()
 
-    def test_deduplicates_same_tokenizer_across_models(self) -> None:
+    @pytest.mark.asyncio
+    async def test_deduplicates_same_tokenizer_across_models(self) -> None:
         resolved = {
             "model-a": "meta-llama/Llama-2-7b-hf",
             "model-b": "meta-llama/Llama-2-7b-hf",
@@ -114,16 +122,17 @@ class TestPreloadTokenizers:
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
             patch.object(Tokenizer, "from_pretrained") as mock_load,
         ):
-            preload_tokenizers(resolved)
+            await preload_tokenizers(resolved)
         mock_load.assert_called_once()
 
-    def test_calls_from_pretrained_with_correct_params(self) -> None:
+    @pytest.mark.asyncio
+    async def test_calls_from_pretrained_with_correct_params(self) -> None:
         resolved = {"model": "meta-llama/Llama-2-7b-hf"}
         with (
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
             patch.object(Tokenizer, "from_pretrained") as mock_load,
         ):
-            preload_tokenizers(
+            await preload_tokenizers(
                 resolved,
                 trust_remote_code=True,
                 revision="v1.0",
@@ -135,7 +144,8 @@ class TestPreloadTokenizers:
             resolve_alias=False,
         )
 
-    def test_swallows_exception_and_warns(self, mock_logger: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_swallows_exception_and_warns(self, mock_logger: MagicMock) -> None:
         resolved = {"model": "meta-llama/Llama-2-7b-hf"}
         with (
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
@@ -143,12 +153,13 @@ class TestPreloadTokenizers:
                 Tokenizer, "from_pretrained", side_effect=RuntimeError("network error")
             ),
         ):
-            preload_tokenizers(resolved, logger=mock_logger)  # must not raise
+            await preload_tokenizers(resolved, logger=mock_logger)  # must not raise
 
         mock_logger.warning.assert_called_once()
         assert "meta-llama/Llama-2-7b-hf" in mock_logger.warning.call_args[0][0]
 
-    def test_loads_multiple_distinct_tokenizers(self) -> None:
+    @pytest.mark.asyncio
+    async def test_loads_multiple_distinct_tokenizers(self) -> None:
         resolved = {
             "model-a": "meta-llama/Llama-2-7b-hf",
             "model-b": "mistralai/Mistral-7B-v0.1",
@@ -157,31 +168,34 @@ class TestPreloadTokenizers:
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
             patch.object(Tokenizer, "from_pretrained") as mock_load,
         ):
-            preload_tokenizers(resolved)
+            await preload_tokenizers(resolved)
         assert mock_load.call_count == 2
 
-    def test_enables_offline_mode_after_successful_preload(self) -> None:
+    @pytest.mark.asyncio
+    async def test_enables_offline_mode_after_successful_preload(self) -> None:
         resolved = {"model": "meta-llama/Llama-2-7b-hf"}
         with (
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
             patch.object(Tokenizer, "from_pretrained"),
         ):
-            preload_tokenizers(resolved)
+            await preload_tokenizers(resolved)
         assert os.environ.get("HF_HUB_OFFLINE") == "1"
         assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
 
-    def test_enables_offline_mode_when_all_already_cached(self) -> None:
+    @pytest.mark.asyncio
+    async def test_enables_offline_mode_when_all_already_cached(self) -> None:
         resolved = {"model": "meta-llama/Llama-2-7b-hf"}
         with (
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=True),
             patch.object(Tokenizer, "from_pretrained") as mock_load,
         ):
-            preload_tokenizers(resolved)
+            await preload_tokenizers(resolved)
         mock_load.assert_not_called()
         assert os.environ.get("HF_HUB_OFFLINE") == "1"
         assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
 
-    def test_does_not_enable_offline_mode_on_failure(self) -> None:
+    @pytest.mark.asyncio
+    async def test_does_not_enable_offline_mode_on_failure(self) -> None:
         resolved = {"model": "meta-llama/Llama-2-7b-hf"}
         with (
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
@@ -189,12 +203,13 @@ class TestPreloadTokenizers:
                 Tokenizer, "from_pretrained", side_effect=RuntimeError("network error")
             ),
         ):
-            preload_tokenizers(resolved)
+            await preload_tokenizers(resolved)
         assert os.environ.get("HF_HUB_OFFLINE") is None
         assert os.environ.get("TRANSFORMERS_OFFLINE") is None
 
-    def test_does_not_enable_offline_mode_when_skipped(self) -> None:
-        preload_tokenizers(None)
+    @pytest.mark.asyncio
+    async def test_does_not_enable_offline_mode_when_skipped(self) -> None:
+        await preload_tokenizers(None)
         assert os.environ.get("HF_HUB_OFFLINE") is None
         assert os.environ.get("TRANSFORMERS_OFFLINE") is None
 

--- a/tests/unit/dataset/generator/test_parallel_decode.py
+++ b/tests/unit/dataset/generator/test_parallel_decode.py
@@ -35,7 +35,10 @@ class TestParallelDecode:
 
         # Should use sequential decoding (Tokenizer.from_pretrained called once)
         mock_tokenizer_class.from_pretrained.assert_called_once_with(
-            "gpt2", trust_remote_code=False, revision="main"
+            "gpt2",
+            trust_remote_code=False,
+            revision="main",
+            resolve_alias=False,
         )
         assert mock_tokenizer.decode.call_count == 2
         assert result == ["decoded", "decoded"]
@@ -313,7 +316,10 @@ class TestParallelDecodeTokenizerArgs:
         )
 
         mock_tokenizer_class.from_pretrained.assert_called_once_with(
-            "kimi-vl", trust_remote_code=True, revision="v1.2"
+            "kimi-vl",
+            trust_remote_code=True,
+            revision="v1.2",
+            resolve_alias=False,
         )
 
     @patch.object(pd_module, "ProcessPoolExecutor")


### PR DESCRIPTION
Add preload_tokenizers() to tokenizer_validator.py that downloads tokenizer files into the HF disk cache once in the main process. Child processes (DatasetManager, InferenceResultParser, RecordProcessor replicas) then hit _is_hf_cached() → True and load from disk via local_files_only=True, making zero HF network calls instead of each downloading independently.

Also adds validate_tokenizer_early() + preload_tokenizers() to the multi-run path, which previously had no tokenizer pre-validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tokenizer preloading added to populate local cache and permit offline operation when successful.

* **Performance**
  * Reduced network activity for multi-process and parallel benchmarks; processes can run offline after successful preload.
  * Sequential decoding now expects pre-resolved tokenizer names and avoids alias resolution during runtime.

* **Behavior**
  * Cache checks are now revision-aware; timing/logging adjusted to exclude the new log call.

* **Tests**
  * New tests cover preload behavior, revision-aware cache checks, deduplication, failure handling, and offline env handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->