### PR TITLE
feat(accuracy): implement AIME accuracy benchmark

### DIFF
--- a/docs/accuracy/accuracy-benchmarking.md
+++ b/docs/accuracy/accuracy-benchmarking.md
@@ -16,6 +16,25 @@ aiperf profile Qwen/Qwen2.5-1.5B-Instruct \
   --extra-inputs '{"temperature": 0, "stop": ["\n"]}'
 ```
 
+```bash
+# AIME competition math (zero-shot, chain-of-thought, math grader)
+aiperf profile Qwen/Qwen2.5-7B-Instruct \
+  --url http://localhost:8000 \
+  --endpoint-type chat \
+  --accuracy-benchmark aime \
+  --accuracy-enable-cot \
+  --num-requests 30 \
+  --concurrency 10 \
+  --extra-inputs '{"temperature": 0}'
+```
+
+## Available Benchmarks
+
+| Benchmark | Default grader | Default n-shots | Source |
+|---|---|---|---|
+| `mmlu` | `multiple_choice` | 5 | `lighteval/mmlu` (57 subjects) |
+| `aime` | `math` | 0 | `Maxwell-Jia/AIME_2024` |
+
 ## CLI Flags
 
 | Flag | Description | Default |
@@ -77,7 +96,36 @@ aiperf profile my-model --url http://localhost:8000 \
   --num-requests 15000 \
   --concurrency 50 \
   --extra-inputs '{"temperature": 0, "stop": ["\n"]}'
+
+# AIME with explicit math grader and few-shot priming
+aiperf profile my-model --url http://localhost:8000 \
+  --endpoint-type chat \
+  --accuracy-benchmark aime \
+  --accuracy-grader math \
+  --accuracy-n-shots 4 \
+  --num-requests 30 \
+  --concurrency 10 \
+  --extra-inputs '{"temperature": 0}'
 ```
+
+## Graders
+
+| Grader | Selection rule | Coverage |
+|---|---|---|
+| `multiple_choice` | A/B/C/D match against gold letter (lighteval `ExactMatches`). | MMLU |
+| `math` | Extract last `\boxed{...}`, fall back to "answer is X" / last number. Compare via `Fraction` parsing or normalized string equality. | AIME |
+| `exact_match` | Stub. | (unused) |
+| `code_execution` | Stub. | (unused) |
+
+The `math` grader extracts the model's final answer using this priority order:
+
+1. The contents of the **last** `\boxed{...}` in the response (the canonical MATH/AIME format).
+2. The tail of an "the answer is X" / "answer: X" / "final answer X" phrase, recursively re-parsed for boxed/numeric content.
+3. The last numeric literal in the response (int, decimal, or `a/b`).
+
+Comparison is numeric when both sides parse as `fractions.Fraction` (so `\frac{1}{2}` ≡ `0.5` ≡ `1/2`), otherwise normalized string equality (whitespace-stripped, `\dfrac` / `\tfrac` / `\left` / `\right` / `\text{}` removed, `$...$` unwrapped). Symbolic equivalence (`\sqrt{2}` vs `2^{1/2}`) is **not** supported and will grade as incorrect.
+
+When the response did not follow the `\boxed{}` instruction and a fallback extractor was used, the response is flagged `unparsed=True` in the per-record output. A correct unparsed response is still scored correct, mirroring `multiple_choice`'s convention.
 
 ## Output
 

--- a/docs/accuracy/accuracy-benchmarking.md
+++ b/docs/accuracy/accuracy-benchmarking.md
@@ -17,23 +17,61 @@ aiperf profile Qwen/Qwen2.5-1.5B-Instruct \
 ```
 
 ```bash
-# AIME competition math (zero-shot, chain-of-thought, math grader)
+# AIME competition math — defaults match the trt-llm benchmark recipe
+# (8-shot, chain-of-thought on, sympy-backed math grader)
 aiperf profile Qwen/Qwen2.5-7B-Instruct \
   --url http://localhost:8000 \
   --endpoint-type chat \
   --accuracy-benchmark aime \
-  --accuracy-enable-cot \
   --num-requests 30 \
   --concurrency 10 \
   --extra-inputs '{"temperature": 0}'
 ```
+
+## trt-llm reference alignment
+
+The `aime` benchmark is aligned with the trt-llm benchmark recipe's
+DeepEval-backed AIME path
+(`trt-llm-benchmark-recipe/src/accuracy/aime/`):
+
+- **Dataset:** `Maxwell-Jia/AIME_2024`, train split.
+- **Defaults:** `n_shots=8`, `enable_cot=True` (the recipe enforces
+  `n_shots <= 8` and aiperf raises `ValueError` if you exceed it).
+- **Prompt format:** byte-equal to `AIMETemplate.generate_output` —
+  `**Problem**: ... **Solution**: ... **Answer**: ...` blocks for
+  few-shots (Solution only when CoT is on), trailing
+  `Let's think step-by-step.` after the final `**Answer**:`.
+- **System prompt (auto-injected):**
+  `"Please reason step by step, and put your final answer within \\boxed{}."`
+  This default lives in `plugins.yaml` under the `aime` benchmark's
+  `default_system_prompt` metadata. Override it with
+  `--accuracy-system-prompt 'your prompt here'`. Pass `--accuracy-system-prompt ''`
+  to disable injection.
+- **Grader:** `MathGrader` with `_math_strip.strip_string` + sympy/
+  latex2sympy2-extended `math_equal`. Requires the `[accuracy]` extra:
+  `uv pip install 'aiperf[accuracy]'`. Without those packages installed
+  the grader falls back to a stdlib normalize+Fraction comparison and
+  emits a one-time warning; reference parity is only achieved with the
+  full sympy stack.
+
+### Per-benchmark default system prompts
+
+| Benchmark | `default_system_prompt` |
+|---|---|
+| `aime` | `Please reason step by step, and put your final answer within \boxed{}.` |
+| (others) | _none — pass via `--accuracy-system-prompt` if desired_ |
+
+The CLI's `--accuracy-system-prompt` flag always wins; the per-benchmark
+default is only consulted when the flag is unset. An empty-string default
+in metadata is treated as no default (aiperf doesn't inject a zero-length
+system message).
 
 ## Available Benchmarks
 
 | Benchmark | Default grader | Default n-shots | Source |
 |---|---|---|---|
 | `mmlu` | `multiple_choice` | 5 | `lighteval/mmlu` (57 subjects) |
-| `aime` | `math` | 0 | `Maxwell-Jia/AIME_2024` |
+| `aime` | `math` | 8 | `Maxwell-Jia/AIME_2024` (trt-llm reference, 8-shot CoT) |
 
 ## CLI Flags
 
@@ -113,19 +151,28 @@ aiperf profile my-model --url http://localhost:8000 \
 | Grader | Selection rule | Coverage |
 |---|---|---|
 | `multiple_choice` | A/B/C/D match against gold letter (lighteval `ExactMatches`). | MMLU |
-| `math` | Extract last `\boxed{...}`, fall back to "answer is X" / last number. Compare via `Fraction` parsing or normalized string equality. | AIME |
+| `math` | Extract last `\boxed{...}`, fall back to "answer is X" / last number. Apply trt-llm `strip_string` normalization, then compare via `math_equal` (lowercase string → numeric `isclose` → symbolic equivalence via sympy + latex2sympy2-extended). | AIME |
 | `exact_match` | Stub. | (unused) |
 | `code_execution` | Stub. | (unused) |
 
-The `math` grader extracts the model's final answer using this priority order:
+The `math` grader pipeline (aligned with `trt-llm-benchmark-recipe/src/accuracy/aime/`):
 
-1. The contents of the **last** `\boxed{...}` in the response (the canonical MATH/AIME format).
-2. The tail of an "the answer is X" / "answer: X" / "final answer X" phrase, recursively re-parsed for boxed/numeric content.
-3. The last numeric literal in the response (int, decimal, or `a/b`).
+1. **Extract** the model's final answer by priority:
+    - The contents of the **last** `\boxed{...}` in the response (canonical MATH/AIME format).
+    - The tail of an "the answer is X" / "answer: X" / "final answer X" phrase, recursively re-parsed for boxed/numeric content.
+    - The last numeric literal in the response.
+2. **Normalize** both prediction and gold via the recipe's `strip_string`: linebreaks/spacing/quote-style braces collapsed, `\dfrac`/`\tfrac` → `\frac`, `\left`/`\right` removed, `\text{...}` unwrapped, MathQA-derived unit tokens dropped, infinity/percent/months/dollar-sign normalization, trailing `.0` decimals trimmed, simple `a/b` rewritten as `\frac{a}{b}`.
+3. **Compare** with `math_equal` (lowercase string equality → choice-prefix unwrap → numerical `isclose` (abs_tol=1e-4) with percentage variants → brace/paren strip + lowercase compare → equation-form rewrite (`f(x) = y` ↔ `y`) → symbolic equivalence via `sympy.parsing.sympy_parser.parse_expr` and `latex2sympy2_extended.latex2sympy`).
 
-Comparison is numeric when both sides parse as `fractions.Fraction` (so `\frac{1}{2}` ≡ `0.5` ≡ `1/2`), otherwise normalized string equality (whitespace-stripped, `\dfrac` / `\tfrac` / `\left` / `\right` / `\text{}` removed, `$...$` unwrapped). Symbolic equivalence (`\sqrt{2}` vs `2^{1/2}`) is **not** supported and will grade as incorrect.
+Symbolic equivalence (e.g. `\sqrt{2}` ↔ `2^{1/2}`, `\frac{1}{3}` ↔ `0.333333`, `1,2,3` ↔ `3,2,1`) requires the `[accuracy]` install:
 
-When the response did not follow the `\boxed{}` instruction and a fallback extractor was used, the response is flagged `unparsed=True` in the per-record output. A correct unparsed response is still scored correct, mirroring `multiple_choice`'s convention.
+```bash
+uv pip install 'aiperf[accuracy]'
+```
+
+Without those optional dependencies (`sympy`, `latex2sympy2-extended`) the grader falls back to a stdlib normalize + `Fraction` comparison and emits a single warning the first time it runs. Reference parity with the trt-llm recipe requires the full sympy stack.
+
+When extraction fell back past the `\boxed{}` step (i.e. the model didn't follow the boxed-answer instruction), the response is flagged `unparsed=True` in the per-record output. A correct unparsed response is still scored correct, mirroring `multiple_choice`'s convention.
 
 ## Output
 

--- a/docs/accuracy/accuracy_stubs.md
+++ b/docs/accuracy/accuracy_stubs.md
@@ -7,7 +7,7 @@
 
 This document catalogs every stubbed method in the accuracy benchmarking scaffolding. The scaffolding is fully integrated into the plugin system, CLI, and config pipeline — the performance benchmarking path is unaffected.
 
-**Status summary (as of PR #815):** 6 of the original stubs are now fully implemented. Use them as canonical references when adding the remaining stubs.
+**Status summary:** As of the AIME loader landing on top of PR #815, `MultipleChoiceGrader`, `MathGrader`, `MMLUBenchmark`, and `AIMEBenchmark` are fully implemented; the remaining graders (`exact_match`, `code_execution`) and benchmarks (`hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gpqa_diamond`, `lcb_codegeneration`) are still stubs and ship behind `NotImplementedError` until each follow-up branch lands. Use the implemented classes as canonical references when filling in the remaining stubs.
 
 ## Table of Contents
 
@@ -139,14 +139,14 @@ class BaseGrader(AIPerfLoggerMixin):
 | # | Class | File | Plugin Key | Description |
 |---|-------|------|------------|-------------|
 | 1 | `MultipleChoiceGrader` | `graders/multiple_choice.py` | `multiple_choice` | **IMPLEMENTED in PR #815** — canonical reference for new graders. Matches choice labels (A/B/C/D) by regex extraction then exact comparison. |
+| 2 | `MathGrader` | `graders/math.py` | `math` | **IMPLEMENTED with the AIME loader.** Extracts the last `\boxed{...}` (balanced braces), falls back to "the answer is X" / last-number heuristics, and compares via `Fraction` parsing or normalized string equality. Stdlib-only; no `math_verify` dependency. |
 
 ### Still Stubbed
 
 | # | Class | File | Plugin Key | Description |
 |---|-------|------|------------|-------------|
 | 1 | `ExactMatchGrader` | `graders/exact_match.py` | `exact_match` | Exact string matching against ground truth |
-| 2 | `MathGrader` | `graders/math.py` | `math` | Mathematical expression equivalence |
-| 3 | `CodeExecutionGrader` | `graders/code_execution.py` | `code_execution` | Execute code and compare output |
+| 2 | `CodeExecutionGrader` | `graders/code_execution.py` | `code_execution` | Execute code and compare output |
 
 **Each grader has 2 methods to implement:**
 
@@ -163,22 +163,22 @@ All benchmarks use `AIPerfLoggerMixin` and must implement 1 method.
 
 ### Implemented
 
-| # | Class | File | Plugin Key | Default Grader | Default N-Shots |
-|---|-------|------|------------|----------------|-----------------|
+| # | Class | File | Plugin Key | Default Grader | Default N-Shots | Notes |
+|---|-------|------|------------|----------------|-----------------|-------|
 | 1 | `MMLUBenchmark` | `benchmarks/mmlu.py` | `mmlu` | `multiple_choice` | 5 | **IMPLEMENTED in PR #815** — canonical reference for new benchmarks. Downloads via HuggingFace datasets, handles few-shot formatting and CoT. |
+| 2 | `AIMEBenchmark` | `benchmarks/aime.py` | `aime` | `math` | 0 | **IMPLEMENTED.** Loads `Maxwell-Jia/AIME_2024`, instructs the model to wrap its final integer in `\boxed{}`, supports few-shot priming and chain-of-thought. |
 
 ### Still Stubbed
 
 | # | Class | File | Plugin Key | Default Grader | Default N-Shots |
 |---|-------|------|------------|----------------|-----------------|
-| 1 | `AIMEBenchmark` | `benchmarks/aime.py` | `aime` | `math` | 0 |
-| 2 | `HellaSwagBenchmark` | `benchmarks/hellaswag.py` | `hellaswag` | `multiple_choice` | 0 |
-| 3 | `BigBenchBenchmark` | `benchmarks/bigbench.py` | `bigbench` | `exact_match` | 3 |
-| 4 | `AIME24Benchmark` | `benchmarks/aime24.py` | `aime24` | `math` | 0 |
-| 5 | `AIME25Benchmark` | `benchmarks/aime25.py` | `aime25` | `math` | 0 |
-| 6 | `Math500Benchmark` | `benchmarks/math_500.py` | `math_500` | `math` | 0 |
-| 7 | `GPQADiamondBenchmark` | `benchmarks/gpqa_diamond.py` | `gpqa_diamond` | `multiple_choice` | 0 |
-| 8 | `LCBCodeGenerationBenchmark` | `benchmarks/lcb_codegeneration.py` | `lcb_codegeneration` | `code_execution` | 0 |
+| 1 | `HellaSwagBenchmark` | `benchmarks/hellaswag.py` | `hellaswag` | `multiple_choice` | 0 |
+| 2 | `BigBenchBenchmark` | `benchmarks/bigbench.py` | `bigbench` | `exact_match` | 3 |
+| 3 | `AIME24Benchmark` | `benchmarks/aime24.py` | `aime24` | `math` | 0 |
+| 4 | `AIME25Benchmark` | `benchmarks/aime25.py` | `aime25` | `math` | 0 |
+| 5 | `Math500Benchmark` | `benchmarks/math_500.py` | `math_500` | `math` | 0 |
+| 6 | `GPQADiamondBenchmark` | `benchmarks/gpqa_diamond.py` | `gpqa_diamond` | `multiple_choice` | 0 |
+| 7 | `LCBCodeGenerationBenchmark` | `benchmarks/lcb_codegeneration.py` | `lcb_codegeneration` | `code_execution` | 0 |
 
 **Each benchmark has 1 method to implement:**
 

--- a/docs/accuracy/accuracy_stubs.md
+++ b/docs/accuracy/accuracy_stubs.md
@@ -139,7 +139,7 @@ class BaseGrader(AIPerfLoggerMixin):
 | # | Class | File | Plugin Key | Description |
 |---|-------|------|------------|-------------|
 | 1 | `MultipleChoiceGrader` | `graders/multiple_choice.py` | `multiple_choice` | **IMPLEMENTED in PR #815** — canonical reference for new graders. Matches choice labels (A/B/C/D) by regex extraction then exact comparison. |
-| 2 | `MathGrader` | `graders/math.py` | `math` | **IMPLEMENTED with the AIME loader.** Extracts the last `\boxed{...}` (balanced braces), falls back to "the answer is X" / last-number heuristics, and compares via `Fraction` parsing or normalized string equality. Stdlib-only; no `math_verify` dependency. |
+| 2 | `MathGrader` | `graders/math.py` | `math` | **IMPLEMENTED with the AIME loader.** Extracts the last `\boxed{...}` (balanced braces), falls back to "the answer is X" / last-number heuristics. Comparison uses a sympy + latex2sympy2-extended symbolic parsing path when the `[accuracy]` extras are installed (ported from the trt-llm benchmark recipe's `math_equal`/`strip_string`); when those packages are missing, the grader transparently falls back to a stdlib `Fraction` parsing + normalized string equality comparison and emits a one-time warning. |
 
 ### Still Stubbed
 

--- a/docs/accuracy/accuracy_stubs.md
+++ b/docs/accuracy/accuracy_stubs.md
@@ -7,7 +7,7 @@
 
 This document catalogs every stubbed method in the accuracy benchmarking scaffolding. The scaffolding is fully integrated into the plugin system, CLI, and config pipeline — the performance benchmarking path is unaffected.
 
-**Status summary:** As of the AIME loader landing on top of PR #815, `MultipleChoiceGrader`, `MathGrader`, `MMLUBenchmark`, and `AIMEBenchmark` are fully implemented; the remaining graders (`exact_match`, `code_execution`) and benchmarks (`hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gpqa_diamond`, `lcb_codegeneration`) are still stubs and ship behind `NotImplementedError` until each follow-up branch lands. Use the implemented classes as canonical references when filling in the remaining stubs.
+**Status summary:** As of the AIME loader landing on top of PR #815, `MultipleChoiceGrader`, `MathGrader`, `CodeExecutionGrader`, `LightevalExprGrader`, `LightevalLatexGrader`, `LightevalGPQAGrader`, `MMLUBenchmark`, and `AIMEBenchmark` are fully implemented; the remaining grader (`exact_match`) and benchmarks (`hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gpqa_diamond`, `lcb_codegeneration`) are still stubs and ship behind `NotImplementedError` until each follow-up branch lands. Use the implemented classes as canonical references when filling in the remaining stubs.
 
 ## Table of Contents
 
@@ -140,13 +140,16 @@ class BaseGrader(AIPerfLoggerMixin):
 |---|-------|------|------------|-------------|
 | 1 | `MultipleChoiceGrader` | `graders/multiple_choice.py` | `multiple_choice` | **IMPLEMENTED in PR #815** — canonical reference for new graders. Matches choice labels (A/B/C/D) by regex extraction then exact comparison. |
 | 2 | `MathGrader` | `graders/math.py` | `math` | **IMPLEMENTED with the AIME loader.** Extracts the last `\boxed{...}` (balanced braces), falls back to "the answer is X" / last-number heuristics. Comparison uses a sympy + latex2sympy2-extended symbolic parsing path when the `[accuracy]` extras are installed (ported from the trt-llm benchmark recipe's `math_equal`/`strip_string`); when those packages are missing, the grader transparently falls back to a stdlib `Fraction` parsing + normalized string equality comparison and emits a one-time warning. |
+| 3 | `CodeExecutionGrader` | `graders/code_execution.py` | `code_execution` | **IMPLEMENTED with the AIME loader.** Wraps lighteval's `codegen_metrics` to grade LCB-style code-generation responses by sandboxed execution: extracts the response's code block via lighteval's `extract_code`, runs it against the bundled public + private test cases in a `ProcessPoolExecutor` with `num_process_evaluate=8`, and reports pass@1. Requires the `[accuracy]` extras (lighteval); raises `RuntimeError` at construction if missing. Used by AIP-881 (LCB CodeGen). |
+| 4 | `LightevalExprGrader` | `graders/lighteval_grader.py` | `lighteval_expr` | **IMPLEMENTED with the AIME loader.** Wraps lighteval's `MultilingualExtractiveMatchMetric` configured with `ExprExtractionConfig` for gold and `(ExprExtractionConfig, LatexExtractionConfig(boxed_match_priority=0))` for predictions — matches the trt-llm recipe's `expr_gold_metric`. Used by AIP-875/876 (AIME24/25). Requires the `[accuracy]` extras. |
+| 5 | `LightevalLatexGrader` | `graders/lighteval_grader.py` | `lighteval_latex` | **IMPLEMENTED with the AIME loader.** Same shape as `LightevalExprGrader` but the gold extractor uses `LatexExtractionConfig` — matches the trt-llm recipe's `latex_gold_metric`. Used by AIP-879 (MATH-500). Requires the `[accuracy]` extras. |
+| 6 | `LightevalGPQAGrader` | `graders/lighteval_grader.py` | `lighteval_gpqa` | **IMPLEMENTED with the AIME loader.** Wraps `MultilingualExtractiveMatchMetric` with `IndicesExtractionConfig(prefix_for_extraction="NativeLetters")` to extract A/B/C/D in both gold and prediction — matches the trt-llm recipe's `gpqa_metric`. Used by AIP-880 (GPQA-Diamond). Requires the `[accuracy]` extras. |
 
 ### Still Stubbed
 
 | # | Class | File | Plugin Key | Description |
 |---|-------|------|------------|-------------|
 | 1 | `ExactMatchGrader` | `graders/exact_match.py` | `exact_match` | Exact string matching against ground truth |
-| 2 | `CodeExecutionGrader` | `graders/code_execution.py` | `code_execution` | Execute code and compare output |
 
 **Each grader has 2 methods to implement:**
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -964,13 +964,13 @@ Number of few-shot examples to include in the prompt. 0 means zero-shot evaluati
 
 #### `--accuracy-enable-cot`
 
-Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instructions to the prompt.
+Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instructions to the prompt. Defaults to the benchmark's ``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).
 <br/>_Flag (no value required)_
 
 #### `--accuracy-grader` `<str>`
 
 Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
-<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`]_
+<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`]_
 
 #### `--accuracy-system-prompt` `<str>`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,12 @@ dev = [
   "trustme>=1.0.0",
 ]
 accuracy = [
-    "latex2sympy2-extended>=1.11.0",
+    # latex2sympy2-extended is co-resolved with lighteval (which pins
+    # ==1.0.6 for its math-verify integration). 1.0.6 ships the same
+    # ``latex2sympy`` API our math grader uses, so we accept the older
+    # version as long as it satisfies our import.
+    "latex2sympy2-extended>=1.0.6",
+    "lighteval>=0.13.0",
     "sympy>=1.14.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,10 @@ dev = [
   "ruff>=0.14.0,<0.15.0",
   "trustme>=1.0.0",
 ]
+accuracy = [
+    "latex2sympy2-extended>=1.11.0",
+    "sympy>=1.14.0",
+]
 
 [tool.ruff]
 # Base settings for ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,12 @@ dev = [
   "trustme>=1.0.0",
 ]
 accuracy = [
-    "latex2sympy2-extended>=1.11.0",
+    # latex2sympy2-extended is co-resolved with lighteval (which pins
+    # ==1.0.6 for its math-verify integration). 1.0.6 ships the same
+    # ``latex2sympy`` API our math grader uses, so we accept the older
+    # version as long as it satisfies our import.
+    "latex2sympy2-extended>=1.0.6",
+    "lighteval>=0.13.0",
     "sympy>=1.14.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,10 @@ dev = [
   "ruff>=0.14.0,<0.15.0",
   "trustme>=1.0.0",
 ]
+accuracy = [
+    "latex2sympy2-extended>=1.11.0",
+    "sympy>=1.14.0",
+]
 
 [dependency-groups]
 dev = [

--- a/src/aiperf/accuracy/benchmark_loader.py
+++ b/src/aiperf/accuracy/benchmark_loader.py
@@ -19,14 +19,19 @@ async def load_benchmark_problems(user_config: UserConfig) -> list[BenchmarkProb
     acc_cfg = user_config.accuracy
     benchmark_cls = plugins.get_class(PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark)
 
+    meta = plugins.get_metadata(PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark)
+
     n_shots = acc_cfg.n_shots
     if n_shots is None:
-        meta = plugins.get_metadata(PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark)
         n_shots = meta.get("default_n_shots", 0)
+
+    enable_cot = acc_cfg.enable_cot
+    if enable_cot is None:
+        enable_cot = bool(meta.get("default_enable_cot", False))
 
     benchmark = benchmark_cls(user_config=user_config)
     return await benchmark.load_problems(
         tasks=acc_cfg.tasks,
         n_shots=n_shots,
-        enable_cot=acc_cfg.enable_cot,
+        enable_cot=enable_cot,
     )

--- a/src/aiperf/accuracy/benchmarks/aime.py
+++ b/src/aiperf/accuracy/benchmarks/aime.py
@@ -1,21 +1,193 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from aiperf.accuracy.models import BenchmarkProblem
+"""AIME benchmark loader, ported from lighteval's competition-math task style.
+
+Loads the Maxwell-Jia/AIME_2024 dataset (DeepEval's canonical AIME 2024
+mirror, with capitalized ``Problem``/``Answer`` field names) and formats
+each problem as a competition-math word problem instructing the model to
+place its final integer answer inside ``\\boxed{...}``. Pair with
+``MathGrader`` for numerical equivalence.
+
+This benchmark is named ``aime`` (no year) so that downstream consumers
+have a stable identifier for "AIME problems" without committing to a year.
+For year-pinned variants see ``aime24``/``aime25``, which use lighteval's
+``HuggingFaceH4/aime_2024`` and ``yentinglin/aime_2025`` mirrors with
+lowercase schemas.
+
+lighteval reference: lighteval/src/lighteval/tasks/extended/aime/main.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from datasets import Dataset, load_dataset
+
+from aiperf.accuracy.models import AccuracyChatMessage, BenchmarkProblem
 from aiperf.common.config import UserConfig
 from aiperf.common.mixins import AIPerfLoggerMixin
 
+DATASET_NAME = "Maxwell-Jia/AIME_2024"
+TASK_NAME = "aime"
+
+# AIME answers are integers in [0, 999]. We allow generous reasoning
+# headroom so chain-of-thought solutions can complete; the per-request
+# max_tokens is read from BenchmarkProblem.metadata["generation_size"]
+# in AccuracyDatasetLoader. 4096 is a defensible default for non-reasoning
+# models; reasoning-heavy models will need a higher cap via the user's
+# server config or a future per-benchmark override.
+DEFAULT_GENERATION_SIZE = 4096
+
+# Instruction prefix shown to the model. Asks for \\boxed{} format so that
+# MathGrader can extract the final answer reliably.
+INSTRUCTION_PREFIX = (
+    "Solve the following competition math problem. The answer is a "
+    "non-negative integer. Place your final answer inside \\boxed{}.\n\n"
+)
+
+# Field names in the Maxwell-Jia/AIME_2024 schema. AIME24/AIME25 use
+# different lowercase field names — see those loaders.
+PROBLEM_FIELD = "Problem"
+ANSWER_FIELD = "Answer"
+
 
 class AIMEBenchmark(AIPerfLoggerMixin):
-    """AIME (American Invitational Mathematics Examination) benchmark loader."""
+    """AIME (American Invitational Mathematics Examination) benchmark loader.
 
-    def __init__(self, user_config: UserConfig, **kwargs) -> None:
+    Loads AIME competition problems from ``Maxwell-Jia/AIME_2024`` (train
+    split) and produces ``BenchmarkProblem`` objects ready for both the
+    completions endpoint (flat ``prompt``) and the chat endpoint
+    (``raw_messages``). Few-shot examples are drawn sequentially from the
+    beginning of the dataset.
+    """
+
+    def __init__(self, user_config: UserConfig, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.user_config = user_config
 
     async def load_problems(
         self, tasks: list[str] | None, n_shots: int, enable_cot: bool
     ) -> list[BenchmarkProblem]:
-        raise NotImplementedError(
-            "aime benchmark is not yet implemented; only 'mmlu' is available in this release."
-        )
+        """Load every AIME problem and format it for the LLM.
+
+        Args:
+            tasks: Ignored — AIME has no subtasks. Accepted for protocol
+                parity with other benchmarks that support task filtering.
+            n_shots: Number of few-shot examples to prepend (drawn from
+                the start of the dataset). 0 disables few-shot prompting.
+            enable_cot: When True, append ``Let's think step by step.`` to
+                each query, encouraging chain-of-thought reasoning before
+                the final ``\\boxed{}`` answer.
+
+        Returns:
+            One ``BenchmarkProblem`` per dataset row, in dataset order.
+        """
+        ds: Dataset = await asyncio.to_thread(load_dataset, DATASET_NAME, split="train")
+        return await asyncio.to_thread(self._build_problems, ds, n_shots, enable_cot)
+
+    def _build_problems(
+        self, ds: Dataset, n_shots: int, enable_cot: bool
+    ) -> list[BenchmarkProblem]:
+        few_shots = self._build_few_shots(ds, n_shots)
+        problems: list[BenchmarkProblem] = []
+        for row in ds:
+            prompt = self._format_prompt(row, few_shots, enable_cot)
+            raw_messages = self._build_chat_messages(row, few_shots, enable_cot)
+            problems.append(
+                BenchmarkProblem(
+                    prompt=prompt,
+                    ground_truth=str(row[ANSWER_FIELD]),
+                    task=TASK_NAME,
+                    metadata={"generation_size": DEFAULT_GENERATION_SIZE},
+                    raw_messages=raw_messages,
+                )
+            )
+        return problems
+
+    def _build_few_shots(self, ds: Dataset, n_shots: int) -> list[dict[str, str]]:
+        """Build few-shot examples by sequentially sampling the dataset start.
+
+        AIME has no separate dev/validation split, so we draw few-shot
+        examples from the same train split. This means the first ``n_shots``
+        problems will appear in their own prompts; lighteval's competition
+        configs do the same when no held-out pool is available.
+        """
+        if n_shots <= 0:
+            return []
+        size = min(n_shots, len(ds))
+        return [self._format_example(ds[i]) for i in range(size)]
+
+    def _format_example(self, row: dict[str, Any]) -> dict[str, str]:
+        """Format a dataset row as a few-shot example.
+
+        Returns a ``{problem, answer, formatted}`` triple where ``formatted``
+        is the flat completions form (used in the completions prompt) and
+        ``problem``/``answer`` are reused when constructing chat messages.
+        """
+        answer = str(row[ANSWER_FIELD])
+        problem = row[PROBLEM_FIELD]
+        return {
+            "problem": problem,
+            "answer": answer,
+            "formatted": f"Problem: {problem}\nAnswer: \\boxed{{{answer}}}",
+        }
+
+    def _format_prompt(
+        self,
+        row: dict[str, Any],
+        few_shots: list[dict[str, str]],
+        enable_cot: bool,
+    ) -> str:
+        """Build the flat completions prompt: instruction + shots + query."""
+        few_shot_text = "\n\n".join(ex["formatted"] for ex in few_shots)
+        if few_shot_text:
+            few_shot_text += "\n\n"
+
+        problem = row[PROBLEM_FIELD]
+        if enable_cot:
+            query = f"Problem: {problem}\nLet's think step by step.\nAnswer:"
+        else:
+            query = f"Problem: {problem}\nAnswer:"
+
+        return INSTRUCTION_PREFIX + few_shot_text + query
+
+    def _build_chat_messages(
+        self,
+        row: dict[str, Any],
+        few_shots: list[dict[str, str]],
+        enable_cot: bool,
+    ) -> list[AccuracyChatMessage]:
+        """Build multi-turn chat messages following lighteval's PromptManager.
+
+        - First few-shot user message includes the instruction prefix.
+        - Subsequent few-shot user messages contain only ``Problem: ... Answer:``.
+        - Each few-shot assistant message holds ``\\boxed{answer}`` so the
+          model is primed to emit the same boxed format.
+        - Main query repeats the user-side format without re-instructing.
+        - When there are no few-shots, the instruction is prepended to the
+          single user message.
+        """
+        messages: list[AccuracyChatMessage] = []
+
+        for ix, ex in enumerate(few_shots):
+            q = f"Problem: {ex['problem']}\nAnswer:"
+            if ix == 0:
+                q = INSTRUCTION_PREFIX + q
+            messages.append({"role": "user", "content": q})
+            messages.append(
+                {"role": "assistant", "content": f"\\boxed{{{ex['answer']}}}"}
+            )
+
+        problem = row[PROBLEM_FIELD]
+        if enable_cot:
+            main_q = f"Problem: {problem}\nLet's think step by step.\nAnswer:"
+        else:
+            main_q = f"Problem: {problem}\nAnswer:"
+
+        if not few_shots:
+            main_q = INSTRUCTION_PREFIX + main_q
+
+        messages.append({"role": "user", "content": main_q})
+        return messages

--- a/src/aiperf/accuracy/benchmarks/aime.py
+++ b/src/aiperf/accuracy/benchmarks/aime.py
@@ -1,21 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""AIME benchmark loader, ported from lighteval's competition-math task style.
+"""AIME benchmark loader, aligned with the trt-llm benchmark recipe.
 
-Loads the Maxwell-Jia/AIME_2024 dataset (DeepEval's canonical AIME 2024
-mirror, with capitalized ``Problem``/``Answer`` field names) and formats
-each problem as a competition-math word problem instructing the model to
-place its final integer answer inside ``\\boxed{...}``. Pair with
-``MathGrader`` for numerical equivalence.
+Loads ``Maxwell-Jia/AIME_2024`` and renders prompts character-for-
+character identical to the recipe's ``AIMETemplate.generate_output``
+(``trt-llm-benchmark-recipe/src/accuracy/aime/template.py``). This is
+the DeepEval-backed AIME path in the trt-llm recipe — distinct from the
+lighteval-backed ``aime24``/``aime25`` loaders that pin to specific
+years and use lighteval's prompt manager.
 
-This benchmark is named ``aime`` (no year) so that downstream consumers
-have a stable identifier for "AIME problems" without committing to a year.
-For year-pinned variants see ``aime24``/``aime25``, which use lighteval's
-``HuggingFaceH4/aime_2024`` and ``yentinglin/aime_2025`` mirrors with
-lowercase schemas.
-
-lighteval reference: lighteval/src/lighteval/tasks/extended/aime/main.py
+Reference: trt-llm-benchmark-recipe/src/accuracy/aime/{aime,template}.py
 """
 
 from __future__ import annotations
@@ -32,35 +27,64 @@ from aiperf.common.mixins import AIPerfLoggerMixin
 DATASET_NAME = "Maxwell-Jia/AIME_2024"
 TASK_NAME = "aime"
 
-# AIME answers are integers in [0, 999]. We allow generous reasoning
-# headroom so chain-of-thought solutions can complete; the per-request
-# max_tokens is read from BenchmarkProblem.metadata["generation_size"]
-# in AccuracyDatasetLoader. 4096 is a defensible default for non-reasoning
-# models; reasoning-heavy models will need a higher cap via the user's
-# server config or a future per-benchmark override.
-DEFAULT_GENERATION_SIZE = 4096
+# Recipe defaults: ``n_shots=8`` (capped), ``enable_cot=True``,
+# ``n_problems=30``. We keep the cap available via the ``tasks``
+# argument's "n_problems:N" semantics if needed in the future, but for
+# now we mirror the recipe's evaluation: 8 shots, CoT on, all 30
+# problems graded.
+DEFAULT_N_SHOTS = 8
+MAX_N_SHOTS = 8
+DEFAULT_ENABLE_COT = True
 
-# Instruction prefix shown to the model. Asks for \\boxed{} format so that
-# MathGrader can extract the final answer reliably.
-INSTRUCTION_PREFIX = (
-    "Solve the following competition math problem. The answer is a "
-    "non-negative integer. Place your final answer inside \\boxed{}.\n\n"
+# Recipe runs with the model's full reasoning budget. lighteval-aligned
+# AIME tasks use 32768; we match that here so reasoning models have
+# room to think before emitting the boxed answer.
+DEFAULT_GENERATION_SIZE = 32768
+
+# Recipe ``aime_test.json`` ships this as the system prompt; aiperf
+# auto-injects it via the per-benchmark ``default_system_prompt``
+# mechanism (plugins.yaml metadata) when the user doesn't override
+# with ``--accuracy-system-prompt``.
+DEFAULT_SYSTEM_PROMPT = (
+    "Please reason step by step, and put your final answer within \\boxed{}."
 )
 
-# Field names in the Maxwell-Jia/AIME_2024 schema. AIME24/AIME25 use
-# different lowercase field names — see those loaders.
+# Recipe ``AIMETemplate.generate_output`` instruction header — used
+# only when there is at least one few-shot example. With zero shots,
+# the recipe emits no header at all.
+FEW_SHOT_HEADER = (
+    "The following are problems from the American Invitational "
+    "Mathematics Examination (AIME) 2024. AIME is a prestigious high "
+    "school mathematics competition known for its challenging "
+    "mathematical problems.\n\n"
+)
+
+# Recipe ``AIMETemplate.generate_output`` trailing CoT trigger. Note
+# this lives AFTER the ``**Answer**:`` marker, not before.
+COT_SUFFIX = "Let's think step-by-step."
+NO_COT_SUFFIX = "No explanation needed. Just return a number."
+
+# Schema field names in Maxwell-Jia/AIME_2024.
 PROBLEM_FIELD = "Problem"
+SOLUTION_FIELD = "Solution"
 ANSWER_FIELD = "Answer"
 
 
 class AIMEBenchmark(AIPerfLoggerMixin):
-    """AIME (American Invitational Mathematics Examination) benchmark loader.
+    """AIME benchmark loader matching the trt-llm DeepEval reference.
 
-    Loads AIME competition problems from ``Maxwell-Jia/AIME_2024`` (train
-    split) and produces ``BenchmarkProblem`` objects ready for both the
-    completions endpoint (flat ``prompt``) and the chat endpoint
-    (``raw_messages``). Few-shot examples are drawn sequentially from the
-    beginning of the dataset.
+    Loads ``Maxwell-Jia/AIME_2024`` (train split) and produces
+    ``BenchmarkProblem`` objects whose flat ``prompt`` is byte-equal to
+    the recipe's ``AIMETemplate.generate_output`` output. Pair with
+    ``MathGrader`` for the recipe's ``math_equal`` grading semantics.
+
+    Default configuration mirrors ``aime_test.json``:
+    - ``n_shots=8`` (the recipe asserts ``n_shots <= 8``; see
+      ``MAX_N_SHOTS``)
+    - ``enable_cot=True``
+    - System prompt: ``"Please reason step by step, and put your final
+      answer within \\boxed{}."`` (set via ``default_system_prompt``
+      metadata in ``plugins.yaml`` so users see it documented)
     """
 
     def __init__(self, user_config: UserConfig, **kwargs: Any) -> None:
@@ -70,20 +94,28 @@ class AIMEBenchmark(AIPerfLoggerMixin):
     async def load_problems(
         self, tasks: list[str] | None, n_shots: int, enable_cot: bool
     ) -> list[BenchmarkProblem]:
-        """Load every AIME problem and format it for the LLM.
+        """Load all AIME problems and format prompts via the recipe template.
 
         Args:
             tasks: Ignored — AIME has no subtasks. Accepted for protocol
-                parity with other benchmarks that support task filtering.
-            n_shots: Number of few-shot examples to prepend (drawn from
-                the start of the dataset). 0 disables few-shot prompting.
-            enable_cot: When True, append ``Let's think step by step.`` to
-                each query, encouraging chain-of-thought reasoning before
-                the final ``\\boxed{}`` answer.
+                parity with other benchmarks.
+            n_shots: Number of few-shot examples to include
+                (capped at :data:`MAX_N_SHOTS`, mirroring the recipe's
+                ``assert n_shots <= 8``). 0 emits no header and no
+                examples.
+            enable_cot: When True, append ``Let's think step-by-step.``
+                after the final ``**Answer**:`` marker; when False,
+                append ``No explanation needed. Just return a number.``
 
         Returns:
             One ``BenchmarkProblem`` per dataset row, in dataset order.
         """
+        if n_shots > MAX_N_SHOTS:
+            raise ValueError(
+                f"AIME supports at most {MAX_N_SHOTS} few-shot examples "
+                f"(got {n_shots}). The trt-llm reference asserts "
+                f"``n_shots <= 8``; raise that limit upstream first."
+            )
         ds: Dataset = await asyncio.to_thread(load_dataset, DATASET_NAME, split="train")
         return await asyncio.to_thread(self._build_problems, ds, n_shots, enable_cot)
 
@@ -107,12 +139,12 @@ class AIMEBenchmark(AIPerfLoggerMixin):
         return problems
 
     def _build_few_shots(self, ds: Dataset, n_shots: int) -> list[dict[str, str]]:
-        """Build few-shot examples by sequentially sampling the dataset start.
+        """Few-shot examples drawn sequentially from the start of the split.
 
-        AIME has no separate dev/validation split, so we draw few-shot
-        examples from the same train split. This means the first ``n_shots``
-        problems will appear in their own prompts; lighteval's competition
-        configs do the same when no held-out pool is available.
+        The recipe takes ``train_set[:n_shots]`` directly. AIME 2024 has
+        no held-out pool, so the first ``n_shots`` problems appear in
+        their own prompts as well — lighteval and the recipe both make
+        this trade-off.
         """
         if n_shots <= 0:
             return []
@@ -120,19 +152,36 @@ class AIMEBenchmark(AIPerfLoggerMixin):
         return [self._format_example(ds[i]) for i in range(size)]
 
     def _format_example(self, row: dict[str, Any]) -> dict[str, str]:
-        """Format a dataset row as a few-shot example.
+        """Bundle the per-row data the prompt builders need.
 
-        Returns a ``{problem, answer, formatted}`` triple where ``formatted``
-        is the flat completions form (used in the completions prompt) and
-        ``problem``/``answer`` are reused when constructing chat messages.
+        Stores both the bare ``problem`` / ``solution`` / ``answer``
+        fields and the recipe's ``formatted`` form. The actual final
+        rendering is decided by ``_format_example_block`` (which honors
+        ``enable_cot``: solutions only appear when CoT is on).
         """
         answer = str(row[ANSWER_FIELD])
         problem = row[PROBLEM_FIELD]
+        solution = str(row.get(SOLUTION_FIELD, ""))
         return {
             "problem": problem,
+            "solution": solution,
             "answer": answer,
-            "formatted": f"Problem: {problem}\nAnswer: \\boxed{{{answer}}}",
         }
+
+    @staticmethod
+    def _format_example_block(example: dict[str, str], enable_cot: bool) -> str:
+        """Render one few-shot example exactly as the recipe does.
+
+        Mirrors ``AIMETemplate.format_example``:
+        - ``**Problem**: <q>``
+        - When CoT: ``**Solution**: <s>``
+        - ``**Answer**: <a>``
+        """
+        block = "**Problem**: " + example["problem"] + "\n"
+        if enable_cot:
+            block += "**Solution**: " + example["solution"] + "\n"
+        block += "**Answer**: " + example["answer"]
+        return block
 
     def _format_prompt(
         self,
@@ -140,18 +189,26 @@ class AIMEBenchmark(AIPerfLoggerMixin):
         few_shots: list[dict[str, str]],
         enable_cot: bool,
     ) -> str:
-        """Build the flat completions prompt: instruction + shots + query."""
-        few_shot_text = "\n\n".join(ex["formatted"] for ex in few_shots)
-        if few_shot_text:
-            few_shot_text += "\n\n"
+        """Render the flat completions prompt byte-equal to the recipe.
 
-        problem = row[PROBLEM_FIELD]
-        if enable_cot:
-            query = f"Problem: {problem}\nLet's think step by step.\nAnswer:"
-        else:
-            query = f"Problem: {problem}\nAnswer:"
+        Recipe ``AIMETemplate.generate_output`` structure:
 
-        return INSTRUCTION_PREFIX + few_shot_text + query
+            [FEW_SHOT_HEADER if n_shots > 0]
+            <example_block>\\n\\n
+            <example_block>\\n\\n
+            ...
+            **Problem**: <test_q>\\n**Answer**: \\n\\n
+            <Let's think step-by-step. | No explanation needed. Just return a number.>
+        """
+        prompt = ""
+        if few_shots:
+            prompt += FEW_SHOT_HEADER
+            for ex in few_shots:
+                prompt += self._format_example_block(ex, enable_cot) + "\n\n"
+
+        prompt += "**Problem**: " + row[PROBLEM_FIELD] + "\n**Answer**: \n\n"
+        prompt += COT_SUFFIX if enable_cot else NO_COT_SUFFIX
+        return prompt
 
     def _build_chat_messages(
         self,
@@ -159,35 +216,17 @@ class AIMEBenchmark(AIPerfLoggerMixin):
         few_shots: list[dict[str, str]],
         enable_cot: bool,
     ) -> list[AccuracyChatMessage]:
-        """Build multi-turn chat messages following lighteval's PromptManager.
+        """Build a single user message that wraps the recipe-rendered prompt.
 
-        - First few-shot user message includes the instruction prefix.
-        - Subsequent few-shot user messages contain only ``Problem: ... Answer:``.
-        - Each few-shot assistant message holds ``\\boxed{answer}`` so the
-          model is primed to emit the same boxed format.
-        - Main query repeats the user-side format without re-instructing.
-        - When there are no few-shots, the instruction is prepended to the
-          single user message.
+        The recipe doesn't use multi-turn chat for AIME — DeepEval sends
+        the full prompt as a single string. We mirror that by emitting
+        a single user message containing the same flat prompt that
+        ``_format_prompt`` produces, so behavior is identical for both
+        completions and chat endpoints.
         """
-        messages: list[AccuracyChatMessage] = []
-
-        for ix, ex in enumerate(few_shots):
-            q = f"Problem: {ex['problem']}\nAnswer:"
-            if ix == 0:
-                q = INSTRUCTION_PREFIX + q
-            messages.append({"role": "user", "content": q})
-            messages.append(
-                {"role": "assistant", "content": f"\\boxed{{{ex['answer']}}}"}
-            )
-
-        problem = row[PROBLEM_FIELD]
-        if enable_cot:
-            main_q = f"Problem: {problem}\nLet's think step by step.\nAnswer:"
-        else:
-            main_q = f"Problem: {problem}\nAnswer:"
-
-        if not few_shots:
-            main_q = INSTRUCTION_PREFIX + main_q
-
-        messages.append({"role": "user", "content": main_q})
-        return messages
+        return [
+            {
+                "role": "user",
+                "content": self._format_prompt(row, few_shots, enable_cot),
+            }
+        ]

--- a/src/aiperf/accuracy/graders/_math_strip.py
+++ b/src/aiperf/accuracy/graders/_math_strip.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LaTeX/math answer normalization for the math grader.
+
+Ported faithfully from the trt-llm benchmark recipe's
+``parser.strip_string`` (``src/accuracy/aime/parser.py``), which itself
+descends from Hendrycks' MATH release and the ToRA/DeepSeek-Math
+evaluation utilities. The intent is character-for-character output
+parity with that pipeline so the math grader behaves identically to the
+trt-llm reference.
+
+Two minor deviations from the upstream:
+- ``convert_word_number`` is a no-op stub here; the recipe pulls in the
+  optional ``word2number`` package, but AIME answers are bounded
+  integers (0-999) for which word-number conversion never fires. If a
+  caller needs it, install ``word2number`` and replace the stub.
+- The ``_fix_a_slash_b`` helper is only invoked on strings that look
+  like simple ratios; we skip the recipe's blanket ``\\frac`` rewrite
+  for non-numeric a/b strings.
+
+Reference:
+    trt-llm-benchmark-recipe/src/accuracy/aime/parser.py:212 (strip_string)
+"""
+
+from __future__ import annotations
+
+import re
+
+# MathQA-derived unit list. The trt-llm strip_string strips these
+# tokens from MATH-style answers (e.g. "5 mph" → "5"). For AIME (pure
+# integer answers) most never fire, but we keep the full list for
+# parity so the grader behaves identically across MATH-family inputs.
+_UNIT_TEXTS_BASE: list[str] = [
+    "east",
+    "degree",
+    "mph",
+    "kmph",
+    "ft",
+    "m sqaure",
+    " m east",
+    "sq m",
+    "deg",
+    "mile",
+    "q .",
+    "monkey",
+    "prime",
+    "ratio",
+    "profit of rs",
+    "rd",
+    "o",
+    "gm",
+    "p . m",
+    "lb",
+    "tile",
+    "per",
+    "dm",
+    "lt",
+    "gain",
+    "ab",
+    "way",
+    "west",
+    "a .",
+    "b .",
+    "c .",
+    "d .",
+    "e .",
+    "f .",
+    "g .",
+    "h .",
+    "t",
+    "a",
+    "h",
+    "no change",
+    "men",
+    "soldier",
+    "pie",
+    "bc",
+    "excess",
+    "st",
+    "inches",
+    "noon",
+    "percent",
+    "by",
+    "gal",
+    "kmh",
+    "c",
+    "acre",
+    "rise",
+    "a . m",
+    "th",
+    "π r 2",
+    "sq",
+    "mark",
+    "l",
+    "toy",
+    "coin",
+    "sq . m",
+    "gallon",
+    "° f",
+    "profit",
+    "minw",
+    "yr",
+    "women",
+    "feet",
+    "am",
+    "pm",
+    "hr",
+    "cu cm",
+    "square",
+    "v â € ™",
+    "are",
+    "rupee",
+    "rounds",
+    "cubic",
+    "cc",
+    "mtr",
+    "s",
+    "ohm",
+    "number",
+    "kmph",
+    "day",
+    "hour",
+    "minute",
+    "min",
+    "second",
+    "man",
+    "woman",
+    "sec",
+    "cube",
+    "mt",
+    "sq inch",
+    "mp",
+    "∏ cm ³",
+    "hectare",
+    "more",
+    "sec",
+    "unit",
+    "cu . m",
+    "cm 2",
+    "rs .",
+    "rs",
+    "kg",
+    "g",
+    "month",
+    "km",
+    "m",
+    "cm",
+    "mm",
+    "apple",
+    "liter",
+    "loss",
+    "yard",
+    "pure",
+    "year",
+    "increase",
+    "decrease",
+    "d",
+    "less",
+    "Surface",
+    "litre",
+    "pi sq m",
+    "s .",
+    "metre",
+    "meter",
+    "inch",
+]
+# Append plural forms — the recipe does this at module import time.
+_UNIT_TEXTS: list[str] = _UNIT_TEXTS_BASE + [t + "s" for t in _UNIT_TEXTS_BASE]
+
+
+def _fix_fracs(string: str) -> str:
+    """Normalize ``\\fracXY`` to ``\\frac{X}{Y}`` — port of recipe helper."""
+    substrs = string.split("\\frac")
+    new_str = substrs[0]
+    if len(substrs) > 1:
+        substrs = substrs[1:]
+        for substr in substrs:
+            new_str += "\\frac"
+            if len(substr) > 0 and substr[0] == "{":
+                new_str += substr
+            else:
+                if len(substr) < 2:
+                    return string
+                a = substr[0]
+                b = substr[1]
+                if b != "{":
+                    if len(substr) > 2:
+                        post_substr = substr[2:]
+                        new_str += "{" + a + "}{" + b + "}" + post_substr
+                    else:
+                        new_str += "{" + a + "}{" + b + "}"
+                else:
+                    if len(substr) > 2:
+                        post_substr = substr[2:]
+                        new_str += "{" + a + "}" + b + post_substr
+                    else:
+                        new_str += "{" + a + "}" + b
+    return new_str
+
+
+def _fix_a_slash_b(string: str) -> str:
+    """Convert simple integer-ratio ``a/b`` to ``\\frac{a}{b}``."""
+    parts = string.split("/")
+    if len(parts) != 2:
+        return string
+    a, b = parts
+    try:
+        if "sqrt" not in a:
+            a = int(a)
+        if "sqrt" not in b:
+            b = int(b)
+        return f"\\frac{{{a}}}{{{b}}}"
+    except (ValueError, TypeError):
+        return string
+
+
+def _fix_sqrt(string: str) -> str:
+    """Normalize ``\\sqrtN`` to ``\\sqrt{N}`` — port of recipe helper."""
+    return re.sub(r"\\sqrt(\w+)", r"\\sqrt{\1}", string)
+
+
+def _convert_word_number(text: str) -> str:
+    """No-op stub for the recipe's word2number conversion.
+
+    The recipe imports ``word2number.w2n`` and turns "two" into "2".
+    For AIME (integer answers) and most MATH-500 cases this never
+    triggers, so we skip the dependency. If a caller needs it, swap
+    this implementation for one that uses ``w2n.word_to_num``.
+    """
+    return text
+
+
+def strip_string(string: str) -> str:
+    """Normalize a math/LaTeX answer string for downstream comparison.
+
+    Mirrors trt-llm-benchmark-recipe/src/accuracy/aime/parser.py
+    line-for-line, with two documented deviations:
+    1. ``_convert_word_number`` is a no-op (no ``word2number`` dep).
+    2. The recipe's ``string.replace("'", "")`` / ``string.replace('"', "")``
+       calls are no-ops there too (they don't reassign), and we keep
+       them as no-ops for parity.
+
+    Returns an empty string when input is empty after normalization.
+    """
+    string = str(string).strip()
+    string = string.replace("\n", "")
+    string = string.rstrip(".")
+
+    string = string.replace("\\!", "")
+
+    # matrix
+    string = re.sub(r"\\begin\{array\}\{.*?\}", r"\\begin{pmatrix}", string)
+    string = re.sub(r"\\end\{array\}", r"\\end{pmatrix}", string)
+    string = string.replace("bmatrix", "pmatrix")
+
+    # fraction variants
+    string = string.replace("tfrac", "frac")
+    string = string.replace("dfrac", "frac")
+    string = (
+        string.replace("\\neq", "\\ne")
+        .replace("\\leq", "\\le")
+        .replace("\\geq", "\\ge")
+    )
+
+    # spacing and quote-style braces
+    string = string.replace("\\left", "")
+    string = string.replace("\\right", "")
+    string = string.replace("\\{", "{")
+    string = string.replace("\\}", "}")
+
+    # Remove trailing \text{...}
+    _string = re.sub(r"\\text{.*?}$", "", string).strip()
+    if _string and _string != string:
+        string = _string
+
+    # Strip MathQA unit tokens (with non-alphanumeric prefix/suffix
+    # boundaries so we don't eat parts of words).
+    for unit_text in _UNIT_TEXTS:
+        _string = re.sub(r"(^|\W)" + unit_text + r"($|\W)", r"\1\2", string)
+        if _string:
+            string = _string
+
+    # Degree symbol variants
+    string = string.replace("^{\\circ}", "")
+    string = string.replace("^\\circ", "")
+
+    # Currency
+    string = string.replace("\\$", "")
+    string = string.replace("$", "")
+    string = string.replace("\\(", "").replace("\\)", "")
+
+    # Word-number conversion (no-op stub)
+    string = _convert_word_number(string)
+
+    # \text{x} → x
+    string = re.sub(r"\\text\{(.*?)\}", r"\1", string)
+
+    # Drop common variable assignments
+    for key in ("x=", "y=", "z=", "x\\in", "y\\in", "z\\in", "x\\to", "y\\to", "z\\to"):
+        string = string.replace(key, "")
+    string = string.replace("\\emptyset", r"{}")
+    string = string.replace("(-\\infty,\\infty)", "\\mathbb{R}")
+
+    # Percentages
+    string = string.replace("\\%", "")
+    string = string.replace("\\%", "")
+    string = string.replace("%", "")
+
+    # Months
+    months = (
+        r"\b(January|February|March|April|May|June|July|August|"
+        r"September|October|November|December)\b"
+    )
+    string = re.sub(months, "", string, flags=re.IGNORECASE)
+
+    # Add leading 0 to bare ".5" → "0.5"
+    string = string.replace(" .", " 0.")
+    string = string.replace("{.", "{0.")
+
+    # Strip wrapping braces/parens around alphanumeric content
+    if (
+        string.startswith("{")
+        and string.endswith("}")
+        and string.isalnum()
+        or string.startswith("(")
+        and string.endswith(")")
+        and string.isalnum()
+        or string.startswith("[")
+        and string.endswith("]")
+        and string.isalnum()
+    ):
+        string = string[1:-1]
+
+    # Infinity
+    string = string.replace("infinity", "\\infty")
+    if "\\infty" not in string:
+        string = string.replace("inf", "\\infty")
+    string = string.replace("+\\inity", "\\infty")
+
+    # Misc keyword strip
+    string = string.replace("and", "")
+    string = string.replace("\\mathbf", "")
+    string = re.sub(r"\\mbox{.*?}", "", string)
+
+    # Quotes — these are no-ops in the recipe (the .replace return
+    # value is discarded). Preserved as no-ops for byte-parity.
+    string.replace("'", "")
+    string.replace('"', "")
+
+    # Imaginary unit normalization
+    if "j" in string and "i" not in string:
+        string = string.replace("j", "i")
+
+    # Trim trailing .000... in numerics
+    string = re.sub(r"(\d+)\.0*([^\d])", r"\1\2", string)
+    string = re.sub(r"(\d+)\.0*$", r"\1", string)
+
+    if not string:
+        return string
+    if string[0] == ".":
+        string = "0" + string
+
+    # "k = X" → "X"
+    if len(string.split("=")) == 2 and len(string.split("=")[0]) <= 2:
+        string = string.split("=")[1]
+
+    string = _fix_sqrt(string)
+    string = string.replace(" ", "")
+
+    string = _fix_fracs(string)
+    string = _fix_a_slash_b(string)
+
+    return string

--- a/src/aiperf/accuracy/graders/_math_strip.py
+++ b/src/aiperf/accuracy/graders/_math_strip.py
@@ -37,7 +37,7 @@ _UNIT_TEXTS_BASE: list[str] = [
     "mph",
     "kmph",
     "ft",
-    "m sqaure",
+    "m square",
     " m east",
     "sq m",
     "deg",

--- a/src/aiperf/accuracy/graders/_math_strip.py
+++ b/src/aiperf/accuracy/graders/_math_strip.py
@@ -318,7 +318,18 @@ def strip_string(string: str) -> str:
     string = string.replace(" .", " 0.")
     string = string.replace("{.", "{0.")
 
-    # Strip wrapping braces/parens around alphanumeric content
+    # Strip wrapping braces/parens around alphanumeric content.
+    #
+    # NOTE: This block is verbatim from the trt-llm recipe
+    # (``parser.py`` lines 292-303) including the latent bug —
+    # ``string.isalnum()`` checks the WHOLE string, which always
+    # includes the wrapper characters, so the condition can never be
+    # True and the branch is effectively dead. We deliberately keep
+    # the dead branch to preserve byte-equal parity with the recipe's
+    # ``strip_string``; rewriting to ``string[1:-1].isalnum()`` would
+    # cause divergent strip output (e.g. ``"{12}" -> "12"`` here vs.
+    # unchanged in the recipe), which would then change downstream
+    # ``math_equal`` numeric-comparison decisions.
     if (
         string.startswith("{")
         and string.endswith("}")

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -1,25 +1,214 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Code-execution grader for LiveCodeBench, backed by lighteval's CodegenMetric.
+
+In the trt-llm benchmark recipe, ``lcb:codegeneration`` is graded by
+lighteval's ``lcb_codegen_metric``
+(``lighteval/tasks/tasks/lcb/main.py``). That metric extracts code
+from the model response, executes it inside a sandboxed subprocess
+against the public + private test cases, and reports pass@1.
+
+Wiring into aiperf:
+    Aiperf's LCB loader serializes ``starter_code`` /
+    ``public_test_cases`` / ``private_test_cases`` / upstream
+    ``metadata`` into the ``BenchmarkProblem.ground_truth`` field as
+    an orjson payload (see ``benchmarks/lcb_codegeneration.py``). This
+    grader parses that payload, builds the ``Doc.specific`` shape
+    lighteval's ``CodegenMetric`` expects, and forwards to
+    ``CodegenMetric.compute`` — which then forks subprocesses to run
+    the generated code in a sandbox.
+
+Process model:
+    ``codegen_metrics`` uses a ``ProcessPoolExecutor`` with
+    ``num_process_evaluate=8`` workers under the hood. Those forks
+    happen inside the record-processor service, not in aiperf's HTTP
+    worker pool. Per-grade fork latency is ~50–200 ms on Linux plus
+    the actual code-execution time (capped by ``timeout=6``).
+
+Reference: ``lighteval/tasks/tasks/lcb/main.py:CodegenMetric``
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import orjson
+
 from aiperf.accuracy.graders.base import BaseGrader
 from aiperf.accuracy.models import GradingResult
 from aiperf.common.config import UserConfig
 
+_log = logging.getLogger(__name__)
+
+try:
+    from lighteval.tasks.tasks.lcb.codegen_metrics import (
+        codegen_metrics,
+        extract_code,
+    )
+
+    _HAS_LIGHTEVAL_LCB = True
+except ImportError:  # pragma: no cover
+    _HAS_LIGHTEVAL_LCB = False
+    codegen_metrics = None  # type: ignore[assignment]
+    extract_code = None  # type: ignore[assignment]
+
+
+_MISSING_LIGHTEVAL_HINT = (
+    "lighteval is not installed; the code_execution grader cannot "
+    "run. Install with: uv pip install 'aiperf[accuracy]'."
+)
+
+# Lighteval's CodegenMetric defaults — reproduced here so the grader
+# behaves identically to the recipe.
+_LCB_PASS_AT_K = (1,)
+_LCB_NUM_PROCESSES = 8
+
 
 class CodeExecutionGrader(BaseGrader):
-    """Grades responses by executing generated code and comparing output against expected results."""
+    """Grades code-generation responses by sandboxed execution via lighteval.
 
-    def __init__(self, user_config: UserConfig, **kwargs) -> None:
+    Pairs with ``LCBCodeGenerationBenchmark``. Expects
+    ``ground_truth`` to be the orjson payload produced by that loader's
+    ``_build_ground_truth``: a JSON object with ``starter_code``,
+    ``public_test_cases``, ``private_test_cases``, and ``metadata``
+    fields. We rebuild the lighteval-shaped sample
+    (``inputs``/``outputs``/``fn_name``) from the payload and call
+    lighteval's ``codegen_metrics`` with a 6-second per-test timeout.
+
+    Returns ``correct=True`` when pass@1 == 1.0 (every test case
+    passed), else ``correct=False``. ``unparsed=True`` when the
+    grader couldn't extract code from the response or lighteval
+    raised an exception during execution.
+    """
+
+    def __init__(self, user_config: UserConfig, **kwargs: Any) -> None:
         super().__init__(user_config=user_config, **kwargs)
+        if not _HAS_LIGHTEVAL_LCB:
+            raise RuntimeError(_MISSING_LIGHTEVAL_HINT)
+
+    def extract_answer(self, response_text: str, **kwargs: Any) -> str:
+        """Return the code block lighteval would extract from the response.
+
+        ``extract_code`` looks for the last ```python ... ``` block in
+        the response and returns its body, or empty string when no
+        block is present.
+        """
+        try:
+            return str(extract_code(response_text) or "")
+        except Exception as exc:  # pragma: no cover - defensive
+            _log.debug("extract_code raised: %s", exc, exc_info=True)
+            return ""
 
     async def grade(
-        self, response_text: str, ground_truth: str, **kwargs
+        self, response_text: str, ground_truth: str, **kwargs: Any
     ) -> GradingResult:
-        raise NotImplementedError(
-            "code_execution grader is not yet implemented; only 'multiple_choice' is available in this release."
+        try:
+            payload = orjson.loads(ground_truth)
+        except orjson.JSONDecodeError as exc:
+            _log.debug("LCB ground_truth payload not JSON: %s", exc)
+            return _grading_failure(
+                response_text, ground_truth, "ground_truth not orjson"
+            )
+
+        try:
+            inputs, outputs, fn_name = _payload_to_test_cases(payload)
+        except (KeyError, ValueError, json.JSONDecodeError) as exc:
+            _log.debug("LCB test-case payload malformed: %s", exc)
+            return _grading_failure(
+                response_text, ground_truth, f"malformed test cases: {exc}"
+            )
+
+        # Build lighteval's expected sample shape (one sample = one
+        # problem with all its test cases bundled into a JSON string).
+        evaluation_sample = [
+            {
+                "input_output": json.dumps(
+                    {
+                        "inputs": inputs,
+                        "outputs": outputs,
+                        "fn_name": fn_name,
+                    }
+                )
+            }
+        ]
+        # ``generations`` is a list-of-lists: one sample, with one
+        # candidate generation. Wrap the response in extract_code so
+        # we send only the code block to the sandbox.
+        snippet = self.extract_answer(response_text)
+        generated_code = [[snippet]]
+
+        try:
+            metrics, _ = codegen_metrics(
+                evaluation_sample,
+                generated_code,
+                k_list=list(_LCB_PASS_AT_K),
+                num_process_evaluate=_LCB_NUM_PROCESSES,
+            )
+        except Exception as exc:
+            _log.debug("lighteval codegen_metrics raised: %s", exc, exc_info=True)
+            return _grading_failure(
+                response_text, ground_truth, f"sandboxed exec failed: {exc}"
+            )
+
+        pass_at_1 = float(metrics.get("pass@1", [0.0])[0])
+        correct = pass_at_1 >= 1.0
+        return GradingResult(
+            correct=correct,
+            unparsed=not snippet,
+            confidence=pass_at_1,
+            reasoning=(
+                f"lighteval codegen_metrics pass@1={pass_at_1:.3f} "
+                f"(snippet length={len(snippet)})"
+                + ("" if snippet else " (no code block extracted)")
+            ),
+            extracted_answer=snippet,
+            ground_truth="<lcb test cases>",
         )
 
-    def extract_answer(self, response_text: str, **kwargs) -> str:
-        raise NotImplementedError(
-            "code_execution grader is not yet implemented; only 'multiple_choice' is available in this release."
+
+def _payload_to_test_cases(
+    payload: dict[str, Any],
+) -> tuple[list[Any], list[Any], str | None]:
+    """Convert aiperf's stored LCB ground_truth payload to lighteval inputs.
+
+    The recipe's ``lcb_codegeneration_prompt_fn`` (in lighteval) does
+    almost the same transform: parse public + private test cases out
+    of the row, concatenate ``inputs`` and ``outputs`` lists, pull
+    ``fn_name`` from ``metadata.func_name``. We replicate that here.
+    """
+    public_raw = payload.get("public_test_cases", "")
+    private_raw = payload.get("private_test_cases", "")
+    metadata_raw = payload.get("metadata", "")
+
+    public_cases = json.loads(public_raw) if public_raw else []
+    private_cases = json.loads(private_raw) if private_raw else []
+    all_cases = public_cases + private_cases
+    inputs = [tc["input"] for tc in all_cases]
+    outputs = [tc["output"] for tc in all_cases]
+
+    fn_name: str | None = None
+    if metadata_raw:
+        meta = (
+            json.loads(metadata_raw) if isinstance(metadata_raw, str) else metadata_raw
         )
+        if isinstance(meta, dict):
+            fn_name = meta.get("func_name")
+
+    return inputs, outputs, fn_name
+
+
+def _grading_failure(
+    response_text: str, ground_truth: str, reason: str
+) -> GradingResult:
+    """Build a failure ``GradingResult`` with the given reason."""
+    return GradingResult(
+        correct=False,
+        unparsed=True,
+        confidence=0.0,
+        reasoning=f"LCB grader failed: {reason}",
+        extracted_answer=response_text.strip()[:200],
+        ground_truth="<lcb test cases>",
+    )

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -31,7 +31,6 @@ Reference: ``lighteval/tasks/tasks/lcb/main.py:CodegenMetric``
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -98,7 +97,7 @@ class CodeExecutionGrader(BaseGrader):
         """
         try:
             return str(extract_code(response_text) or "")
-        except Exception as exc:  # pragma: no cover - defensive
+        except Exception as exc:  # pragma: no cover - defensive  # noqa: BLE001
             _log.debug("extract_code raised: %s", exc, exc_info=True)
             return ""
 
@@ -115,7 +114,7 @@ class CodeExecutionGrader(BaseGrader):
 
         try:
             inputs, outputs, fn_name = _payload_to_test_cases(payload)
-        except (KeyError, ValueError, json.JSONDecodeError) as exc:
+        except (KeyError, ValueError, orjson.JSONDecodeError) as exc:
             _log.debug("LCB test-case payload malformed: %s", exc)
             return _grading_failure(
                 response_text, ground_truth, f"malformed test cases: {exc}"
@@ -125,13 +124,13 @@ class CodeExecutionGrader(BaseGrader):
         # problem with all its test cases bundled into a JSON string).
         evaluation_sample = [
             {
-                "input_output": json.dumps(
+                "input_output": orjson.dumps(
                     {
                         "inputs": inputs,
                         "outputs": outputs,
                         "fn_name": fn_name,
                     }
-                )
+                ).decode()
             }
         ]
         # ``generations`` is a list-of-lists: one sample, with one
@@ -147,7 +146,7 @@ class CodeExecutionGrader(BaseGrader):
                 k_list=list(_LCB_PASS_AT_K),
                 num_process_evaluate=_LCB_NUM_PROCESSES,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             _log.debug("lighteval codegen_metrics raised: %s", exc, exc_info=True)
             return _grading_failure(
                 response_text, ground_truth, f"sandboxed exec failed: {exc}"
@@ -183,8 +182,8 @@ def _payload_to_test_cases(
     private_raw = payload.get("private_test_cases", "")
     metadata_raw = payload.get("metadata", "")
 
-    public_cases = json.loads(public_raw) if public_raw else []
-    private_cases = json.loads(private_raw) if private_raw else []
+    public_cases = orjson.loads(public_raw) if public_raw else []
+    private_cases = orjson.loads(private_raw) if private_raw else []
     all_cases = public_cases + private_cases
     inputs = [tc["input"] for tc in all_cases]
     outputs = [tc["output"] for tc in all_cases]
@@ -192,7 +191,9 @@ def _payload_to_test_cases(
     fn_name: str | None = None
     if metadata_raw:
         meta = (
-            json.loads(metadata_raw) if isinstance(metadata_raw, str) else metadata_raw
+            orjson.loads(metadata_raw)
+            if isinstance(metadata_raw, str)
+            else metadata_raw
         )
         if isinstance(meta, dict):
             fn_name = meta.get("func_name")

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -164,7 +164,13 @@ class CodeExecutionGrader(BaseGrader):
                 response_text, ground_truth, f"sandboxed exec failed: {exc}"
             )
 
-        pass_at_1 = float(metrics.get("pass@1", [0.0])[0])
+        # ``metrics.get("pass@1", [0.0])[0]`` would IndexError when
+        # lighteval returns ``{"pass@1": []}`` (a present-but-empty
+        # list). That indexing sits outside the surrounding except, so
+        # an empty list would crash the record processor instead of
+        # producing a failed grade. Default to 0.0 instead.
+        pass_at_1_list = metrics.get("pass@1")
+        pass_at_1 = float(pass_at_1_list[0]) if pass_at_1_list else 0.0
         correct = pass_at_1 >= 1.0
         return GradingResult(
             correct=correct,

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -31,6 +31,7 @@ Reference: ``lighteval/tasks/tasks/lcb/main.py:CodegenMetric``
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -146,7 +147,12 @@ class CodeExecutionGrader(BaseGrader):
         generated_code = [[snippet]]
 
         try:
-            metrics, _ = codegen_metrics(
+            # ``codegen_metrics`` is synchronous and spins up a
+            # ProcessPoolExecutor internally — pushing it to a worker
+            # thread keeps the event loop free for other concurrent
+            # grade() calls during a benchmark run.
+            metrics, _ = await asyncio.to_thread(
+                codegen_metrics,
                 evaluation_sample,
                 generated_code,
                 k_list=list(_LCB_PASS_AT_K),

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -127,19 +127,7 @@ class CodeExecutionGrader(BaseGrader):
                 response_text, ground_truth, f"malformed test cases: {exc}"
             )
 
-        # Build lighteval's expected sample shape (one sample = one
-        # problem with all its test cases bundled into a JSON string).
-        evaluation_sample = [
-            {
-                "input_output": orjson.dumps(
-                    {
-                        "inputs": inputs,
-                        "outputs": outputs,
-                        "fn_name": fn_name,
-                    }
-                ).decode()
-            }
-        ]
+        evaluation_sample = _build_evaluation_sample(inputs, outputs, fn_name)
         # ``generations`` is a list-of-lists: one sample, with one
         # candidate generation. Wrap the response in extract_code so
         # we send only the code block to the sandbox.
@@ -184,6 +172,20 @@ class CodeExecutionGrader(BaseGrader):
             extracted_answer=snippet,
             ground_truth="<lcb test cases>",
         )
+
+
+def _build_evaluation_sample(
+    inputs: list[Any], outputs: list[Any], fn_name: str | None
+) -> list[dict[str, str]]:
+    """Build lighteval's expected sample shape (one sample = one problem
+    with all its test cases bundled into a JSON string under ``input_output``)."""
+    return [
+        {
+            "input_output": orjson.dumps(
+                {"inputs": inputs, "outputs": outputs, "fn_name": fn_name}
+            ).decode()
+        }
+    ]
 
 
 def _payload_to_test_cases(

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -152,13 +152,11 @@ class CodeExecutionGrader(BaseGrader):
                 response_text, ground_truth, f"sandboxed exec failed: {exc}"
             )
 
-        # ``metrics.get("pass@1", [0.0])[0]`` would IndexError when
-        # lighteval returns ``{"pass@1": []}`` (a present-but-empty
-        # list). That indexing sits outside the surrounding except, so
-        # an empty list would crash the record processor instead of
-        # producing a failed grade. Default to 0.0 instead.
-        pass_at_1_list = metrics.get("pass@1")
-        pass_at_1 = float(pass_at_1_list[0]) if pass_at_1_list else 0.0
+        pass_at_1 = _extract_pass_at_1(metrics)
+        if pass_at_1 is None:
+            return _grading_failure(
+                response_text, ground_truth, "lighteval pass@1 not numeric"
+            )
         correct = pass_at_1 >= 1.0
         return GradingResult(
             correct=correct,
@@ -172,6 +170,32 @@ class CodeExecutionGrader(BaseGrader):
             extracted_answer=snippet,
             ground_truth="<lcb test cases>",
         )
+
+
+def _extract_pass_at_1(metrics: dict[str, Any]) -> float | None:
+    """Read the aggregate ``pass@1`` from ``codegen_metrics``' return shape.
+
+    ``codegen_metrics`` returns the aggregate pass@1 under the
+    ``"pass@1"`` key — a numpy scalar on lighteval 0.13+, a list on
+    older pins. (The per-task scores live under
+    ``metrics["detail"]["pass@1"]``, NOT the aggregate key.) We accept
+    both shapes and let ``float()`` coerce numpy/Python numerics
+    uniformly. Returns ``None`` when the value is missing or not
+    numerically coercible so the caller can route through
+    ``_grading_failure`` instead of crashing on a stale assumption.
+    """
+    raw = metrics.get("pass@1", 0.0)
+    if isinstance(raw, list):
+        raw = raw[0] if raw else 0.0
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        _log.debug(
+            "lighteval pass@1 not numeric: %r (type=%s)",
+            raw,
+            type(raw).__name__,
+        )
+        return None
 
 
 def _build_evaluation_sample(

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -114,7 +114,13 @@ class CodeExecutionGrader(BaseGrader):
 
         try:
             inputs, outputs, fn_name = _payload_to_test_cases(payload)
-        except (KeyError, ValueError, orjson.JSONDecodeError) as exc:
+        except (
+            KeyError,
+            ValueError,
+            TypeError,
+            AttributeError,
+            orjson.JSONDecodeError,
+        ) as exc:
             _log.debug("LCB test-case payload malformed: %s", exc)
             return _grading_failure(
                 response_text, ground_truth, f"malformed test cases: {exc}"
@@ -169,7 +175,7 @@ class CodeExecutionGrader(BaseGrader):
 
 
 def _payload_to_test_cases(
-    payload: dict[str, Any],
+    payload: Any,
 ) -> tuple[list[Any], list[Any], str | None]:
     """Convert aiperf's stored LCB ground_truth payload to lighteval inputs.
 
@@ -177,18 +183,23 @@ def _payload_to_test_cases(
     almost the same transform: parse public + private test cases out
     of the row, concatenate ``inputs`` and ``outputs`` lists, pull
     ``fn_name`` from ``metadata.func_name``. We replicate that here.
-    """
-    public_raw = payload.get("public_test_cases", "")
-    private_raw = payload.get("private_test_cases", "")
-    metadata_raw = payload.get("metadata", "")
 
-    public_cases = orjson.loads(public_raw) if public_raw else []
-    private_cases = orjson.loads(private_raw) if private_raw else []
+    Accepts both JSON-string and already-deserialized values for each
+    field, so a payload built by the loader (strings, matching the HF
+    dataset shape) and a payload constructed in-process by a caller or
+    test (lists/dicts) both work.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected dict payload, got {type(payload).__name__}")
+
+    public_cases = _parse_test_cases(payload.get("public_test_cases", ""))
+    private_cases = _parse_test_cases(payload.get("private_test_cases", ""))
     all_cases = public_cases + private_cases
     inputs = [tc["input"] for tc in all_cases]
     outputs = [tc["output"] for tc in all_cases]
 
     fn_name: str | None = None
+    metadata_raw = payload.get("metadata", "")
     if metadata_raw:
         meta = (
             orjson.loads(metadata_raw)
@@ -199,6 +210,19 @@ def _payload_to_test_cases(
             fn_name = meta.get("func_name")
 
     return inputs, outputs, fn_name
+
+
+def _parse_test_cases(raw: Any) -> list[dict[str, Any]]:
+    """Accept a JSON-string payload or an already-deserialized list."""
+    if not raw:
+        return []
+    if isinstance(raw, str | bytes | bytearray):
+        return orjson.loads(raw)
+    if isinstance(raw, list):
+        return raw
+    raise TypeError(
+        f"test cases must be a JSON string or list, got {type(raw).__name__}"
+    )
 
 
 def _grading_failure(

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -201,6 +201,18 @@ def _payload_to_test_cases(
     public_cases = _parse_test_cases(payload.get("public_test_cases", ""))
     private_cases = _parse_test_cases(payload.get("private_test_cases", ""))
     all_cases = public_cases + private_cases
+    if not all_cases:
+        # A payload with zero test cases is unambiguously malformed:
+        # lighteval's ``codegen_metrics`` will trivially report
+        # ``pass@1 = 1.0`` against an empty test suite (vacuous truth),
+        # which would silently grade every response as correct. Fail
+        # fast so the existing ``ValueError`` branch in ``grade()``
+        # surfaces this as a clean ``_grading_failure`` rather than
+        # forwarding a false-positive verdict.
+        raise ValueError(
+            "LCB payload has no test cases — both public_test_cases "
+            "and private_test_cases are missing or empty"
+        )
     inputs = [tc["input"] for tc in all_cases]
     outputs = [tc["output"] for tc in all_cases]
 

--- a/src/aiperf/accuracy/graders/lighteval_grader.py
+++ b/src/aiperf/accuracy/graders/lighteval_grader.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lighteval-backed graders for the AIME24/25, MATH-500, and GPQA-Diamond benchmarks.
+
+These three benchmarks are graded by lighteval in the trt-llm benchmark
+recipe (``trt-llm-benchmark-recipe/src/accuracy/acc_bench_lighteval.py``):
+
+- ``aime24`` / ``aime25`` → ``expr_gold_metric`` (expression extraction)
+- ``math_500`` → ``latex_gold_metric`` (LaTeX extraction with boxed
+  priority)
+- ``gpqa_diamond`` → ``gpqa_metric`` (multiple-choice index extraction)
+
+Each is a different parameterization of lighteval's
+``MultilingualExtractiveMatchMetric``. We expose three grader plugins
+(``lighteval_expr``, ``lighteval_latex``, ``lighteval_gpqa``) so each
+benchmark can pick the right one via its ``default_grader`` metadata.
+
+The lighteval API moved between the recipe's vendored 0.6.0 and the
+current 0.13.0 PyPI release: the factory function
+``multilingual_extractive_match_metric`` is now a class
+``MultilingualExtractiveMatchMetric``. The configuration is otherwise
+identical, so the behavior is the same.
+
+Call shape:
+    lighteval expects a ``Doc`` (with ``query``/``choices``/
+    ``gold_index``) and a ``ModelResponse`` (with ``text``). We bridge
+    aiperf's ``(response_text, ground_truth)`` arguments to this shape
+    inside ``_grade_via_lighteval``.
+
+Reference:
+    trt-llm-benchmark-recipe/src/accuracy/acc_bench_lighteval.py
+        latex_gold_metric / expr_gold_metric / gpqa_metric definitions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiperf.accuracy.graders.base import BaseGrader
+from aiperf.accuracy.models import GradingResult
+from aiperf.common.config import UserConfig
+
+_log = logging.getLogger(__name__)
+
+try:
+    from lighteval.metrics.dynamic_metrics import (
+        ExprExtractionConfig,
+        LatexExtractionConfig,
+        MultilingualExtractiveMatchMetric,
+    )
+    from lighteval.metrics.utils.extractive_match_utils import (
+        IndicesExtractionConfig,
+    )
+    from lighteval.models.model_output import ModelResponse
+    from lighteval.tasks.requests import Doc
+    from lighteval.utils.language import Language
+
+    _HAS_LIGHTEVAL = True
+except ImportError:  # pragma: no cover - exercised only without optional dep
+    _HAS_LIGHTEVAL = False
+    MultilingualExtractiveMatchMetric = None  # type: ignore[assignment]
+    ExprExtractionConfig = None  # type: ignore[assignment]
+    LatexExtractionConfig = None  # type: ignore[assignment]
+    IndicesExtractionConfig = None  # type: ignore[assignment]
+    ModelResponse = None  # type: ignore[assignment]
+    Doc = None  # type: ignore[assignment]
+    Language = None  # type: ignore[assignment]
+
+
+_MISSING_LIGHTEVAL_HINT = (
+    "lighteval is not installed; AIME24/AIME25/MATH-500/GPQA-Diamond "
+    "graders cannot run. Install with: uv pip install 'aiperf[accuracy]'."
+)
+
+
+def _require_lighteval() -> None:
+    """Raise a clear error if lighteval is missing.
+
+    We don't fall back silently for these graders because there's no
+    stdlib equivalent of lighteval's extractive-match pipeline that
+    would produce comparable scores; running with a different grader
+    silently would mislead users into thinking they're reproducing
+    trt-llm reference numbers.
+    """
+    if not _HAS_LIGHTEVAL:
+        raise RuntimeError(_MISSING_LIGHTEVAL_HINT)
+
+
+class _LightevalBaseGrader(BaseGrader):
+    """Shared infrastructure for lighteval-backed graders.
+
+    Subclasses build a ``MultilingualExtractiveMatchMetric`` in
+    ``__init__`` (matching one of the recipe's three configs) and the
+    base class drives the call: build a fresh ``Doc`` per grade with
+    the gold answer in ``choices[0]``, build a ``ModelResponse``
+    wrapping the response text, call ``metric.compute(doc, response)``,
+    return a ``GradingResult``.
+
+    Lighteval's metric returns a ``float`` (1.0 correct / 0.0 wrong /
+    sometimes a fraction for partial matches). We treat anything > 0.5
+    as correct, mirroring how the recipe uses these metrics in a
+    pass/fail context.
+    """
+
+    _CORRECTNESS_THRESHOLD = 0.5
+
+    def __init__(self, user_config: UserConfig, **kwargs: Any) -> None:
+        super().__init__(user_config=user_config, **kwargs)
+        _require_lighteval()
+        self._metric = self._build_metric()
+
+    def _build_metric(self) -> Any:
+        """Subclasses return the configured ``MultilingualExtractiveMatchMetric``."""
+        raise NotImplementedError
+
+    def extract_answer(self, response_text: str, **kwargs: Any) -> str:
+        """Return the raw response.
+
+        lighteval's metric does its own extraction internally, so we
+        don't surface a separate ``extract_answer`` step. The raw
+        response is what the metric receives anyway, so returning it
+        keeps ``GradingResult.extracted_answer`` informative.
+        """
+        return response_text.strip()
+
+    async def grade(
+        self, response_text: str, ground_truth: str, **kwargs: Any
+    ) -> GradingResult:
+        score = self._safe_compute(response_text, ground_truth)
+        correct = score is not None and score > self._CORRECTNESS_THRESHOLD
+        unparsed = score is None
+        return GradingResult(
+            correct=correct,
+            unparsed=unparsed,
+            confidence=float(score) if score is not None else 0.0,
+            reasoning=(
+                f"lighteval {type(self).__name__}: score={score} "
+                f"(threshold {self._CORRECTNESS_THRESHOLD})"
+                + (" (raised exception)" if unparsed else "")
+            ),
+            extracted_answer=response_text.strip(),
+            ground_truth=ground_truth.strip(),
+        )
+
+    def _safe_compute(self, response_text: str, ground_truth: str) -> float | None:
+        """Run lighteval's metric.compute with crash-safety.
+
+        lighteval can raise on malformed predictions (e.g. when its
+        sympy-backed extractor times out or hits an unparseable LaTeX
+        construct). We catch and report ``unparsed=True`` rather than
+        crashing the record processor.
+        """
+        try:
+            doc = self._build_doc(ground_truth)
+            response = ModelResponse(text=[response_text])
+            return float(self._metric.compute(doc, response))
+        except Exception as exc:
+            _log.debug("lighteval grader exception: %s", exc, exc_info=True)
+            return None
+
+    def _build_doc(self, ground_truth: str) -> Any:
+        """Build the lighteval ``Doc`` for a single grade.
+
+        Default implementation: gold goes in ``choices[0]``,
+        ``gold_index=0``. ``query`` is unused by the extractive-match
+        metric but lighteval requires it to be set, so we pass an
+        empty string. Subclasses override for benchmark-specific
+        shapes (e.g. GPQA-Diamond uses A/B/C/D choices and an integer
+        gold index).
+        """
+        return Doc(
+            task_name=type(self).__name__,
+            query="",
+            choices=[ground_truth],
+            gold_index=0,
+        )
+
+
+class LightevalExprGrader(_LightevalBaseGrader):
+    """Lighteval ``expr_gold_metric`` — used for AIME24, AIME25.
+
+    Matches the recipe's:
+        multilingual_extractive_match_metric(
+            language=Language.ENGLISH,
+            fallback_mode='first_match',
+            precision=5,
+            gold_extraction_target=(ExprExtractionConfig(),),
+            pred_extraction_target=(
+                ExprExtractionConfig(),
+                LatexExtractionConfig(boxed_match_priority=0),
+            ),
+            aggregation_function=max,
+        )
+    """
+
+    def _build_metric(self) -> Any:
+        return MultilingualExtractiveMatchMetric(
+            language=Language.ENGLISH,
+            fallback_mode="first_match",
+            precision=5,
+            gold_extraction_target=(ExprExtractionConfig(),),
+            pred_extraction_target=(
+                ExprExtractionConfig(),
+                LatexExtractionConfig(boxed_match_priority=0),
+            ),
+            aggregation_function=max,
+        )
+
+
+class LightevalLatexGrader(_LightevalBaseGrader):
+    """Lighteval ``latex_gold_metric`` — used for MATH-500.
+
+    Same structure as ``LightevalExprGrader`` but the gold extractor
+    uses ``LatexExtractionConfig`` (gold answers in MATH-500 are LaTeX
+    snippets like ``\\frac{1}{3}`` or ``\\sqrt{2}``).
+    """
+
+    def _build_metric(self) -> Any:
+        return MultilingualExtractiveMatchMetric(
+            language=Language.ENGLISH,
+            fallback_mode="first_match",
+            precision=5,
+            gold_extraction_target=(LatexExtractionConfig(),),
+            pred_extraction_target=(
+                ExprExtractionConfig(),
+                LatexExtractionConfig(boxed_match_priority=0),
+            ),
+            aggregation_function=max,
+        )
+
+
+class LightevalGPQAGrader(_LightevalBaseGrader):
+    """Lighteval ``gpqa_metric`` — used for GPQA-Diamond.
+
+    Looks for ``Answer: $LETTER`` (or any ``A``/``B``/``C``/``D``
+    extraction) in both gold and prediction. The recipe's prompt
+    template instructs the model to produce ``Answer: $LETTER``;
+    aiperf's GPQA-Diamond loader uses the same template for parity.
+
+    Because the metric extracts via NativeLetters (A/B/C/D), the
+    ``ground_truth`` we pass should also be a single letter (``"A"``,
+    ``"B"``, ``"C"``, or ``"D"``) — strip the leading-space
+    convention of MultipleChoiceGrader before passing in.
+    """
+
+    def _build_metric(self) -> Any:
+        return MultilingualExtractiveMatchMetric(
+            language=Language.ENGLISH,
+            gold_extraction_target=(
+                IndicesExtractionConfig(prefix_for_extraction="NativeLetters"),
+            ),
+            pred_extraction_target=(
+                IndicesExtractionConfig(prefix_for_extraction="NativeLetters"),
+            ),
+            precision=5,
+        )
+
+    def _build_doc(self, ground_truth: str) -> Any:
+        """GPQA-Diamond gold is a single A/B/C/D letter.
+
+        ``MultipleChoiceGrader``'s convention stores the gold as
+        ``" A"`` (leading-space). lighteval expects a bare letter, so
+        we strip here. We also build the four-choice shape lighteval
+        uses for indices extraction.
+        """
+        letter = ground_truth.strip().upper()
+        gold_index = "ABCD".index(letter) if letter in "ABCD" else 0
+        return Doc(
+            task_name=type(self).__name__,
+            query="",
+            choices=["A", "B", "C", "D"],
+            gold_index=gold_index,
+        )

--- a/src/aiperf/accuracy/graders/lighteval_grader.py
+++ b/src/aiperf/accuracy/graders/lighteval_grader.py
@@ -264,9 +264,21 @@ class LightevalGPQAGrader(_LightevalBaseGrader):
         ``" A"`` (leading-space). lighteval expects a bare letter, so
         we strip here. We also build the four-choice shape lighteval
         uses for indices extraction.
+
+        Raises:
+            ValueError: when ``ground_truth`` does not normalize to a
+                single A/B/C/D letter. Silently coercing invalid gold
+                to choice A would treat every model picking "A" as
+                correct on a malformed row, so we fail fast and let
+                ``_safe_compute`` surface it as ``unparsed=True``.
         """
         letter = ground_truth.strip().upper()
-        gold_index = "ABCD".index(letter) if letter in "ABCD" else 0
+        if letter not in {"A", "B", "C", "D"}:
+            raise ValueError(
+                "GPQA-Diamond ground_truth must normalize to one of "
+                f"A/B/C/D; got {ground_truth!r} (cleaned: {letter!r})"
+            )
+        gold_index = "ABCD".index(letter)
         return Doc(
             task_name=type(self).__name__,
             query="",

--- a/src/aiperf/accuracy/graders/lighteval_grader.py
+++ b/src/aiperf/accuracy/graders/lighteval_grader.py
@@ -148,7 +148,7 @@ class _LightevalBaseGrader(BaseGrader):
         """Run lighteval's metric.compute with crash-safety.
 
         lighteval can raise on malformed predictions (e.g. when its
-        sympy-backed extractor times out or hits an unparseable LaTeX
+        sympy-backed extractor times out or hits an unparsable LaTeX
         construct). We catch and report ``unparsed=True`` rather than
         crashing the record processor.
         """
@@ -156,7 +156,7 @@ class _LightevalBaseGrader(BaseGrader):
             doc = self._build_doc(ground_truth)
             response = ModelResponse(text=[response_text])
             return float(self._metric.compute(doc, response))
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             _log.debug("lighteval grader exception: %s", exc, exc_info=True)
             return None
 

--- a/src/aiperf/accuracy/graders/math.py
+++ b/src/aiperf/accuracy/graders/math.py
@@ -1,25 +1,233 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Math grader for numeric and algebraic answer equivalence.
+
+Ported in spirit from lighteval's MATH/AIME extraction and normalization
+pipeline. The lighteval reference relies on the optional ``math_verify``
+library for full symbolic equivalence; we deliberately limit ourselves to
+stdlib-only normalization + fraction-based numeric comparison so that the
+grader has zero extra dependencies and is fully deterministic.
+
+Coverage:
+- Integer answers (AIME, AIME24, AIME25)
+- Simple fractions ``\\frac{a}{b}``, ``a/b``
+- Decimal numbers
+- LaTeX-wrapped expressions inside ``\\boxed{...}``
+- Mixed-format strings like ``$\\boxed{42}$`` or ``the answer is 42``
+
+Out of scope (these will fall through to normalized-string equality and
+may grade strict-but-correct answers as incorrect; document as known):
+- Symbolic equivalence (e.g. ``\\sqrt{2}`` vs ``2^{1/2}``)
+- Algebraic simplification (e.g. ``x+1`` vs ``1+x``)
+- Trig identities
+
+Use ``--accuracy-grader exact_match`` to opt out of normalization when the
+benchmark's gold answers are already canonicalized.
+"""
+
+from __future__ import annotations
+
+import re
+from fractions import Fraction
+from typing import Any
+
 from aiperf.accuracy.graders.base import BaseGrader
 from aiperf.accuracy.models import GradingResult
 from aiperf.common.config import UserConfig
 
+# Recognized "the answer is X" suffixes used by models that ignore the
+# \\boxed{} instruction. Captures everything to end-of-line so we can re-run
+# the boxed/numeric extractors on the captured tail.
+_ANSWER_PHRASE_RE = re.compile(
+    r"(?:final\s+answer|the\s+answer\s+is|answer\s*[:=]|answer\s+is)\s*[:=]?\s*(.+?)(?:\.|$)",
+    re.IGNORECASE,
+)
+
+# Matches signed/unsigned int, decimal, or simple ratio (e.g. "1/2", "-3.14").
+# Anchors avoid bleeding into LaTeX commands; we intentionally skip variables
+# and only catch numeric literals.
+_NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?(?:/\d+)?")
+
+# LaTeX wrappers we strip before comparison. \\dfrac and \\tfrac collapse to
+# \\frac because they are visual variants only.
+_DFRAC_RE = re.compile(r"\\(?:dfrac|tfrac)")
+_LEFT_RIGHT_RE = re.compile(r"\\(?:left|right)")
+# \\frac{a}{b} → (a)/(b). Conservative: only matches single-brace contents
+# without nested braces, which is the common case for AIME/MATH-500.
+_SIMPLE_FRAC_RE = re.compile(r"\\frac\{([^{}]+)\}\{([^{}]+)\}")
+_TEXT_WRAPPER_RE = re.compile(r"\\(?:text|mathrm|mathit|mathbf)\{([^{}]*)\}")
+# Trailing punctuation that often appears after a final answer.
+_TRAILING_PUNCT_RE = re.compile(r"[.,;:!?]+$")
+
+_BOXED_TOKEN = "\\boxed{"
+
+
+def _extract_last_boxed(text: str) -> str | None:
+    """Return the contents of the last ``\\boxed{...}`` in ``text``.
+
+    Implements brace-balanced matching so that nested LaTeX like
+    ``\\boxed{\\frac{1}{2}}`` is captured intact. Returns None when there
+    is no balanced ``\\boxed{}`` in the input.
+    """
+    last_idx = text.rfind(_BOXED_TOKEN)
+    if last_idx == -1:
+        return None
+    start = last_idx + len(_BOXED_TOKEN)
+    depth = 0
+    for i in range(start, len(text)):
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            if depth == 0:
+                return text[start:i]
+            depth -= 1
+    return None
+
+
+def _extract_last_number(text: str) -> str | None:
+    """Return the last numeric literal in ``text`` (int, decimal, or a/b)."""
+    matches = _NUMBER_RE.findall(text)
+    return matches[-1] if matches else None
+
+
+def _normalize(expr: str) -> str:
+    """Normalize a math expression for string-equality comparison.
+
+    Operations applied in order, mirroring lighteval's pre-comparison pass:
+
+    1. Strip whitespace.
+    2. Drop trailing punctuation (so ``$42$.`` doesn't keep the period
+       and prevent the dollar-strip from firing).
+    3. Strip surrounding ``$...$`` math delimiters.
+    4. Remove ``\\left`` / ``\\right`` (visual sizing only).
+    5. Collapse ``\\dfrac``/``\\tfrac`` to ``\\frac``.
+    6. Expand simple ``\\frac{a}{b}`` to ``(a)/(b)``.
+    7. Unwrap ``\\text{x}`` / ``\\mathrm{x}`` / similar to ``x``.
+    8. Remove all interior whitespace (so ``1 / 2`` matches ``1/2``).
+
+    Math is case-sensitive (variable names matter), so case is preserved.
+    Idempotent: ``_normalize(_normalize(s)) == _normalize(s)``.
+    """
+    s = expr.strip()
+    s = _TRAILING_PUNCT_RE.sub("", s)
+    if s.startswith("$") and s.endswith("$") and len(s) >= 2:
+        s = s[1:-1]
+    s = _LEFT_RIGHT_RE.sub("", s)
+    s = _DFRAC_RE.sub(r"\\frac", s)
+    s = _SIMPLE_FRAC_RE.sub(r"(\1)/(\2)", s)
+    s = _TEXT_WRAPPER_RE.sub(r"\1", s)
+    s = re.sub(r"\s+", "", s)
+    return s
+
+
+def _to_fraction(value: str) -> Fraction | None:
+    """Parse ``value`` as a ``Fraction``, or return None if it isn't numeric.
+
+    Accepts:
+    - Integers: ``42``, ``-7``
+    - Decimals: ``3.14``, ``-0.5``
+    - Ratios: ``1/2``, ``-3/4``
+    - Parenthesized ratios produced by ``_normalize``: ``(1)/(2)``
+
+    Rejects anything else (variable names, expressions, empty string).
+    """
+    if not value:
+        return None
+    s = value.strip().replace("(", "").replace(")", "")
+    try:
+        return Fraction(s)
+    except (ValueError, ZeroDivisionError):
+        return None
+
 
 class MathGrader(BaseGrader):
-    """Grades responses by evaluating mathematical expressions for equivalence."""
+    """Grades numeric/algebraic responses by extracting then normalizing.
 
-    def __init__(self, user_config: UserConfig, **kwargs) -> None:
+    Extraction priority (first hit wins):
+
+    1. Last ``\\boxed{...}`` in the response (the canonical MATH/AIME format).
+    2. Last "the answer is X" / "answer: X" phrase, recursively parsed.
+    3. Last numeric literal in the response (int, decimal, or a/b).
+
+    Comparison strategy:
+
+    1. Normalize both predicted and gold answers (see ``_normalize``).
+    2. Try to parse both as ``Fraction``. If both parse, compare numerically
+       (so ``0.5 == 1/2 == \\frac{1}{2}``).
+    3. Otherwise, fall back to exact string equality on the normalized form.
+
+    The ``unparsed`` flag is set whenever extraction fell back past the
+    boxed-answer step. A correct unparsed response is still scored correct,
+    matching MultipleChoiceGrader's convention.
+    """
+
+    def __init__(self, user_config: UserConfig, **kwargs: Any) -> None:
         super().__init__(user_config=user_config, **kwargs)
 
-    async def grade(
-        self, response_text: str, ground_truth: str, **kwargs
-    ) -> GradingResult:
-        raise NotImplementedError(
-            "math grader is not yet implemented; only 'multiple_choice' is available in this release."
-        )
+    def _extract_with_flag(self, response_text: str) -> tuple[str, bool]:
+        """Return ``(answer, unparsed)``.
 
-    def extract_answer(self, response_text: str, **kwargs) -> str:
-        raise NotImplementedError(
-            "math grader is not yet implemented; only 'multiple_choice' is available in this release."
+        ``unparsed`` is True when extraction had to fall back past the
+        ``\\boxed{}`` step (i.e. the model didn't follow the boxed-answer
+        instruction).
+        """
+        if not response_text:
+            return "", True
+
+        boxed = _extract_last_boxed(response_text)
+        if boxed is not None:
+            return boxed.strip(), False
+
+        m = _ANSWER_PHRASE_RE.search(response_text)
+        if m:
+            tail = m.group(1).strip()
+            tail_boxed = _extract_last_boxed(tail)
+            if tail_boxed is not None:
+                return tail_boxed.strip(), True
+            tail_num = _extract_last_number(tail)
+            if tail_num is not None:
+                return tail_num, True
+            return tail, True
+
+        last_num = _extract_last_number(response_text)
+        if last_num is not None:
+            return last_num, True
+
+        return response_text.strip(), True
+
+    def extract_answer(self, response_text: str, **kwargs: Any) -> str:
+        """Extract the answer from a model response (boxed > phrase > last number)."""
+        answer, _ = self._extract_with_flag(response_text)
+        return answer
+
+    async def grade(
+        self, response_text: str, ground_truth: str, **kwargs: Any
+    ) -> GradingResult:
+        pred_raw, unparsed = self._extract_with_flag(response_text)
+        pred_norm = _normalize(pred_raw)
+        gold_norm = _normalize(ground_truth)
+
+        pred_frac = _to_fraction(pred_norm)
+        gold_frac = _to_fraction(gold_norm)
+        if pred_frac is not None and gold_frac is not None:
+            correct = pred_frac == gold_frac
+            mode = "numeric"
+        else:
+            correct = pred_norm == gold_norm and pred_norm != ""
+            mode = "string"
+
+        return GradingResult(
+            correct=correct,
+            unparsed=unparsed,
+            confidence=1.0 if correct else 0.0,
+            reasoning=(
+                f"extracted '{pred_raw}' (normalized '{pred_norm}'); "
+                f"ground_truth '{ground_truth}' (normalized '{gold_norm}'); "
+                f"compared via {mode}; match={correct}"
+                + (" (regex fallback)" if unparsed else "")
+            ),
+            extracted_answer=pred_raw,
+            ground_truth=ground_truth.strip(),
         )

--- a/src/aiperf/accuracy/graders/math.py
+++ b/src/aiperf/accuracy/graders/math.py
@@ -1,40 +1,89 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Math grader for numeric and algebraic answer equivalence.
+"""Math grader for numeric, algebraic, and LaTeX answer equivalence.
 
-Ported in spirit from lighteval's MATH/AIME extraction and normalization
-pipeline. The lighteval reference relies on the optional ``math_verify``
-library for full symbolic equivalence; we deliberately limit ourselves to
-stdlib-only normalization + fraction-based numeric comparison so that the
-grader has zero extra dependencies and is fully deterministic.
+Ported faithfully from the trt-llm benchmark recipe's
+``src/accuracy/aime/grader.py`` (``math_equal``), which itself descends
+from Hendrycks' MATH release and the ToRA / DeepSeek-Math / OpenAI
+PRM800K evaluation utilities. The grader pipeline is:
 
-Coverage:
-- Integer answers (AIME, AIME24, AIME25)
-- Simple fractions ``\\frac{a}{b}``, ``a/b``
-- Decimal numbers
-- LaTeX-wrapped expressions inside ``\\boxed{...}``
-- Mixed-format strings like ``$\\boxed{42}$`` or ``the answer is 42``
+1. ``_extract_with_flag`` extracts the model's answer from the response
+   (last ``\\boxed{...}`` first, then "the answer is X" / last-number
+   fallbacks) — same as before.
+2. ``_strip_string`` (ported in ``_math_strip``) normalizes the
+   prediction and the gold using the recipe's exact pipeline.
+3. ``_math_equal`` compares them: lowercase string equality, then
+   numerical equality with a small tolerance, then symbolic equality
+   via sympy + latex2sympy2-extended.
 
-Out of scope (these will fall through to normalized-string equality and
-may grade strict-but-correct answers as incorrect; document as known):
-- Symbolic equivalence (e.g. ``\\sqrt{2}`` vs ``2^{1/2}``)
-- Algebraic simplification (e.g. ``x+1`` vs ``1+x``)
-- Trig identities
+Optional dependencies:
+    The full grader requires ``sympy`` and ``latex2sympy2-extended``.
+    These ship in aiperf's ``[accuracy]`` optional-dependency group:
+        ``uv pip install 'aiperf[accuracy]'``
+    When they're missing, the grader falls back to a stdlib
+    normalize+Fraction comparison and emits a single warning the first
+    time it's invoked. Cases the stdlib path can't handle (symbolic
+    equivalence like ``\\sqrt{2}`` ↔ ``2^{1/2}``, equation-form
+    parsing) will then grade as incorrect.
 
-Use ``--accuracy-grader exact_match`` to opt out of normalization when the
-benchmark's gold answers are already canonicalized.
+Reference:
+    trt-llm-benchmark-recipe/src/accuracy/aime/grader.py:math_equal
+    trt-llm-benchmark-recipe/src/accuracy/aime/parser.py:strip_string
 """
 
 from __future__ import annotations
 
+import logging
 import re
 from fractions import Fraction
+from math import isclose
 from typing import Any
 
+from aiperf.accuracy.graders._math_strip import strip_string
 from aiperf.accuracy.graders.base import BaseGrader
 from aiperf.accuracy.models import GradingResult
 from aiperf.common.config import UserConfig
+
+_log = logging.getLogger(__name__)
+
+# Try-import the optional sympy stack. ``_HAS_SYMPY`` gates the
+# symbolic-equality path; the stdlib fallback runs without it.
+try:
+    from sympy import N, simplify
+    from sympy.parsing.sympy_parser import parse_expr
+
+    _HAS_SYMPY = True
+except ImportError:  # pragma: no cover - exercised only without optional dep
+    _HAS_SYMPY = False
+    parse_expr = None  # type: ignore[assignment]
+    simplify = None  # type: ignore[assignment]
+    N = None  # type: ignore[assignment]
+
+try:
+    from latex2sympy2_extended import latex2sympy
+
+    _HAS_LATEX2SYMPY = True
+except ImportError:  # pragma: no cover - exercised only without optional dep
+    _HAS_LATEX2SYMPY = False
+    latex2sympy = None  # type: ignore[assignment]
+
+# One-time fallback warning so we don't spam logs per-grade.
+_FALLBACK_WARNED = False
+
+
+def _warn_fallback_once() -> None:
+    """Emit a one-time warning when the stdlib fallback path is taken."""
+    global _FALLBACK_WARNED
+    if not _FALLBACK_WARNED:
+        _FALLBACK_WARNED = True
+        _log.warning(
+            "MathGrader running in stdlib fallback mode (sympy/latex2sympy2-"
+            "extended not installed). Symbolic equivalence (e.g. \\sqrt{2} "
+            "vs 2^{1/2}) and LaTeX-form normalization will grade as "
+            "incorrect. Install with: uv pip install 'aiperf[accuracy]'."
+        )
+
 
 # Recognized "the answer is X" suffixes used by models that ignore the
 # \\boxed{} instruction. Captures everything to end-of-line so we can re-run
@@ -45,30 +94,53 @@ _ANSWER_PHRASE_RE = re.compile(
 )
 
 # Matches signed/unsigned int, decimal, or simple ratio (e.g. "1/2", "-3.14").
-# Anchors avoid bleeding into LaTeX commands; we intentionally skip variables
-# and only catch numeric literals.
 _NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?(?:/\d+)?")
 
-# LaTeX wrappers we strip before comparison. \\dfrac and \\tfrac collapse to
-# \\frac because they are visual variants only.
-_DFRAC_RE = re.compile(r"\\(?:dfrac|tfrac)")
-_LEFT_RIGHT_RE = re.compile(r"\\(?:left|right)")
-# \\frac{a}{b} → (a)/(b). Conservative: only matches single-brace contents
-# without nested braces, which is the common case for AIME/MATH-500.
-_SIMPLE_FRAC_RE = re.compile(r"\\frac\{([^{}]+)\}\{([^{}]+)\}")
-_TEXT_WRAPPER_RE = re.compile(r"\\(?:text|mathrm|mathit|mathbf)\{([^{}]*)\}")
-# Trailing punctuation that often appears after a final answer.
-_TRAILING_PUNCT_RE = re.compile(r"[.,;:!?]+$")
-
 _BOXED_TOKEN = "\\boxed{"
+
+# Numerical tolerance for ``isclose``. Mirrors the recipe's value.
+_NUMERIC_ABS_TOL = 1e-4
+
+# Recursion guard for ``math_equal``'s self-recursion (equation rewrites,
+# choice-pattern unwraps). Mirrors the recipe.
+_MAX_DEPTH = 5
+
+# Single-choice-pattern preamble strippers from the recipe. If the
+# prediction starts with one of these, we strip the prefix and recurse.
+_SINGLE_CHOICE_PATTERNS: tuple[str, ...] = (
+    r"^\(A\)",
+    r"^\(B\)",
+    r"^\(C\)",
+    r"^\(D\)",
+    r"^\(E\)",
+    r"^A\.",
+    r"^B\.",
+    r"^C\.",
+    r"^D\.",
+    r"^E\.",
+    r"^A\)",
+    r"^B\)",
+    r"^C\)",
+    r"^D\)",
+    r"^E\)",
+    r"^\*\*A\*\*",
+    r"^\*\*B\*\*",
+    r"^\*\*C\*\*",
+    r"^\*\*D\*\*",
+    r"^\*\*E\*\*",
+    r"^A:",
+    r"^B:",
+    r"^C:",
+    r"^D:",
+    r"^E:",
+)
 
 
 def _extract_last_boxed(text: str) -> str | None:
     """Return the contents of the last ``\\boxed{...}`` in ``text``.
 
-    Implements brace-balanced matching so that nested LaTeX like
-    ``\\boxed{\\frac{1}{2}}`` is captured intact. Returns None when there
-    is no balanced ``\\boxed{}`` in the input.
+    Brace-balanced match so nested LaTeX like ``\\boxed{\\frac{1}{2}}``
+    is captured intact.
     """
     last_idx = text.rfind(_BOXED_TOKEN)
     if last_idx == -1:
@@ -92,23 +164,229 @@ def _extract_last_number(text: str) -> str | None:
     return matches[-1] if matches else None
 
 
-def _normalize(expr: str) -> str:
-    """Normalize a math expression for string-equality comparison.
+def _parse_digits(num: Any) -> float | None:
+    """Mirror of recipe ``parser.parse_digits``: comma-strip → float, with
+    ``%`` fallback dividing by 100. Returns None on parse failure."""
+    s = str(num).replace(",", "")
+    try:
+        return float(s)
+    except ValueError:
+        if s.endswith("%"):
+            inner = s[:-1]
+            if inner.endswith("\\"):
+                inner = inner[:-1]
+            try:
+                return float(inner) / 100
+            except ValueError:
+                pass
+    return None
 
-    Operations applied in order, mirroring lighteval's pre-comparison pass:
 
-    1. Strip whitespace.
-    2. Drop trailing punctuation (so ``$42$.`` doesn't keep the period
-       and prevent the dollar-strip from firing).
-    3. Strip surrounding ``$...$`` math delimiters.
-    4. Remove ``\\left`` / ``\\right`` (visual sizing only).
-    5. Collapse ``\\dfrac``/``\\tfrac`` to ``\\frac``.
-    6. Expand simple ``\\frac{a}{b}`` to ``(a)/(b)``.
-    7. Unwrap ``\\text{x}`` / ``\\mathrm{x}`` / similar to ``x``.
-    8. Remove all interior whitespace (so ``1 / 2`` matches ``1/2``).
+def _is_digit(num: Any) -> bool:
+    """Whether ``num`` parses as a numeric literal via ``_parse_digits``."""
+    return _parse_digits(num) is not None
 
-    Math is case-sensitive (variable names matter), so case is preserved.
-    Idempotent: ``_normalize(_normalize(s)) == _normalize(s)``.
+
+def _to_fraction(value: str) -> Fraction | None:
+    """Stdlib fallback: parse ``value`` as a Fraction (int / decimal / a/b)."""
+    if not value:
+        return None
+    s = value.strip().replace("(", "").replace(")", "")
+    try:
+        return Fraction(s)
+    except (ValueError, ZeroDivisionError):
+        return None
+
+
+def _sympy_parse(s: str) -> Any:
+    """Try parsing ``s`` via sympy/latex2sympy parsers, in priority order.
+
+    Returns the parsed sympy expression on first success, or the raw
+    string on total failure (so the caller can still attempt direct
+    string equality). Mirrors recipe's ``symbolic_equal._parse``.
+    """
+    parsers: list[Any] = []
+    if _HAS_SYMPY:
+        parsers.append(parse_expr)
+    if _HAS_LATEX2SYMPY:
+        parsers.append(latex2sympy)
+    for f in parsers:
+        # The recipe's ``s.replace("\\\\", "\\")`` first-pass.
+        for arg in (s.replace("\\\\", "\\"), s):
+            try:
+                return f(arg)
+            except Exception:
+                continue
+    return s
+
+
+def _symbolic_equal(a_raw: str, b_raw: str) -> bool:
+    """Sympy-backed symbolic equivalence check, mirroring the recipe.
+
+    Strategies tried in order: direct string-of-parsed-expr equality,
+    ``equals`` / ``simplify(a - b) == 0``, and numerical equality at
+    1e-4 absolute tolerance after ``N(.)`` evaluation.
+    """
+    if not _HAS_SYMPY:
+        return False
+    a = _sympy_parse(a_raw)
+    b = _sympy_parse(b_raw)
+
+    # Direct expression equality.
+    try:
+        if str(a) == str(b) or a == b:
+            return True
+    except Exception:
+        pass
+
+    # Symbolic simplify.
+    try:
+        if a.equals(b) or simplify(a - b) == 0:
+            return True
+    except Exception:
+        pass
+
+    # Numerical evaluation.
+    try:
+        if isclose(float(N(a)), float(N(b)), abs_tol=_NUMERIC_ABS_TOL):
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def _math_equal(prediction: str, reference: str, depth: int = 0) -> bool:
+    """Hendrycks-style equality check, ported from the recipe.
+
+    Tries (in order): lowercased string equality, single-choice prefix
+    strip + recurse, comma-list ordering (sorted compare), numerical
+    equality with percentage variants, brace/paren strip + lowercase
+    compare, equation-form rewrite, and finally symbolic equality via
+    sympy.
+
+    The ``depth`` parameter is a recursion guard for the rewrites.
+    """
+    if depth > _MAX_DEPTH:
+        return False
+
+    if prediction is None or reference is None:
+        return False
+
+    pred_s = str(prediction).strip().lower()
+    ref_s = str(reference).strip().lower()
+    if pred_s == ref_s:
+        return True
+
+    # Single-letter answer with prefix unwrapping.
+    if reference in ("A", "B", "C", "D", "E"):
+        cleaned = prediction.strip("\n").rstrip(".").rstrip("/").strip(" ").lstrip(":")
+        letters = re.findall(r"\b(A|B|C|D|E)\b", cleaned.upper())
+        if letters and letters[-1] == reference:
+            return True
+
+    for pat in _SINGLE_CHOICE_PATTERNS:
+        if re.match(pat, prediction):
+            cleaned = re.sub(pat, "", prediction, count=1).strip()
+            if _math_equal(cleaned, reference, depth + 1):
+                return True
+
+    # Comma-separated unordered match.
+    if "," in prediction and "," in reference:
+        pred_parts = sorted(p.strip() for p in prediction.split(","))
+        ref_parts = sorted(p.strip() for p in reference.split(","))
+        if len(pred_parts) == len(ref_parts) and all(
+            _math_equal(pp, rp, depth + 1)
+            for pp, rp in zip(pred_parts, ref_parts, strict=False)
+        ):
+            return True
+
+    # Numerical equality (with percentage variants).
+    if _is_digit(prediction) and _is_digit(reference):
+        p_num = _parse_digits(prediction)
+        r_num = _parse_digits(reference)
+        if p_num is None or r_num is None:
+            return False
+        candidates = (r_num / 100, r_num, r_num * 100)
+        return any(isclose(p_num, c, abs_tol=_NUMERIC_ABS_TOL) for c in candidates)
+
+    if not prediction and prediction not in (0, False):
+        return False
+
+    # Brace/paren strip + lowercase compare.
+    pred_str = str(prediction).strip()
+    ref_str = str(reference).strip()
+    if (
+        pred_str.startswith("[")
+        and pred_str.endswith("]")
+        and not ref_str.startswith("(")
+    ) or (
+        pred_str.startswith("(")
+        and pred_str.endswith(")")
+        and not ref_str.startswith("[")
+    ):
+        pred_str = pred_str.strip("[]()")
+        ref_str = ref_str.strip("[]()")
+    for s in ("{", "}", "(", ")"):
+        ref_str = ref_str.replace(s, "")
+        pred_str = pred_str.replace(s, "")
+    if pred_str.lower() == ref_str.lower():
+        return True
+
+    # Equation-form rewrites.
+    if prediction.count("=") == 1 and reference.count("=") == 1:
+        p_lhs, p_rhs = (s.strip() for s in prediction.split("="))
+        r_lhs, r_rhs = (s.strip() for s in reference.split("="))
+        if _symbolic_equal(f"{p_lhs} - ({p_rhs})", f"{r_lhs} - ({r_rhs})"):
+            return True
+    elif (
+        prediction.count("=") == 1
+        and len(prediction.split("=")[0].strip()) <= 2
+        and "=" not in reference
+    ):
+        if _math_equal(prediction.split("=")[1], reference, depth + 1):
+            return True
+    elif (
+        reference.count("=") == 1
+        and len(reference.split("=")[0].strip()) <= 2
+        and "=" not in prediction
+    ):
+        if _math_equal(prediction, reference.split("=")[1], depth + 1):
+            return True
+
+    # Final symbolic check.
+    return _symbolic_equal(prediction, reference)
+
+
+def _stdlib_fallback_equal(prediction: str, reference: str) -> bool:
+    """Stdlib-only fallback used when sympy isn't installed.
+
+    Same as the previous (pre-trt-llm-port) MathGrader behavior:
+    normalize on both sides, attempt Fraction parse for numerics,
+    otherwise compare the normalized strings.
+    """
+    pred_norm = _stdlib_normalize(prediction)
+    gold_norm = _stdlib_normalize(reference)
+    pred_frac = _to_fraction(pred_norm)
+    gold_frac = _to_fraction(gold_norm)
+    if pred_frac is not None and gold_frac is not None:
+        return pred_frac == gold_frac
+    return pred_norm == gold_norm and pred_norm != ""
+
+
+_DFRAC_RE = re.compile(r"\\(?:dfrac|tfrac)")
+_LEFT_RIGHT_RE = re.compile(r"\\(?:left|right)")
+_SIMPLE_FRAC_RE = re.compile(r"\\frac\{([^{}]+)\}\{([^{}]+)\}")
+_TEXT_WRAPPER_RE = re.compile(r"\\(?:text|mathrm|mathit|mathbf)\{([^{}]*)\}")
+_TRAILING_PUNCT_RE = re.compile(r"[.,;:!?]+$")
+
+
+def _stdlib_normalize(expr: str) -> str:
+    """Lightweight LaTeX-aware normalization for the stdlib fallback path.
+
+    Strips $...$, \\left/\\right, expands \\frac{a}{b} to (a)/(b),
+    unwraps \\text{...}, drops trailing punctuation, removes interior
+    whitespace. Idempotent.
     """
     s = expr.strip()
     s = _TRAILING_PUNCT_RE.sub("", s)
@@ -122,45 +400,33 @@ def _normalize(expr: str) -> str:
     return s
 
 
-def _to_fraction(value: str) -> Fraction | None:
-    """Parse ``value`` as a ``Fraction``, or return None if it isn't numeric.
-
-    Accepts:
-    - Integers: ``42``, ``-7``
-    - Decimals: ``3.14``, ``-0.5``
-    - Ratios: ``1/2``, ``-3/4``
-    - Parenthesized ratios produced by ``_normalize``: ``(1)/(2)``
-
-    Rejects anything else (variable names, expressions, empty string).
-    """
-    if not value:
-        return None
-    s = value.strip().replace("(", "").replace(")", "")
-    try:
-        return Fraction(s)
-    except (ValueError, ZeroDivisionError):
-        return None
+# Public alias retained for backward compatibility with the v1 tests
+# that imported ``_normalize`` directly. The body is the stdlib path;
+# in the new pipeline it's only used inside the fallback.
+_normalize = _stdlib_normalize
 
 
 class MathGrader(BaseGrader):
-    """Grades numeric/algebraic responses by extracting then normalizing.
+    """Grades math/AIME responses with the trt-llm reference algorithm.
 
-    Extraction priority (first hit wins):
+    Extraction priority (mirrors recipe ``format_response``):
 
-    1. Last ``\\boxed{...}`` in the response (the canonical MATH/AIME format).
-    2. Last "the answer is X" / "answer: X" phrase, recursively parsed.
-    3. Last numeric literal in the response (int, decimal, or a/b).
+    1. Last ``\\boxed{...}`` in the response (canonical MATH/AIME format).
+    2. Last "the answer is X" / "answer: X" phrase, recursively re-parsed.
+    3. Last numeric literal in the response.
 
-    Comparison strategy:
+    Comparison pipeline (mirrors recipe ``check_is_correct`` →
+    ``math_equal`` → ``symbolic_equal``):
 
-    1. Normalize both predicted and gold answers (see ``_normalize``).
-    2. Try to parse both as ``Fraction``. If both parse, compare numerically
-       (so ``0.5 == 1/2 == \\frac{1}{2}``).
-    3. Otherwise, fall back to exact string equality on the normalized form.
+    1. ``strip_string`` both sides (LaTeX/unit normalization).
+    2. ``_math_equal``: lowercase string equality, choice-prefix unwrap,
+       numerical isclose (abs_tol=1e-4) with percentage variants,
+       brace/paren strip + compare, equation-form rewrite, finally
+       symbolic equality via sympy + latex2sympy2-extended.
 
     The ``unparsed`` flag is set whenever extraction fell back past the
-    boxed-answer step. A correct unparsed response is still scored correct,
-    matching MultipleChoiceGrader's convention.
+    boxed-answer step. A correct unparsed response is still scored
+    correct, matching ``MultipleChoiceGrader``'s convention.
     """
 
     def __init__(self, user_config: UserConfig, **kwargs: Any) -> None:
@@ -171,21 +437,22 @@ class MathGrader(BaseGrader):
 
         ``unparsed`` is True when extraction had to fall back past the
         ``\\boxed{}`` step (i.e. the model didn't follow the boxed-answer
-        instruction).
+        instruction). Mirrors ``format_response`` from the recipe but
+        also surfaces the unparsed flag for downstream auditing.
         """
         if not response_text:
             return "", True
 
         boxed = _extract_last_boxed(response_text)
         if boxed is not None:
-            return boxed.strip(), False
+            return _format_response_tail(boxed), False
 
         m = _ANSWER_PHRASE_RE.search(response_text)
         if m:
             tail = m.group(1).strip()
             tail_boxed = _extract_last_boxed(tail)
             if tail_boxed is not None:
-                return tail_boxed.strip(), True
+                return _format_response_tail(tail_boxed), True
             tail_num = _extract_last_number(tail)
             if tail_num is not None:
                 return tail_num, True
@@ -206,28 +473,46 @@ class MathGrader(BaseGrader):
         self, response_text: str, ground_truth: str, **kwargs: Any
     ) -> GradingResult:
         pred_raw, unparsed = self._extract_with_flag(response_text)
-        pred_norm = _normalize(pred_raw)
-        gold_norm = _normalize(ground_truth)
 
-        pred_frac = _to_fraction(pred_norm)
-        gold_frac = _to_fraction(gold_norm)
-        if pred_frac is not None and gold_frac is not None:
-            correct = pred_frac == gold_frac
-            mode = "numeric"
+        pred_stripped = strip_string(pred_raw)
+        gold_stripped = strip_string(ground_truth)
+
+        if _HAS_SYMPY:
+            correct = _math_equal(pred_stripped, gold_stripped)
+            mode = "math_equal"
         else:
-            correct = pred_norm == gold_norm and pred_norm != ""
-            mode = "string"
+            _warn_fallback_once()
+            correct = _stdlib_fallback_equal(pred_stripped, gold_stripped)
+            mode = "stdlib-fallback"
 
         return GradingResult(
             correct=correct,
             unparsed=unparsed,
             confidence=1.0 if correct else 0.0,
             reasoning=(
-                f"extracted '{pred_raw}' (normalized '{pred_norm}'); "
-                f"ground_truth '{ground_truth}' (normalized '{gold_norm}'); "
+                f"extracted '{pred_raw}' (stripped '{pred_stripped}'); "
+                f"ground_truth '{ground_truth}' (stripped '{gold_stripped}'); "
                 f"compared via {mode}; match={correct}"
                 + (" (regex fallback)" if unparsed else "")
             ),
             extracted_answer=pred_raw,
             ground_truth=ground_truth.strip(),
         )
+
+
+def _format_response_tail(boxed_content: str) -> str:
+    """Apply the recipe's ``format_response`` post-extraction cleanup.
+
+    Handles the trailing-character trim that the recipe does AFTER
+    extracting the boxed content: collapse newlines, drop a leading
+    ``:``, drop a trailing ``.`` or ``/``.
+    """
+    pred = boxed_content
+    pred = re.sub(r"\n\s*", "", pred)
+    if pred and pred[0] == ":":
+        pred = pred[1:]
+    if pred and pred[-1] == ".":
+        pred = pred[:-1]
+    if pred and pred[-1] == "/":
+        pred = pred[:-1]
+    return pred

--- a/src/aiperf/accuracy/graders/math.py
+++ b/src/aiperf/accuracy/graders/math.py
@@ -86,10 +86,15 @@ def _warn_fallback_once() -> None:
 
 
 # Recognized "the answer is X" suffixes used by models that ignore the
-# \\boxed{} instruction. Captures everything to end-of-line so we can re-run
-# the boxed/numeric extractors on the captured tail.
+# \\boxed{} instruction. Captures everything to end-of-line so we can
+# re-run the boxed/numeric extractors on the captured tail.
+#
+# Terminator is ``\n`` (or end-of-string), NOT ``\.``: the regex used
+# to stop at the first period, which silently truncated decimals like
+# ``"the answer is 3.14"`` to ``"3"``. The downstream
+# ``_extract_last_number`` regex already strips trailing punctuation.
 _ANSWER_PHRASE_RE = re.compile(
-    r"(?:final\s+answer|the\s+answer\s+is|answer\s*[:=]|answer\s+is)\s*[:=]?\s*(.+?)(?:\.|$)",
+    r"(?:final\s+answer|the\s+answer\s+is|answer\s*[:=]|answer\s+is)\s*[:=]?\s*(.+?)(?:\n|$)",
     re.IGNORECASE,
 )
 
@@ -508,9 +513,12 @@ class MathGrader(BaseGrader):
         if boxed is not None:
             return _format_response_tail(boxed), False
 
-        m = _ANSWER_PHRASE_RE.search(response_text)
-        if m:
-            tail = m.group(1).strip()
+        # Take the LAST answer-phrase match, not the first: reasoning
+        # models often self-correct ("the answer is 5. Wait, actually
+        # the answer is 12") and the final claim is what we want.
+        phrase_matches = _ANSWER_PHRASE_RE.findall(response_text)
+        if phrase_matches:
+            tail = phrase_matches[-1].strip()
             tail_boxed = _extract_last_boxed(tail)
             if tail_boxed is not None:
                 return _format_response_tail(tail_boxed), True

--- a/src/aiperf/accuracy/graders/math.py
+++ b/src/aiperf/accuracy/graders/math.py
@@ -89,12 +89,21 @@ def _warn_fallback_once() -> None:
 # \\boxed{} instruction. Captures everything to end-of-line so we can
 # re-run the boxed/numeric extractors on the captured tail.
 #
-# Terminator is ``\n`` (or end-of-string), NOT ``\.``: the regex used
-# to stop at the first period, which silently truncated decimals like
-# ``"the answer is 3.14"`` to ``"3"``. The downstream
-# ``_extract_last_number`` regex already strips trailing punctuation.
+# Terminator combines three rules (decimals must survive, multi-line
+# responses must terminate cleanly, sentence-ending periods should be
+# stripped):
+#
+#   (?<!\d)\.(?!\d) — a period NOT surrounded by digits (sentence period)
+#   \n              — end of line for multi-line responses
+#   $               — end of string
+#
+# The previous implementation used just ``\.`` which silently truncated
+# decimals like ``3.14`` to ``3``; the simpler ``\n|$`` alternative
+# regresses to keeping trailing-sentence text in the tail. This hybrid
+# handles all three concerns.
 _ANSWER_PHRASE_RE = re.compile(
-    r"(?:final\s+answer|the\s+answer\s+is|answer\s*[:=]|answer\s+is)\s*[:=]?\s*(.+?)(?:\n|$)",
+    r"(?:final\s+answer|the\s+answer\s+is|answer\s*[:=]|answer\s+is)\s*[:=]?\s*"
+    r"(.+?)(?:(?<!\d)\.(?!\d)|\n|$)",
     re.IGNORECASE,
 )
 

--- a/src/aiperf/accuracy/graders/math.py
+++ b/src/aiperf/accuracy/graders/math.py
@@ -110,6 +110,14 @@ _ANSWER_PHRASE_RE = re.compile(
 # Matches signed/unsigned int, decimal, or simple ratio (e.g. "1/2", "-3.14").
 _NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?(?:/\d+)?")
 
+# Recognizes "expression-shaped" content in an answer-phrase tail —
+# LaTeX commands (``\frac``, ``\sqrt``, ``\pi``, ...) or curly braces
+# from any TeX construct. When the tail contains one of these, fall
+# through to ``strip_string`` + ``math_equal`` whole, instead of
+# running ``_extract_last_number`` which would silently grade
+# ``"\frac{1}{2}"`` as ``"2"`` (the last digit it finds).
+_LATEX_HINT_RE = re.compile(r"[\\{}]")
+
 _BOXED_TOKEN = "\\boxed{"
 
 # Numerical tolerance for ``isclose``. Mirrors the recipe's value.
@@ -531,6 +539,15 @@ class MathGrader(BaseGrader):
             tail_boxed = _extract_last_boxed(tail)
             if tail_boxed is not None:
                 return _format_response_tail(tail_boxed), True
+            # If the tail looks like a LaTeX expression (contains a
+            # backslash or curly brace), preserve it whole so
+            # ``strip_string`` + ``math_equal`` can normalize and
+            # compare it. Falling through to the last-number extractor
+            # would grade ``"\frac{1}{2}"`` against gold ``"1/2"`` as
+            # ``"2"`` — exactly the asymmetry that ``\boxed{...}``
+            # tails correctly avoid.
+            if _LATEX_HINT_RE.search(tail):
+                return tail, True
             tail_num = _extract_last_number(tail)
             if tail_num is not None:
                 return tail_num, True

--- a/src/aiperf/accuracy/graders/math.py
+++ b/src/aiperf/accuracy/graders/math.py
@@ -256,64 +256,66 @@ def _symbolic_equal(a_raw: str, b_raw: str) -> bool:
     return False
 
 
-def _math_equal(prediction: str, reference: str, depth: int = 0) -> bool:
-    """Hendrycks-style equality check, ported from the recipe.
-
-    Tries (in order): lowercased string equality, single-choice prefix
-    strip + recurse, comma-list ordering (sorted compare), numerical
-    equality with percentage variants, brace/paren strip + lowercase
-    compare, equation-form rewrite, and finally symbolic equality via
-    sympy.
-
-    The ``depth`` parameter is a recursion guard for the rewrites.
-    """
-    if depth > _MAX_DEPTH:
+def _handle_single_choice_prefix(prediction: str, reference: str) -> bool:
+    """Match a single-letter A-E reference by extracting the last A-E letter
+    from a cleaned prediction string."""
+    if reference not in ("A", "B", "C", "D", "E"):
         return False
+    cleaned = prediction.strip("\n").rstrip(".").rstrip("/").strip(" ").lstrip(":")
+    letters = re.findall(r"\b(A|B|C|D|E)\b", cleaned.upper())
+    return bool(letters and letters[-1] == reference)
 
-    if prediction is None or reference is None:
-        return False
 
-    pred_s = str(prediction).strip().lower()
-    ref_s = str(reference).strip().lower()
-    if pred_s == ref_s:
-        return True
-
-    # Single-letter answer with prefix unwrapping.
-    if reference in ("A", "B", "C", "D", "E"):
-        cleaned = prediction.strip("\n").rstrip(".").rstrip("/").strip(" ").lstrip(":")
-        letters = re.findall(r"\b(A|B|C|D|E)\b", cleaned.upper())
-        if letters and letters[-1] == reference:
-            return True
-
+def _apply_single_choice_patterns(prediction: str, reference: str, depth: int) -> bool:
+    """Strip a recognized choice-prefix pattern off the prediction and
+    recurse into ``_math_equal`` on the remainder."""
     for pat in _SINGLE_CHOICE_PATTERNS:
         if re.match(pat, prediction):
             cleaned = re.sub(pat, "", prediction, count=1).strip()
             if _math_equal(cleaned, reference, depth + 1):
                 return True
+    return False
 
-    # Comma-separated unordered match.
-    if "," in prediction and "," in reference:
-        pred_parts = sorted(p.strip() for p in prediction.split(","))
-        ref_parts = sorted(p.strip() for p in reference.split(","))
-        if len(pred_parts) == len(ref_parts) and all(
-            _math_equal(pp, rp, depth + 1)
-            for pp, rp in zip(pred_parts, ref_parts, strict=False)
-        ):
-            return True
 
-    # Numerical equality (with percentage variants).
-    if _is_digit(prediction) and _is_digit(reference):
-        p_num = _parse_digits(prediction)
-        r_num = _parse_digits(reference)
-        if p_num is None or r_num is None:
-            return False
-        candidates = (r_num / 100, r_num, r_num * 100)
-        return any(isclose(p_num, c, abs_tol=_NUMERIC_ABS_TOL) for c in candidates)
-
-    if not prediction and prediction not in (0, False):
+def _compare_comma_list(prediction: str, reference: str, depth: int) -> bool:
+    """Sort comma-separated lists and compare element-wise via _math_equal."""
+    if "," not in prediction or "," not in reference:
         return False
+    pred_parts = sorted(p.strip() for p in prediction.split(","))
+    ref_parts = sorted(p.strip() for p in reference.split(","))
+    return len(pred_parts) == len(ref_parts) and all(
+        _math_equal(pp, rp, depth + 1)
+        for pp, rp in zip(pred_parts, ref_parts, strict=False)
+    )
 
-    # Brace/paren strip + lowercase compare.
+
+def _numeric_equality_with_percent(prediction: str, reference: str) -> bool | None:
+    """Numeric comparison with percentage variants.
+
+    Tri-state semantics — caller must respect them:
+
+    * ``None``  → inputs are not both numeric; fall through to the next
+      strategy.
+    * ``True``  → numeric match (one of the percent-scaled candidates is
+      within ``_NUMERIC_ABS_TOL``).
+    * ``False`` → both inputs were numeric, but the parsed values are
+      not close. **Terminal** — do not fall through to brace/paren,
+      equation-rewrite, or symbolic checks. Mirrors the recipe's
+      ``return any(...)`` short-circuit.
+    """
+    if not (_is_digit(prediction) and _is_digit(reference)):
+        return None
+    p_num = _parse_digits(prediction)
+    r_num = _parse_digits(reference)
+    if p_num is None or r_num is None:
+        return False
+    candidates = (r_num / 100, r_num, r_num * 100)
+    return any(isclose(p_num, c, abs_tol=_NUMERIC_ABS_TOL) for c in candidates)
+
+
+def _brace_paren_compare(prediction: str, reference: str) -> bool:
+    """Strip mismatched outer brackets / braces / parens, then compare
+    the residual strings case-insensitively."""
     pred_str = str(prediction).strip()
     ref_str = str(reference).strip()
     if (
@@ -330,31 +332,90 @@ def _math_equal(prediction: str, reference: str, depth: int = 0) -> bool:
     for s in ("{", "}", "(", ")"):
         ref_str = ref_str.replace(s, "")
         pred_str = pred_str.replace(s, "")
-    if pred_str.lower() == ref_str.lower():
-        return True
+    return pred_str.lower() == ref_str.lower()
 
-    # Equation-form rewrites.
+
+def _equation_rewrites(prediction: str, reference: str, depth: int) -> bool:
+    """Equation-form rewrites:
+
+    * ``a = b`` vs ``c = d`` → compare ``a - (b)`` to ``c - (d)`` symbolically.
+    * ``x = v`` (lhs ≤ 2 chars) on one side, plain value on the other →
+      compare the rhs to the plain value via ``_math_equal``.
+    """
     if prediction.count("=") == 1 and reference.count("=") == 1:
         p_lhs, p_rhs = (s.strip() for s in prediction.split("="))
         r_lhs, r_rhs = (s.strip() for s in reference.split("="))
-        if _symbolic_equal(f"{p_lhs} - ({p_rhs})", f"{r_lhs} - ({r_rhs})"):
-            return True
-    elif (
+        return _symbolic_equal(f"{p_lhs} - ({p_rhs})", f"{r_lhs} - ({r_rhs})")
+    if (
         prediction.count("=") == 1
         and len(prediction.split("=")[0].strip()) <= 2
         and "=" not in reference
     ):
-        if _math_equal(prediction.split("=")[1], reference, depth + 1):
-            return True
-    elif (
+        return _math_equal(prediction.split("=")[1], reference, depth + 1)
+    if (
         reference.count("=") == 1
         and len(reference.split("=")[0].strip()) <= 2
         and "=" not in prediction
     ):
-        if _math_equal(prediction, reference.split("=")[1], depth + 1):
-            return True
+        return _math_equal(prediction, reference.split("=")[1], depth + 1)
+    return False
 
-    # Final symbolic check.
+
+def _math_equal(prediction: str, reference: str, depth: int = 0) -> bool:
+    """Hendrycks-style equality check, ported from the recipe.
+
+    Strategy order (each falls through on no-match unless noted):
+
+    1. Recursion-depth guard, then null-input guard.
+    2. Direct lowercased string equality.
+    3. ``_handle_single_choice_prefix`` — A-E letter answer matching.
+    4. ``_apply_single_choice_patterns`` — strip a choice-prefix and recurse.
+    5. ``_compare_comma_list`` — sorted comma-list element-wise compare.
+    6. ``_numeric_equality_with_percent`` — **terminal** when both inputs
+       look numeric: returns the verdict directly without falling through
+       to symbolic.
+    7. Empty-prediction shortcut (matches the recipe's exact placement
+       AFTER the numeric branch).
+    8. ``_brace_paren_compare`` — bracket-stripped lowercase compare.
+    9. ``_equation_rewrites`` — equation-form normalizations.
+    10. ``_symbolic_equal`` — sympy/latex2sympy symbolic equivalence
+        (final fallback).
+
+    ``depth`` is a recursion guard for the rewrites (capped at
+    ``_MAX_DEPTH``).
+    """
+    if depth > _MAX_DEPTH:
+        return False
+    if prediction is None or reference is None:
+        return False
+
+    if str(prediction).strip().lower() == str(reference).strip().lower():
+        return True
+
+    if _handle_single_choice_prefix(prediction, reference):
+        return True
+    if _apply_single_choice_patterns(prediction, reference, depth):
+        return True
+    if _compare_comma_list(prediction, reference, depth):
+        return True
+
+    # Numeric equality is terminal — see the helper docstring for why.
+    numeric_verdict = _numeric_equality_with_percent(prediction, reference)
+    if numeric_verdict is not None:
+        return numeric_verdict
+
+    # Post-numeric empty-pred shortcut, kept inline because it sits
+    # between two strategies in the recipe and excludes 0 / False to
+    # avoid eating valid numeric-zero predictions that the numeric
+    # branch above already handled.
+    if not prediction and prediction not in (0, False):
+        return False
+
+    if _brace_paren_compare(prediction, reference):
+        return True
+    if _equation_rewrites(prediction, reference, depth):
+        return True
+
     return _symbolic_equal(prediction, reference)
 
 

--- a/src/aiperf/accuracy/graders/math.py
+++ b/src/aiperf/accuracy/graders/math.py
@@ -477,7 +477,14 @@ class MathGrader(BaseGrader):
         pred_stripped = strip_string(pred_raw)
         gold_stripped = strip_string(ground_truth)
 
-        if _HAS_SYMPY:
+        # The full ``math_equal`` path needs BOTH sympy (for parse_expr
+        # and ``_symbolic_equal``) and latex2sympy2-extended (for
+        # LaTeX-shaped expressions inside ``_sympy_parse``). Requiring
+        # both matches the contract the module docstring and the
+        # warning text already promise — a "sympy alone" middle state
+        # would silently regress LaTeX equivalence without telling
+        # users to install the missing package.
+        if _HAS_SYMPY and _HAS_LATEX2SYMPY:
             correct = _math_equal(pred_stripped, gold_stripped)
             mode = "math_equal"
         else:

--- a/src/aiperf/accuracy/graders/math.py
+++ b/src/aiperf/accuracy/graders/math.py
@@ -215,7 +215,7 @@ def _sympy_parse(s: str) -> Any:
         for arg in (s.replace("\\\\", "\\"), s):
             try:
                 return f(arg)
-            except Exception:
+            except Exception:  # noqa: BLE001, S112
                 continue
     return s
 
@@ -236,21 +236,21 @@ def _symbolic_equal(a_raw: str, b_raw: str) -> bool:
     try:
         if str(a) == str(b) or a == b:
             return True
-    except Exception:
+    except Exception:  # noqa: BLE001, S110
         pass
 
     # Symbolic simplify.
     try:
         if a.equals(b) or simplify(a - b) == 0:
             return True
-    except Exception:
+    except Exception:  # noqa: BLE001, S110
         pass
 
     # Numerical evaluation.
     try:
         if isclose(float(N(a)), float(N(b)), abs_tol=_NUMERIC_ABS_TOL):
             return True
-    except Exception:
+    except Exception:  # noqa: BLE001, S110
         pass
 
     return False

--- a/src/aiperf/common/config/accuracy_config.py
+++ b/src/aiperf/common/config/accuracy_config.py
@@ -112,16 +112,17 @@ class AccuracyConfig(BaseConfig):
     ] = None
 
     enable_cot: Annotated[
-        bool,
+        bool | None,
         Field(
             description="Enable chain-of-thought prompting for accuracy evaluation. "
-            "Adds reasoning instructions to the prompt.",
+            "Adds reasoning instructions to the prompt. Defaults to the benchmark's "
+            "``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).",
         ),
         CLIParameter(
             name=("--accuracy-enable-cot",),
             group=Groups.ACCURACY,
         ),
-    ] = False
+    ] = None
 
     grader: Annotated[
         AccuracyGraderType | None,

--- a/src/aiperf/common/config/accuracy_config.py
+++ b/src/aiperf/common/config/accuracy_config.py
@@ -58,16 +58,17 @@ class AccuracyConfig(BaseConfig):
     ] = None
 
     enable_cot: Annotated[
-        bool,
+        bool | None,
         Field(
             description="Enable chain-of-thought prompting for accuracy evaluation. "
-            "Adds reasoning instructions to the prompt.",
+            "Adds reasoning instructions to the prompt. Defaults to the benchmark's "
+            "``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).",
         ),
         CLIParameter(
             name=("--accuracy-enable-cot",),
             group=_CLI_GROUP,
         ),
-    ] = False
+    ] = None
 
     grader: Annotated[
         AccuracyGraderType | None,

--- a/src/aiperf/dataset/loader/accuracy_dataset_loader.py
+++ b/src/aiperf/dataset/loader/accuracy_dataset_loader.py
@@ -27,11 +27,38 @@ from aiperf.accuracy.models import AccuracyChatMessage, BenchmarkProblem
 from aiperf.common.config import UserConfig
 from aiperf.common.models.dataset_models import Conversation, Text, Turn
 from aiperf.common.session_id_generator import SessionIDGenerator
+from aiperf.plugin import plugins
+from aiperf.plugin.enums import PluginType
 
 # Default max_tokens when a benchmark omits generation_size from metadata.
 # MMLU sets 5 (single-letter answer); long-form benchmarks should set
 # their own value in BenchmarkProblem.metadata["generation_size"].
 DEFAULT_GENERATION_SIZE = 100
+
+
+def _resolve_system_prompt(user_config: UserConfig) -> str | None:
+    """Pick the effective system prompt for the active accuracy benchmark.
+
+    Resolution order:
+        1. ``--accuracy-system-prompt`` (user override) wins absolutely.
+        2. The benchmark plugin's ``default_system_prompt`` metadata,
+           if any. Per-benchmark defaults are documented in
+           ``docs/accuracy/accuracy-benchmarking.md`` so users know
+           what's being injected on their behalf.
+        3. ``None`` (no system prompt).
+    """
+    user_value = user_config.accuracy.system_prompt
+    if user_value is not None:
+        return user_value
+    benchmark = user_config.accuracy.benchmark
+    if benchmark is None:
+        return None
+    try:
+        meta = plugins.get_metadata(PluginType.ACCURACY_BENCHMARK, benchmark)
+    except Exception:
+        return None
+    default = meta.get("default_system_prompt")
+    return default if default else None
 
 
 class AccuracyDatasetLoader:
@@ -66,7 +93,7 @@ class AccuracyDatasetLoader:
         self, problems: list[BenchmarkProblem]
     ) -> list[Conversation]:
         session_gen = SessionIDGenerator(seed=self.user_config.input.random_seed)
-        system_prompt = self.user_config.accuracy.system_prompt
+        system_prompt = _resolve_system_prompt(self.user_config)
         conversations: list[Conversation] = []
 
         for problem in problems:

--- a/src/aiperf/dataset/loader/accuracy_dataset_loader.py
+++ b/src/aiperf/dataset/loader/accuracy_dataset_loader.py
@@ -29,6 +29,7 @@ from aiperf.common.models.dataset_models import Conversation, Text, Turn
 from aiperf.common.session_id_generator import SessionIDGenerator
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import PluginType
+from aiperf.plugin.types import PluginError
 
 # Default max_tokens when a benchmark omits generation_size from metadata.
 # MMLU sets 5 (single-letter answer); long-form benchmarks should set
@@ -55,7 +56,7 @@ def _resolve_system_prompt(user_config: UserConfig) -> str | None:
         return None
     try:
         meta = plugins.get_metadata(PluginType.ACCURACY_BENCHMARK, benchmark)
-    except Exception:
+    except (KeyError, PluginError):
         return None
     default = meta.get("default_system_prompt")
     return default if default else None

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -83,7 +83,7 @@ ResultsProcessorType = plugins.create_enum(PluginType.RESULTS_PROCESSOR, "Result
 
 AccuracyGraderTypeStr: TypeAlias = str
 AccuracyGraderType = plugins.create_enum(PluginType.ACCURACY_GRADER, "AccuracyGraderType", module=__name__)
-"""Dynamic enum for accuracy grader. Example: AccuracyGraderType.CODE_EXECUTION, AccuracyGraderType.MATH, AccuracyGraderType.MULTIPLE_CHOICE"""
+"""Dynamic enum for accuracy grader. Example: AccuracyGraderType.CODE_EXECUTION, AccuracyGraderType.LIGHTEVAL_GPQA, AccuracyGraderType.MULTIPLE_CHOICE"""
 
 AccuracyBenchmarkTypeStr: TypeAlias = str
 AccuracyBenchmarkType = plugins.create_enum(PluginType.ACCURACY_BENCHMARK, "AccuracyBenchmarkType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1022,8 +1022,35 @@ accuracy_grader:
   code_execution:
     class: aiperf.accuracy.graders.code_execution:CodeExecutionGrader
     description: |
-      Code execution grader that runs generated code in a sandboxed environment
-      and compares output against expected results.
+      Code execution grader for LiveCodeBench, backed by lighteval's
+      ``lcb_codegen_metric``. Extracts the model's code block, executes it
+      against public + private test cases in sandboxed subprocesses, and
+      reports pass@1. Requires the ``[accuracy]`` install.
+
+  lighteval_expr:
+    class: aiperf.accuracy.graders.lighteval_grader:LightevalExprGrader
+    description: |
+      Lighteval ``expr_gold_metric`` — used by AIME24/AIME25. Wraps lighteval's
+      ``MultilingualExtractiveMatchMetric`` configured with
+      ``ExprExtractionConfig`` for gold and
+      ``(ExprExtractionConfig, LatexExtractionConfig(boxed_match_priority=0))``
+      for predictions, matching the trt-llm benchmark recipe's
+      ``acc_bench_lighteval.py`` definition.
+
+  lighteval_latex:
+    class: aiperf.accuracy.graders.lighteval_grader:LightevalLatexGrader
+    description: |
+      Lighteval ``latex_gold_metric`` — used by MATH-500. Same as
+      ``lighteval_expr`` but the gold extractor uses
+      ``LatexExtractionConfig`` since MATH-500 gold answers are LaTeX
+      snippets like ``\\frac{1}{3}``.
+
+  lighteval_gpqa:
+    class: aiperf.accuracy.graders.lighteval_grader:LightevalGPQAGrader
+    description: |
+      Lighteval ``gpqa_metric`` — used by GPQA-Diamond. Extracts via
+      ``IndicesExtractionConfig(prefix_for_extraction="NativeLetters")``
+      to find the chosen A/B/C/D letter in both gold and prediction.
 
 # =============================================================================
 # Accuracy Benchmarks

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1045,10 +1045,15 @@ accuracy_benchmark:
     class: aiperf.accuracy.benchmarks.aime:AIMEBenchmark
     description: |
       AIME (American Invitational Mathematics Examination) benchmark for
-      advanced high school mathematics problems.
+      advanced high school mathematics problems. Aligned with the trt-llm
+      benchmark recipe's DeepEval-backed AIME path: same dataset
+      (Maxwell-Jia/AIME_2024), same prompt template, same default n_shots
+      (8) and chain-of-thought (on), same default system prompt.
     metadata:
       default_grader: math
-      default_n_shots: 0
+      default_n_shots: 8
+      default_enable_cot: true
+      default_system_prompt: "Please reason step by step, and put your final answer within \\boxed{}."
 
   hellaswag:
     class: aiperf.accuracy.benchmarks.hellaswag:HellaSwagBenchmark

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1076,8 +1076,6 @@ accuracy_grader:
     description: |
       Math grader that evaluates mathematical expressions for equivalence.
       Handles symbolic comparison, numeric tolerance, and expression normalization.
-    metadata:
-      is_implemented: false
 
   multiple_choice:
     class: aiperf.accuracy.graders.multiple_choice:MultipleChoiceGrader
@@ -1113,11 +1111,15 @@ accuracy_benchmark:
     class: aiperf.accuracy.benchmarks.aime:AIMEBenchmark
     description: |
       AIME (American Invitational Mathematics Examination) benchmark for
-      advanced high school mathematics problems.
+      advanced high school mathematics problems. Aligned with the trt-llm
+      benchmark recipe's DeepEval-backed AIME path: same dataset
+      (Maxwell-Jia/AIME_2024), same prompt template, same default n_shots
+      (8) and chain-of-thought (on), same default system prompt.
     metadata:
       default_grader: math
-      default_n_shots: 0
-      is_implemented: false
+      default_n_shots: 8
+      default_enable_cot: true
+      default_system_prompt: "Please reason step by step, and put your final answer within \\boxed{}."
 
   hellaswag:
     class: aiperf.accuracy.benchmarks.hellaswag:HellaSwagBenchmark

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1086,10 +1086,35 @@ accuracy_grader:
   code_execution:
     class: aiperf.accuracy.graders.code_execution:CodeExecutionGrader
     description: |
-      Code execution grader that runs generated code in a sandboxed environment
-      and compares output against expected results.
-    metadata:
-      is_implemented: false
+      Code execution grader for LiveCodeBench, backed by lighteval's
+      ``lcb_codegen_metric``. Extracts the model's code block, executes it
+      against public + private test cases in sandboxed subprocesses, and
+      reports pass@1. Requires the ``[accuracy]`` install.
+
+  lighteval_expr:
+    class: aiperf.accuracy.graders.lighteval_grader:LightevalExprGrader
+    description: |
+      Lighteval ``expr_gold_metric`` — used by AIME24/AIME25. Wraps lighteval's
+      ``MultilingualExtractiveMatchMetric`` configured with
+      ``ExprExtractionConfig`` for gold and
+      ``(ExprExtractionConfig, LatexExtractionConfig(boxed_match_priority=0))``
+      for predictions, matching the trt-llm benchmark recipe's
+      ``acc_bench_lighteval.py`` definition.
+
+  lighteval_latex:
+    class: aiperf.accuracy.graders.lighteval_grader:LightevalLatexGrader
+    description: |
+      Lighteval ``latex_gold_metric`` — used by MATH-500. Same as
+      ``lighteval_expr`` but the gold extractor uses
+      ``LatexExtractionConfig`` since MATH-500 gold answers are LaTeX
+      snippets like ``\\frac{1}{3}``.
+
+  lighteval_gpqa:
+    class: aiperf.accuracy.graders.lighteval_grader:LightevalGPQAGrader
+    description: |
+      Lighteval ``gpqa_metric`` — used by GPQA-Diamond. Extracts via
+      ``IndicesExtractionConfig(prefix_for_extraction="NativeLetters")``
+      to find the chosen A/B/C/D letter in both gold and prediction.
 
 # =============================================================================
 # Accuracy Benchmarks

--- a/tests/unit/accuracy/test_accuracy_config.py
+++ b/tests/unit/accuracy/test_accuracy_config.py
@@ -20,8 +20,9 @@ from aiperf.common.config.accuracy_config import AccuracyConfig
 # Stub names match the ``is_implemented: false`` entries in plugins.yaml.
 # Update both lists together when a follow-up branch lands an
 # implementation (and remove the ``is_implemented: false`` from the YAML).
+# This branch (AIP-874) implements ``aime``, ``math``, and ``code_execution``,
+# so those names are absent from the stub lists.
 STUB_BENCHMARKS = (
-    "aime",
     "hellaswag",
     "bigbench",
     "aime24",
@@ -30,7 +31,7 @@ STUB_BENCHMARKS = (
     "gpqa_diamond",
     "lcb_codegeneration",
 )
-STUB_GRADERS = ("exact_match", "math", "code_execution")
+STUB_GRADERS = ("exact_match",)
 
 
 class TestAcceptsImplemented:
@@ -113,9 +114,8 @@ class TestRejectsStubGrader:
 
         AccuracyConfig stays neutral about which grader the benchmark
         defaults to — the dataset loader resolves that. This test pins
-        that behavior so the validator never blocks the default-grader
-        path even when the default itself is currently a stub (e.g.
-        ``aime`` defaulting to ``math``).
+        that behavior so the validator only ever inspects an explicit
+        ``--accuracy-grader`` override.
         """
         cfg = AccuracyConfig(benchmark="mmlu")
         assert cfg.grader is None

--- a/tests/unit/accuracy/test_accuracy_config.py
+++ b/tests/unit/accuracy/test_accuracy_config.py
@@ -34,18 +34,18 @@ STUB_GRADERS = ("exact_match", "math", "code_execution")
 
 
 class TestAcceptsImplemented:
-    def test_no_benchmark_set_is_valid(self) -> None:
+    def test_accuracyconfig_no_benchmark_returns_defaults(self) -> None:
         cfg = AccuracyConfig()
         assert cfg.benchmark is None
         assert cfg.grader is None
         assert cfg.enabled is False
 
-    def test_implemented_benchmark_passes(self) -> None:
+    def test_accuracyconfig_with_implemented_benchmark_enables_config(self) -> None:
         cfg = AccuracyConfig(benchmark="mmlu")
         assert str(cfg.benchmark) == "mmlu"
         assert cfg.enabled is True
 
-    def test_implemented_grader_override_passes(self) -> None:
+    def test_accuracyconfig_with_grader_override_sets_grader(self) -> None:
         cfg = AccuracyConfig(benchmark="mmlu", grader="multiple_choice")
         assert str(cfg.grader) == "multiple_choice"
 
@@ -55,7 +55,9 @@ class TestRejectsStubBenchmark:
         "name",
         [param(n, id=n) for n in STUB_BENCHMARKS],
     )  # fmt: skip
-    def test_stub_benchmark_rejected(self, name: str) -> None:
+    def test_accuracyconfig_with_stub_benchmark_raises_validationerror(
+        self, name: str
+    ) -> None:
         with pytest.raises(ValidationError) as exc:
             AccuracyConfig(benchmark=name)
         msg = str(exc.value)
@@ -67,7 +69,9 @@ class TestRejectsStubBenchmark:
         # must surface at least that as a usable alternative.
         assert "mmlu" in msg.split("Available:")[-1]
 
-    def test_hyphenated_stub_name_also_rejected(self) -> None:
+    def test_accuracyconfig_with_hyphenated_stub_name_raises_validationerror(
+        self,
+    ) -> None:
         """Reproduces the original bug: ``--accuracy-benchmark lcb-codegeneration``
         used the hyphen-tolerant enum lookup and reached the loader."""
         with pytest.raises(ValidationError) as exc:
@@ -78,7 +82,9 @@ class TestRejectsStubBenchmark:
         assert "lcb_codegeneration" in msg
         assert "not yet implemented" in msg
 
-    def test_uppercase_stub_name_also_rejected(self) -> None:
+    def test_accuracyconfig_with_uppercase_stub_name_raises_validationerror(
+        self,
+    ) -> None:
         """Case-insensitive enum lookup must not bypass the validator."""
         with pytest.raises(ValidationError) as exc:
             AccuracyConfig(benchmark="HELLASWAG")
@@ -90,7 +96,9 @@ class TestRejectsStubGrader:
         "name",
         [param(n, id=n) for n in STUB_GRADERS],
     )  # fmt: skip
-    def test_stub_grader_override_rejected(self, name: str) -> None:
+    def test_accuracyconfig_with_stub_grader_override_raises_validationerror(
+        self, name: str
+    ) -> None:
         with pytest.raises(ValidationError) as exc:
             AccuracyConfig(benchmark="mmlu", grader=name)
         msg = str(exc.value)
@@ -100,7 +108,7 @@ class TestRejectsStubGrader:
         # ``multiple_choice`` is the one always-implemented grader.
         assert "multiple_choice" in msg.split("Available:")[-1]
 
-    def test_grader_unset_falls_back_to_default(self) -> None:
+    def test_accuracyconfig_grader_unset_allows_default(self) -> None:
         """Leaving ``grader`` unset must not trigger the stub check.
 
         AccuracyConfig stays neutral about which grader the benchmark

--- a/tests/unit/accuracy/test_accuracy_dataset_loader.py
+++ b/tests/unit/accuracy/test_accuracy_dataset_loader.py
@@ -188,3 +188,82 @@ class TestAccuracyDatasetLoaderRawMessages:
         assert turn.raw_messages is not None
         assert turn.raw_messages[0] == {"role": "system", "content": "Be concise."}
         assert turn.raw_messages[1] == {"role": "user", "content": "What is 2+2?"}
+
+
+class TestDefaultSystemPromptResolution:
+    """Per-benchmark ``default_system_prompt`` metadata injection.
+
+    The trt-llm AIME recipe sets a ``Please reason step by step, and
+    put your final answer within \\boxed{}.`` system prompt via its
+    ``aime_test.json``. We mirror that by reading
+    ``default_system_prompt`` from plugin metadata when the user
+    hasn't passed ``--accuracy-system-prompt``. Documented in
+    ``docs/accuracy/accuracy-benchmarking.md`` so users see what
+    aiperf injects on their behalf.
+    """
+
+    def test_user_override_wins_over_metadata_default(self) -> None:
+        loader = AccuracyDatasetLoader(
+            user_config=_make_user_config(system_prompt="user-supplied")
+        )
+        problem = _make_problem()
+        with patch(
+            "aiperf.dataset.loader.accuracy_dataset_loader.plugins.get_metadata",
+            return_value={"default_system_prompt": "metadata-default"},
+        ):
+            conversations = loader._convert_to_conversations([problem])
+        turn = conversations[0].turns[0]
+        assert turn.raw_messages is not None
+        assert turn.raw_messages[0] == {
+            "role": "system",
+            "content": "user-supplied",
+        }
+
+    def test_metadata_default_used_when_user_unset(self) -> None:
+        loader = AccuracyDatasetLoader(
+            user_config=_make_user_config(system_prompt=None)
+        )
+        problem = _make_problem()
+        with patch(
+            "aiperf.dataset.loader.accuracy_dataset_loader.plugins.get_metadata",
+            return_value={
+                "default_system_prompt": "Please reason step by step, "
+                "and put your final answer within \\boxed{}."
+            },
+        ):
+            conversations = loader._convert_to_conversations([problem])
+        turn = conversations[0].turns[0]
+        assert turn.raw_messages is not None
+        assert turn.raw_messages[0]["role"] == "system"
+        assert "reason step by step" in turn.raw_messages[0]["content"]
+
+    def test_no_system_prompt_when_neither_set(self) -> None:
+        loader = AccuracyDatasetLoader(
+            user_config=_make_user_config(system_prompt=None)
+        )
+        problem = _make_problem()
+        with patch(
+            "aiperf.dataset.loader.accuracy_dataset_loader.plugins.get_metadata",
+            return_value={},
+        ):
+            conversations = loader._convert_to_conversations([problem])
+        turn = conversations[0].turns[0]
+        assert turn.raw_messages is not None
+        roles = [m["role"] for m in turn.raw_messages]
+        assert "system" not in roles
+
+    def test_empty_string_metadata_default_treated_as_none(self) -> None:
+        """Empty-string metadata default is dropped (not injected as a
+        zero-length system message)."""
+        loader = AccuracyDatasetLoader(
+            user_config=_make_user_config(system_prompt=None)
+        )
+        problem = _make_problem()
+        with patch(
+            "aiperf.dataset.loader.accuracy_dataset_loader.plugins.get_metadata",
+            return_value={"default_system_prompt": ""},
+        ):
+            conversations = loader._convert_to_conversations([problem])
+        turn = conversations[0].turns[0]
+        roles = [m["role"] for m in turn.raw_messages]
+        assert "system" not in roles

--- a/tests/unit/accuracy/test_aime_benchmark.py
+++ b/tests/unit/accuracy/test_aime_benchmark.py
@@ -1,0 +1,442 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``AIMEBenchmark``.
+
+The HuggingFace dataset is mocked end-to-end so the suite is fully offline
+and deterministic. Coverage targets:
+
+1. Prompt construction (completions form): instruction, few-shots, CoT.
+2. Chat-message construction: lighteval-style multi-turn structure with
+   the instruction on the first user message only and ``\\boxed{}``
+   assistant primers.
+3. Few-shot sampling: order-stable, capped at dataset size, empty when
+   ``n_shots <= 0``.
+4. ``load_problems`` end-to-end: returns one ``BenchmarkProblem`` per row
+   with the right field shape (``raw_messages``, ``ground_truth``,
+   ``metadata.generation_size``, ``task``), and the ``tasks`` parameter
+   is correctly ignored.
+5. Pathological dataset rows: empty splits, very long problems, integer
+   answers stringified, unicode in problem text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aiperf.accuracy.benchmarks.aime import (
+    DEFAULT_GENERATION_SIZE,
+    INSTRUCTION_PREFIX,
+    TASK_NAME,
+    AIMEBenchmark,
+)
+from aiperf.accuracy.models import BenchmarkProblem
+from aiperf.common.config import EndpointConfig, UserConfig
+from aiperf.common.config.accuracy_config import AccuracyConfig
+from aiperf.plugin.enums import AccuracyBenchmarkType, EndpointType
+
+
+def _make_user_config() -> UserConfig:
+    return UserConfig(
+        endpoint=EndpointConfig(
+            model_names=["test-model"],
+            type=EndpointType.COMPLETIONS,
+            streaming=False,
+        ),
+        accuracy=AccuracyConfig(benchmark=AccuracyBenchmarkType.AIME),
+    )
+
+
+def _make_row(problem: str = "What is 1+1?", answer: int = 2) -> dict[str, Any]:
+    return {"Problem": problem, "Answer": answer}
+
+
+def _make_fake_dataset(rows: list[dict[str, Any]]) -> MagicMock:
+    """Return a MagicMock that quacks like a HuggingFace ``Dataset``.
+
+    Supports iteration (``for row in ds``), length (``len(ds)``), and
+    integer indexing (``ds[i]``) — the three operations the AIME loader
+    actually uses.
+    """
+    ds = MagicMock()
+    ds.__iter__ = MagicMock(side_effect=lambda: iter(rows))
+    ds.__len__ = MagicMock(return_value=len(rows))
+    ds.__getitem__ = MagicMock(side_effect=lambda i: rows[i])
+    return ds
+
+
+@pytest.fixture
+def bench() -> AIMEBenchmark:
+    return AIMEBenchmark(user_config=_make_user_config())
+
+
+class TestFormatPrompt:
+    """Flat-completions prompt construction."""
+
+    def test_instruction_prefix_is_present(self, bench: AIMEBenchmark) -> None:
+        prompt = bench._format_prompt(
+            _make_row("What is 5+5?", 10), few_shots=[], enable_cot=False
+        )
+        assert prompt.startswith(INSTRUCTION_PREFIX)
+
+    def test_problem_text_appears(self, bench: AIMEBenchmark) -> None:
+        prompt = bench._format_prompt(
+            _make_row("Compute 2^10.", 1024),
+            few_shots=[],
+            enable_cot=False,
+        )
+        assert "Compute 2^10." in prompt
+
+    def test_zero_shot_no_cot_ends_with_answer_marker(
+        self, bench: AIMEBenchmark
+    ) -> None:
+        prompt = bench._format_prompt(
+            _make_row("trivial", 1), few_shots=[], enable_cot=False
+        )
+        assert prompt.endswith("Answer:")
+        assert "step by step" not in prompt
+
+    def test_cot_inserts_step_by_step_before_answer(self, bench: AIMEBenchmark) -> None:
+        prompt = bench._format_prompt(
+            _make_row("trivial", 1), few_shots=[], enable_cot=True
+        )
+        assert "Let's think step by step" in prompt
+        assert prompt.endswith("Answer:")
+
+    def test_few_shot_examples_precede_test_problem(self, bench: AIMEBenchmark) -> None:
+        shot = bench._format_example(_make_row("FIRST", 1))
+        prompt = bench._format_prompt(
+            _make_row("SECOND", 2), few_shots=[shot], enable_cot=False
+        )
+        assert prompt.index("FIRST") < prompt.index("SECOND")
+
+    def test_few_shot_uses_boxed_answer(self, bench: AIMEBenchmark) -> None:
+        """Few-shot examples must show \\boxed{} so the model is primed
+        to emit the same format."""
+        shot = bench._format_example(_make_row("ex", 7))
+        prompt = bench._format_prompt(
+            _make_row("test", 8), few_shots=[shot], enable_cot=False
+        )
+        assert "\\boxed{7}" in prompt
+
+    def test_few_shot_does_not_use_boxed_for_test_query(
+        self, bench: AIMEBenchmark
+    ) -> None:
+        """The trailing test query has no boxed answer (the model must
+        produce one)."""
+        shot = bench._format_example(_make_row("ex", 7))
+        prompt = bench._format_prompt(
+            _make_row("test", 8), few_shots=[shot], enable_cot=False
+        )
+        # The "8" answer is the gold for the test query and must NOT appear
+        # in the prompt (would be cheating).
+        assert "\\boxed{8}" not in prompt
+
+
+class TestBuildChatMessages:
+    """lighteval-style multi-turn chat construction."""
+
+    def test_zero_shot_zero_cot_is_single_user_message(
+        self, bench: AIMEBenchmark
+    ) -> None:
+        msgs = bench._build_chat_messages(
+            _make_row("Q?", 1), few_shots=[], enable_cot=False
+        )
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+
+    def test_zero_shot_user_message_includes_instruction(
+        self, bench: AIMEBenchmark
+    ) -> None:
+        msgs = bench._build_chat_messages(
+            _make_row("Q?", 1), few_shots=[], enable_cot=False
+        )
+        assert "non-negative integer" in msgs[0]["content"]
+        assert "\\boxed" in msgs[0]["content"]
+
+    def test_cot_appends_step_by_step(self, bench: AIMEBenchmark) -> None:
+        msgs = bench._build_chat_messages(
+            _make_row("Q?", 1), few_shots=[], enable_cot=True
+        )
+        assert "step by step" in msgs[-1]["content"]
+
+    def test_few_shot_pairs_are_user_then_assistant(self, bench: AIMEBenchmark) -> None:
+        shots = [
+            bench._format_example(_make_row("A", 1)),
+            bench._format_example(_make_row("B", 2)),
+        ]
+        msgs = bench._build_chat_messages(
+            _make_row("C", 3), few_shots=shots, enable_cot=False
+        )
+        # Expected: user/assistant/user/assistant/user
+        assert [m["role"] for m in msgs] == [
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+            "user",
+        ]
+
+    def test_only_first_user_message_has_instruction(
+        self, bench: AIMEBenchmark
+    ) -> None:
+        shots = [
+            bench._format_example(_make_row("A", 1)),
+            bench._format_example(_make_row("B", 2)),
+        ]
+        msgs = bench._build_chat_messages(
+            _make_row("C", 3), few_shots=shots, enable_cot=False
+        )
+        user_messages = [m["content"] for m in msgs if m["role"] == "user"]
+        assert "non-negative integer" in user_messages[0]
+        for content in user_messages[1:]:
+            assert "non-negative integer" not in content
+
+    def test_assistant_messages_use_boxed_format(self, bench: AIMEBenchmark) -> None:
+        shots = [bench._format_example(_make_row("A", 7))]
+        msgs = bench._build_chat_messages(
+            _make_row("B", 8), few_shots=shots, enable_cot=False
+        )
+        assistant = [m for m in msgs if m["role"] == "assistant"]
+        assert assistant[0]["content"] == "\\boxed{7}"
+
+
+class TestFormatExample:
+    """Few-shot example formatting helper."""
+
+    def test_answer_is_stringified(self, bench: AIMEBenchmark) -> None:
+        ex = bench._format_example(_make_row("Q?", 42))
+        assert ex["answer"] == "42"
+        assert isinstance(ex["answer"], str)
+
+    def test_formatted_uses_boxed_answer(self, bench: AIMEBenchmark) -> None:
+        ex = bench._format_example(_make_row("Q?", 42))
+        assert "\\boxed{42}" in ex["formatted"]
+
+    def test_formatted_contains_problem_text(self, bench: AIMEBenchmark) -> None:
+        ex = bench._format_example(_make_row("MyProblem", 1))
+        assert "MyProblem" in ex["formatted"]
+
+
+class TestBuildFewShots:
+    """Few-shot sampling: order-stable, bounded, sequential."""
+
+    def test_zero_shots_returns_empty(self, bench: AIMEBenchmark) -> None:
+        ds = _make_fake_dataset([_make_row("a", 1), _make_row("b", 2)])
+        assert bench._build_few_shots(ds, n_shots=0) == []
+
+    def test_negative_shots_returns_empty(self, bench: AIMEBenchmark) -> None:
+        ds = _make_fake_dataset([_make_row("a", 1)])
+        assert bench._build_few_shots(ds, n_shots=-3) == []
+
+    def test_n_shots_clamped_to_dataset_size(self, bench: AIMEBenchmark) -> None:
+        ds = _make_fake_dataset([_make_row("only", 1)])
+        shots = bench._build_few_shots(ds, n_shots=5)
+        assert len(shots) == 1
+
+    def test_shots_drawn_from_start_in_order(self, bench: AIMEBenchmark) -> None:
+        rows = [_make_row(f"problem-{i}", i) for i in range(10)]
+        ds = _make_fake_dataset(rows)
+        shots = bench._build_few_shots(ds, n_shots=3)
+        assert [s["problem"] for s in shots] == [
+            "problem-0",
+            "problem-1",
+            "problem-2",
+        ]
+
+
+class TestLoadProblems:
+    """End-to-end ``load_problems`` with a mocked HuggingFace dataset."""
+
+    @pytest.mark.asyncio
+    async def test_returns_one_problem_per_row(self) -> None:
+        rows = [_make_row(f"q{i}", i) for i in range(5)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert len(problems) == 5
+        assert all(isinstance(p, BenchmarkProblem) for p in problems)
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_is_string_form_of_integer_answer(self) -> None:
+        rows = [_make_row("q", 42)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert problems[0].ground_truth == "42"
+        assert isinstance(problems[0].ground_truth, str)
+
+    @pytest.mark.asyncio
+    async def test_task_name_is_aime(self) -> None:
+        rows = [_make_row("q", 1)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert problems[0].task == TASK_NAME
+
+    @pytest.mark.asyncio
+    async def test_metadata_carries_default_generation_size(self) -> None:
+        rows = [_make_row("q", 1)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert problems[0].metadata["generation_size"] == DEFAULT_GENERATION_SIZE
+
+    @pytest.mark.asyncio
+    async def test_raw_messages_populated_for_chat_endpoint(self) -> None:
+        rows = [_make_row("q", 1)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert problems[0].raw_messages is not None
+        assert len(problems[0].raw_messages) >= 1
+        assert problems[0].raw_messages[0]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_few_shot_count_matches_n_shots(self) -> None:
+        rows = [_make_row(f"q{i}", i) for i in range(10)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=3, enable_cot=False
+            )
+        # With 3 few-shots, every problem's chat messages should have:
+        # 3 user + 3 assistant + 1 user = 7 messages.
+        assert len(problems[0].raw_messages) == 7
+
+    @pytest.mark.asyncio
+    async def test_tasks_argument_is_ignored(self) -> None:
+        """AIME has no subtasks; ``tasks=["foo"]`` must not filter or error."""
+        rows = [_make_row("a", 1), _make_row("b", 2)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            none_problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+            named_problems = await bench.load_problems(
+                tasks=["aime"], n_shots=0, enable_cot=False
+            )
+            unknown_problems = await bench.load_problems(
+                tasks=["does-not-exist"], n_shots=0, enable_cot=False
+            )
+        assert len(none_problems) == len(named_problems) == len(unknown_problems) == 2
+
+    @pytest.mark.asyncio
+    async def test_cot_propagates_to_every_problem(self) -> None:
+        rows = [_make_row(f"q{i}", i) for i in range(3)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(tasks=None, n_shots=0, enable_cot=True)
+        assert all("step by step" in p.prompt for p in problems)
+
+
+class TestPathologicalDatasetRows:
+    """Adversarial / boundary inputs that must not crash the loader."""
+
+    @pytest.mark.asyncio
+    async def test_empty_dataset_returns_empty_list(self) -> None:
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset([]),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert problems == []
+
+    @pytest.mark.asyncio
+    async def test_unicode_problem_text_preserved(self) -> None:
+        rows = [_make_row("Solve ∑₁ⁿ k² for n=10. ✓", 385)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert "∑₁ⁿ" in problems[0].prompt
+
+    @pytest.mark.asyncio
+    async def test_very_long_problem_text_does_not_crash(self) -> None:
+        long_problem = "Q. " + ("blah " * 50_000) + "Find x."
+        rows = [_make_row(long_problem, 1)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert len(problems) == 1
+        assert long_problem in problems[0].prompt
+
+    @pytest.mark.asyncio
+    async def test_zero_padded_three_digit_answer_stringifies_cleanly(
+        self,
+    ) -> None:
+        """AIME answers can be 0-999; some sources zero-pad. Our schema
+        uses Python ints, so str(7) == '7' (no padding). Document via test."""
+        rows = [_make_row("q", 7)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=0, enable_cot=False
+            )
+        assert problems[0].ground_truth == "7"
+
+    @pytest.mark.asyncio
+    async def test_n_shots_larger_than_dataset_clamps(self) -> None:
+        rows = [_make_row("only-one", 1)]
+        with patch(
+            "aiperf.accuracy.benchmarks.aime.load_dataset",
+            return_value=_make_fake_dataset(rows),
+        ):
+            bench = AIMEBenchmark(user_config=_make_user_config())
+            problems = await bench.load_problems(
+                tasks=None, n_shots=999, enable_cot=False
+            )
+        # 1 few-shot pair (user + assistant) + 1 main user = 3 messages.
+        assert len(problems[0].raw_messages) == 3

--- a/tests/unit/accuracy/test_aime_benchmark.py
+++ b/tests/unit/accuracy/test_aime_benchmark.py
@@ -1,23 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for ``AIMEBenchmark``.
+"""Unit tests for ``AIMEBenchmark`` after trt-llm reference alignment.
 
-The HuggingFace dataset is mocked end-to-end so the suite is fully offline
-and deterministic. Coverage targets:
-
-1. Prompt construction (completions form): instruction, few-shots, CoT.
-2. Chat-message construction: lighteval-style multi-turn structure with
-   the instruction on the first user message only and ``\\boxed{}``
-   assistant primers.
-3. Few-shot sampling: order-stable, capped at dataset size, empty when
-   ``n_shots <= 0``.
-4. ``load_problems`` end-to-end: returns one ``BenchmarkProblem`` per row
-   with the right field shape (``raw_messages``, ``ground_truth``,
-   ``metadata.generation_size``, ``task``), and the ``tasks`` parameter
-   is correctly ignored.
-5. Pathological dataset rows: empty splits, very long problems, integer
-   answers stringified, unicode in problem text.
+The expected prompt strings in this suite are byte-equal to the output
+of the recipe's ``AIMETemplate.generate_output``
+(``trt-llm-benchmark-recipe/src/accuracy/aime/template.py``) — any
+divergence between aiperf and the reference would be caught here.
 """
 
 from __future__ import annotations
@@ -28,8 +17,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aiperf.accuracy.benchmarks.aime import (
+    COT_SUFFIX,
     DEFAULT_GENERATION_SIZE,
-    INSTRUCTION_PREFIX,
+    DEFAULT_N_SHOTS,
+    FEW_SHOT_HEADER,
+    MAX_N_SHOTS,
+    NO_COT_SUFFIX,
     TASK_NAME,
     AIMEBenchmark,
 )
@@ -50,17 +43,15 @@ def _make_user_config() -> UserConfig:
     )
 
 
-def _make_row(problem: str = "What is 1+1?", answer: int = 2) -> dict[str, Any]:
-    return {"Problem": problem, "Answer": answer}
+def _make_row(
+    problem: str = "What is 1+1?",
+    answer: int = 2,
+    solution: str = "Add the numbers.",
+) -> dict[str, Any]:
+    return {"Problem": problem, "Answer": answer, "Solution": solution}
 
 
 def _make_fake_dataset(rows: list[dict[str, Any]]) -> MagicMock:
-    """Return a MagicMock that quacks like a HuggingFace ``Dataset``.
-
-    Supports iteration (``for row in ds``), length (``len(ds)``), and
-    integer indexing (``ds[i]``) — the three operations the AIME loader
-    actually uses.
-    """
     ds = MagicMock()
     ds.__iter__ = MagicMock(side_effect=lambda: iter(rows))
     ds.__len__ = MagicMock(return_value=len(rows))
@@ -73,157 +64,128 @@ def bench() -> AIMEBenchmark:
     return AIMEBenchmark(user_config=_make_user_config())
 
 
+class TestDefaults:
+    """Defaults must mirror the trt-llm recipe."""
+
+    def test_n_shots_default_is_8(self) -> None:
+        assert DEFAULT_N_SHOTS == 8
+
+    def test_max_n_shots_is_8(self) -> None:
+        """Recipe asserts ``n_shots <= 8`` — we mirror that cap."""
+        assert MAX_N_SHOTS == 8
+
+    def test_generation_size_default_is_32k(self) -> None:
+        """Recipe runs unbounded; lighteval-aligned tasks use 32768."""
+        assert DEFAULT_GENERATION_SIZE == 32768
+
+
 class TestFormatPrompt:
-    """Flat-completions prompt construction."""
+    """Flat prompt must be byte-equal to recipe ``AIMETemplate.generate_output``."""
 
-    def test_instruction_prefix_is_present(self, bench: AIMEBenchmark) -> None:
-        prompt = bench._format_prompt(
-            _make_row("What is 5+5?", 10), few_shots=[], enable_cot=False
+    def test_zero_shot_no_cot_matches_recipe(self, bench: AIMEBenchmark) -> None:
+        """Zero shots, CoT off — recipe emits no header, no examples,
+        and the no-CoT suffix after **Answer**:."""
+        row = _make_row(problem="Compute 2+2.", answer=4)
+        prompt = bench._format_prompt(row, few_shots=[], enable_cot=False)
+        expected = (
+            "**Problem**: Compute 2+2.\n"
+            "**Answer**: \n"
+            "\n"
+            "No explanation needed. Just return a number."
         )
-        assert prompt.startswith(INSTRUCTION_PREFIX)
+        assert prompt == expected
 
-    def test_problem_text_appears(self, bench: AIMEBenchmark) -> None:
-        prompt = bench._format_prompt(
-            _make_row("Compute 2^10.", 1024),
-            few_shots=[],
-            enable_cot=False,
+    def test_zero_shot_with_cot_matches_recipe(self, bench: AIMEBenchmark) -> None:
+        row = _make_row(problem="Compute 2+2.", answer=4)
+        prompt = bench._format_prompt(row, few_shots=[], enable_cot=True)
+        expected = (
+            "**Problem**: Compute 2+2.\n**Answer**: \n\nLet's think step-by-step."
         )
-        assert "Compute 2^10." in prompt
+        assert prompt == expected
 
-    def test_zero_shot_no_cot_ends_with_answer_marker(
+    def test_one_shot_with_cot_includes_solution(self, bench: AIMEBenchmark) -> None:
+        """Recipe includes **Solution**: in few-shot blocks ONLY when CoT is on."""
+        shot = bench._format_example(
+            _make_row(problem="What is 1+1?", answer=2, solution="Trivial.")
+        )
+        row = _make_row(problem="What is 2+2?", answer=4)
+        prompt = bench._format_prompt(row, few_shots=[shot], enable_cot=True)
+        expected = (
+            FEW_SHOT_HEADER
+            + "**Problem**: What is 1+1?\n"
+            + "**Solution**: Trivial.\n"
+            + "**Answer**: 2\n"
+            + "\n"
+            + "**Problem**: What is 2+2?\n"
+            + "**Answer**: \n"
+            + "\n"
+            + COT_SUFFIX
+        )
+        assert prompt == expected
+
+    def test_one_shot_no_cot_omits_solution(self, bench: AIMEBenchmark) -> None:
+        shot = bench._format_example(
+            _make_row(problem="What is 1+1?", answer=2, solution="Trivial.")
+        )
+        row = _make_row(problem="What is 2+2?", answer=4)
+        prompt = bench._format_prompt(row, few_shots=[shot], enable_cot=False)
+        # No **Solution**: line in few-shot block
+        assert "**Solution**:" not in prompt
+        # No-CoT suffix at the end
+        assert prompt.endswith(NO_COT_SUFFIX)
+
+    def test_zero_shot_emits_no_header(self, bench: AIMEBenchmark) -> None:
+        """When n_shots=0 the recipe emits no header at all (the
+        ``FEW_SHOT_HEADER`` only appears for n_shots > 0)."""
+        prompt = bench._format_prompt(_make_row(), few_shots=[], enable_cot=False)
+        assert FEW_SHOT_HEADER not in prompt
+
+    def test_few_shot_header_present_when_shots_present(
         self, bench: AIMEBenchmark
     ) -> None:
-        prompt = bench._format_prompt(
-            _make_row("trivial", 1), few_shots=[], enable_cot=False
-        )
-        assert prompt.endswith("Answer:")
-        assert "step by step" not in prompt
+        shot = bench._format_example(_make_row())
+        prompt = bench._format_prompt(_make_row(), few_shots=[shot], enable_cot=False)
+        assert prompt.startswith(FEW_SHOT_HEADER)
 
-    def test_cot_inserts_step_by_step_before_answer(self, bench: AIMEBenchmark) -> None:
-        prompt = bench._format_prompt(
-            _make_row("trivial", 1), few_shots=[], enable_cot=True
-        )
-        assert "Let's think step by step" in prompt
-        assert prompt.endswith("Answer:")
 
-    def test_few_shot_examples_precede_test_problem(self, bench: AIMEBenchmark) -> None:
-        shot = bench._format_example(_make_row("FIRST", 1))
-        prompt = bench._format_prompt(
-            _make_row("SECOND", 2), few_shots=[shot], enable_cot=False
-        )
-        assert prompt.index("FIRST") < prompt.index("SECOND")
+class TestFormatExample:
+    def test_collects_problem_solution_answer(self, bench: AIMEBenchmark) -> None:
+        ex = bench._format_example(_make_row(problem="Q?", answer=42, solution="S"))
+        assert ex["problem"] == "Q?"
+        assert ex["solution"] == "S"
+        assert ex["answer"] == "42"
+        assert isinstance(ex["answer"], str)
 
-    def test_few_shot_uses_boxed_answer(self, bench: AIMEBenchmark) -> None:
-        """Few-shot examples must show \\boxed{} so the model is primed
-        to emit the same format."""
-        shot = bench._format_example(_make_row("ex", 7))
-        prompt = bench._format_prompt(
-            _make_row("test", 8), few_shots=[shot], enable_cot=False
-        )
-        assert "\\boxed{7}" in prompt
-
-    def test_few_shot_does_not_use_boxed_for_test_query(
-        self, bench: AIMEBenchmark
-    ) -> None:
-        """The trailing test query has no boxed answer (the model must
-        produce one)."""
-        shot = bench._format_example(_make_row("ex", 7))
-        prompt = bench._format_prompt(
-            _make_row("test", 8), few_shots=[shot], enable_cot=False
-        )
-        # The "8" answer is the gold for the test query and must NOT appear
-        # in the prompt (would be cheating).
-        assert "\\boxed{8}" not in prompt
+    def test_missing_solution_field_handled(self, bench: AIMEBenchmark) -> None:
+        """Some upstream rows omit Solution; we tolerate that with empty."""
+        row = {"Problem": "Q?", "Answer": 1}
+        ex = bench._format_example(row)
+        assert ex["solution"] == ""
 
 
 class TestBuildChatMessages:
-    """lighteval-style multi-turn chat construction."""
+    """Chat-message form is the recipe's flat prompt wrapped in one user message.
+
+    The trt-llm recipe sends AIME prompts as a single string to DeepEval
+    (no multi-turn conversation), so our chat representation does the
+    same: one user message containing the recipe-rendered prompt.
+    """
 
     def test_zero_shot_zero_cot_is_single_user_message(
         self, bench: AIMEBenchmark
     ) -> None:
-        msgs = bench._build_chat_messages(
-            _make_row("Q?", 1), few_shots=[], enable_cot=False
-        )
+        msgs = bench._build_chat_messages(_make_row(), few_shots=[], enable_cot=False)
         assert len(msgs) == 1
         assert msgs[0]["role"] == "user"
 
-    def test_zero_shot_user_message_includes_instruction(
-        self, bench: AIMEBenchmark
-    ) -> None:
-        msgs = bench._build_chat_messages(
-            _make_row("Q?", 1), few_shots=[], enable_cot=False
-        )
-        assert "non-negative integer" in msgs[0]["content"]
-        assert "\\boxed" in msgs[0]["content"]
-
-    def test_cot_appends_step_by_step(self, bench: AIMEBenchmark) -> None:
-        msgs = bench._build_chat_messages(
-            _make_row("Q?", 1), few_shots=[], enable_cot=True
-        )
-        assert "step by step" in msgs[-1]["content"]
-
-    def test_few_shot_pairs_are_user_then_assistant(self, bench: AIMEBenchmark) -> None:
-        shots = [
-            bench._format_example(_make_row("A", 1)),
-            bench._format_example(_make_row("B", 2)),
-        ]
-        msgs = bench._build_chat_messages(
-            _make_row("C", 3), few_shots=shots, enable_cot=False
-        )
-        # Expected: user/assistant/user/assistant/user
-        assert [m["role"] for m in msgs] == [
-            "user",
-            "assistant",
-            "user",
-            "assistant",
-            "user",
-        ]
-
-    def test_only_first_user_message_has_instruction(
-        self, bench: AIMEBenchmark
-    ) -> None:
-        shots = [
-            bench._format_example(_make_row("A", 1)),
-            bench._format_example(_make_row("B", 2)),
-        ]
-        msgs = bench._build_chat_messages(
-            _make_row("C", 3), few_shots=shots, enable_cot=False
-        )
-        user_messages = [m["content"] for m in msgs if m["role"] == "user"]
-        assert "non-negative integer" in user_messages[0]
-        for content in user_messages[1:]:
-            assert "non-negative integer" not in content
-
-    def test_assistant_messages_use_boxed_format(self, bench: AIMEBenchmark) -> None:
-        shots = [bench._format_example(_make_row("A", 7))]
-        msgs = bench._build_chat_messages(
-            _make_row("B", 8), few_shots=shots, enable_cot=False
-        )
-        assistant = [m for m in msgs if m["role"] == "assistant"]
-        assert assistant[0]["content"] == "\\boxed{7}"
-
-
-class TestFormatExample:
-    """Few-shot example formatting helper."""
-
-    def test_answer_is_stringified(self, bench: AIMEBenchmark) -> None:
-        ex = bench._format_example(_make_row("Q?", 42))
-        assert ex["answer"] == "42"
-        assert isinstance(ex["answer"], str)
-
-    def test_formatted_uses_boxed_answer(self, bench: AIMEBenchmark) -> None:
-        ex = bench._format_example(_make_row("Q?", 42))
-        assert "\\boxed{42}" in ex["formatted"]
-
-    def test_formatted_contains_problem_text(self, bench: AIMEBenchmark) -> None:
-        ex = bench._format_example(_make_row("MyProblem", 1))
-        assert "MyProblem" in ex["formatted"]
+    def test_chat_content_equals_flat_prompt(self, bench: AIMEBenchmark) -> None:
+        row = _make_row(problem="Sample.", answer=7)
+        flat = bench._format_prompt(row, few_shots=[], enable_cot=True)
+        msgs = bench._build_chat_messages(row, few_shots=[], enable_cot=True)
+        assert msgs[0]["content"] == flat
 
 
 class TestBuildFewShots:
-    """Few-shot sampling: order-stable, bounded, sequential."""
-
     def test_zero_shots_returns_empty(self, bench: AIMEBenchmark) -> None:
         ds = _make_fake_dataset([_make_row("a", 1), _make_row("b", 2)])
         assert bench._build_few_shots(ds, n_shots=0) == []
@@ -249,8 +211,6 @@ class TestBuildFewShots:
 
 
 class TestLoadProblems:
-    """End-to-end ``load_problems`` with a mocked HuggingFace dataset."""
-
     @pytest.mark.asyncio
     async def test_returns_one_problem_per_row(self) -> None:
         rows = [_make_row(f"q{i}", i) for i in range(5)]
@@ -306,7 +266,7 @@ class TestLoadProblems:
         assert problems[0].metadata["generation_size"] == DEFAULT_GENERATION_SIZE
 
     @pytest.mark.asyncio
-    async def test_raw_messages_populated_for_chat_endpoint(self) -> None:
+    async def test_raw_messages_populated(self) -> None:
         rows = [_make_row("q", 1)]
         with patch(
             "aiperf.accuracy.benchmarks.aime.load_dataset",
@@ -317,27 +277,19 @@ class TestLoadProblems:
                 tasks=None, n_shots=0, enable_cot=False
             )
         assert problems[0].raw_messages is not None
-        assert len(problems[0].raw_messages) >= 1
+        assert len(problems[0].raw_messages) == 1
         assert problems[0].raw_messages[0]["role"] == "user"
 
     @pytest.mark.asyncio
-    async def test_few_shot_count_matches_n_shots(self) -> None:
-        rows = [_make_row(f"q{i}", i) for i in range(10)]
-        with patch(
-            "aiperf.accuracy.benchmarks.aime.load_dataset",
-            return_value=_make_fake_dataset(rows),
-        ):
-            bench = AIMEBenchmark(user_config=_make_user_config())
-            problems = await bench.load_problems(
-                tasks=None, n_shots=3, enable_cot=False
-            )
-        # With 3 few-shots, every problem's chat messages should have:
-        # 3 user + 3 assistant + 1 user = 7 messages.
-        assert len(problems[0].raw_messages) == 7
+    async def test_max_n_shots_enforced(self) -> None:
+        """The recipe asserts ``n_shots <= 8``; we raise ``ValueError``
+        rather than silently accepting more."""
+        bench = AIMEBenchmark(user_config=_make_user_config())
+        with pytest.raises(ValueError, match="at most 8"):
+            await bench.load_problems(tasks=None, n_shots=9, enable_cot=False)
 
     @pytest.mark.asyncio
     async def test_tasks_argument_is_ignored(self) -> None:
-        """AIME has no subtasks; ``tasks=["foo"]`` must not filter or error."""
         rows = [_make_row("a", 1), _make_row("b", 2)]
         with patch(
             "aiperf.accuracy.benchmarks.aime.load_dataset",
@@ -350,10 +302,7 @@ class TestLoadProblems:
             named_problems = await bench.load_problems(
                 tasks=["aime"], n_shots=0, enable_cot=False
             )
-            unknown_problems = await bench.load_problems(
-                tasks=["does-not-exist"], n_shots=0, enable_cot=False
-            )
-        assert len(none_problems) == len(named_problems) == len(unknown_problems) == 2
+        assert len(none_problems) == len(named_problems) == 2
 
     @pytest.mark.asyncio
     async def test_cot_propagates_to_every_problem(self) -> None:
@@ -364,12 +313,11 @@ class TestLoadProblems:
         ):
             bench = AIMEBenchmark(user_config=_make_user_config())
             problems = await bench.load_problems(tasks=None, n_shots=0, enable_cot=True)
-        assert all("step by step" in p.prompt for p in problems)
+        # Every prompt ends with the CoT suffix.
+        assert all(p.prompt.endswith(COT_SUFFIX) for p in problems)
 
 
 class TestPathologicalDatasetRows:
-    """Adversarial / boundary inputs that must not crash the loader."""
-
     @pytest.mark.asyncio
     async def test_empty_dataset_returns_empty_list(self) -> None:
         with patch(
@@ -414,8 +362,6 @@ class TestPathologicalDatasetRows:
     async def test_zero_padded_three_digit_answer_stringifies_cleanly(
         self,
     ) -> None:
-        """AIME answers can be 0-999; some sources zero-pad. Our schema
-        uses Python ints, so str(7) == '7' (no padding). Document via test."""
         rows = [_make_row("q", 7)]
         with patch(
             "aiperf.accuracy.benchmarks.aime.load_dataset",
@@ -426,17 +372,3 @@ class TestPathologicalDatasetRows:
                 tasks=None, n_shots=0, enable_cot=False
             )
         assert problems[0].ground_truth == "7"
-
-    @pytest.mark.asyncio
-    async def test_n_shots_larger_than_dataset_clamps(self) -> None:
-        rows = [_make_row("only-one", 1)]
-        with patch(
-            "aiperf.accuracy.benchmarks.aime.load_dataset",
-            return_value=_make_fake_dataset(rows),
-        ):
-            bench = AIMEBenchmark(user_config=_make_user_config())
-            problems = await bench.load_problems(
-                tasks=None, n_shots=999, enable_cot=False
-            )
-        # 1 few-shot pair (user + assistant) + 1 main user = 3 messages.
-        assert len(problems[0].raw_messages) == 3

--- a/tests/unit/accuracy/test_benchmark_loader.py
+++ b/tests/unit/accuracy/test_benchmark_loader.py
@@ -29,8 +29,14 @@ def _make_problem() -> BenchmarkProblem:
 
 @pytest.mark.asyncio
 class TestLoadBenchmarkProblemsNShots:
-    async def test_uses_explicit_n_shots_without_consulting_metadata(self) -> None:
-        """When n_shots is set explicitly, plugin metadata is never consulted."""
+    async def test_explicit_n_shots_passes_through_unchanged(self) -> None:
+        """When ``n_shots`` is set explicitly, it's forwarded verbatim.
+
+        The benchmark loader still reads metadata once (to resolve
+        ``default_enable_cot``), so we don't assert the mock was
+        un-called — we assert that metadata's ``default_n_shots`` is
+        ignored when the user provides their own value.
+        """
         user_config = _make_user_config(n_shots=3)
         problem = _make_problem()
 
@@ -45,15 +51,77 @@ class TestLoadBenchmarkProblemsNShots:
                 "aiperf.accuracy.benchmark_loader.plugins.get_class",
                 return_value=mock_cls,
             ),
-            patch("aiperf.accuracy.benchmark_loader.plugins.get_metadata") as mock_meta,
+            patch(
+                "aiperf.accuracy.benchmark_loader.plugins.get_metadata",
+                # Metadata claims default_n_shots=99; user said 3, so 3 wins.
+                return_value={"default_n_shots": 99},
+            ),
         ):
             result = await load_benchmark_problems(user_config)
 
-        mock_meta.assert_not_called()
         mock_benchmark.load_problems.assert_awaited_once_with(
             tasks=None, n_shots=3, enable_cot=False
         )
         assert result == [problem]
+
+    async def test_metadata_default_enable_cot_used_when_unset(self) -> None:
+        """When ``enable_cot`` is None, the benchmark's
+        ``default_enable_cot`` from plugin metadata is honored."""
+        user_config = _make_user_config(n_shots=0)
+        # AccuracyConfig.enable_cot defaults to None now; explicitly None.
+        user_config.accuracy.enable_cot = None
+        problem = _make_problem()
+
+        mock_benchmark = AsyncMock()
+        mock_benchmark.load_problems = AsyncMock(return_value=[problem])
+
+        def mock_cls(**_kwargs):
+            return mock_benchmark
+
+        with (
+            patch(
+                "aiperf.accuracy.benchmark_loader.plugins.get_class",
+                return_value=mock_cls,
+            ),
+            patch(
+                "aiperf.accuracy.benchmark_loader.plugins.get_metadata",
+                return_value={"default_enable_cot": True},
+            ),
+        ):
+            await load_benchmark_problems(user_config)
+
+        mock_benchmark.load_problems.assert_awaited_once_with(
+            tasks=None, n_shots=0, enable_cot=True
+        )
+
+    async def test_explicit_enable_cot_overrides_metadata(self) -> None:
+        """When the user explicitly sets ``enable_cot`` (True or False),
+        the metadata default is ignored."""
+        user_config = _make_user_config(n_shots=0)
+        user_config.accuracy.enable_cot = False
+        problem = _make_problem()
+
+        mock_benchmark = AsyncMock()
+        mock_benchmark.load_problems = AsyncMock(return_value=[problem])
+
+        def mock_cls(**_kwargs):
+            return mock_benchmark
+
+        with (
+            patch(
+                "aiperf.accuracy.benchmark_loader.plugins.get_class",
+                return_value=mock_cls,
+            ),
+            patch(
+                "aiperf.accuracy.benchmark_loader.plugins.get_metadata",
+                return_value={"default_enable_cot": True},
+            ),
+        ):
+            await load_benchmark_problems(user_config)
+
+        mock_benchmark.load_problems.assert_awaited_once_with(
+            tasks=None, n_shots=0, enable_cot=False
+        )
 
     async def test_falls_back_to_default_n_shots_from_metadata(self) -> None:
         """When n_shots is None, default_n_shots from plugin metadata is used."""

--- a/tests/unit/accuracy/test_math_grader.py
+++ b/tests/unit/accuracy/test_math_grader.py
@@ -1,0 +1,385 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``MathGrader``.
+
+Coverage targets the three layers separately:
+
+1. Pure helpers (``_extract_last_boxed``, ``_extract_last_number``,
+   ``_normalize``, ``_to_fraction``) — exhaustive parametrized cases.
+2. ``MathGrader._extract_with_flag`` — extraction priority and the
+   ``unparsed`` flag semantics.
+3. ``MathGrader.grade`` — end-to-end correctness, including adversarial
+   responses that try to fool the grader (decoy numbers, multiple boxes,
+   "the answer is X — just kidding, it's Y" patterns, unicode, empty,
+   whitespace-only).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest import param
+
+from aiperf.accuracy.graders.math import (
+    MathGrader,
+    _extract_last_boxed,
+    _extract_last_number,
+    _normalize,
+    _to_fraction,
+)
+from aiperf.common.config import EndpointConfig, UserConfig
+from aiperf.common.config.accuracy_config import AccuracyConfig
+from aiperf.plugin.enums import AccuracyBenchmarkType, EndpointType
+
+
+def _make_user_config() -> UserConfig:
+    return UserConfig(
+        endpoint=EndpointConfig(
+            model_names=["test-model"],
+            type=EndpointType.COMPLETIONS,
+            streaming=False,
+        ),
+        accuracy=AccuracyConfig(benchmark=AccuracyBenchmarkType.AIME),
+    )
+
+
+@pytest.fixture
+def grader() -> MathGrader:
+    return MathGrader(user_config=_make_user_config())
+
+
+class TestExtractLastBoxed:
+    """``_extract_last_boxed`` — balanced-brace LaTeX extraction."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            param("\\boxed{42}", "42", id="simple-int"),
+            param("Some prose. \\boxed{42}", "42", id="prose-prefix"),
+            param("\\boxed{42} and more", "42", id="prose-suffix"),
+            param("\\boxed{1}\\boxed{2}\\boxed{3}", "3", id="multiple-takes-last"),
+            param(
+                "\\boxed{\\frac{1}{2}}",
+                "\\frac{1}{2}",
+                id="nested-frac",
+            ),
+            param(
+                "\\boxed{a\\cdot b^{n+1}}",
+                "a\\cdot b^{n+1}",
+                id="nested-superscript",
+            ),
+            param("\\boxed{}", "", id="empty-box"),
+            param("no box here", None, id="no-box"),
+            param("", None, id="empty-input"),
+        ],
+    )  # fmt: skip
+    def test_extract_last_boxed(self, text: str, expected: str | None) -> None:
+        assert _extract_last_boxed(text) == expected
+
+    def test_extract_last_boxed_unbalanced_returns_none(self) -> None:
+        assert _extract_last_boxed("\\boxed{42") is None
+        assert _extract_last_boxed("\\boxed{\\frac{1}{2}") is None
+
+    def test_extract_last_boxed_takes_truly_last_with_dec(self) -> None:
+        text = "First try \\boxed{99}, but actually the answer is \\boxed{42}."
+        assert _extract_last_boxed(text) == "42"
+
+
+class TestExtractLastNumber:
+    """``_extract_last_number`` — last numeric literal in text."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            param("42", "42", id="bare-int"),
+            param("the answer is 42", "42", id="trailing-int"),
+            param("3.14 then 2.71", "2.71", id="multiple-decimals"),
+            param("1/2", "1/2", id="ratio"),
+            param("-7 and -3", "-3", id="negatives"),
+            param("price: $99.99 plus tax", "99.99", id="dollar-prefix"),
+            param("answer is 42.", "42", id="trailing-period-not-decimal"),
+            param("no numbers here", None, id="no-numbers"),
+            param("", None, id="empty"),
+        ],
+    )  # fmt: skip
+    def test_extract_last_number(self, text: str, expected: str | None) -> None:
+        assert _extract_last_number(text) == expected
+
+
+class TestNormalize:
+    """``_normalize`` — pre-comparison string canonicalization."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            param("42", "42", id="int-passthrough"),
+            param(" 42 ", "42", id="whitespace-stripped"),
+            param("$42$", "42", id="dollar-strip"),
+            param("$\\boxed{42}$", "\\boxed{42}", id="dollars-around-boxed"),
+            param("\\dfrac{1}{2}", "(1)/(2)", id="dfrac-collapsed"),
+            param("\\tfrac{1}{2}", "(1)/(2)", id="tfrac-collapsed"),
+            param("\\frac{3}{4}", "(3)/(4)", id="frac-expanded"),
+            param("\\left( 1 \\right)", "(1)", id="left-right-stripped"),
+            param("\\text{42}", "42", id="text-wrapper-stripped"),
+            param("\\mathrm{abc}", "abc", id="mathrm-wrapper-stripped"),
+            param("42.", "42", id="trailing-period"),
+            param("42,", "42", id="trailing-comma"),
+            param("1 / 2", "1/2", id="interior-whitespace"),
+            param("X", "X", id="case-preserved"),
+            param("", "", id="empty"),
+        ],
+    )  # fmt: skip
+    def test_normalize(self, raw: str, expected: str) -> None:
+        assert _normalize(raw) == expected
+
+    def test_normalize_idempotent(self) -> None:
+        once = _normalize("$\\dfrac{1}{2}$.")
+        twice = _normalize(once)
+        assert once == twice
+
+
+class TestToFraction:
+    """``_to_fraction`` — numeric-literal parsing."""
+
+    @pytest.mark.parametrize(
+        "raw,expected_numerator,expected_denominator",
+        [
+            param("42", 42, 1, id="int"),
+            param("-7", -7, 1, id="negative-int"),
+            param("0", 0, 1, id="zero"),
+            param("3.14", 157, 50, id="decimal"),  # 314/100 reduces to 157/50
+            param("1/2", 1, 2, id="ratio"),
+            param("-3/4", -3, 4, id="negative-ratio"),
+            param("(1)/(2)", 1, 2, id="parenthesized-ratio"),
+        ],
+    )  # fmt: skip
+    def test_to_fraction_parses(
+        self, raw: str, expected_numerator: int, expected_denominator: int
+    ) -> None:
+        result = _to_fraction(raw)
+        assert result is not None
+        assert result.numerator == expected_numerator
+        assert result.denominator == expected_denominator
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            param("", id="empty"),
+            param("abc", id="alpha"),
+            param("x+1", id="expression"),
+            param("1/0", id="div-by-zero"),
+            param("\\sqrt{2}", id="latex-command"),
+        ],
+    )  # fmt: skip
+    def test_to_fraction_rejects(self, raw: str) -> None:
+        assert _to_fraction(raw) is None
+
+
+class TestExtractWithFlag:
+    """Extraction priority and ``unparsed`` semantics."""
+
+    def test_boxed_is_primary(self, grader: MathGrader) -> None:
+        answer, unparsed = grader._extract_with_flag("Reasoning... \\boxed{42}")
+        assert answer == "42"
+        assert unparsed is False
+
+    def test_boxed_overrides_decoy_numbers(self, grader: MathGrader) -> None:
+        answer, unparsed = grader._extract_with_flag(
+            "I considered 99 and 11, but \\boxed{42}"
+        )
+        assert answer == "42"
+        assert unparsed is False
+
+    def test_phrase_fallback_when_no_box(self, grader: MathGrader) -> None:
+        answer, unparsed = grader._extract_with_flag(
+            "After careful thought, the answer is 42."
+        )
+        assert answer == "42"
+        assert unparsed is True
+
+    def test_phrase_recurses_into_boxed(self, grader: MathGrader) -> None:
+        answer, unparsed = grader._extract_with_flag("the answer is \\boxed{42}")
+        assert answer == "42"
+        assert unparsed is False
+
+    def test_last_number_fallback(self, grader: MathGrader) -> None:
+        answer, unparsed = grader._extract_with_flag("I think it might be 99 or 42")
+        assert answer == "42"
+        assert unparsed is True
+
+    def test_empty_response_marked_unparsed(self, grader: MathGrader) -> None:
+        answer, unparsed = grader._extract_with_flag("")
+        assert answer == ""
+        assert unparsed is True
+
+    def test_whitespace_only_response_marked_unparsed(self, grader: MathGrader) -> None:
+        answer, unparsed = grader._extract_with_flag("   \n\t  ")
+        assert unparsed is True
+
+    def test_no_numbers_falls_through_to_raw(self, grader: MathGrader) -> None:
+        answer, unparsed = grader._extract_with_flag("I don't know.")
+        assert unparsed is True
+        assert "don't know" in answer
+
+
+class TestGradeNumeric:
+    """``MathGrader.grade`` — numeric equivalence."""
+
+    @pytest.mark.asyncio
+    async def test_boxed_int_match(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{42}", "42")
+        assert result.correct is True
+        assert result.unparsed is False
+        assert result.confidence == 1.0
+        assert result.extracted_answer == "42"
+
+    @pytest.mark.asyncio
+    async def test_boxed_int_mismatch(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{99}", "42")
+        assert result.correct is False
+        assert result.unparsed is False
+        assert result.confidence == 0.0
+
+    @pytest.mark.asyncio
+    async def test_decimal_matches_fraction(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{0.5}", "1/2")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_dfrac_matches_decimal(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{\\dfrac{1}{2}}", "0.5")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_negative_match(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{-7}", "-7")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_zero_match(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{0}", "0")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_dollar_wrapped_match(self, grader: MathGrader) -> None:
+        result = await grader.grade("$\\boxed{42}$", "42")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_left_right_stripped_match(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{\\left(\\dfrac{1}{2}\\right)}", "1/2")
+        assert result.correct is True
+
+
+class TestGradeAdversarial:
+    """Pathological inputs that should NOT confuse the grader."""
+
+    @pytest.mark.asyncio
+    async def test_decoy_number_before_box(self, grader: MathGrader) -> None:
+        """Earlier numbers must not override a later \\boxed{}."""
+        response = "Initially I thought 99, but recomputing gives \\boxed{42}."
+        result = await grader.grade(response, "42")
+        assert result.correct is True
+        assert result.unparsed is False
+
+    @pytest.mark.asyncio
+    async def test_multiple_boxes_takes_last(self, grader: MathGrader) -> None:
+        """When the model emits multiple boxes, the last one is final."""
+        response = "Try \\boxed{99}. Wait, actually \\boxed{42}."
+        result = await grader.grade(response, "42")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_correct_phrase_but_wrong_box(self, grader: MathGrader) -> None:
+        """If both phrase and box are present, box wins (not phrase tail)."""
+        response = "the answer is 42, oops I mean \\boxed{99}"
+        result = await grader.grade(response, "42")
+        assert result.correct is False
+
+    @pytest.mark.asyncio
+    async def test_adjacent_text_does_not_pollute(self, grader: MathGrader) -> None:
+        result = await grader.grade(
+            "Therefore, after computing, \\boxed{42} is the answer.", "42"
+        )
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_unicode_response_does_not_crash(self, grader: MathGrader) -> None:
+        result = await grader.grade("∴ \\boxed{42} ✓", "42")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_very_long_response(self, grader: MathGrader) -> None:
+        """A long response should still extract the trailing box."""
+        prefix = "Step. " * 5000
+        result = await grader.grade(prefix + "\\boxed{42}", "42")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_empty_response_is_incorrect_unparsed(
+        self, grader: MathGrader
+    ) -> None:
+        result = await grader.grade("", "42")
+        assert result.correct is False
+        assert result.unparsed is True
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_response_is_incorrect(
+        self, grader: MathGrader
+    ) -> None:
+        result = await grader.grade("   \n\n  \t  ", "42")
+        assert result.correct is False
+        assert result.unparsed is True
+
+    @pytest.mark.asyncio
+    async def test_empty_box_is_incorrect_but_parsed(self, grader: MathGrader) -> None:
+        """The model followed format (boxed) but provided no content."""
+        result = await grader.grade("\\boxed{}", "42")
+        assert result.correct is False
+        assert result.unparsed is False
+
+    @pytest.mark.asyncio
+    async def test_unbalanced_box_falls_through(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{42 trailing", "42")
+        assert result.unparsed is True
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_phrase_with_negation(self, grader: MathGrader) -> None:
+        """Adversarial: 'the answer is NOT 99' — we still grab 99 as a fallback,
+        but unparsed=True flags this so the caller can audit."""
+        response = "the answer is not 99"
+        result = await grader.grade(response, "42")
+        assert result.unparsed is True
+        assert result.correct is False
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_with_whitespace(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{42}", "  42  ")
+        assert result.correct is True
+
+    @pytest.mark.asyncio
+    async def test_reasoning_field_is_populated(self, grader: MathGrader) -> None:
+        result = await grader.grade("\\boxed{42}", "42")
+        assert "extracted '42'" in result.reasoning
+        assert "match=True" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_reasoning_flags_regex_fallback(self, grader: MathGrader) -> None:
+        result = await grader.grade("the answer is 42", "42")
+        assert "regex fallback" in result.reasoning
+
+
+class TestExtractAnswerInterface:
+    """``extract_answer`` is the synchronous interface used by exporters."""
+
+    def test_extract_answer_strips_outer_whitespace(self, grader: MathGrader) -> None:
+        assert grader.extract_answer("  \\boxed{42}  ") == "42"
+
+    def test_extract_answer_returns_raw_pre_normalization(
+        self, grader: MathGrader
+    ) -> None:
+        """``extract_answer`` returns the raw extracted string, not the
+        normalized form, so users can see what the model actually wrote."""
+        out = grader.extract_answer("\\boxed{\\dfrac{1}{2}}")
+        assert out == "\\dfrac{1}{2}"

--- a/tests/unit/accuracy/test_math_grader.py
+++ b/tests/unit/accuracy/test_math_grader.py
@@ -274,6 +274,40 @@ class TestExtractWithFlag:
         answer, _ = grader._extract_with_flag(response)
         assert answer == expected
 
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [
+            param(
+                "the answer is 3.14\nand more context follows",
+                "3.14",
+                id="decimal_then_newline",
+            ),
+            param(
+                "the answer is X. The rest is unrelated.",
+                "X",
+                id="non_numeric_then_sentence",
+            ),
+            param(
+                "the answer is 5.\nMore reasoning",
+                "5",
+                id="trailing_period_then_newline",
+            ),
+        ],
+    )  # fmt: skip
+    def test_phrase_fallback_terminator_handles_decimals_newlines_and_sentences(
+        self, grader: MathGrader, response: str, expected: str
+    ) -> None:
+        """Pin the three-way terminator behaviour:
+
+        * a period *not* surrounded by digits ends the tail (so a
+          trailing sentence doesn't pollute the captured answer),
+        * a ``\\n`` ends the tail (so the regex doesn't slurp the rest
+          of a multi-line response),
+        * end-of-string is the final fallback.
+        """
+        answer, _ = grader._extract_with_flag(response)
+        assert answer == expected
+
 
 class TestGradeNumeric:
     """``MathGrader.grade`` — numeric equivalence."""

--- a/tests/unit/accuracy/test_math_grader.py
+++ b/tests/unit/accuracy/test_math_grader.py
@@ -221,6 +221,59 @@ class TestExtractWithFlag:
         assert unparsed is True
         assert "don't know" in answer
 
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [
+            param("the answer is 3.14", "3.14", id="pi-like_decimal"),
+            param("final answer: 0.5", "0.5", id="leading_zero_decimal"),
+            param("Answer = 100.001", "100.001", id="multi_digit_decimal"),
+            param("the answer is -2.5", "-2.5", id="negative_decimal"),
+        ],
+    )  # fmt: skip
+    def test_phrase_fallback_preserves_decimal(
+        self, grader: MathGrader, response: str, expected: str
+    ) -> None:
+        """The answer-phrase regex used to terminate on ``.`` and silently
+        truncate decimals to their integer part. Pin that the full decimal
+        survives so MATH-500-style numeric answers grade correctly."""
+        answer, unparsed = grader._extract_with_flag(response)
+        assert answer == expected
+        assert unparsed is True
+
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [
+            param(
+                "the answer is 5. Wait, the answer is 12",
+                "12",
+                id="reflection_inline",
+            ),
+            param(
+                "My first thought: the answer is 7. After reflection, the answer is 9.",
+                "9",
+                id="reflection_paragraph",
+            ),
+            param(
+                "the answer is 5\nthe answer is 12",
+                "12",
+                id="reflection_newline",
+            ),
+            param(
+                "Final answer: 5. Hmm, actually final answer: 12.",
+                "12",
+                id="self_correct_final_answer",
+            ),
+        ],
+    )  # fmt: skip
+    def test_phrase_fallback_takes_last_match(
+        self, grader: MathGrader, response: str, expected: str
+    ) -> None:
+        """Reasoning models often self-correct mid-response. The
+        answer-phrase regex used to take the first match and grade
+        against the abandoned guess; pin that the LAST claim wins."""
+        answer, _ = grader._extract_with_flag(response)
+        assert answer == expected
+
 
 class TestGradeNumeric:
     """``MathGrader.grade`` — numeric equivalence."""

--- a/tests/unit/accuracy/test_math_grader.py
+++ b/tests/unit/accuracy/test_math_grader.py
@@ -213,7 +213,7 @@ class TestExtractWithFlag:
         assert unparsed is True
 
     def test_whitespace_only_response_marked_unparsed(self, grader: MathGrader) -> None:
-        answer, unparsed = grader._extract_with_flag("   \n\t  ")
+        _, unparsed = grader._extract_with_flag("   \n\t  ")
         assert unparsed is True
 
     def test_no_numbers_falls_through_to_raw(self, grader: MathGrader) -> None:

--- a/tests/unit/accuracy/test_math_grader.py
+++ b/tests/unit/accuracy/test_math_grader.py
@@ -308,6 +308,42 @@ class TestExtractWithFlag:
         answer, _ = grader._extract_with_flag(response)
         assert answer == expected
 
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [
+            param("The answer is \\frac{1}{2}.", "\\frac{1}{2}", id="frac_latex"),
+            param("the answer is \\sqrt{2}", "\\sqrt{2}", id="sqrt_latex"),
+            param("final answer: \\pi", "\\pi", id="bare_latex_command"),
+            param("The answer is {1,2,3}", "{1,2,3}", id="braced_set"),
+            param("the answer is \\binom{n}{2}", "\\binom{n}{2}", id="binom_latex"),
+        ],
+    )  # fmt: skip
+    def test_phrase_fallback_preserves_latex_tail(
+        self, grader: MathGrader, response: str, expected: str
+    ) -> None:
+        """A tail containing a backslash or curly brace must be preserved
+        whole so ``strip_string`` + ``math_equal`` can normalize and
+        compare it. The previous implementation ran the last-number
+        extractor on the tail and silently graded ``"\\frac{1}{2}"`` as
+        ``"2"`` — the opposite of what the equivalent ``\\boxed{...}``
+        wrapping does."""
+        answer, _ = grader._extract_with_flag(response)
+        assert answer == expected
+
+    @pytest.mark.asyncio
+    async def test_unboxed_frac_grades_same_as_boxed_frac(
+        self, grader: MathGrader
+    ) -> None:
+        """The reviewer's specific regression: ``"The answer is \\frac{1}{2}"``
+        and ``"\\boxed{\\frac{1}{2}}"`` should grade identically against
+        gold ``"1/2"``. Previously the unboxed form extracted ``"2"`` and
+        graded as incorrect."""
+        unboxed = await grader.grade("The answer is \\frac{1}{2}", "1/2")
+        boxed = await grader.grade("\\boxed{\\frac{1}{2}}", "1/2")
+        assert unboxed.correct is True
+        assert boxed.correct is True
+        assert unboxed.correct == boxed.correct
+
 
 class TestGradeNumeric:
     """``MathGrader.grade`` — numeric equivalence."""

--- a/tools/ergonomics_baseline.json
+++ b/tools/ergonomics_baseline.json
@@ -3,6 +3,11 @@
   "violations": [
     [
       "file-size",
+      "src/aiperf/accuracy/graders/math.py",
+      ""
+    ],
+    [
+      "file-size",
       "src/aiperf/common/config/loadgen_config.py",
       ""
     ],
@@ -235,6 +240,16 @@
       "file-size",
       "src/aiperf/workers/worker.py",
       ""
+    ],
+    [
+      "function-size",
+      "src/aiperf/accuracy/graders/_math_strip.py",
+      "strip_string"
+    ],
+    [
+      "function-size",
+      "src/aiperf/accuracy/graders/math.py",
+      "_math_equal"
     ],
     [
       "function-size",

--- a/tools/ergonomics_baseline.json
+++ b/tools/ergonomics_baseline.json
@@ -248,11 +248,6 @@
     ],
     [
       "function-size",
-      "src/aiperf/accuracy/graders/math.py",
-      "_math_equal"
-    ],
-    [
-      "function-size",
       "src/aiperf/cli_runner.py",
       "_run_multi_benchmark"
     ],

--- a/tools/ruff_baseline.json
+++ b/tools/ruff_baseline.json
@@ -794,6 +794,16 @@
     ],
     [
       "C901",
+      "src/aiperf/accuracy/graders/_math_strip.py",
+      "strip_string"
+    ],
+    [
+      "C901",
+      "src/aiperf/accuracy/graders/math.py",
+      "_math_equal"
+    ],
+    [
+      "C901",
       "src/aiperf/cli_runner.py",
       "_run_multi_benchmark"
     ],
@@ -1234,6 +1244,11 @@
     ],
     [
       "PLR0912",
+      "src/aiperf/accuracy/graders/math.py",
+      "_math_equal"
+    ],
+    [
+      "PLR0912",
       "src/aiperf/cli_runner.py",
       "_run_multi_benchmark"
     ],
@@ -1426,6 +1441,11 @@
       "PLR0912",
       "src/aiperf/ui/dashboard/progress_dashboard.py",
       "ProgressDashboard.create_stats_table"
+    ],
+    [
+      "PLR0915",
+      "src/aiperf/accuracy/graders/_math_strip.py",
+      "strip_string"
     ],
     [
       "PLR0915",

--- a/tools/ruff_baseline.json
+++ b/tools/ruff_baseline.json
@@ -1244,11 +1244,6 @@
     ],
     [
       "PLR0912",
-      "src/aiperf/accuracy/graders/math.py",
-      "_math_equal"
-    ],
-    [
-      "PLR0912",
       "src/aiperf/cli_runner.py",
       "_run_multi_benchmark"
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AIME-2024 benchmark with few-shot/CoT templates, system-prompt injection, and implemented Math, Code-Execution (sandboxed), and multiple LightEval graders.

* **Documentation**
  * Expanded accuracy guide with AIME quick-start, examples, grader selection/behavior, and updated CLI accuracy options.

* **Config**
  * enable_cot is now optional (falls back to benchmark default); system-prompt resolution honors user override then benchmark default.

* **Tests**
  * New unit tests for AIME, Math grader, benchmark loader, and system-prompt resolution.

* **Chores**
  * Added optional accuracy dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/849)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->