### PR TITLE
feat(metrics): add RTFx and audio duration metrics for ASR benchmarks

### DIFF
--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -40,6 +40,8 @@ This document provides a comprehensive reference of all metrics available in AIP
   - [Video Metrics](#video-metrics)
     - [Video Inference Time](#video-inference-time)
     - [Video Peak Memory](#video-peak-memory)
+  - [Audio Metrics](#audio-metrics)
+    - [Real-Time Factor (RTFx)](#real-time-factor-rtfx)
   - [Reasoning Metrics](#reasoning-metrics)
     - [Reasoning Token Count](#reasoning-token-count)
     - [Total Reasoning Tokens](#total-reasoning-tokens)
@@ -557,6 +559,29 @@ video_peak_memory = response.data.peak_memory_mb
 **Notes:**
 - Value comes from the server, not computed by AIPerf.
 - Unit is megabytes.
+
+---
+
+## Audio Metrics
+
+> [!NOTE]
+> Metrics in this section require an audio input on the request (e.g., ASR datasets such as LibriSpeech, GigaSpeech, AMI, VoxPopuli). They are not computed for text-only or non-audio requests.
+
+### Real-Time Factor (RTFx)
+
+**Type:** [Record Metric](#record-metrics)
+
+Inverse Real-Time Factor — the ratio of input audio duration to request latency. The standard ASR throughput metric, used by the HuggingFace Open ASR Leaderboard, NVIDIA Riva, and NVIDIA NeMo.
+
+**Formula:**
+```python
+rtfx = audio_duration_seconds / request_latency_seconds
+```
+
+**Notes:**
+- Higher is better. A value of 10 means the server transcribed audio 10× faster than real-time playback.
+- RTFx < 1 means the server is slower than real-time and not suitable for live transcription.
+- Per-request `audio_duration_seconds` is also exported in the JSON / CSV record export so you can correlate latency with clip length post-hoc.
 
 ---
 

--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -41,7 +41,8 @@ This document provides a comprehensive reference of all metrics available in AIP
     - [Video Inference Time](#video-inference-time)
     - [Video Peak Memory](#video-peak-memory)
   - [Audio Metrics](#audio-metrics)
-    - [Real-Time Factor (RTFx)](#real-time-factor-rtfx)
+    - [Audio Duration](#audio-duration)
+    - [Inverse Real-Time Factor (RTFx)](#inverse-real-time-factor-rtfx)
   - [Reasoning Metrics](#reasoning-metrics)
     - [Reasoning Token Count](#reasoning-token-count)
     - [Total Reasoning Tokens](#total-reasoning-tokens)
@@ -567,11 +568,21 @@ video_peak_memory = response.data.peak_memory_mb
 > [!NOTE]
 > Metrics in this section require an audio input on the request (e.g., ASR datasets such as LibriSpeech, GigaSpeech, AMI, VoxPopuli). They are not computed for text-only or non-audio requests.
 
-### Real-Time Factor (RTFx)
+### Audio Duration
 
 **Type:** [Record Metric](#record-metrics)
 
-Inverse Real-Time Factor — the ratio of input audio duration to request latency. The standard ASR throughput metric, used by the HuggingFace Open ASR Leaderboard, NVIDIA Riva, and NVIDIA NeMo.
+Per-request input audio duration in seconds. Hidden from the console summary; available in JSON / CSV record exports for characterizing dataset shape and verifying RTFx calculations.
+
+**Notes:**
+- Only computed when the request carries `audio_duration_seconds` (e.g., ASR datasets such as LibriSpeech).
+- Aggregate stats (avg, p50, p99) are computed automatically.
+
+### Inverse Real-Time Factor (RTFx)
+
+**Type:** [Record Metric](#record-metrics)
+
+The ratio of input audio duration to request latency. The standard ASR throughput metric, used by the HuggingFace Open ASR Leaderboard, NVIDIA Riva, and NVIDIA NeMo.
 
 **Formula:**
 ```python
@@ -581,7 +592,7 @@ rtfx = audio_duration_seconds / request_latency_seconds
 **Notes:**
 - Higher is better. A value of 10 means the server transcribed audio 10× faster than real-time playback.
 - RTFx < 1 means the server is slower than real-time and not suitable for live transcription.
-- Per-request `audio_duration_seconds` is also exported in the JSON / CSV record export so you can correlate latency with clip length post-hoc.
+- Requires `audio_duration` and `request_latency` metrics to be computed first.
 
 ---
 

--- a/src/aiperf/common/models/dataset_models.py
+++ b/src/aiperf/common/models/dataset_models.py
@@ -158,6 +158,11 @@ class Turn(AIPerfBaseModel):
     videos: list[Video] = Field(
         default=[], description="Collection of video data in each turn."
     )
+    audio_duration_seconds: float | None = Field(
+        default=None,
+        description="Duration of the audio content in seconds. Used by ASR-specific "
+        "metrics like RTFx. Set by ASR dataset loaders.",
+    )
 
     def metadata(self) -> TurnMetadata:
         """Get the metadata of the turn."""
@@ -209,6 +214,7 @@ class Turn(AIPerfBaseModel):
                 )
                 for vid in self.videos
             ],
+            audio_duration_seconds=self.audio_duration_seconds,
         )
 
 

--- a/src/aiperf/dataset/loader/hf_asr.py
+++ b/src/aiperf/dataset/loader/hf_asr.py
@@ -131,6 +131,7 @@ class HFASRDatasetLoader(BaseHFDatasetLoader):
                         Turn(
                             texts=[Text(contents=[_ASR_PROMPT])],
                             audios=audios,
+                            audio_duration_seconds=duration,
                         )
                     ],
                 )

--- a/src/aiperf/metrics/types/audio_duration_metric.py
+++ b/src/aiperf/metrics/types/audio_duration_metric.py
@@ -17,16 +17,24 @@ class AudioDurationMetric(BaseRecordMetric[float]):
     (avg, p50, p99) are still computed automatically and available for
     characterizing dataset shape.
 
+    Example:
+        A 12.5s audio clip produces audio_duration = 12.5. Useful for
+        correlating latency with clip length and verifying RTFx post-hoc.
+
     Computed only when the request's first turn carries
     ``audio_duration_seconds``. Non-ASR requests yield no metric value.
+
+    Raises:
+        NoMetricValue: when the request has no turns, or the first turn
+            lacks ``audio_duration_seconds`` (or it is non-positive).
     """
 
     tag = "audio_duration"
     header = "Audio Duration"
     short_header = "Audio Dur"
     unit = MetricTimeUnit.SECONDS
-    display_order = 860
-    flags = MetricFlags.NO_CONSOLE
+    display_order = 870
+    flags = MetricFlags.SUPPORTS_AUDIO_ONLY | MetricFlags.NO_CONSOLE
     required_metrics = None
 
     def _parse_record(
@@ -41,7 +49,7 @@ class AudioDurationMetric(BaseRecordMetric[float]):
         audio_duration = turns[0].audio_duration_seconds
         if audio_duration is None or audio_duration <= 0:
             raise NoMetricValue(
-                "Turn has no audio_duration_seconds; metric applies to ASR requests only."
+                "Turn has no audio_duration_seconds; audio_duration metric applies to ASR requests only."
             )
 
         return audio_duration

--- a/src/aiperf/metrics/types/audio_duration_metric.py
+++ b/src/aiperf/metrics/types/audio_duration_metric.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from aiperf.common.enums import MetricFlags, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import ParsedResponseRecord
+from aiperf.metrics import BaseRecordMetric
+from aiperf.metrics.metric_dicts import MetricRecordDict
+
+
+class AudioDurationMetric(BaseRecordMetric[float]):
+    """Per-request input audio duration in seconds.
+
+    Surfaces the duration set by ASR dataset loaders so it appears in
+    JSON / CSV record exports alongside other per-request metrics. Hidden
+    from the console summary (the headline is RTFx); aggregate stats
+    (avg, p50, p99) are still computed automatically and available for
+    characterizing dataset shape.
+
+    Computed only when the request's first turn carries
+    ``audio_duration_seconds``. Non-ASR requests yield no metric value.
+    """
+
+    tag = "audio_duration"
+    header = "Audio Duration"
+    short_header = "Audio Dur"
+    unit = MetricTimeUnit.SECONDS
+    display_order = 860
+    flags = MetricFlags.NO_CONSOLE
+    required_metrics = None
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> float:
+        turns = record.request.turns
+        if not turns:
+            raise NoMetricValue("No turns in request; audio duration unavailable.")
+
+        audio_duration = turns[0].audio_duration_seconds
+        if audio_duration is None or audio_duration <= 0:
+            raise NoMetricValue(
+                "Turn has no audio_duration_seconds; metric applies to ASR requests only."
+            )
+
+        return audio_duration

--- a/src/aiperf/metrics/types/rtfx_metric.py
+++ b/src/aiperf/metrics/types/rtfx_metric.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from aiperf.common.enums import GenericMetricUnit, MetricFlags, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import ParsedResponseRecord
+from aiperf.metrics import BaseRecordMetric
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+
+
+class RTFxMetric(BaseRecordMetric[float]):
+    """Inverse Real-Time Factor (RTFx) for ASR benchmarks.
+
+    Formula:
+        RTFx = audio_duration_seconds / request_latency_seconds
+
+    Higher is better; expressed as "Nx faster than real-time." This is the
+    industry-standard ASR throughput metric (HuggingFace Open ASR Leaderboard
+    requires it; NVIDIA Riva and NeMo use it as headline metric).
+
+    Computed only when the request's first turn carries
+    ``audio_duration_seconds``. Non-ASR requests yield no metric value.
+    """
+
+    tag = "rtfx"
+    header = "Real-Time Factor (RTFx)"
+    short_header = "RTFx"
+    short_header_hide_unit = True
+    unit = GenericMetricUnit.RATIO
+    display_order = 850
+    flags = MetricFlags.LARGER_IS_BETTER
+    required_metrics = {RequestLatencyMetric.tag}
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> float:
+        turns = record.request.turns
+        if not turns:
+            raise NoMetricValue("No turns in request; cannot compute RTFx.")
+
+        audio_duration = turns[0].audio_duration_seconds
+        if audio_duration is None or audio_duration <= 0:
+            raise NoMetricValue(
+                "Turn has no audio_duration_seconds; RTFx applies to ASR requests only."
+            )
+
+        latency_seconds = record_metrics.get_converted_or_raise(
+            RequestLatencyMetric, MetricTimeUnit.SECONDS
+        )
+        if latency_seconds <= 0:
+            raise NoMetricValue("Request latency is zero; cannot compute RTFx.")
+
+        return audio_duration / latency_seconds

--- a/src/aiperf/metrics/types/rtfx_metric.py
+++ b/src/aiperf/metrics/types/rtfx_metric.py
@@ -6,6 +6,7 @@ from aiperf.common.exceptions import NoMetricValue
 from aiperf.common.models import ParsedResponseRecord
 from aiperf.metrics import BaseRecordMetric
 from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.audio_duration_metric import AudioDurationMetric
 from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
 
 
@@ -19,38 +20,42 @@ class RTFxMetric(BaseRecordMetric[float]):
     industry-standard ASR throughput metric (HuggingFace Open ASR Leaderboard
     requires it; NVIDIA Riva and NeMo use it as headline metric).
 
-    Computed only when the request's first turn carries
-    ``audio_duration_seconds``. Non-ASR requests yield no metric value.
+    Example:
+        10s of input audio transcribed with 1s request latency -> RTFx = 10.0
+        ("10x faster than real-time"). RTFx < 1.0 means the server is slower
+        than real-time and not suitable for live transcription.
+
+    Requires ``AudioDurationMetric`` and ``RequestLatencyMetric`` to be
+    computed first. Non-ASR requests (no audio duration) yield no metric value.
+
+    Raises:
+        NoMetricValue: when ``audio_duration`` is missing from the record
+            metrics, or the measured request latency is non-positive.
     """
 
     tag = "rtfx"
-    header = "Real-Time Factor (RTFx)"
+    header = "Inverse Real-Time Factor (RTFx)"
     short_header = "RTFx"
     short_header_hide_unit = True
     unit = GenericMetricUnit.RATIO
     display_order = 850
-    flags = MetricFlags.LARGER_IS_BETTER
-    required_metrics = {RequestLatencyMetric.tag}
+    flags = MetricFlags.SUPPORTS_AUDIO_ONLY | MetricFlags.LARGER_IS_BETTER
+    required_metrics = {AudioDurationMetric.tag, RequestLatencyMetric.tag}
 
     def _parse_record(
         self,
         record: ParsedResponseRecord,
         record_metrics: MetricRecordDict,
     ) -> float:
-        turns = record.request.turns
-        if not turns:
-            raise NoMetricValue("No turns in request; cannot compute RTFx.")
-
-        audio_duration = turns[0].audio_duration_seconds
-        if audio_duration is None or audio_duration <= 0:
-            raise NoMetricValue(
-                "Turn has no audio_duration_seconds; RTFx applies to ASR requests only."
-            )
+        audio_duration = record_metrics.get_or_raise(AudioDurationMetric)
 
         latency_seconds = record_metrics.get_converted_or_raise(
             RequestLatencyMetric, MetricTimeUnit.SECONDS
         )
         if latency_seconds <= 0:
-            raise NoMetricValue("Request latency is zero; cannot compute RTFx.")
+            raise NoMetricValue(
+                f"Request latency is non-positive ({latency_seconds}s); "
+                "RTFx undefined. Likely an upstream measurement bug."
+            )
 
         return audio_duration / latency_seconds

--- a/tests/unit/metrics/test_audio_duration_metric.py
+++ b/tests/unit/metrics/test_audio_duration_metric.py
@@ -46,3 +46,4 @@ class TestAudioDurationMetric:
         assert metric.tag == "audio_duration"
         assert metric.header == "Audio Duration"
         assert MetricFlags.NO_CONSOLE in metric.flags
+        assert MetricFlags.SUPPORTS_AUDIO_ONLY in metric.flags

--- a/tests/unit/metrics/test_audio_duration_metric.py
+++ b/tests/unit/metrics/test_audio_duration_metric.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.enums import MetricFlags
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import Turn
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.audio_duration_metric import AudioDurationMetric
+from tests.unit.metrics.conftest import create_record
+
+
+class TestAudioDurationMetric:
+    def test_returns_audio_duration(self):
+        record = create_record()
+        record.request.turns = [Turn(audio_duration_seconds=12.5)]
+        metric = AudioDurationMetric()
+
+        result = metric.parse_record(record, MetricRecordDict())
+        assert result == pytest.approx(12.5, rel=1e-6)
+
+    def test_no_turns_raises(self):
+        record = create_record()
+        record.request.turns = []
+        metric = AudioDurationMetric()
+        with pytest.raises(NoMetricValue, match="No turns"):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_no_audio_duration_raises(self):
+        record = create_record()
+        record.request.turns = [Turn(audio_duration_seconds=None)]
+        metric = AudioDurationMetric()
+        with pytest.raises(NoMetricValue, match="ASR requests only"):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_zero_audio_duration_raises(self):
+        record = create_record()
+        record.request.turns = [Turn(audio_duration_seconds=0.0)]
+        metric = AudioDurationMetric()
+        with pytest.raises(NoMetricValue, match="ASR requests only"):
+            metric.parse_record(record, MetricRecordDict())
+
+    def test_metric_properties(self):
+        metric = AudioDurationMetric()
+        assert metric.tag == "audio_duration"
+        assert metric.header == "Audio Duration"
+        assert MetricFlags.NO_CONSOLE in metric.flags

--- a/tests/unit/metrics/test_rtfx_metric.py
+++ b/tests/unit/metrics/test_rtfx_metric.py
@@ -33,7 +33,11 @@ class TestRTFxMetric:
         cases = [
             (5.0, 500_000_000, 10.0),  # 5s audio, 0.5s latency -> 10x
             (60.0, 12_000_000_000, 5.0),  # 60s audio, 12s latency -> 5x
-            (1.0, 2_000_000_000, 0.5),  # 1s audio, 2s latency -> 0.5x (slower than real-time)
+            (
+                1.0,
+                2_000_000_000,
+                0.5,
+            ),  # 1s audio, 2s latency -> 0.5x (slower than real-time)
             (30.0, 100_000_000, 300.0),  # 30s audio, 100ms latency -> 300x
         ]
         for audio_dur, latency_ns, expected in cases:

--- a/tests/unit/metrics/test_rtfx_metric.py
+++ b/tests/unit/metrics/test_rtfx_metric.py
@@ -2,87 +2,71 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from pytest import param
 
+from aiperf.common.enums import MetricFlags
 from aiperf.common.exceptions import NoMetricValue
-from aiperf.common.models import Turn
 from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.audio_duration_metric import AudioDurationMetric
 from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
 from aiperf.metrics.types.rtfx_metric import RTFxMetric
 from tests.unit.metrics.conftest import create_record
 
 
-def _record_with_audio_duration(audio_duration: float | None) -> "object":
-    record = create_record()
-    record.request.turns = [Turn(audio_duration_seconds=audio_duration)]
-    return record
+def _metric_dict(audio_duration: float, latency_ns: int) -> MetricRecordDict:
+    md = MetricRecordDict()
+    md[AudioDurationMetric.tag] = audio_duration
+    md[RequestLatencyMetric.tag] = latency_ns
+    return md
 
 
 class TestRTFxMetric:
     def test_rtfx_basic(self):
         """10s audio, 1s latency -> RTFx = 10."""
-        record = _record_with_audio_duration(10.0)
+        record = create_record()
         metric = RTFxMetric()
-        metric_dict = MetricRecordDict()
-        metric_dict[RequestLatencyMetric.tag] = 1_000_000_000  # 1s in ns
+        md = _metric_dict(10.0, 1_000_000_000)
 
-        result = metric.parse_record(record, metric_dict)
+        result = metric.parse_record(record, md)
         assert result == pytest.approx(10.0, rel=1e-6)
 
-    def test_rtfx_various_values(self):
-        metric = RTFxMetric()
-        cases = [
-            (5.0, 500_000_000, 10.0),  # 5s audio, 0.5s latency -> 10x
-            (60.0, 12_000_000_000, 5.0),  # 60s audio, 12s latency -> 5x
-            (
-                1.0,
-                2_000_000_000,
-                0.5,
-            ),  # 1s audio, 2s latency -> 0.5x (slower than real-time)
-            (30.0, 100_000_000, 300.0),  # 30s audio, 100ms latency -> 300x
-        ]
-        for audio_dur, latency_ns, expected in cases:
-            record = _record_with_audio_duration(audio_dur)
-            md = MetricRecordDict()
-            md[RequestLatencyMetric.tag] = latency_ns
-            assert metric.parse_record(record, md) == pytest.approx(expected, rel=1e-6)
+    @pytest.mark.parametrize(
+        "audio_duration_s,latency_ns,expected_rtfx",
+        [
+            param(5.0, 500_000_000, 10.0, id="5s_audio_500ms_latency_10x"),
+            param(60.0, 12_000_000_000, 5.0, id="60s_audio_12s_latency_5x"),
+            param(1.0, 2_000_000_000, 0.5, id="1s_audio_2s_latency_slower_than_realtime"),
+            param(30.0, 100_000_000, 300.0, id="30s_audio_100ms_latency_300x"),
+        ],
+    )  # fmt: skip
+    def test_rtfx_various_values(self, audio_duration_s, latency_ns, expected_rtfx):
+        md = _metric_dict(audio_duration_s, latency_ns)
+        assert RTFxMetric().parse_record(create_record(), md) == pytest.approx(
+            expected_rtfx, rel=1e-6
+        )
 
     def test_rtfx_no_audio_duration_raises_no_metric_value(self):
-        record = _record_with_audio_duration(None)
+        record = create_record()
         metric = RTFxMetric()
         md = MetricRecordDict()
         md[RequestLatencyMetric.tag] = 1_000_000_000
-        with pytest.raises(NoMetricValue, match="ASR requests only"):
-            metric.parse_record(record, md)
-
-    def test_rtfx_zero_audio_duration_raises_no_metric_value(self):
-        record = _record_with_audio_duration(0.0)
-        metric = RTFxMetric()
-        md = MetricRecordDict()
-        md[RequestLatencyMetric.tag] = 1_000_000_000
-        with pytest.raises(NoMetricValue, match="ASR requests only"):
+        with pytest.raises(NoMetricValue, match="audio_duration"):
             metric.parse_record(record, md)
 
     def test_rtfx_zero_latency_raises_no_metric_value(self):
-        record = _record_with_audio_duration(5.0)
-        metric = RTFxMetric()
-        md = MetricRecordDict()
-        md[RequestLatencyMetric.tag] = 0
-        with pytest.raises(NoMetricValue, match="latency is zero"):
-            metric.parse_record(record, md)
-
-    def test_rtfx_no_turns_raises_no_metric_value(self):
         record = create_record()
-        record.request.turns = []
         metric = RTFxMetric()
-        md = MetricRecordDict()
-        md[RequestLatencyMetric.tag] = 1_000_000_000
-        with pytest.raises(NoMetricValue, match="No turns"):
+        md = _metric_dict(5.0, 0)
+        with pytest.raises(NoMetricValue, match="non-positive"):
             metric.parse_record(record, md)
 
     def test_rtfx_metric_properties(self):
         metric = RTFxMetric()
         assert metric.tag == "rtfx"
-        assert metric.header == "Real-Time Factor (RTFx)"
+        assert metric.header == "Inverse Real-Time Factor (RTFx)"
         assert metric.short_header == "RTFx"
         assert metric.short_header_hide_unit is True
+        assert AudioDurationMetric.tag in metric.required_metrics
         assert RequestLatencyMetric.tag in metric.required_metrics
+        assert MetricFlags.SUPPORTS_AUDIO_ONLY in metric.flags
+        assert MetricFlags.LARGER_IS_BETTER in metric.flags

--- a/tests/unit/metrics/test_rtfx_metric.py
+++ b/tests/unit/metrics/test_rtfx_metric.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import Turn
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+from aiperf.metrics.types.rtfx_metric import RTFxMetric
+from tests.unit.metrics.conftest import create_record
+
+
+def _record_with_audio_duration(audio_duration: float | None) -> "object":
+    record = create_record()
+    record.request.turns = [Turn(audio_duration_seconds=audio_duration)]
+    return record
+
+
+class TestRTFxMetric:
+    def test_rtfx_basic(self):
+        """10s audio, 1s latency -> RTFx = 10."""
+        record = _record_with_audio_duration(10.0)
+        metric = RTFxMetric()
+        metric_dict = MetricRecordDict()
+        metric_dict[RequestLatencyMetric.tag] = 1_000_000_000  # 1s in ns
+
+        result = metric.parse_record(record, metric_dict)
+        assert result == pytest.approx(10.0, rel=1e-6)
+
+    def test_rtfx_various_values(self):
+        metric = RTFxMetric()
+        cases = [
+            (5.0, 500_000_000, 10.0),  # 5s audio, 0.5s latency -> 10x
+            (60.0, 12_000_000_000, 5.0),  # 60s audio, 12s latency -> 5x
+            (1.0, 2_000_000_000, 0.5),  # 1s audio, 2s latency -> 0.5x (slower than real-time)
+            (30.0, 100_000_000, 300.0),  # 30s audio, 100ms latency -> 300x
+        ]
+        for audio_dur, latency_ns, expected in cases:
+            record = _record_with_audio_duration(audio_dur)
+            md = MetricRecordDict()
+            md[RequestLatencyMetric.tag] = latency_ns
+            assert metric.parse_record(record, md) == pytest.approx(expected, rel=1e-6)
+
+    def test_rtfx_no_audio_duration_raises_no_metric_value(self):
+        record = _record_with_audio_duration(None)
+        metric = RTFxMetric()
+        md = MetricRecordDict()
+        md[RequestLatencyMetric.tag] = 1_000_000_000
+        with pytest.raises(NoMetricValue, match="ASR requests only"):
+            metric.parse_record(record, md)
+
+    def test_rtfx_zero_audio_duration_raises_no_metric_value(self):
+        record = _record_with_audio_duration(0.0)
+        metric = RTFxMetric()
+        md = MetricRecordDict()
+        md[RequestLatencyMetric.tag] = 1_000_000_000
+        with pytest.raises(NoMetricValue, match="ASR requests only"):
+            metric.parse_record(record, md)
+
+    def test_rtfx_zero_latency_raises_no_metric_value(self):
+        record = _record_with_audio_duration(5.0)
+        metric = RTFxMetric()
+        md = MetricRecordDict()
+        md[RequestLatencyMetric.tag] = 0
+        with pytest.raises(NoMetricValue, match="latency is zero"):
+            metric.parse_record(record, md)
+
+    def test_rtfx_no_turns_raises_no_metric_value(self):
+        record = create_record()
+        record.request.turns = []
+        metric = RTFxMetric()
+        md = MetricRecordDict()
+        md[RequestLatencyMetric.tag] = 1_000_000_000
+        with pytest.raises(NoMetricValue, match="No turns"):
+            metric.parse_record(record, md)
+
+    def test_rtfx_metric_properties(self):
+        metric = RTFxMetric()
+        assert metric.tag == "rtfx"
+        assert metric.header == "Real-Time Factor (RTFx)"
+        assert metric.short_header == "RTFx"
+        assert metric.short_header_hide_unit is True
+        assert RequestLatencyMetric.tag in metric.required_metrics


### PR DESCRIPTION
Adds two ASR-specific metrics to AIPerf:

- **RTFx (Inverse Real-Time Factor)** — `audio_duration / request_latency` per request, with full percentile aggregates. Surfaced in console + JSON/CSV.
- **Audio duration** — per-request input audio duration in seconds. Surfaced in JSON/CSV (hidden from console via `NO_CONSOLE` flag).

Based on the [article](https://huggingface.co/learn/audio-course/chapter5/evaluation#inverse-real-time-factor-rtfx) from HuggingFace evaluating ASR

- `Turn.audio_duration_seconds` — new optional field carrying per-turn audio duration
- `HFASRDatasetLoader` — populates the new field from already-computed `_duration_seconds()`
- `RTFxMetric` — new `BaseRecordMetric[float]`; depends on `RequestLatencyMetric`
- `AudioDurationMetric` — new `BaseRecordMetric[float]` with `NO_CONSOLE` flag (JSON/CSV only)
- Both metrics auto-register and inherit AIPerf's existing percentile-aggregation pipeline

