### PR TITLE
docs: fix fern errors in parameter-sweeping.md

### DIFF
--- a/docs/api/sweep-aggregates.md
+++ b/docs/api/sweep-aggregates.md
@@ -697,4 +697,4 @@ print(f"  Score: {best_score:.3f}")
 - [Parameter Sweeping Tutorial](../tutorials/parameter-sweeping.md) - User guide with examples
 - [Multi-Run Confidence Tutorial](../tutorials/multi-run-confidence.md) - Understanding confidence statistics
 - [Working with Profile Exports](../tutorials/working-with-profile-exports.md) - General export analysis
-- [CLI Options Reference](../cli_options.md) - Complete CLI documentation
+- [CLI Options Reference](../cli-options.md) - Complete CLI documentation

--- a/docs/troubleshooting/parameter-sweeping-errors.md
+++ b/docs/troubleshooting/parameter-sweeping-errors.md
@@ -303,7 +303,7 @@ If you encounter an error not covered in this guide:
 
 2. **Review the documentation**:
    - [Parameter Sweeping Tutorial](../tutorials/parameter-sweeping.md)
-   - [CLI Options Reference](../cli_options.md)
+   - [CLI Options Reference](../cli-options.md)
 
 3. **Report a bug** if:
    - The error message is unclear or unhelpful

--- a/docs/tutorials/parameter-sweeping.md
+++ b/docs/tutorials/parameter-sweeping.md
@@ -375,8 +375,8 @@ For each parameter combination, you get:
 - **min, max**: Range of observed values
 
 **What to look for:**
-- **Low CV (<10%)**: Consistent performance at this concurrency level
-- **High CV (>20%)**: High variability, may need more trials or investigation
+- **Low CV (`<10%`)**: Consistent performance at this concurrency level
+- **High CV (`>20%`)**: High variability, may need more trials or investigation
 - **Narrow CI**: High confidence in the mean estimate
 - **Wide CI**: More uncertainty, consider more trials
 
@@ -623,7 +623,7 @@ aiperf profile \
 
 ### High Variance at Some Values
 
-**Symptom:** Some concurrency values show high CV (>20%) while others are stable.
+**Symptom:** Some concurrency values show high CV (`>20%`) while others are stable.
 
 **Possible causes:**
 - That concurrency level is near a system threshold
@@ -906,5 +906,5 @@ aiperf profile --concurrency 10,20,30,40 --num-profile-runs 5 [other options]
 For more details, see:
 - [Sweep Aggregates API Reference](../api/sweep-aggregates.md) - Complete data format documentation
 - [Multi-Run Confidence](./multi-run-confidence.md) - Understanding confidence intervals
-- [CLI Options](../cli_options.md) - Full parameter reference
-- [Metrics Reference](../metrics_reference.md) - Detailed metric descriptions
+- [CLI Options](../cli-options.md) - Full parameter reference
+- [Metrics Reference](../metrics-reference.md) - Detailed metric descriptions


### PR DESCRIPTION

Fixes Fern check failures introduced by parameter-sweeping documentation:

1. MDX parse error — `<10%` and `>20%` outside code blocks confuse the MDX
   parser, which interprets `<` as the start of a JSX tag. Wrapped in backticks.
2. Broken links — references to `cli_options.md` and `metrics_reference.md`
   used underscores; actual filenames use hyphens (`cli-options.md`,
   `metrics-reference.md`).
