### PR TITLE
feat: Add concurrency schedule replay for agentic traces

### DIFF
--- a/docs/benchmark-modes/trace-replay.md
+++ b/docs/benchmark-modes/trace-replay.md
@@ -20,6 +20,7 @@ For other use cases:
 - **Custom prompts without timing**: See [Custom Prompt Benchmarking](../tutorials/custom-prompt-benchmarking.md)
 - **Precise timestamp control for any dataset**: See [Fixed Schedule](../tutorials/fixed-schedule.md)
 - **Multi-turn conversations from files**: See [Multi-Turn Conversations](../tutorials/multi-turn.md)
+- **Changing concurrency over time**: See [Request Rate with Max Concurrency](../tutorials/request-rate-concurrency.md#scheduled-concurrency)
 
 ## Start a vLLM Server
 
@@ -87,6 +88,43 @@ aiperf profile \
 <!-- /aiperf-run-vllm-default-openai-endpoint-server -->
 
 The `--fixed-schedule` flag tells AIPerf to send requests at the exact timestamps specified in the trace. This reproduces the original timing pattern.
+
+## Replay With a Concurrency Schedule
+
+`--fixed-schedule` controls when individual trace rows are sent. Separately,
+`--concurrency-schedule-file` controls how many sessions may be active over
+time. Use it when replaying a trace against a planned load shape, such as a
+warm-up period followed by sustained peak concurrency.
+
+Create a concurrency schedule:
+
+```bash
+cat > concurrency_schedule.jsonl << 'EOF'
+{"time_sec": 0, "concurrency": 1}
+{"time_sec": 60, "concurrency": 25}
+{"time_sec": 300, "concurrency": 100}
+{"time_sec": 900, "concurrency": 100}
+EOF
+```
+
+Replay the trace with that schedule:
+
+```bash
+aiperf profile \
+    --model Qwen/Qwen3-0.6B \
+    --endpoint-type chat \
+    --streaming \
+    --url localhost:8000 \
+    --input-file custom_trace.jsonl \
+    --custom-dataset-type mooncake_trace \
+    --fixed-schedule \
+    --concurrency-schedule-file concurrency_schedule.jsonl
+```
+
+Each schedule row is `{"time_sec": float, "concurrency": int}`. The first row
+must be at `time_sec: 0`, timestamps must increase strictly, and the
+concurrency values are applied as step changes. If `--benchmark-duration` is
+omitted, the last schedule timestamp becomes the profiling duration.
 
 ## Using Pre-formatted Messages
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -795,6 +795,10 @@ The number of initial users to use for --user-centric-rate mode.
 Duration in seconds to ramp session concurrency from 1 to target. Useful for gradual warm-up of the target system.
 <br/>_Constraints: > 0_
 
+#### `--concurrency-schedule-file` `<str>`
+
+Path to a schedule.jsonl (emitted by agentic_code_gen synthesize) that drives session concurrency over wall-clock time. Each line is {"time_sec": float, "concurrency": int}. Mutually exclusive with --concurrency-ramp-duration.
+
 #### `--prefill-concurrency-ramp-duration` `<float>`
 
 Duration in seconds to ramp prefill concurrency from 1 to target.

--- a/docs/tutorials/agentic-code-generator.md
+++ b/docs/tutorials/agentic-code-generator.md
@@ -11,7 +11,8 @@ layers, session-specific repository context, incremental conversation growth,
 inter-turn delays, resets, and restart continuations.
 
 The generator writes Mooncake trace JSONL, so the output can be replayed with
-the existing `mooncake_trace` custom dataset loader.
+the existing `mooncake_trace` custom dataset loader. Configs can also emit a
+`schedule.jsonl` file that drives replay concurrency over wall-clock time.
 
 ## Prefix Layers
 
@@ -113,6 +114,8 @@ Each run creates a timestamped directory:
 The directory contains:
 
 - `dataset.jsonl`: Mooncake-compatible trace rows.
+- `schedule.jsonl`: optional replay concurrency schedule, emitted only when
+  `concurrency_schedule` is set in the generator config.
 - `manifest.json`: seed, session count, config name, and generation parameters.
 - `quality.json`: target-vs-observed distribution statistics.
 - `report.html`: summary dashboard for generated sessions.
@@ -145,7 +148,9 @@ aiperf profile \
 ```
 
 For longer runs, use the same generated trace with the usual Mooncake replay
-controls:
+controls. If the generator emitted `schedule.jsonl`, pass it with
+`--concurrency-schedule-file`; otherwise use the usual static concurrency or
+ramp options.
 
 ```bash
 aiperf profile \
@@ -154,6 +159,7 @@ aiperf profile \
   --url http://localhost:8000 \
   --endpoint-type chat \
   --input-file .test/default_1000s_seed42_YYYYMMDD-HHMMSS/dataset.jsonl \
+  --concurrency-schedule-file .test/default_1000s_seed42_YYYYMMDD-HHMMSS/schedule.jsonl \
   --custom-dataset-type mooncake_trace \
   --concurrency 50 \
   --benchmark-duration 2400 \
@@ -225,6 +231,37 @@ aiperf synthesize agentic-code \
 
 The config schema is generated at
 `src/aiperf/dataset/agentic_code_gen/configs/spec.json`.
+
+### Concurrency Schedule
+
+Add `concurrency_schedule` to a generator config to write `schedule.jsonl`
+beside `dataset.jsonl`. The generator expands sparse anchors into one JSONL row
+per tick, so replay follows the baked schedule literally:
+
+```json
+{
+  "concurrency_schedule": {
+    "interpolation": "linear",
+    "tick_sec": 1.0,
+    "noise_sigma": 0.0,
+    "anchors": [
+      {"time_sec": 0, "concurrency": 1},
+      {"time_sec": 300, "concurrency": 50},
+      {"time_sec": 2400, "concurrency": 50}
+    ]
+  }
+}
+```
+
+Replay the trace with:
+
+```bash
+aiperf profile \
+  --input-file .test/default_1000s_seed42_YYYYMMDD-HHMMSS/dataset.jsonl \
+  --concurrency-schedule-file .test/default_1000s_seed42_YYYYMMDD-HHMMSS/schedule.jsonl \
+  --custom-dataset-type mooncake_trace \
+  --concurrency 50
+```
 
 ## Related Tutorials
 

--- a/docs/tutorials/fixed-schedule.md
+++ b/docs/tutorials/fixed-schedule.md
@@ -36,6 +36,12 @@ Fixed schedule files use JSONL format with timestamp-based entries:
 - `output_length`: Maximum number of tokens in the response (optional)
 - `hash_ids`: Hash block identifiers to simulate text reuse with 512-token blocks (optional)
 
+> [!NOTE]
+> Fixed schedule files describe request arrivals with `timestamp` in
+> milliseconds. They are different from concurrency schedule files used by
+> `--concurrency-schedule-file`, which contain `time_sec` and `concurrency`
+> rows to change the session concurrency limit over time.
+
 ## Basic Fixed Schedule Execution
 
 ### Setting Up the Server

--- a/docs/tutorials/request-rate-concurrency.md
+++ b/docs/tutorials/request-rate-concurrency.md
@@ -161,6 +161,46 @@ JSON Export: artifacts/Qwen_Qwen3-0.6B-chat-concurrency50-rate50/profile_export_
 
 With constant mode, requests arrive at precisely 20ms intervals (1 / 50 req/s = 20ms). This creates predictable, reproducible load patterns ideal for regression testing. The system reaches max concurrency of 50 after exactly 1 second (50 requests / 50 req/s).
 
+## Scheduled Concurrency
+
+Use `--concurrency-schedule-file` when the concurrency ceiling itself should
+change over time. The schedule file is JSONL with one target per line:
+
+```jsonl
+{"time_sec": 0, "concurrency": 1}
+{"time_sec": 60, "concurrency": 25}
+{"time_sec": 300, "concurrency": 100}
+{"time_sec": 900, "concurrency": 100}
+```
+
+`time_sec` is seconds from the benchmark start. The first row must start at
+`0`, later rows must be strictly increasing, and `concurrency` must be a
+positive integer. AIPerf follows the rows as a step schedule. If you need
+linear interpolation or jitter, generate a dense schedule first; for example,
+`aiperf synthesize agentic-code` can emit `schedule.jsonl` from a
+`concurrency_schedule` config.
+
+```bash
+aiperf profile \
+    --model Qwen/Qwen3-0.6B \
+    --endpoint-type chat \
+    --streaming \
+    --url localhost:8000 \
+    --concurrency-schedule-file concurrency_schedule.jsonl \
+    --request-rate 200 \
+    --request-rate-mode poisson \
+    --synthetic-input-tokens-mean 800 \
+    --output-tokens-mean 400
+```
+
+The schedule controls the session concurrency limit; request rate still controls
+when requests attempt to launch. If `--benchmark-duration` is omitted, AIPerf
+uses the final `time_sec` as the profiling duration. `--concurrency` is optional
+with a schedule; when omitted or lower than the schedule peak, AIPerf sizes the
+internal limiter to the peak schedule value. `--concurrency-schedule-file` is
+mutually exclusive with `--concurrency-ramp-duration` because the file already
+describes the ramp.
+
 ## Common Use Cases
 
 Here are practical scenarios where combining request rate with max concurrency is particularly valuable:
@@ -188,6 +228,8 @@ Simulate organic user behavior with natural variance in request timing. The Pois
 **Key Parameters:**
 - `--request-rate <number>` — Target requests per second
 - `--concurrency <number>` — Maximum concurrent requests (acts as ceiling)
+- `--concurrency-schedule-file <path>` — Step schedule for changing the
+  concurrency ceiling over wall-clock time
 - `--arrival-pattern <pattern>` — Request timing distribution (default: `poisson`)
   - Options: `poisson`, `constant`, `gamma`, `concurrency_burst`
 - `--arrival-smoothness <number>` — Smoothness for gamma distribution (default: 1.0)
@@ -198,6 +240,8 @@ Simulate organic user behavior with natural variance in request timing. The Pois
 - Continuation turns block on concurrency; new sessions skip if no slot available
 - No catch-up: the schedule continues at the configured rate regardless of blocking
 - Sustained concurrency: achieved when request rate exceeds server response time
+- Scheduled concurrency: `--concurrency-schedule-file` updates the semaphore
+  ceiling at each `time_sec` tick
 
 **Choosing a pattern:**
 - Use `poisson` for realistic traffic simulation with natural variance

--- a/src/aiperf/common/config/loadgen_config.py
+++ b/src/aiperf/common/config/loadgen_config.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from typing import Annotated
 
 from cyclopts import Parameter
@@ -315,6 +316,20 @@ class LoadGeneratorConfig(BaseConfig):
         ),
     ] = None
 
+    concurrency_schedule_file: Annotated[
+        Path | None,
+        Field(
+            description="Path to a schedule.jsonl (emitted by agentic_code_gen synthesize) "
+            "that drives session concurrency over wall-clock time. Each line is "
+            '{"time_sec": float, "concurrency": int}. Mutually exclusive with '
+            "--concurrency-ramp-duration.",
+        ),
+        CLIParameter(
+            name=("--concurrency-schedule-file",),
+            group=_CLI_GROUP,
+        ),
+    ] = None
+
     prefill_concurrency_ramp_duration: Annotated[
         float | None,
         Field(
@@ -562,6 +577,30 @@ class LoadGeneratorConfig(BaseConfig):
         self.warmup_concurrency_ramp_duration = None
         self.warmup_prefill_concurrency_ramp_duration = None
         self.warmup_request_rate_ramp_duration = None
+
+    @model_validator(mode="after")
+    def validate_concurrency_schedule_exclusivity(self) -> "LoadGeneratorConfig":
+        """concurrency_schedule_file is mutually exclusive with concurrency_ramp_duration.
+
+        The schedule already describes the full concurrency trajectory, so a
+        separate ramp would fight it. File existence is checked here so misspelled
+        paths fail early instead of crashing inside the phase runner.
+        """
+        if self.concurrency_schedule_file is None:
+            return self
+
+        if self.concurrency_ramp_duration is not None:
+            raise ValueError(
+                "--concurrency-schedule-file cannot be combined with "
+                "--concurrency-ramp-duration (the schedule already encodes the ramp)."
+            )
+
+        if not self.concurrency_schedule_file.is_file():
+            raise ValueError(
+                f"--concurrency-schedule-file path does not exist: "
+                f"{self.concurrency_schedule_file}"
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_multi_run_params(self) -> "LoadGeneratorConfig":

--- a/src/aiperf/dataset/agentic_code_gen/cli.py
+++ b/src/aiperf/dataset/agentic_code_gen/cli.py
@@ -68,7 +68,7 @@ def synthesize(
     console.print(f"Generating {num_sessions} sessions (seed={seed})...")
     sessions = synth.synthesize_sessions(num_sessions)
 
-    jsonl_path, manifest_path, quality_path = write_dataset(
+    jsonl_path, manifest_path, quality_path, schedule_path = write_dataset(
         sessions, run_dir, dist_config, seed=seed, config_name=config_name
     )
     validated_rows = _validate_mooncake_or_exit(jsonl_path, console)
@@ -92,6 +92,8 @@ def synthesize(
     console.print(f"  Dashboard:       {run_dir / 'report.html'}")
     console.print(f"  Cache explorer:  {run_dir / 'cache_explorer.html'}")
     console.print(f"  Simulation:      {sim_path}")
+    if schedule_path is not None:
+        console.print(f"  Schedule:        {schedule_path}")
     console.print()
 
     comparison_path = run_dir / "comparison.txt"

--- a/src/aiperf/dataset/agentic_code_gen/configs/spec.json
+++ b/src/aiperf/dataset/agentic_code_gen/configs/spec.json
@@ -30,6 +30,74 @@
       "title": "CacheLayerConfig",
       "type": "object"
     },
+    "ConcurrencyScheduleAnchor": {
+      "additionalProperties": true,
+      "description": "A single anchor point in the concurrency schedule.",
+      "properties": {
+        "concurrency": {
+          "description": "Target session concurrency at this anchor.",
+          "minimum": 1,
+          "title": "Concurrency",
+          "type": "integer"
+        },
+        "time_sec": {
+          "description": "Wall-clock seconds from benchmark start.",
+          "minimum": 0.0,
+          "title": "Time Sec",
+          "type": "number"
+        }
+      },
+      "required": [
+        "time_sec",
+        "concurrency"
+      ],
+      "title": "ConcurrencyScheduleAnchor",
+      "type": "object"
+    },
+    "ConcurrencyScheduleConfig": {
+      "additionalProperties": true,
+      "description": "High-level concurrency schedule spec.\n\nExpanded at write time into a dense tick stream (schedule.jsonl) that\naiperf follows literally: one record per ``tick_sec``, interpolation and\ngaussian noise baked in. aiperf's runtime sees only the tick stream and\nhas no knowledge of interpolation mode or noise_sigma.",
+      "properties": {
+        "anchors": {
+          "description": "Ordered schedule anchors. First anchor must be at time_sec=0.",
+          "items": {
+            "$ref": "#/$defs/ConcurrencyScheduleAnchor"
+          },
+          "minItems": 2,
+          "title": "Anchors",
+          "type": "array"
+        },
+        "interpolation": {
+          "default": "linear",
+          "description": "How to interpolate between anchors when expanding to ticks. 'linear' walks the straight line between adjacent anchors. 'step' holds each anchor's value until the next anchor.",
+          "enum": [
+            "linear",
+            "step"
+          ],
+          "title": "Interpolation",
+          "type": "string"
+        },
+        "noise_sigma": {
+          "default": 0.0,
+          "description": "Gaussian multiplicative jitter baked into each tick. 0 disables noise.",
+          "minimum": 0.0,
+          "title": "Noise Sigma",
+          "type": "number"
+        },
+        "tick_sec": {
+          "default": 1.0,
+          "description": "Emission granularity for the expanded tick stream.",
+          "exclusiveMinimum": 0.0,
+          "title": "Tick Sec",
+          "type": "number"
+        }
+      },
+      "required": [
+        "anchors"
+      ],
+      "title": "ConcurrencyScheduleConfig",
+      "type": "object"
+    },
     "Layer15GroupConfig": {
       "additionalProperties": true,
       "description": "Group assignment for L1.5 cache sharing via Zipf distribution.",
@@ -352,6 +420,18 @@
     "cache": {
       "$ref": "#/$defs/CacheLayerConfig",
       "description": "Cache layer config"
+    },
+    "concurrency_schedule": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ConcurrencyScheduleConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional concurrency schedule. When set, synthesize emits schedule.jsonl alongside dataset.jsonl; aiperf consumes it via --concurrency-schedule-file to drive session concurrency over wall-clock time."
     },
     "generation_length": {
       "$ref": "#/$defs/LognormalParams",

--- a/src/aiperf/dataset/agentic_code_gen/models.py
+++ b/src/aiperf/dataset/agentic_code_gen/models.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import math
 from enum import Enum
+from typing import Literal
 
 import numpy as np
 from pydantic import ConfigDict, Field, model_validator
@@ -254,6 +255,61 @@ def _default_generation_length() -> LognormalParams:
     return LognormalParams(mean=500, median=300)
 
 
+class ConcurrencyScheduleAnchor(AIPerfBaseModel):
+    """A single anchor point in the concurrency schedule."""
+
+    time_sec: float = Field(
+        ge=0.0, description="Wall-clock seconds from benchmark start."
+    )
+    concurrency: int = Field(
+        ge=1, description="Target session concurrency at this anchor."
+    )
+
+
+class ConcurrencyScheduleConfig(AIPerfBaseModel):
+    """High-level concurrency schedule spec.
+
+    Expanded at write time into a dense tick stream (schedule.jsonl) that
+    aiperf follows literally: one record per ``tick_sec``, interpolation and
+    gaussian noise baked in. aiperf's runtime sees only the tick stream and
+    has no knowledge of interpolation mode or noise_sigma.
+    """
+
+    interpolation: Literal["linear", "step"] = Field(
+        default="linear",
+        description=(
+            "How to interpolate between anchors when expanding to ticks. "
+            "'linear' walks the straight line between adjacent anchors. 'step' "
+            "holds each anchor's value until the next anchor."
+        ),
+    )
+    tick_sec: float = Field(
+        default=1.0,
+        gt=0.0,
+        description="Emission granularity for the expanded tick stream.",
+    )
+    noise_sigma: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Gaussian multiplicative jitter baked into each tick. 0 disables noise."
+        ),
+    )
+    anchors: list[ConcurrencyScheduleAnchor] = Field(
+        min_length=2,
+        description="Ordered schedule anchors. First anchor must be at time_sec=0.",
+    )
+
+    @model_validator(mode="after")
+    def validate_anchors(self) -> ConcurrencyScheduleConfig:
+        if self.anchors[0].time_sec != 0:
+            raise ValueError("first anchor must be at time_sec=0")
+        times = [a.time_sec for a in self.anchors]
+        if times != sorted(times) or len(set(times)) != len(times):
+            raise ValueError("anchors must be strictly monotonic in time_sec")
+        return self
+
+
 class SessionDistributionConfig(BaseConfig):
     """Full configuration for synthesizing Agentic Code sessions.
 
@@ -305,6 +361,15 @@ class SessionDistributionConfig(BaseConfig):
         min_length=2,
         max_length=2,
         description="[min, max) turn index range for restart split point",
+    )
+    concurrency_schedule: ConcurrencyScheduleConfig | None = Field(
+        default=None,
+        description=(
+            "Optional concurrency schedule. When set, synthesize emits "
+            "schedule.jsonl alongside dataset.jsonl; aiperf consumes it via "
+            "--concurrency-schedule-file to drive session concurrency over "
+            "wall-clock time."
+        ),
     )
 
     @model_validator(mode="before")

--- a/src/aiperf/dataset/agentic_code_gen/schedule.py
+++ b/src/aiperf/dataset/agentic_code_gen/schedule.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Expand a ConcurrencyScheduleConfig into a dense (time_sec, concurrency) tick stream."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from aiperf.dataset.agentic_code_gen.models import ConcurrencyScheduleConfig
+
+
+def expand_schedule(
+    cfg: ConcurrencyScheduleConfig, rng: np.random.Generator
+) -> list[tuple[float, int]]:
+    """Walk cfg.anchors at cfg.tick_sec granularity, interpolate, apply noise.
+
+    Returns a chronological list of (time_sec, concurrency) ticks where every
+    concurrency is a positive int. Values are rounded and clamped to >= 1.
+
+    The caller-supplied RNG makes noise deterministic under a given seed.
+    """
+    end = cfg.anchors[-1].time_sec
+    ticks: list[tuple[float, int]] = []
+
+    step = cfg.tick_sec
+    num_ticks = int(end / step) + 1
+    seg_idx = 0
+    for i in range(num_ticks):
+        t = round(i * step, 6)
+        while (
+            seg_idx + 1 < len(cfg.anchors) - 1
+            and cfg.anchors[seg_idx + 1].time_sec <= t
+        ):
+            seg_idx += 1
+        a = cfg.anchors[seg_idx]
+        b = cfg.anchors[min(seg_idx + 1, len(cfg.anchors) - 1)]
+
+        if cfg.interpolation == "step":
+            # Leading-edge step: at the exact b.time_sec we've already jumped.
+            value = float(b.concurrency if t >= b.time_sec else a.concurrency)
+        elif a.time_sec == b.time_sec:
+            value = float(a.concurrency)
+        else:
+            alpha = (t - a.time_sec) / (b.time_sec - a.time_sec)
+            alpha = max(0.0, min(1.0, alpha))
+            value = a.concurrency + alpha * (b.concurrency - a.concurrency)
+
+        if cfg.noise_sigma > 0:
+            value *= max(0.0, 1.0 + float(rng.normal(0.0, cfg.noise_sigma)))
+
+        ticks.append((t, max(1, int(round(value)))))
+
+    if ticks[-1][0] < end:
+        # Ensure the final anchor is explicitly emitted even if end is not a
+        # multiple of tick_sec.
+        final = cfg.anchors[-1]
+        ticks.append((round(final.time_sec, 6), max(1, int(final.concurrency))))
+
+    return ticks

--- a/src/aiperf/dataset/agentic_code_gen/writer.py
+++ b/src/aiperf/dataset/agentic_code_gen/writer.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import math
 from pathlib import Path
 
+import numpy as np
 import orjson
 
 from aiperf.dataset.agentic_code_gen.models import (
@@ -19,6 +20,7 @@ from aiperf.dataset.agentic_code_gen.reporting.metrics import (
     compute_quality_report,
 )
 from aiperf.dataset.agentic_code_gen.reporting.report import write_generated_reports
+from aiperf.dataset.agentic_code_gen.schedule import expand_schedule
 
 
 def write_dataset(
@@ -27,11 +29,13 @@ def write_dataset(
     config: SessionDistributionConfig,
     seed: int,
     config_name: str | None = None,
-) -> tuple[Path, Path, Path]:
-    """Write JSONL dataset, manifest, quality report, and cache explorer into *output_dir*.
+) -> tuple[Path, Path, Path, Path | None]:
+    """Write JSONL dataset, manifest, quality report, cache explorer, and
+    (optionally) a concurrency schedule into *output_dir*.
 
     Returns:
-        Tuple of (jsonl_path, manifest_path, quality_path).
+        Tuple of (jsonl_path, manifest_path, quality_path, schedule_path).
+        schedule_path is None when config.concurrency_schedule is not set.
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -60,7 +64,25 @@ def write_dataset(
 
     write_generated_reports(sessions, manifest, quality_dict, output_dir)
 
-    return jsonl_path, manifest_path, quality_path
+    schedule_path: Path | None = None
+    if config.concurrency_schedule is not None:
+        schedule_path = output_dir / "schedule.jsonl"
+        # Dedicated RNG so schedule reproducibility doesn't perturb session
+        # sampling or vice-versa.
+        schedule_rng = np.random.default_rng(seed)
+        ticks = expand_schedule(config.concurrency_schedule, schedule_rng)
+        _write_schedule_jsonl(ticks, schedule_path)
+
+    return jsonl_path, manifest_path, quality_path, schedule_path
+
+
+def _write_schedule_jsonl(ticks: list[tuple[float, int]], path: Path) -> None:
+    """Write the dense tick stream as one JSON object per line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        b"\n".join(orjson.dumps({"time_sec": t, "concurrency": c}) for t, c in ticks)
+        + b"\n"
+    )
 
 
 def _write_jsonl(

--- a/src/aiperf/dataset/loader/schedule.py
+++ b/src/aiperf/dataset/loader/schedule.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load a concurrency schedule.jsonl emitted by agentic_code_gen synthesize.
+
+The on-disk format is deliberately minimal — one JSON object per line with
+exactly ``time_sec`` and ``concurrency`` fields. Interpolation and noise have
+already been baked into the stream by the generator; this loader's only job
+is to validate the envelope (monotonic timestamps, starts at zero, positive
+concurrency) and hand back a ready-to-consume list of ticks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import orjson
+from pydantic import Field
+
+from aiperf.common.models import AIPerfBaseModel
+
+
+class ScheduleTick(AIPerfBaseModel):
+    """A single (time, concurrency) point on the schedule."""
+
+    time_sec: float = Field(ge=0.0, description="Seconds from benchmark start.")
+    concurrency: int = Field(
+        ge=1, description="Target session concurrency at time_sec."
+    )
+
+
+def load_schedule(path: Path) -> list[ScheduleTick]:
+    """Read and validate a schedule.jsonl file.
+
+    Raises ValueError on empty files, non-zero first timestamp, or any
+    non-strictly-monotonic segment.
+    """
+    lines = [line for line in path.read_bytes().splitlines() if line.strip()]
+    if not lines:
+        raise ValueError(f"schedule file is empty: {path}")
+
+    ticks = [ScheduleTick.model_validate(orjson.loads(line)) for line in lines]
+
+    if ticks[0].time_sec != 0:
+        raise ValueError(f"schedule must start at time_sec=0, got {ticks[0].time_sec}")
+
+    for prev, curr in zip(ticks, ticks[1:], strict=False):
+        if curr.time_sec <= prev.time_sec:
+            raise ValueError(
+                "schedule ticks must be strictly monotonic in time_sec "
+                f"(tick at {curr.time_sec} followed {prev.time_sec})"
+            )
+
+    return ticks

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -39,7 +39,7 @@ ArrivalPattern = plugins.create_enum(PluginType.ARRIVAL_PATTERN, "ArrivalPattern
 
 RampTypeStr: TypeAlias = str
 RampType = plugins.create_enum(PluginType.RAMP, "RampType", module=__name__)
-"""Dynamic enum for ramp. Example: RampType.EXPONENTIAL, RampType.LINEAR, RampType.POISSON"""
+"""Dynamic enum for ramp. Example: RampType.EXPONENTIAL, RampType.POISSON, RampType.SCHEDULE_FOLLOWER"""
 
 DatasetBackingStoreTypeStr: TypeAlias = str
 DatasetBackingStoreType = plugins.create_enum(PluginType.DATASET_BACKING_STORE, "DatasetBackingStoreType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -645,6 +645,13 @@ ramp:
       Poisson ramp strategy with exponentially-distributed intervals.
       Provides stochastic burstiness while guaranteeing completion within duration.
 
+  schedule_follower:
+    class: aiperf.timing.ramping:ScheduleFollowerStrategy
+    description: |
+      Replay a pre-computed (time_sec, concurrency) tick stream in discrete mode.
+      Interpolation and noise are baked in by the upstream generator; this
+      strategy performs zero math and just walks the ticks.
+
 # =============================================================================
 # Record Processors
 # =============================================================================

--- a/src/aiperf/timing/config.py
+++ b/src/aiperf/timing/config.py
@@ -168,6 +168,14 @@ class CreditPhaseConfig(AIPerfBaseModel):
         description="Duration in seconds to ramp request rate from 1 QPS to target. "
         "If None, request rate starts at target immediately.",
     )
+    concurrency_schedule_ticks: tuple[tuple[float, int], ...] | None = Field(
+        default=None,
+        description=(
+            "Pre-computed (time_sec, concurrency) tick stream driving session "
+            "concurrency over wall-clock time. Loaded from schedule.jsonl. "
+            "Mutually exclusive with concurrency_ramp_duration_sec."
+        ),
+    )
     auto_offset_timestamps: bool = Field(
         default=InputDefaults.FIXED_SCHEDULE_AUTO_OFFSET,
         description="The auto offset timestamps of the timing manager.",
@@ -247,13 +255,32 @@ def _build_profiling_config(user_config: UserConfig) -> CreditPhaseConfig:
     loadgen = user_config.loadgen
     input = user_config.input
 
+    schedule_ticks: tuple[tuple[float, int], ...] | None = None
+    expected_duration_sec = loadgen.benchmark_duration
+    concurrency = loadgen.concurrency
+    if loadgen.concurrency_schedule_file is not None:
+        # Local import so loader dependency stays inside the runtime's dataset tree.
+        from aiperf.dataset.loader.schedule import load_schedule
+
+        ticks = load_schedule(loadgen.concurrency_schedule_file)
+        schedule_ticks = tuple((t.time_sec, t.concurrency) for t in ticks)
+        # Upper-bound the limiter pool on the schedule's peak so set_session_limit
+        # calls always land within the configured range.
+        schedule_peak = max(t.concurrency for t in ticks)
+        if concurrency is None or schedule_peak > concurrency:
+            concurrency = schedule_peak
+        # Default the phase duration to the last tick timestamp; user-supplied
+        # benchmark_duration still wins if set explicitly.
+        if expected_duration_sec is None:
+            expected_duration_sec = ticks[-1].time_sec
+
     return CreditPhaseConfig(
         phase=CreditPhase.PROFILING,
         timing_mode=user_config.timing_mode,
-        expected_duration_sec=loadgen.benchmark_duration,
+        expected_duration_sec=expected_duration_sec,
         total_expected_requests=loadgen.request_count,
         expected_num_sessions=input.conversation.num,
-        concurrency=loadgen.concurrency,
+        concurrency=concurrency,
         prefill_concurrency=loadgen.prefill_concurrency,
         request_rate=loadgen.request_rate or loadgen.user_centric_rate,
         arrival_pattern=loadgen.arrival_pattern,
@@ -263,6 +290,7 @@ def _build_profiling_config(user_config: UserConfig) -> CreditPhaseConfig:
         concurrency_ramp_duration_sec=loadgen.concurrency_ramp_duration,
         prefill_concurrency_ramp_duration_sec=loadgen.prefill_concurrency_ramp_duration,
         request_rate_ramp_duration_sec=loadgen.request_rate_ramp_duration,
+        concurrency_schedule_ticks=schedule_ticks,
         # Fixed schedule config
         auto_offset_timestamps=input.fixed_schedule_auto_offset,
         fixed_schedule_start_offset=input.fixed_schedule_start_offset,

--- a/src/aiperf/timing/phase/runner.py
+++ b/src/aiperf/timing/phase/runner.py
@@ -313,8 +313,29 @@ class PhaseRunner(TaskManagerMixin):
         self._rampers = []
         config = self._config
 
-        # Session concurrency ramper (stepped mode)
-        if config.concurrency_ramp_duration_sec and config.concurrency:
+        # Session concurrency: either a pre-computed schedule or a linear
+        # warm-up ramp. Validated as mutually exclusive at config load time.
+        if config.concurrency_schedule_ticks:
+            ticks = config.concurrency_schedule_ticks
+            self.info(
+                f"Starting concurrency schedule: {len(ticks)} ticks over "
+                f"{ticks[-1][0]:.1f}s (first={ticks[0][1]}, last={ticks[-1][1]})"
+            )
+            ramp_config = RampConfig(
+                ramp_type=RampType.SCHEDULE_FOLLOWER,
+                start=float(ticks[0][1]),
+                target=float(ticks[-1][1]),
+                duration_sec=max(ticks[-1][0], 1e-6),
+                schedule_ticks=ticks,
+            )
+
+            def schedule_setter(limit: float) -> None:
+                return self._concurrency_manager.set_session_limit(
+                    config.phase, int(limit)
+                )
+
+            self._rampers.append(Ramper(setter=schedule_setter, config=ramp_config))
+        elif config.concurrency_ramp_duration_sec and config.concurrency:
             self.info(
                 f"Starting session concurrency ramp: 1 → {config.concurrency} "
                 f"over {config.concurrency_ramp_duration_sec}s"

--- a/src/aiperf/timing/ramping.py
+++ b/src/aiperf/timing/ramping.py
@@ -92,6 +92,13 @@ class RampConfig(AIPerfBaseModel):
         gt=1.0,
         description="Exponent for ExponentialStrategy (default: 2.0). Must be > 1.0.",
     )
+    schedule_ticks: tuple[tuple[float, int], ...] | None = Field(
+        default=None,
+        description=(
+            "Pre-computed (time_sec, concurrency) stream for ScheduleFollowerStrategy. "
+            "Tuple (not list) so the frozen model stays hashable."
+        ),
+    )
 
 
 # =============================================================================
@@ -485,3 +492,53 @@ class PoissonStrategy(BaseRampStrategy):
         # Binary search: find first event AFTER elapsed_sec
         idx = bisect.bisect_right(self._event_times, elapsed_sec)
         return self._values[idx]
+
+
+# =============================================================================
+# ScheduleFollowerStrategy - Replay a pre-computed (time, concurrency) stream
+# =============================================================================
+
+
+class ScheduleFollowerStrategy:
+    """Walk a pre-computed (time_sec, concurrency) tick stream in discrete mode.
+
+    Each call to ``next_step`` returns the next (delay, value) pair. The stream
+    encodes the exact load shape — no interpolation, no math — so any ramp or
+    noise profile has already been baked in by the generator that emitted it
+    (e.g., ``agentic_code_gen.schedule.expand_schedule``).
+    """
+
+    def __init__(self, config: RampConfig) -> None:
+        if not config.schedule_ticks:
+            raise ValueError("ScheduleFollowerStrategy requires config.schedule_ticks")
+        self._ticks: tuple[tuple[float, int], ...] = config.schedule_ticks
+        self._idx = 0
+
+    @property
+    def start(self) -> float:
+        return float(self._ticks[0][1])
+
+    @property
+    def target(self) -> float:
+        return float(self._ticks[-1][1])
+
+    def next_step(
+        self, current: float, elapsed_sec: float
+    ) -> tuple[float, float] | None:
+        """Return (delay_until_next_tick, concurrency) or None when exhausted."""
+        if self._idx >= len(self._ticks):
+            return None
+        time_sec, concurrency = self._ticks[self._idx]
+        self._idx += 1
+        delay = max(0.0, time_sec - elapsed_sec)
+        return (delay, float(concurrency))
+
+    def value_at(self, elapsed_sec: float) -> float | None:
+        """Continuous-mode fallback: step function over the tick stream."""
+        if not self._ticks:
+            return None
+        if elapsed_sec >= self._ticks[-1][0]:
+            return None
+        idx = bisect.bisect_right([t for t, _ in self._ticks], elapsed_sec) - 1
+        idx = max(0, idx)
+        return float(self._ticks[idx][1])

--- a/tests/component_integration/timing/test_concurrency_schedule.py
+++ b/tests/component_integration/timing/test_concurrency_schedule.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Component integration tests for concurrency schedule ingestion.
+
+Validates the full pipeline end-to-end:
+- `schedule.jsonl` file consumed by `--concurrency-schedule-file`
+- `ScheduleFollowerStrategy` drives `set_session_limit` at each tick
+- `DynamicConcurrencyLimit` ramps up immediately and drains gracefully on
+  ramp-down (in-flight requests are never killed)
+
+Tests run aiperf in burst mode against the in-process FakeTransport mock
+endpoint with TTFT=5ms / ITL=1ms (see `realistic_latency` fixture). With
+OSL=50 every request takes ~55ms, giving enough concurrency pressure to
+observe the schedule's effect on dispatch while keeping tests fast.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import orjson
+import pytest
+
+from tests.component_integration.timing.conftest import defaults
+from tests.harness.analyzers import ConcurrencyAnalyzer
+from tests.harness.utils import AIPerfCLI, AIPerfResults
+
+
+def _write_schedule(path: Path, ticks: list[tuple[float, int]]) -> Path:
+    """Write a schedule.jsonl file with the given (time_sec, concurrency) ticks."""
+    path.write_bytes(
+        b"\n".join(
+            orjson.dumps({"time_sec": float(t), "concurrency": int(c)})
+            for t, c in ticks
+        )
+        + b"\n"
+    )
+    return path
+
+
+def _build_schedule_command(
+    schedule_path: Path,
+    *,
+    num_sessions: int,
+    concurrency_upper_bound: int,
+    osl: int = 50,
+) -> str:
+    """Build an aiperf burst command bound to a concurrency schedule file."""
+    return f"""
+        aiperf profile \
+            --model {defaults.model} \
+            --streaming \
+            --num-sessions {num_sessions} \
+            --concurrency {concurrency_upper_bound} \
+            --concurrency-schedule-file {schedule_path} \
+            --osl {osl} \
+            --extra-inputs ignore_eos:true \
+            --ui {defaults.ui}
+    """
+
+
+def _concurrent_at_time(intervals: list[tuple[int, int]], sample_time_ns: int) -> int:
+    """Count how many request intervals are in flight at a given monotonic timestamp."""
+    return sum(1 for start, end in intervals if start <= sample_time_ns <= end)
+
+
+def _phase_start_ns(result: AIPerfResults) -> int:
+    """Return the earliest credit issue timestamp as the logical phase start."""
+    intervals = ConcurrencyAnalyzer(result).get_request_intervals()
+    return min(start for start, _ in intervals)
+
+
+@pytest.mark.component_integration
+class TestConcurrencySchedule:
+    """End-to-end coverage: schedule.jsonl drives live concurrency changes."""
+
+    def test_ramp_up_then_down_1_to_2_to_1(
+        self, cli: AIPerfCLI, tmp_path: Path
+    ) -> None:
+        """A 1 → 2 → 1 schedule must:
+        - cap peak concurrency at 2 (never exceed the highest tick)
+        - actually reach 2 during the C=2 window (the ramp-up is exercised)
+        - stay at 1 during the opening C=1 window
+        - drain to 1 after the ramp-down (no requests killed mid-flight).
+        """
+        schedule_path = _write_schedule(
+            tmp_path / "schedule.jsonl",
+            [(0.0, 1), (2.0, 2), (4.0, 1), (6.0, 1)],
+        )
+
+        cmd = _build_schedule_command(
+            schedule_path,
+            num_sessions=500,
+            concurrency_upper_bound=2,
+        )
+        result = cli.run_sync(cmd, timeout=30.0)
+
+        analyzer = ConcurrencyAnalyzer(result)
+        intervals = analyzer.get_request_intervals()
+        assert intervals, "expected at least one request to fire"
+
+        peak = analyzer.get_max_concurrent()
+        assert peak <= 2, f"peak concurrency {peak} exceeded schedule cap of 2"
+        assert peak == 2, (
+            f"schedule's C=2 window should have been exercised; peak was {peak}"
+        )
+
+        phase_start = _phase_start_ns(result)
+        one_sec = 1_000_000_000
+
+        # Sample the opening C=1 window (the schedule initial limit is 1).
+        opening_max = max(
+            _concurrent_at_time(intervals, phase_start + int(t_ms * 1_000_000))
+            for t_ms in (100, 500, 1000, 1500, 1900)
+        )
+        assert opening_max <= 1, f"opening C=1 window saw concurrency {opening_max} > 1"
+
+        # Sample inside the C=2 window (tick fires at 2s, leave slack for dispatch
+        # latency + request duration so the slot is actually filled).
+        mid_max = max(
+            _concurrent_at_time(
+                intervals, phase_start + 2 * one_sec + int(t_ms * 1_000_000)
+            )
+            for t_ms in (300, 800, 1200, 1700)
+        )
+        assert mid_max == 2, f"C=2 window should drive concurrency to 2, saw {mid_max}"
+
+        # Ramp-down: after a grace window the debt has drained and C is 1 again.
+        # Sample late in the C=1 closing window (t=4→6); leave slack for the
+        # last C=2 request (max ~55ms) to complete.
+        closing_max = max(
+            _concurrent_at_time(intervals, phase_start + int(t_ms * 1_000_000))
+            for t_ms in (4500, 5000, 5500, 5800)
+        )
+        assert closing_max <= 1, (
+            f"closing C=1 window saw concurrency {closing_max} > 1 — "
+            "ramp-down should have drained debt by now"
+        )
+
+    def test_ramp_down_does_not_kill_in_flight(
+        self, cli: AIPerfCLI, tmp_path: Path
+    ) -> None:
+        """A steep ramp from C=5 → C=1 must drain gracefully: every credit
+        issued while the cap was 5 eventually returns (no in-flight kills)."""
+        schedule_path = _write_schedule(
+            tmp_path / "schedule.jsonl",
+            [(0.0, 5), (2.0, 5), (2.01, 1), (4.0, 1)],
+        )
+
+        cmd = _build_schedule_command(
+            schedule_path,
+            num_sessions=500,
+            concurrency_upper_bound=5,
+        )
+        result = cli.run_sync(cmd, timeout=30.0)
+
+        analyzer = ConcurrencyAnalyzer(result)
+        intervals = analyzer.get_request_intervals()
+        assert intervals, "expected at least one request to fire"
+
+        # Every issued credit (Credit message) must have a matching CreditReturn,
+        # i.e. every start has a valid end. ConcurrencyAnalyzer only builds
+        # intervals where both sides match, so the analyzer's interval count
+        # tells us how many credits were dispatched AND completed cleanly.
+        runner = result.runner_result
+        from aiperf.credit.messages import CreditReturn
+        from aiperf.credit.structs import Credit
+
+        dispatched = [
+            p.payload.id for p in runner.sent_payloads if isinstance(p.payload, Credit)
+        ]
+        returned = {
+            p.payload.credit.id
+            for p in runner.sent_payloads
+            if isinstance(p.payload, CreditReturn)
+        }
+        leaked = [cid for cid in dispatched if cid not in returned]
+        assert not leaked, (
+            f"{len(leaked)} credits dispatched during C=5 were never returned "
+            "— ramp-down should not kill in-flight requests"
+        )
+
+        # The peak must have been ≤ 5 (schedule cap) but ≥ 2 so we actually
+        # exercised the steep drop.
+        peak = analyzer.get_max_concurrent()
+        assert peak <= 5
+        assert peak >= 2, (
+            f"didn't reach enough concurrency to test a ramp-down (peak={peak})"
+        )
+
+    def test_schedule_ends_drive_phase_shutdown(
+        self, cli: AIPerfCLI, tmp_path: Path
+    ) -> None:
+        """When the user doesn't pass --benchmark-duration, the phase should
+        stop at the last tick's timestamp. Confirm no credit fires meaningfully
+        after the schedule terminates."""
+        schedule_end_sec = 3.0
+        schedule_path = _write_schedule(
+            tmp_path / "schedule.jsonl",
+            [(0.0, 2), (schedule_end_sec, 2)],
+        )
+
+        cmd = _build_schedule_command(
+            schedule_path,
+            num_sessions=1000,
+            concurrency_upper_bound=2,
+        )
+        result = cli.run_sync(cmd, timeout=30.0)
+
+        analyzer = ConcurrencyAnalyzer(result)
+        intervals = analyzer.get_request_intervals()
+        assert intervals
+
+        phase_start = _phase_start_ns(result)
+        last_issue_ns = max(start for start, _ in intervals)
+        last_issue_relative_sec = (last_issue_ns - phase_start) / 1_000_000_000
+
+        # Grace window: credits issued after schedule end would indicate the
+        # phase kept running. 1.0s grace accounts for ramper shutdown latency.
+        assert last_issue_relative_sec <= schedule_end_sec + 1.0, (
+            f"credit issued {last_issue_relative_sec:.2f}s after start, "
+            f"schedule ends at {schedule_end_sec}s"
+        )

--- a/tests/unit/dataset/agentic_code_gen/test_exact_fixtures.py
+++ b/tests/unit/dataset/agentic_code_gen/test_exact_fixtures.py
@@ -74,7 +74,7 @@ def _generate_trace(
 ) -> tuple[Path, list[dict]]:
     sessions = SessionSynthesizer(config, seed=7).synthesize_sessions(1)
     run_dir = tmp_path / "run"
-    jsonl_path, _, _ = write_dataset(sessions, run_dir, config, seed=7)
+    jsonl_path, _, _, _ = write_dataset(sessions, run_dir, config, seed=7)
     rows = [
         orjson.loads(line)
         for line in jsonl_path.read_bytes().splitlines()

--- a/tests/unit/dataset/agentic_code_gen/test_roundtrip.py
+++ b/tests/unit/dataset/agentic_code_gen/test_roundtrip.py
@@ -30,7 +30,7 @@ class TestRoundtrip:
         sessions = synth.synthesize_sessions(50)
 
         run_dir = tmp_path / "run"
-        jsonl_path, manifest_path, quality_path = write_dataset(
+        jsonl_path, manifest_path, quality_path, _ = write_dataset(
             sessions, run_dir, config, seed=42, config_name="default"
         )
 
@@ -102,7 +102,7 @@ class TestRoundtrip:
         sessions = synth.synthesize_sessions(100)
 
         run_dir = tmp_path / "block_check"
-        jsonl_path, _, _ = write_dataset(
+        jsonl_path, _, _, _ = write_dataset(
             sessions, run_dir, config, seed=42, config_name="default"
         )
         block_size = config.block_size
@@ -163,7 +163,7 @@ class TestRoundtrip:
         sessions = synth.synthesize_sessions(20)
 
         run_dir = tmp_path / "run"
-        jsonl_path, _, _ = write_dataset(
+        jsonl_path, _, _, _ = write_dataset(
             sessions, run_dir, config, seed=42, config_name="default"
         )
 
@@ -206,7 +206,7 @@ class TestRoundtrip:
         assert len(session.turns) >= 3, f"Expected >= 3 turns, got {len(session.turns)}"
 
         run_dir = tmp_path / "run"
-        jsonl_path, _, _ = write_dataset(
+        jsonl_path, _, _, _ = write_dataset(
             sessions, run_dir, config, seed=99, config_name="test"
         )
 
@@ -250,7 +250,7 @@ class TestRoundtrip:
         sessions = synth.synthesize_sessions(20)
 
         run_dir = tmp_path / "run"
-        jsonl_path, _, _ = write_dataset(
+        jsonl_path, _, _, _ = write_dataset(
             sessions, run_dir, config, seed=42, config_name="default"
         )
 
@@ -274,7 +274,7 @@ class TestRoundtrip:
         l15 = alloc.l15_blocks
 
         run_dir = tmp_path / "run"
-        jsonl_path, _, _ = write_dataset(
+        jsonl_path, _, _, _ = write_dataset(
             sessions, run_dir, config, seed=42, config_name="default"
         )
 
@@ -307,7 +307,7 @@ class TestRoundtrip:
         sessions = synth.synthesize_sessions(10)
 
         run_dir = tmp_path / "run"
-        _, manifest_path, _ = write_dataset(
+        _, manifest_path, _, _ = write_dataset(
             sessions, run_dir, config, seed=42, config_name="default"
         )
 

--- a/tests/unit/dataset/agentic_code_gen/test_schedule.py
+++ b/tests/unit/dataset/agentic_code_gen/test_schedule.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the concurrency schedule expansion and writer output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import orjson
+import pytest
+from pydantic import ValidationError
+
+from aiperf.dataset.agentic_code_gen.models import (
+    ConcurrencyScheduleAnchor,
+    ConcurrencyScheduleConfig,
+    SessionDistributionConfig,
+)
+from aiperf.dataset.agentic_code_gen.schedule import expand_schedule
+from aiperf.dataset.agentic_code_gen.session_synthesizer import SessionSynthesizer
+from aiperf.dataset.agentic_code_gen.writer import write_dataset
+
+
+def _cfg(**kwargs) -> ConcurrencyScheduleConfig:
+    defaults = {
+        "interpolation": "linear",
+        "tick_sec": 1.0,
+        "noise_sigma": 0.0,
+        "anchors": [
+            ConcurrencyScheduleAnchor(time_sec=0, concurrency=10),
+            ConcurrencyScheduleAnchor(time_sec=10, concurrency=20),
+        ],
+    }
+    defaults.update(kwargs)
+    return ConcurrencyScheduleConfig(**defaults)
+
+
+class TestExpandSchedule:
+    def test_linear_ramp_matches_endpoints(self) -> None:
+        rng = np.random.default_rng(0)
+        ticks = expand_schedule(_cfg(), rng)
+        assert ticks[0] == (0.0, 10)
+        assert ticks[-1][1] == 20
+        assert len(ticks) == 11
+
+    def test_linear_interpolates_intermediate_values(self) -> None:
+        rng = np.random.default_rng(0)
+        ticks = expand_schedule(_cfg(), rng)
+        values = [c for _, c in ticks]
+        assert values == [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+
+    def test_step_interpolation_holds_previous_value(self) -> None:
+        rng = np.random.default_rng(0)
+        ticks = expand_schedule(_cfg(interpolation="step"), rng)
+        values = [c for _, c in ticks]
+        assert values[:-1] == [10] * 10
+        assert values[-1] == 20
+
+    def test_hold_then_ramp(self) -> None:
+        rng = np.random.default_rng(0)
+        cfg = _cfg(
+            tick_sec=100.0,
+            anchors=[
+                ConcurrencyScheduleAnchor(time_sec=0, concurrency=10),
+                ConcurrencyScheduleAnchor(time_sec=600, concurrency=10),
+                ConcurrencyScheduleAnchor(time_sec=900, concurrency=20),
+            ],
+        )
+        ticks = expand_schedule(cfg, rng)
+        values_before_ramp = [c for t, c in ticks if t <= 600]
+        values_after_600 = [c for t, c in ticks if t > 600]
+        assert set(values_before_ramp) == {10}
+        assert values_after_600[-1] == 20
+        assert all(v >= 10 for v in values_after_600)
+
+    def test_same_seed_produces_identical_ticks(self) -> None:
+        cfg = _cfg(noise_sigma=0.2)
+        ticks_a = expand_schedule(cfg, np.random.default_rng(42))
+        ticks_b = expand_schedule(cfg, np.random.default_rng(42))
+        assert ticks_a == ticks_b
+
+    def test_different_seeds_produce_different_noisy_ticks(self) -> None:
+        cfg = _cfg(noise_sigma=0.3)
+        ticks_a = expand_schedule(cfg, np.random.default_rng(1))
+        ticks_b = expand_schedule(cfg, np.random.default_rng(2))
+        assert ticks_a != ticks_b
+
+    def test_noise_shifts_distribution_around_target(self) -> None:
+        flat_cfg = _cfg(
+            tick_sec=1.0,
+            noise_sigma=0.1,
+            anchors=[
+                ConcurrencyScheduleAnchor(time_sec=0, concurrency=100),
+                ConcurrencyScheduleAnchor(time_sec=2000, concurrency=100),
+            ],
+        )
+        ticks = expand_schedule(flat_cfg, np.random.default_rng(42))
+        values = np.array([c for _, c in ticks], dtype=float)
+        assert 95 < values.mean() < 105
+        assert 8 < values.std() < 14
+
+    def test_concurrency_clamped_to_at_least_one(self) -> None:
+        cfg = _cfg(
+            noise_sigma=2.0,
+            anchors=[
+                ConcurrencyScheduleAnchor(time_sec=0, concurrency=1),
+                ConcurrencyScheduleAnchor(time_sec=100, concurrency=1),
+            ],
+        )
+        ticks = expand_schedule(cfg, np.random.default_rng(42))
+        assert all(c >= 1 for _, c in ticks)
+
+
+class TestScheduleConfigValidation:
+    def test_rejects_first_anchor_not_at_zero(self) -> None:
+        with pytest.raises(ValidationError, match="first anchor must be at time_sec=0"):
+            ConcurrencyScheduleConfig(
+                anchors=[
+                    ConcurrencyScheduleAnchor(time_sec=5, concurrency=10),
+                    ConcurrencyScheduleAnchor(time_sec=10, concurrency=20),
+                ],
+            )
+
+    def test_rejects_non_monotonic_anchors(self) -> None:
+        with pytest.raises(ValidationError, match="anchors must be strictly monotonic"):
+            ConcurrencyScheduleConfig(
+                anchors=[
+                    ConcurrencyScheduleAnchor(time_sec=0, concurrency=10),
+                    ConcurrencyScheduleAnchor(time_sec=10, concurrency=20),
+                    ConcurrencyScheduleAnchor(time_sec=5, concurrency=15),
+                ],
+            )
+
+    def test_rejects_duplicate_timestamps(self) -> None:
+        with pytest.raises(ValidationError, match="anchors must be strictly monotonic"):
+            ConcurrencyScheduleConfig(
+                anchors=[
+                    ConcurrencyScheduleAnchor(time_sec=0, concurrency=10),
+                    ConcurrencyScheduleAnchor(time_sec=10, concurrency=20),
+                    ConcurrencyScheduleAnchor(time_sec=10, concurrency=30),
+                ],
+            )
+
+    def test_rejects_single_anchor(self) -> None:
+        with pytest.raises(ValidationError):
+            ConcurrencyScheduleConfig(
+                anchors=[ConcurrencyScheduleAnchor(time_sec=0, concurrency=10)],
+            )
+
+
+class TestScheduleWriterIntegration:
+    """The writer only emits schedule.jsonl when concurrency_schedule is set."""
+
+    def test_no_schedule_when_not_configured(
+        self, tmp_path: Path, coding_config: SessionDistributionConfig
+    ) -> None:
+        synth = SessionSynthesizer(coding_config, seed=42)
+        sessions = synth.synthesize_sessions(3)
+        _, _, _, schedule_path = write_dataset(
+            sessions, tmp_path / "run", coding_config, seed=42
+        )
+        assert schedule_path is None
+        assert not (tmp_path / "run" / "schedule.jsonl").exists()
+
+    def test_schedule_written_when_configured(
+        self, tmp_path: Path, coding_config: SessionDistributionConfig
+    ) -> None:
+        config = coding_config.model_copy(
+            update={
+                "concurrency_schedule": ConcurrencyScheduleConfig(
+                    tick_sec=5.0,
+                    anchors=[
+                        ConcurrencyScheduleAnchor(time_sec=0, concurrency=10),
+                        ConcurrencyScheduleAnchor(time_sec=30, concurrency=20),
+                    ],
+                )
+            }
+        )
+        synth = SessionSynthesizer(config, seed=42)
+        sessions = synth.synthesize_sessions(3)
+        _, _, _, schedule_path = write_dataset(
+            sessions, tmp_path / "run", config, seed=42
+        )
+        assert schedule_path is not None
+        assert schedule_path.name == "schedule.jsonl"
+
+        lines = [
+            orjson.loads(line)
+            for line in schedule_path.read_bytes().splitlines()
+            if line.strip()
+        ]
+        assert all(set(row.keys()) == {"time_sec", "concurrency"} for row in lines)
+        assert lines[0] == {"time_sec": 0.0, "concurrency": 10}
+        assert lines[-1]["concurrency"] == 20
+
+    def test_schedule_respects_synth_seed(
+        self, tmp_path: Path, coding_config: SessionDistributionConfig
+    ) -> None:
+        """Same seed → identical schedule.jsonl even when noise is applied."""
+        config = coding_config.model_copy(
+            update={
+                "concurrency_schedule": ConcurrencyScheduleConfig(
+                    tick_sec=1.0,
+                    noise_sigma=0.3,
+                    anchors=[
+                        ConcurrencyScheduleAnchor(time_sec=0, concurrency=50),
+                        ConcurrencyScheduleAnchor(time_sec=10, concurrency=50),
+                    ],
+                )
+            }
+        )
+        synth = SessionSynthesizer(config, seed=7)
+        sessions = synth.synthesize_sessions(1)
+        _, _, _, schedule_path_a = write_dataset(
+            sessions, tmp_path / "run_a", config, seed=7
+        )
+        _, _, _, schedule_path_b = write_dataset(
+            sessions, tmp_path / "run_b", config, seed=7
+        )
+        assert schedule_path_a.read_bytes() == schedule_path_b.read_bytes()

--- a/tests/unit/dataset/agentic_code_gen/test_writer.py
+++ b/tests/unit/dataset/agentic_code_gen/test_writer.py
@@ -38,7 +38,7 @@ class TestWriteDataset:
         self, tmp_path: Path, sessions, coding_config: SessionDistributionConfig
     ) -> None:
         run_dir = tmp_path / "run"
-        jsonl_path, manifest_path, quality_path = write_dataset(
+        jsonl_path, manifest_path, quality_path, _ = write_dataset(
             sessions, run_dir, coding_config, seed=42, config_name="default"
         )
         assert jsonl_path.exists()
@@ -66,7 +66,7 @@ class TestWriteDataset:
         self, tmp_path: Path, sessions, coding_config: SessionDistributionConfig
     ) -> None:
         run_dir = tmp_path / "run"
-        _, manifest_path, _ = write_dataset(
+        _, manifest_path, _, _ = write_dataset(
             sessions, run_dir, coding_config, seed=42, config_name="default"
         )
         manifest = orjson.loads(manifest_path.read_bytes())

--- a/tests/unit/dataset/loader/test_schedule_loader.py
+++ b/tests/unit/dataset/loader/test_schedule_loader.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the concurrency schedule loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import orjson
+import pytest
+
+from aiperf.dataset.loader.schedule import ScheduleTick, load_schedule
+
+
+def _write_schedule(path: Path, rows: list[dict]) -> Path:
+    path.write_bytes(b"\n".join(orjson.dumps(row) for row in rows) + b"\n")
+    return path
+
+
+class TestLoadSchedule:
+    def test_round_trip_basic(self, tmp_path: Path) -> None:
+        path = _write_schedule(
+            tmp_path / "schedule.jsonl",
+            [
+                {"time_sec": 0.0, "concurrency": 10},
+                {"time_sec": 5.0, "concurrency": 15},
+                {"time_sec": 10.0, "concurrency": 20},
+            ],
+        )
+        ticks = load_schedule(path)
+        assert ticks == [
+            ScheduleTick(time_sec=0.0, concurrency=10),
+            ScheduleTick(time_sec=5.0, concurrency=15),
+            ScheduleTick(time_sec=10.0, concurrency=20),
+        ]
+
+    def test_ignores_blank_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "schedule.jsonl"
+        path.write_bytes(
+            b'{"time_sec":0,"concurrency":10}\n\n{"time_sec":5,"concurrency":20}\n'
+        )
+        ticks = load_schedule(path)
+        assert len(ticks) == 2
+
+    def test_rejects_empty_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "schedule.jsonl"
+        path.write_bytes(b"")
+        with pytest.raises(ValueError, match="empty"):
+            load_schedule(path)
+
+    def test_rejects_non_zero_start(self, tmp_path: Path) -> None:
+        path = _write_schedule(
+            tmp_path / "schedule.jsonl",
+            [
+                {"time_sec": 5.0, "concurrency": 10},
+                {"time_sec": 10.0, "concurrency": 20},
+            ],
+        )
+        with pytest.raises(ValueError, match="time_sec=0"):
+            load_schedule(path)
+
+    def test_rejects_non_monotonic_ticks(self, tmp_path: Path) -> None:
+        path = _write_schedule(
+            tmp_path / "schedule.jsonl",
+            [
+                {"time_sec": 0.0, "concurrency": 10},
+                {"time_sec": 10.0, "concurrency": 15},
+                {"time_sec": 5.0, "concurrency": 20},
+            ],
+        )
+        with pytest.raises(ValueError, match="strictly monotonic"):
+            load_schedule(path)
+
+    def test_rejects_duplicate_timestamps(self, tmp_path: Path) -> None:
+        path = _write_schedule(
+            tmp_path / "schedule.jsonl",
+            [
+                {"time_sec": 0.0, "concurrency": 10},
+                {"time_sec": 5.0, "concurrency": 15},
+                {"time_sec": 5.0, "concurrency": 20},
+            ],
+        )
+        with pytest.raises(ValueError, match="strictly monotonic"):
+            load_schedule(path)
+
+    def test_rejects_non_positive_concurrency(self, tmp_path: Path) -> None:
+        path = _write_schedule(
+            tmp_path / "schedule.jsonl",
+            [
+                {"time_sec": 0.0, "concurrency": 0},
+                {"time_sec": 5.0, "concurrency": 10},
+            ],
+        )
+        with pytest.raises(Exception, match="greater than or equal to 1"):
+            load_schedule(path)

--- a/tests/unit/timing/test_schedule_end_to_end.py
+++ b/tests/unit/timing/test_schedule_end_to_end.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end test: agentic_code_gen emits schedule.jsonl -> aiperf loads it ->
+Ramper + ScheduleFollowerStrategy drive set_session_limit."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from aiperf.dataset.agentic_code_gen.models import (
+    ConcurrencyScheduleAnchor,
+    ConcurrencyScheduleConfig,
+    SessionDistributionConfig,
+)
+from aiperf.dataset.agentic_code_gen.session_synthesizer import SessionSynthesizer
+from aiperf.dataset.agentic_code_gen.writer import write_dataset
+from aiperf.dataset.loader.schedule import load_schedule
+from aiperf.plugin.enums import RampType
+from aiperf.timing.ramping import RampConfig, Ramper
+
+
+@pytest.mark.asyncio
+async def test_schedule_round_trip_drives_setter_in_order(tmp_path: Path) -> None:
+    """Generator -> schedule.jsonl -> loader -> Ramper produces setter calls
+    that follow the tick stream's concurrency values in order."""
+    base_config = SessionDistributionConfig()
+    config = base_config.model_copy(
+        update={
+            "concurrency_schedule": ConcurrencyScheduleConfig(
+                interpolation="linear",
+                tick_sec=0.01,
+                noise_sigma=0.0,
+                anchors=[
+                    ConcurrencyScheduleAnchor(time_sec=0, concurrency=5),
+                    ConcurrencyScheduleAnchor(time_sec=0.05, concurrency=10),
+                ],
+            )
+        }
+    )
+    synth = SessionSynthesizer(config, seed=42)
+    sessions = synth.synthesize_sessions(2)
+    _, _, _, schedule_path = write_dataset(sessions, tmp_path / "run", config, seed=42)
+    assert schedule_path is not None
+
+    ticks = load_schedule(schedule_path)
+    tick_tuples = tuple((t.time_sec, t.concurrency) for t in ticks)
+
+    applied: list[int] = []
+
+    def setter(v: float) -> None:
+        applied.append(int(v))
+
+    ramp_config = RampConfig(
+        ramp_type=RampType.SCHEDULE_FOLLOWER,
+        start=float(ticks[0].concurrency),
+        target=float(ticks[-1].concurrency),
+        duration_sec=max(ticks[-1].time_sec, 1e-6),
+        schedule_ticks=tick_tuples,
+    )
+    ramper = Ramper(setter=setter, config=ramp_config)
+    task = ramper.start()
+    await asyncio.wait_for(task, timeout=5.0)
+
+    # First call is Ramper's initial setter(start). Subsequent calls come from
+    # next_step. After dedup, the sequence must contain the full tick trajectory.
+    assert applied, "setter should have been called"
+    assert applied[0] == ticks[0].concurrency
+    # Every tick's concurrency must appear at least once in order.
+    tick_values = [t.concurrency for t in ticks]
+    # applied starts with the initial call duplicating tick[0], followed by each tick in order
+    after_initial = applied[1:]
+    assert after_initial == tick_values

--- a/tests/unit/timing/test_schedule_follower_strategy.py
+++ b/tests/unit/timing/test_schedule_follower_strategy.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ScheduleFollowerStrategy ramp strategy."""
+
+from __future__ import annotations
+
+import pytest
+
+from aiperf.plugin.enums import RampType
+from aiperf.timing.ramping import RampConfig, ScheduleFollowerStrategy
+
+
+def _config(ticks: tuple[tuple[float, int], ...]) -> RampConfig:
+    return RampConfig(
+        ramp_type=RampType.SCHEDULE_FOLLOWER,
+        start=float(ticks[0][1]),
+        target=float(ticks[-1][1]),
+        duration_sec=max(ticks[-1][0], 1e-6),
+        schedule_ticks=ticks,
+    )
+
+
+class TestScheduleFollowerStrategy:
+    def test_missing_ticks_raises(self) -> None:
+        config = RampConfig(
+            ramp_type=RampType.SCHEDULE_FOLLOWER,
+            start=1.0,
+            target=10.0,
+            duration_sec=10.0,
+        )
+        with pytest.raises(ValueError, match="schedule_ticks"):
+            ScheduleFollowerStrategy(config)
+
+    def test_next_step_walks_ticks_in_order(self) -> None:
+        ticks = ((0.0, 10), (5.0, 15), (10.0, 20))
+        strat = ScheduleFollowerStrategy(_config(ticks))
+        assert strat.next_step(0.0, 0.0) == (0.0, 10.0)
+        assert strat.next_step(10.0, 0.0) == (5.0, 15.0)
+        assert strat.next_step(15.0, 5.0) == (5.0, 20.0)
+        assert strat.next_step(20.0, 10.0) is None
+
+    def test_next_step_clamps_negative_delay_to_zero(self) -> None:
+        """If the runner is running behind schedule, delays clamp to 0."""
+        ticks = ((0.0, 10), (5.0, 15))
+        strat = ScheduleFollowerStrategy(_config(ticks))
+        delay, _ = strat.next_step(0.0, 100.0)
+        assert delay == 0.0
+
+    def test_value_at_returns_step_function(self) -> None:
+        ticks = ((0.0, 10), (5.0, 15), (10.0, 20))
+        strat = ScheduleFollowerStrategy(_config(ticks))
+        assert strat.value_at(0.0) == 10.0
+        assert strat.value_at(3.0) == 10.0
+        assert strat.value_at(5.0) == 15.0
+        assert strat.value_at(7.5) == 15.0
+        assert strat.value_at(10.0) is None
+
+    def test_start_and_target_reflect_tick_endpoints(self) -> None:
+        ticks = ((0.0, 10), (100.0, 200))
+        strat = ScheduleFollowerStrategy(_config(ticks))
+        assert strat.start == 10.0
+        assert strat.target == 200.0

--- a/tests/unit/timing/test_schedule_follower_strategy.py
+++ b/tests/unit/timing/test_schedule_follower_strategy.py
@@ -34,30 +34,30 @@ class TestScheduleFollowerStrategy:
 
     def test_next_step_walks_ticks_in_order(self) -> None:
         ticks = ((0.0, 10), (5.0, 15), (10.0, 20))
-        strat = ScheduleFollowerStrategy(_config(ticks))
-        assert strat.next_step(0.0, 0.0) == (0.0, 10.0)
-        assert strat.next_step(10.0, 0.0) == (5.0, 15.0)
-        assert strat.next_step(15.0, 5.0) == (5.0, 20.0)
-        assert strat.next_step(20.0, 10.0) is None
+        strategy = ScheduleFollowerStrategy(_config(ticks))
+        assert strategy.next_step(0.0, 0.0) == (0.0, 10.0)
+        assert strategy.next_step(10.0, 0.0) == (5.0, 15.0)
+        assert strategy.next_step(15.0, 5.0) == (5.0, 20.0)
+        assert strategy.next_step(20.0, 10.0) is None
 
     def test_next_step_clamps_negative_delay_to_zero(self) -> None:
         """If the runner is running behind schedule, delays clamp to 0."""
         ticks = ((0.0, 10), (5.0, 15))
-        strat = ScheduleFollowerStrategy(_config(ticks))
-        delay, _ = strat.next_step(0.0, 100.0)
+        strategy = ScheduleFollowerStrategy(_config(ticks))
+        delay, _ = strategy.next_step(0.0, 100.0)
         assert delay == 0.0
 
     def test_value_at_returns_step_function(self) -> None:
         ticks = ((0.0, 10), (5.0, 15), (10.0, 20))
-        strat = ScheduleFollowerStrategy(_config(ticks))
-        assert strat.value_at(0.0) == 10.0
-        assert strat.value_at(3.0) == 10.0
-        assert strat.value_at(5.0) == 15.0
-        assert strat.value_at(7.5) == 15.0
-        assert strat.value_at(10.0) is None
+        strategy = ScheduleFollowerStrategy(_config(ticks))
+        assert strategy.value_at(0.0) == 10.0
+        assert strategy.value_at(3.0) == 10.0
+        assert strategy.value_at(5.0) == 15.0
+        assert strategy.value_at(7.5) == 15.0
+        assert strategy.value_at(10.0) is None
 
     def test_start_and_target_reflect_tick_endpoints(self) -> None:
         ticks = ((0.0, 10), (100.0, 200))
-        strat = ScheduleFollowerStrategy(_config(ticks))
-        assert strat.start == 10.0
-        assert strat.target == 200.0
+        strategy = ScheduleFollowerStrategy(_config(ticks))
+        assert strategy.start == 10.0
+        assert strategy.target == 200.0

--- a/tests/unit/timing/test_timing_config.py
+++ b/tests/unit/timing/test_timing_config.py
@@ -62,6 +62,7 @@ def make_user_config(**overrides) -> UserConfig:
     )
     loadgen.request_rate_ramp_duration = overrides.get("request_rate_ramp_duration")
     loadgen.arrival_smoothness = overrides.get("arrival_smoothness")
+    loadgen.concurrency_schedule_file = overrides.get("concurrency_schedule_file")
     input_config = MagicMock()
     input_config.random_seed = overrides.get("random_seed")
     input_config.fixed_schedule_auto_offset = overrides.get(


### PR DESCRIPTION
## Summary

Adds optional concurrency schedule generation and replay for agentic-code traces.

The generator can emit `schedule.jsonl` beside `dataset.jsonl`, and AIPerf can consume it via `--concurrency-schedule-file` to drive session concurrency over wall-clock time. This PR keeps the scheduler/runtime path separate from the restart-depth generator work.

## What changed

Generation side:

- Adds `ConcurrencyScheduleConfig` with interpolation, tick size, noise, and anchors.
- Adds schedule expansion code and emits `schedule.jsonl` from the agentic-code writer when configured.
- Updates the agentic-code CLI, schema, and docs to describe the new schedule artifact.

Replay side:

- Adds `--concurrency-schedule-file` to load `{time_sec, concurrency}` JSONL ticks.
- Adds a schedule loader and `ScheduleFollowerStrategy` ramp plugin.
- Wires schedule ticks into timing config and the profiling phase runner.
- Auto-sizes the limiter pool to the schedule peak and defaults duration to the final tick when no benchmark duration is supplied.

Validation and docs:

- Adds unit, round-trip, end-to-end, and component-integration coverage for schedule generation and replay.
- Documents the distinction between request fixed schedules and concurrency schedules.

## Validation

- `uv run pytest tests/unit/dataset/agentic_code_gen/test_schedule.py tests/unit/dataset/agentic_code_gen/test_writer.py tests/unit/dataset/agentic_code_gen/test_roundtrip.py tests/unit/dataset/loader/test_schedule_loader.py tests/unit/timing/test_schedule_end_to_end.py tests/unit/timing/test_schedule_follower_strategy.py tests/unit/timing/test_timing_config.py -q` — 84 passed
- `uv run pytest -m component_integration tests/component_integration/timing/test_concurrency_schedule.py -q` — 3 passed
- `pre-commit run --files $(git diff --name-only origin/main..aflowers/concurrency-schedule-replay)` — passed
