### PR TITLE
docs(tutorials): swap audio model to Qwen2.5-Omni-3B

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -877,6 +877,7 @@ jobs:
             echo "| pre-commit | ${{ needs.pre-commit.result }} |"
             echo "| unit-tests | ${{ needs.unit-tests.result }} |"
             echo "| integration-tests | ${{ needs.integration-tests.result }} |"
+            echo "| test-docs-end-to-end | ${{ needs.test-docs-end-to-end.result }} |"
             echo ""
             echo "### Build + Upload"
             echo "| Job | Result |"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -292,6 +292,9 @@ jobs:
     name: Test Docs End-to-End
     needs: [prepare-nightly]
     uses: ./.github/workflows/test-docs-end-to-end.yml
+    with:
+      source_ref: ${{ needs.prepare-nightly.outputs.resolved_sha }}
+    secrets: inherit
 
   # ============================================================================
   # PHASE 3: BUILD

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -288,28 +288,10 @@ jobs:
       - name: Run integration tests
         run: make integration-tests-ci PYTHON_VERSION=3.12
 
-  # TODO: re-enable when GPU runner is available. Also restore references in
-  # build-container.needs and pipeline-summary (needs: list + summary table).
-  # gpu-e2e-tests:
-  #   name: GPU End-to-End Tests
-  #   needs: [prepare-nightly]
-  #   runs-on: prod-aiperf-tester-amd-gpu-v1
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ inputs.ref || github.ref }}
-  #
-  #     - name: Run test_docs_end_to_end
-  #       env:
-  #         AIPERF_SOURCE_DIR: ${{ github.workspace }}
-  #         CI_JOB_NAME: test_docs_end_to_end
-  #       run: |
-  #         bash -x tests/ci/test_docs_end_to_end/setup_test.sh
-  #
-  #     - name: Cleanup Docker containers
-  #       if: always()
-  #       run: docker compose -f docker-compose.yml down || true
+  test-docs-end-to-end:
+    name: Test Docs End-to-End
+    needs: [prepare-nightly]
+    uses: ./.github/workflows/test-docs-end-to-end.yml
 
   # ============================================================================
   # PHASE 3: BUILD
@@ -323,7 +305,7 @@ jobs:
   # the pipeline continues to build, stage, and scan.
   build-container:
     name: Build Container (${{ matrix.arch }})
-    needs: [prepare-nightly, pre-commit, unit-tests, integration-tests]
+    needs: [prepare-nightly, pre-commit, unit-tests, integration-tests, test-docs-end-to-end]
     if: >-
       ${{ always()
           && needs.prepare-nightly.result == 'success'
@@ -860,7 +842,7 @@ jobs:
       - pre-commit
       - unit-tests
       - integration-tests
-      # - gpu-e2e-tests  # temporarily commented out with the job
+      - test-docs-end-to-end
       - build-container
       - create-multiarch-manifest-ecr
       - stage-nightly-container

--- a/.github/workflows/test-docs-end-to-end.yml
+++ b/.github/workflows/test-docs-end-to-end.yml
@@ -23,6 +23,11 @@ on:
       - 'tests/ci/test_docs_end_to_end/**'
   workflow_dispatch:
   workflow_call:
+    inputs:
+      source_ref:
+        description: "Commit SHA or ref to checkout when invoked from another workflow."
+        required: false
+        type: string
 
 jobs:
   detect-changes:
@@ -34,6 +39,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.source_ref || github.sha }}
 
       - uses: actions/setup-python@v5
         with:
@@ -95,6 +101,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref || github.sha }}
 
       - name: Run test_docs_end_to_end
         env:

--- a/.github/workflows/test-docs-end-to-end.yml
+++ b/.github/workflows/test-docs-end-to-end.yml
@@ -100,6 +100,7 @@ jobs:
         env:
           AIPERF_SOURCE_DIR: ${{ github.workspace }}
           CI_JOB_NAME: test_docs_end_to_end
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: bash -x tests/ci/test_docs_end_to_end/setup_test.sh
 
       - name: Cleanup Docker containers

--- a/.github/workflows/test-docs-end-to-end.yml
+++ b/.github/workflows/test-docs-end-to-end.yml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs tests/ci/test_docs_end_to_end/setup_test.sh on the AMD GPU runner.
+#
+# Triggers:
+#   pull_request      — auto-runs on PRs that touch tutorial markdown or the
+#                       test runner itself.
+#   workflow_dispatch — manual trigger from the Actions UI / gh CLI.
+#   workflow_call     — invoked by nightly.yml so the nightly stays green.
+#
+# A cheap ubuntu-latest detect-changes job pre-flights the work and skips the
+# AMD GPU job when a PR doesn't actually change anything the parser would
+# extract from the tutorials.
+
+name: Test Docs End-to-End
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/tutorials/**'
+      - 'tests/ci/test_docs_end_to_end/**'
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_test: ${{ steps.compare.outputs.run_test }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - id: compare
+        name: Compare parser-extracted config between base and head
+        run: |
+          set -euo pipefail
+
+          # Non-PR triggers (workflow_dispatch, workflow_call from nightly)
+          # have no base/head to compare; always run the test.
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+
+          # Safety net: any change under the test runner directory always runs
+          # the test (covers parser.py, test_runner.py, constants, etc.).
+          if git diff --name-only "$BASE" "$HEAD" -- 'tests/ci/test_docs_end_to_end/' | grep -q .; then
+            echo "Test runner code changed; running GPU test."
+            echo "run_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Compare parser-extracted server config between base and head.
+          # If the script fails on either side, fall back to running the test.
+          git worktree add /tmp/base-tree "$BASE"
+          if ! BASE_HASH=$(python3 /tmp/base-tree/tests/ci/test_docs_end_to_end/dump_config_hash.py); then
+            echo "::warning::Could not compute base hash; running GPU test."
+            echo "run_test=true" >> "$GITHUB_OUTPUT"
+            git worktree remove /tmp/base-tree --force
+            exit 0
+          fi
+          git worktree remove /tmp/base-tree --force
+
+          if ! HEAD_HASH=$(python3 tests/ci/test_docs_end_to_end/dump_config_hash.py); then
+            echo "::warning::Could not compute head hash; running GPU test."
+            echo "run_test=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$BASE_HASH" == "$HEAD_HASH" ]]; then
+            echo "::notice::No parser-relevant changes; skipping GPU test."
+            echo "run_test=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Parser-extracted config differs; running GPU test."
+            echo "run_test=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  test-docs-end-to-end:
+    name: Test Docs End-to-End
+    needs: detect-changes
+    if: needs.detect-changes.outputs.run_test == 'true'
+    runs-on: prod-aiperf-tester-amd-gpu-v1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run test_docs_end_to_end
+        env:
+          AIPERF_SOURCE_DIR: ${{ github.workspace }}
+          CI_JOB_NAME: test_docs_end_to_end
+        run: bash -x tests/ci/test_docs_end_to_end/setup_test.sh
+
+      - name: Cleanup Docker containers
+        if: always()
+        run: docker compose -f docker-compose.yml down || true

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -16,6 +16,7 @@ models using various inference solutions.
 docker pull vllm/vllm-openai:latest
 docker run --gpus all -p 8000:8000 -e HF_TOKEN vllm/vllm-openai:latest \
   --model Qwen/Qwen3-0.6B \
+  --enforce-eager \
   --reasoning-parser qwen3 \
   --host 0.0.0.0 --port 8000
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -14,7 +14,7 @@ models using various inference solutions.
 ```bash
 # Pull and run vLLM Docker container:
 docker pull vllm/vllm-openai:latest
-docker run --gpus all -p 8000:8000 vllm/vllm-openai:latest \
+docker run --gpus all -p 8000:8000 -e HF_TOKEN vllm/vllm-openai:latest \
   --model Qwen/Qwen3-0.6B \
   --reasoning-parser qwen3 \
   --host 0.0.0.0 --port 8000

--- a/docs/tutorials/audio.md
+++ b/docs/tutorials/audio.md
@@ -25,7 +25,7 @@ RUN pip install 'vllm[audio]'
 EOF
 
 # Run the server
-docker run --gpus all -p 8000:8000 vllm-audio \
+docker run --gpus all -p 8000:8000 -e HF_TOKEN vllm-audio \
   --model Qwen/Qwen2.5-Omni-3B \
   --trust-remote-code
 ```

--- a/docs/tutorials/audio.md
+++ b/docs/tutorials/audio.md
@@ -27,6 +27,7 @@ EOF
 # Run the server
 docker run --gpus all -p 8000:8000 -e HF_TOKEN vllm-audio \
   --model Qwen/Qwen2.5-Omni-3B \
+  --enforce-eager \
   --trust-remote-code
 ```
 <!-- /setup-vllm-audio-openai-endpoint-server -->

--- a/docs/tutorials/audio.md
+++ b/docs/tutorials/audio.md
@@ -14,7 +14,7 @@ This guide covers profiling audio models using OpenAI-compatible chat completion
 
 ## Start a vLLM Server
 
-Launch the vLLM server with Qwen2-Audio-7B-Instruct. Audio support requires the `vllm[audio]` extras to be installed:
+Launch the vLLM server with Qwen2.5-Omni-3B. Audio support requires the `vllm[audio]` extras to be installed:
 
 <!-- setup-vllm-audio-openai-endpoint-server -->
 ```bash
@@ -26,7 +26,7 @@ EOF
 
 # Run the server
 docker run --gpus all -p 8000:8000 vllm-audio \
-  --model Qwen/Qwen2-Audio-7B-Instruct \
+  --model Qwen/Qwen2.5-Omni-3B \
   --trust-remote-code
 ```
 <!-- /setup-vllm-audio-openai-endpoint-server -->
@@ -36,7 +36,7 @@ Verify the server is ready:
 
 <!-- health-check-vllm-audio-openai-endpoint-server -->
 ```bash
-timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"Qwen/Qwen2-Audio-7B-Instruct\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":1}")" != "200" ]; do sleep 2; done' || { echo "vLLM not ready after 15min"; exit 1; }
+timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"Qwen/Qwen2.5-Omni-3B\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":1}")" != "200" ]; do sleep 2; done' || { echo "vLLM not ready after 15min"; exit 1; }
 ```
 <!-- /health-check-vllm-audio-openai-endpoint-server -->
 
@@ -49,7 +49,7 @@ AIPerf can generate synthetic audio for benchmarking:
 <!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 aiperf profile \
-    --model Qwen/Qwen2-Audio-7B-Instruct \
+    --model Qwen/Qwen2.5-Omni-3B \
     --endpoint-type chat \
     --audio-length-mean 5.0 \
     --audio-format wav \
@@ -83,14 +83,14 @@ aiperf profile \
 │             Request Count (requests) │    20.00 │    N/A │       N/A │       N/A │       N/A │    N/A │      N/A │
 └──────────────────────────────────────┴──────────┴────────┴───────────┴───────────┴───────────┴────────┴──────────┘
 
-CLI Command: aiperf profile --model 'Qwen/Qwen2-Audio-7B-Instruct' --endpoint-type 'chat' --audio-length-mean 5.0
+CLI Command: aiperf profile --model 'Qwen/Qwen2.5-Omni-3B' --endpoint-type 'chat' --audio-length-mean 5.0
 --audio-format 'wav' --audio-sample-rates 16 --streaming --url 'localhost:8000' --request-count 20 --concurrency 4
 Benchmark Duration: 21.80 sec
 CSV Export:
-artifacts/Qwen_Qwen2-Audio-7B-Instruct-openai-chat-concurrency4/profile_export_aiperf.csv
+artifacts/Qwen_Qwen2.5-Omni-3B-openai-chat-concurrency4/profile_export_aiperf.csv
 JSON Export:
-artifacts/Qwen_Qwen2-Audio-7B-Instruct-openai-chat-concurrency4/profile_export_aiperf.json
-Log File: artifacts/Qwen_Qwen2-Audio-7B-Instruct-openai-chat-concurrency4/logs/aiperf.log
+artifacts/Qwen_Qwen2.5-Omni-3B-openai-chat-concurrency4/profile_export_aiperf.json
+Log File: artifacts/Qwen_Qwen2.5-Omni-3B-openai-chat-concurrency4/logs/aiperf.log
 ```
 
 To add text prompts alongside audio, include `--synthetic-input-tokens-mean 100`
@@ -111,7 +111,7 @@ cat <<EOF > inputs.jsonl
 EOF
 
 aiperf profile \
-    --model Qwen/Qwen2-Audio-7B-Instruct \
+    --model Qwen/Qwen2.5-Omni-3B \
     --endpoint-type chat \
     --input-file inputs.jsonl \
     --custom-dataset-type single_turn \
@@ -148,12 +148,12 @@ AIPerf will automatically:
 │             Request Count (requests) │     3.00 │    N/A │      N/A │      N/A │      N/A │    N/A │    N/A │
 └──────────────────────────────────────┴──────────┴────────┴──────────┴──────────┴──────────┴────────┴────────┘
 
-CLI Command: aiperf profile --model 'Qwen/Qwen2-Audio-7B-Instruct' --endpoint-type 'chat' --input-file
+CLI Command: aiperf profile --model 'Qwen/Qwen2.5-Omni-3B' --endpoint-type 'chat' --input-file
 'inputs_filepaths.jsonl' --custom-dataset-type 'single_turn' --streaming --url 'localhost:8000' --request-count 3
 Benchmark Duration: 3.16 sec
 CSV Export:
-artifacts/Qwen_Qwen2-Audio-7B-Instruct-openai-chat-concurrency1/profile_export_aiperf.csv
+artifacts/Qwen_Qwen2.5-Omni-3B-openai-chat-concurrency1/profile_export_aiperf.csv
 JSON Export:
-artifacts/Qwen_Qwen2-Audio-7B-Instruct-openai-chat-concurrency1/profile_export_aiperf.json
-Log File: artifacts/Qwen_Qwen2-Audio-7B-Instruct-openai-chat-concurrency1/logs/aiperf.log
+artifacts/Qwen_Qwen2.5-Omni-3B-openai-chat-concurrency1/profile_export_aiperf.json
+Log File: artifacts/Qwen_Qwen2.5-Omni-3B-openai-chat-concurrency1/logs/aiperf.log
 ```

--- a/docs/tutorials/mmvu.md
+++ b/docs/tutorials/mmvu.md
@@ -24,7 +24,8 @@ Launch a vLLM server with a video-capable vision language model:
 ```bash
 docker pull vllm/vllm-openai:latest
 docker run --gpus all -p 8000:8000 -e HF_TOKEN vllm/vllm-openai:latest \
-  --model Qwen/Qwen2-VL-2B-Instruct
+  --model Qwen/Qwen2-VL-2B-Instruct \
+  --enforce-eager
 ```
 <!-- /setup-vllm-video-openai-endpoint-server -->
 

--- a/docs/tutorials/mmvu.md
+++ b/docs/tutorials/mmvu.md
@@ -23,7 +23,7 @@ Launch a vLLM server with a video-capable vision language model:
 <!-- setup-vllm-video-openai-endpoint-server -->
 ```bash
 docker pull vllm/vllm-openai:latest
-docker run --gpus all -p 8000:8000 vllm/vllm-openai:latest \
+docker run --gpus all -p 8000:8000 -e HF_TOKEN vllm/vllm-openai:latest \
   --model Qwen/Qwen2-VL-2B-Instruct
 ```
 <!-- /setup-vllm-video-openai-endpoint-server -->

--- a/docs/tutorials/openai-responses.md
+++ b/docs/tutorials/openai-responses.md
@@ -169,7 +169,7 @@ Profile audio-capable models with the Responses API:
 
 ```bash
 aiperf profile \
-    --model Qwen/Qwen2-Audio-7B-Instruct \
+    --model Qwen/Qwen2.5-Omni-3B \
     --endpoint-type responses \
     --endpoint /v1/responses \
     --streaming \

--- a/docs/tutorials/synthetic-dataset.md
+++ b/docs/tutorials/synthetic-dataset.md
@@ -145,7 +145,7 @@ Audio files are generated as synthetic Gaussian noise:
 <!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 aiperf profile \
-  --model Qwen/Qwen2-Audio-7B-Instruct \
+  --model Qwen/Qwen2.5-Omni-3B \
   --url localhost:8000 \
   --endpoint-type chat \
   --audio-length-mean 5.0 \

--- a/docs/tutorials/vision.md
+++ b/docs/tutorials/vision.md
@@ -19,7 +19,7 @@ Launch a vLLM server with a vision language model:
 <!-- setup-vllm-vision-openai-endpoint-server -->
 ```bash
 docker pull vllm/vllm-openai:latest
-docker run --gpus all -p 8000:8000 vllm/vllm-openai:latest \
+docker run --gpus all -p 8000:8000 -e HF_TOKEN vllm/vllm-openai:latest \
   --model Qwen/Qwen2-VL-2B-Instruct
 ```
 <!-- /setup-vllm-vision-openai-endpoint-server -->

--- a/docs/tutorials/vision.md
+++ b/docs/tutorials/vision.md
@@ -20,7 +20,8 @@ Launch a vLLM server with a vision language model:
 ```bash
 docker pull vllm/vllm-openai:latest
 docker run --gpus all -p 8000:8000 -e HF_TOKEN vllm/vllm-openai:latest \
-  --model Qwen/Qwen2-VL-2B-Instruct
+  --model Qwen/Qwen2-VL-2B-Instruct \
+  --enforce-eager
 ```
 <!-- /setup-vllm-vision-openai-endpoint-server -->
 

--- a/tests/ci/test_docs_end_to_end/dump_config_hash.py
+++ b/tests/ci/test_docs_end_to_end/dump_config_hash.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Print a stable hash of the parser-extracted server config.
+
+Used by CI to skip the GPU test when a PR doesn't change anything the
+parser would extract from the markdown tutorials.
+"""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = THIS_DIR.parent.parent.parent
+sys.path.insert(0, str(THIS_DIR))
+
+from parser import MarkdownParser  # noqa: E402
+
+servers = MarkdownParser().parse_directory(str(REPO_ROOT))
+normalized = sorted(
+    [
+        {
+            "name": name,
+            "setup": s.setup_command.command if s.setup_command else None,
+            "health_check": (
+                s.health_check_command.command if s.health_check_command else None
+            ),
+            "aiperf_commands": sorted(c.command for c in s.aiperf_commands),
+        }
+        for name, s in servers.items()
+    ],
+    key=lambda d: d["name"],
+)
+print(hashlib.sha256(json.dumps(normalized).encode()).hexdigest())

--- a/tests/ci/test_docs_end_to_end/dump_config_hash.py
+++ b/tests/ci/test_docs_end_to_end/dump_config_hash.py
@@ -32,4 +32,4 @@ normalized = sorted(
     ],
     key=lambda d: d["name"],
 )
-print(hashlib.sha256(json.dumps(normalized).encode()).hexdigest())
+print(hashlib.sha256(json.dumps(normalized, sort_keys=True).encode()).hexdigest())


### PR DESCRIPTION
Two paired changes:

1. **Swap the audio benchmarking tutorial** from `Qwen/Qwen2-Audio-7B-Instruct` (~14.5 GiB fp16) to `Qwen/Qwen2.5-Omni-3B` (~6 GiB), so the tutorial fits on smaller-VRAM cards including the 24 GB AMD GPU runner used by GitHub Actions.
2. **Re-enable `test_docs_end_to_end` on GitHub Actions** for both per-PR and nightly coverage, with a parser-aware pre-flight that skips the 54-minute GPU job on PRs that don't change anything the test would actually exercise.

The two are paired because the GitHub job was disabled (`d9bdfd9f`) specifically because the audio tutorial OOMed on its hardware; the model swap is what makes re-enabling viable.

## Why

`test_docs_end_to_end` runs in two places:

- **GitLab nightly** — H100/L40-class GPUs, 50+ GiB KV cache available. Green for ~10 of the last 11 days.
- **GitHub Actions** — `prod-aiperf-tester-amd-gpu-v1`, ~24 GB AMD card. Disabled for two weeks.

With the GitHub side dark, regressions that affect users on smaller GPUs go undetected. Restoring it forces tutorials to stay copyable on hardware most users have, not just on H100s.

## Changes

### Doc updates (audio model swap)

| File | Change |
|---|---|
| `docs/tutorials/audio.md` | `--model` in server setup, both `aiperf-run` blocks, health-check JSON, example-output CLI lines, and embedded artifact paths |
| `docs/tutorials/synthetic-dataset.md` | `--model` on the audio `aiperf-run` block (shares the same vLLM server via tag) |
| `docs/tutorials/openai-responses.md` | `--model` on the audio responses example (doc-consistency) |

aiperf source needs no change. Its `input_audio` content-part wire format (`src/aiperf/endpoints/openai_chat.py:170-178`) works against Omni-3B unchanged. The vLLM image and flags stay the same; Omni's audio-out path stays off because chat-completions defaults to text-only with no `--modalities` flag.

### CI updates (re-enable + parser-aware skip)

- **New reusable workflow** `.github/workflows/test-docs-end-to-end.yml` with three triggers: `pull_request` (paths-filtered), `workflow_dispatch`, and `workflow_call`.
- **New helper** `tests/ci/test_docs_end_to_end/dump_config_hash.py` — imports the existing `MarkdownParser`, normalizes the extracted server config, prints a stable SHA-256.
- **Nightly delegation** — `nightly.yml` replaces the previously-commented-out block with a one-liner that delegates to the reusable workflow; restores the `needs:` references in `build-container` and `pipeline-summary`.
- **Renamed** the GitHub job from `gpu-e2e-tests` / "GPU End-to-End Tests" to `test-docs-end-to-end` / "Test Docs End-to-End" to match the GitLab job name and the underlying test directory.

### How the parser-aware skip works

PRs matching the path filter (`docs/tutorials/**` or `tests/ci/test_docs_end_to_end/**`) trigger a cheap `ubuntu-latest` `detect-changes` job:

1. Non-PR triggers (`workflow_dispatch`, `workflow_call`) always run the test — no base/head to compare.
2. For PRs:
   - Any change under `tests/ci/test_docs_end_to_end/` always runs the test (safety net for parser/runner edits).
   - Otherwise, run `dump_config_hash.py` at base and head; compare. Different → run. Same → skip.

The hash is the parser's own output, so the detection logic is automatically correct against any future tag-handling change. No separate path lists to keep in sync. If the hash script errors on either side, the GPU test runs (conservative default).

## Validation

- **Manual end-to-end** of Qwen2.5-Omni-3B against `vllm/vllm-openai:latest` on 2026-04-27: server started cleanly, health check returned 200, both `aiperf-run` blocks succeeded, response payloads were text-only.
- **GitLab nightly** has been green for ~12 of the last 13 days (one unrelated timeout on a slower node).
- **GitHub CI run** is wired up and triggered correctly on this PR (`detect-changes` correctly decides "run", GPU job is dispatched). Will go end-to-end green once the dependencies in the next section are in place.

## Pre-merge dependencies

The diff in this PR is complete; the following are admin/infra tasks owned outside this PR but required for the GitHub side to actually pass:

- **`HF_TOKEN` secret on `ai-dynamo/aiperf`** (or inherited from the org). vLLM downloads model weights from HuggingFace at startup; unauthenticated requests from GitHub-hosted runner IPs are rate-limited hard enough that downloads stall past the 15-min health-check window. A free HF account's read-only token suffices. Confirmed via probe workflow that no `HF_TOKEN` is currently reachable at the repo or org level.
- **`prod-aiperf-tester-amd-gpu-v1` runner online and accepting jobs.** The runner is self-hosted; if it's offline it has to be brought back via Settings → Actions → Runners.

GitLab CI doesn't need either — its cluster IPs aren't rate-limited the same way, and the runner pool is managed separately.

## Test plan

- [x] PR triggers `test-docs-end-to-end` workflow.
- [x] `detect-changes` decides "run" (this PR changes audio commands).
- [ ] GPU job passes against Qwen2.5-Omni-3B (pending dependencies above).
- [ ] Next nightly invokes the workflow via `workflow_call` and passes.
- [ ] A follow-up no-op PR (e.g., a typo fix) is correctly skipped by `detect-changes`.

## Notes

A few non-obvious choices worth flagging for reviewers:

- **The original disable was a misdiagnosis.** The TODO at `nightly.yml:288` framed the failure as "GPU runners are healthy" pending — but the runner was fine; the audio model didn't fit. Re-enabling alone would have reproduced the OOM. The model swap is the precondition.
- **`Qwen2.5-Omni-3B` is a class change, not just a size change.** Qwen2-Audio is single-modality (audio→text); Omni is multimodal Thinker-Talker. Wire compatibility is preserved through `input_audio` content parts; Omni's audio-out path stays off behind explicit `modalities` opt-in that the tutorial doesn't enable.
- **Detection reuses the parser deliberately.** A static path list of "files that contain CI tags" would need manual maintenance every time a new tutorial added tags. Hashing the parser's output makes "what counts as a relevant change" the same definition the test itself uses.
- **Two-job CI structure** so the AMD runner stays free for the ~30s of detection on no-op PRs; `ubuntu-latest` is free, the AMD runner is scarce.

## Out of scope

- **`test_runner.py` cleanup-on-failure bug** — `_test_server` only stops Docker containers at the end of the per-server function, so a failed health check returns early and leaks the server's container into the next iteration (manifests as `port 8000 already allocated` on subsequent servers). Pre-existing, only visible when health checks fail (rare on H100s, common on smaller runners). Separate ticket.
- **Pinning `vllm/vllm-openai:latest`** — user-facing freshness > paper reproducibility; a future vLLM regression is a signal worth surfacing.
- **Parser hardening against orphaned `aiperf-run-*` tags** — separate ticket.
- **Pipeline-runtime mitigation for slower GitLab nodes** — observed once on 2026-04-20, not recurring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated tutorials to use the new audio model identifier, adjusted referenced artifact paths, and added HF_TOKEN plus an eager-enforcement flag to container startup examples.

* **Tests**
  * Added an end-to-end docs test workflow that conditionally runs when docs/config changes.

* **Chores**
  * Integrated the docs end-to-end test into nightly CI and added a CI helper to compute config hashes for conditional execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->