### PR TITLE
ci(fern-docs): split validation from preview so flaky preview never blocks PRs

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -21,13 +21,18 @@
 #    - Triggers on PRs when docs/** or fern/** files change
 #    - Runs `fern check` and `fern docs broken-links`
 #
-# 2. SYNC & PUBLISH/PREVIEW: Syncs docs/ from source branch to fern/ on docs-website
+# 2. VALIDATE & PUBLISH: Syncs docs/ from source branch to fern/ on docs-website,
+#    validates the synced content, and on main publishes via `fern generate --docs`
 #    - Triggers on push to main or PRs when docs/** or fern/** files change
 #    - On main: commits and pushes to docs-website, then publishes via `fern generate --docs`
-#    - On PRs: generates a preview URL via `fern generate --docs --preview` and comments on PR
+#    - On PRs: only validates (preview lives in a separate, non-blocking job)
 #    - Preserves versioned documentation (products[0]) from docs-website's docs.yml
 #
-# 3. VERSION RELEASE (tags): Creates versioned documentation snapshot
+# 3. PREVIEW (PRs, non-blocking): Generates a preview URL and comments on the PR.
+#    - `continue-on-error: true` so flaky `fern generate --preview` failures never
+#      block PR merges. Validation correctness is enforced by job (2).
+#
+# 4. VERSION RELEASE (tags): Creates versioned documentation snapshot
 #    - Triggers on new version tags (vX.Y.Z format)
 #    - Creates fern/pages-vX.Y.Z/ directory on docs-website branch
 #    - Updates fern/docs.yml with new version entry
@@ -84,13 +89,14 @@ jobs:
 
 
   #############################################################################
-  # SYNC & PUBLISH/PREVIEW - Syncs docs content to docs-website structure
-  # On main: commits, pushes to docs-website, then publishes via `fern generate --docs`
-  # On PRs: generates a preview URL via `fern generate --docs --preview` and comments on PR
+  # VALIDATE & PUBLISH - Syncs docs content to docs-website structure and
+  # validates the result. On main: commits, pushes, and publishes via
+  # `fern generate --docs`. On PRs: validation only — preview is a separate,
+  # non-blocking job below so flaky preview failures don't gate PR merges.
   #############################################################################
 
-  preview-or-publish-docs:
-    name: Preview or publish docs
+  validate-and-publish-docs:
+    name: Validate (and publish on main) synced docs
     if: |
       github.ref_type != 'tag' &&
       (github.event.inputs.tag == '' || github.event.inputs.tag == null)
@@ -222,22 +228,133 @@ jobs:
             git status --short
           fi
 
+      - name: Setup Git
+        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
+        run: |
+          cd docs-checkout
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push changes
+        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
+        run: |
+          cd docs-checkout
+
+          git add -A
+          git commit -m "docs(fern): sync dev from main
+
+          Automated sync of docs/ directory from main branch.
+          Preserves versioned documentation snapshots.
+
+          Source commit: ${{ github.sha }}"
+
+          git push origin docs-website
+
+          echo "Successfully synced dev docs to docs-website branch"
+
+      - name: Publish Docs
+        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        working-directory: docs-checkout/fern
+        run: fern generate --docs
+
+  #############################################################################
+  # PREVIEW (PRs, non-blocking) - Generates a preview URL and comments on PR.
+  # Runs in parallel with validate-and-publish-docs and is marked
+  # `continue-on-error: true` so flaky `fern generate --preview` failures don't
+  # block PR merges. Validation correctness is enforced by the job above; this
+  # job only provides the preview-link convenience.
+  #############################################################################
+
+  preview-docs:
+    name: Preview docs (non-blocking)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v4
+        with:
+          path: source-checkout
+          fetch-depth: 1
+
+      - name: Checkout docs-website branch
+        uses: actions/checkout@v4
+        with:
+          ref: docs-website
+          path: docs-checkout
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync dev content from source
+        run: |
+          # Sync content directories from docs/ to fern/pages-dev/ on docs-website
+          rm -rf docs-checkout/fern/pages-dev
+          mkdir -p docs-checkout/fern/pages-dev
+          rsync -a \
+            --exclude='index.yml' \
+            source-checkout/docs/ docs-checkout/fern/pages-dev/
+
+          # Sync index.yml as versions/dev.yml and transform paths for docs-website layout
+          cp source-checkout/docs/index.yml docs-checkout/fern/versions/dev.yml
+
+          # Sync fern.config.json
+          cp source-checkout/fern/fern.config.json docs-checkout/fern/fern.config.json
+
+          # Sync .gitignore if it exists
+          if [ -f source-checkout/fern/.gitignore ]; then
+            cp source-checkout/fern/.gitignore docs-checkout/fern/.gitignore
+          fi
+
+          # Sync md_to_mdx.py script (required — fail fast if missing)
+          cp source-checkout/fern/md_to_mdx.py docs-checkout/fern/md_to_mdx.py
+
+          # Sync components/ directory (e.g., CustomFooter.tsx)
+          if [ -d source-checkout/fern/components ]; then
+            rm -rf docs-checkout/fern/components
+            cp -r source-checkout/fern/components docs-checkout/fern/components
+          fi
+
+          # Sync main.css
+          if [ -f source-checkout/fern/main.css ]; then
+            cp source-checkout/fern/main.css docs-checkout/fern/main.css
+          fi
+
+      - name: Transform paths in dev.yml for docs-website layout
+        run: |
+          yq -i '(.. | select(has("path")).path) |= sub("^([a-zA-Z])", "../pages-dev/${1}")' docs-checkout/fern/versions/dev.yml
+
+      - name: Convert Markdown to Fern MDX format
+        run: python3 docs-checkout/fern/md_to_mdx.py --dir docs-checkout/fern/pages-dev
+
+      - name: Update docs.yml preserving products
+        run: |
+          cd docs-checkout/fern
+          yq '.products[0]' docs.yml > /tmp/preserved_product.yml
+          cp ../../source-checkout/fern/docs.yml docs.yml
+          yq -i '.products[0] = load("/tmp/preserved_product.yml")' docs.yml
+
       - name: Setup Node.js
-        if: steps.changes.outputs.has_changes == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
 
       - name: Install Fern CLI
-        if: steps.changes.outputs.has_changes == 'true'
         run: npm install -g fern-api@$(jq -r '.version' docs-checkout/fern/fern.config.json)
 
-      ##########################################################################
-      # PREVIEW - Generate a preview URL for docs changes on PRs
-      ##########################################################################
+      - name: Check for changes
+        id: changes
+        run: |
+          cd docs-checkout
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Generate docs preview
-        if: steps.ctx.outputs.is_main != 'true' && steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         id: preview
         working-directory: docs-checkout/fern
         env:
@@ -259,7 +376,7 @@ jobs:
           fi
 
       - name: Comment preview URL on PR
-        if: steps.ctx.outputs.is_main != 'true' && steps.preview.outputs.url != '' && github.event_name == 'pull_request'
+        if: steps.preview.outputs.url != ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -293,42 +410,6 @@ jobs:
                 body: body
               });
             }
-
-      ##########################################################################
-      # PUSH AND PUBLISH - push changes to docs-website branch and publish docs
-      # TODO(AIP-855): Re-enable once convert_mdx_comments.py transform is wired in (PR 2)
-      ##########################################################################
-
-      - name: Setup Git
-        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
-        run: |
-          cd docs-checkout
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit and push changes
-        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
-        run: |
-          cd docs-checkout
-
-          git add -A
-          git commit -m "docs(fern): sync dev from main
-
-          Automated sync of docs/ directory from main branch.
-          Preserves versioned documentation snapshots.
-
-          Source commit: ${{ github.sha }}"
-
-          git push origin docs-website
-
-          echo "Successfully synced dev docs to docs-website branch"
-
-      - name: Publish Docs
-        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
-        env:
-          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        working-directory: docs-checkout/fern
-        run: fern generate --docs
 
   #############################################################################
   # VERSION RELEASE - Run on new version tags (vX.Y.Z)

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -29,16 +29,21 @@
 #    - Preserves versioned documentation (products[0]) from docs-website's docs.yml
 #
 # 3. PREVIEW (non-blocking): Generates a preview URL and comments on the PR.
-#    - `continue-on-error: true` so flaky `fern generate --preview` failures never
-#      block PR merges. Validation correctness is enforced by job (2).
-#    - On same-repo PRs: runs on the `pull_request` event with full secret access.
-#    - On fork PRs (no secrets in `pull_request` events): skipped on the
-#      `pull_request` event, then re-runs on push to `pull-request/<N>` after a
-#      maintainer approves the PR via copy-pr-bot (`/ok to test`). The mirror
-#      branch is in the trusted org repo, so it gets `FERN_TOKEN` and can post
-#      the preview URL back to the original PR.
-#    - On un-mirrored fork PRs: simply skipped — no fake yellow continue-on-error
-#      check, just no preview link until a maintainer kicks off copy-pr-bot.
+#    - A small `preview-context` job decides whether the actual `preview-docs`
+#      job should run for this event, then `preview-docs` does the work.
+#    - The `Generate docs preview` step never `exit 1`s — failures emit a
+#      ::warning:: and the comment step posts a "preview unavailable" message
+#      instead. continue-on-error stays as belt-and-suspenders for any other
+#      unexpected failure (sync, network, rate limit at sync time, etc.).
+#    - On same-repo PRs: runs on the `pull_request` event with FERN_TOKEN.
+#    - On fork PRs: skipped on `pull_request` (no secrets in untrusted
+#      context); re-runs on push to `pull-request/<N>` after a maintainer
+#      approves the PR via copy-pr-bot (`/ok to test`). The mirror branch is
+#      in the trusted org repo, so it gets FERN_TOKEN and posts the preview
+#      URL back to the original PR.
+#    - On un-mirrored fork PRs: simply skipped — no fake yellow check on the PR.
+#    - On same-repo PRs that copy-pr-bot also mirrors: the mirror push event
+#      is skipped (the original `pull_request` already ran preview).
 #
 # 4. VERSION RELEASE (tags): Creates versioned documentation snapshot
 #    - Triggers on new version tags (vX.Y.Z format)
@@ -273,38 +278,76 @@ jobs:
         run: fern generate --docs
 
   #############################################################################
-  # PREVIEW (PRs, non-blocking) - Generates a preview URL and comments on PR.
-  # Runs in parallel with validate-and-publish-docs and is marked
-  # `continue-on-error: true` so flaky `fern generate --preview` failures don't
-  # block PR merges. Validation correctness is enforced by the job above; this
-  # job only provides the preview-link convenience.
+  # PREVIEW CONTEXT - resolves the PR number and decides whether `preview-docs`
+  # should run for this event. Always succeeds (it's just a lookup job), so
+  # it stays out of the way of branch protection. preview-docs `needs:` this.
+  #
+  # Decision logic:
+  #   - same-repo PR on `pull_request`: run (has FERN_TOKEN).
+  #   - fork PR on `pull_request`: skip (no secrets in untrusted context;
+  #     copy-pr-bot will mirror after `/ok to test` and we'll catch the push).
+  #   - mirror push (`pull-request/<N>`) for a fork PR: run (trusted context).
+  #   - mirror push for a same-repo PR: skip (the original `pull_request`
+  #     event already ran preview — avoids duplicate preview generation).
+  #############################################################################
+
+  preview-context:
+    name: Preview docs context
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/'))
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      pr_number: ${{ steps.decide.outputs.pr_number }}
+    steps:
+      - name: Decide whether preview should run
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_NUMBER_FROM_EVENT: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_NUMBER="$PR_NUMBER_FROM_EVENT"
+            HEAD_REPO="$PR_HEAD_REPO"
+          else
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            PR_NUMBER="${BRANCH#pull-request/}"
+            HEAD_REPO=$(gh api "/repos/$REPO/pulls/$PR_NUMBER" --jq '.head.repo.full_name' 2>/dev/null || echo "")
+          fi
+
+          SHOULD_RUN=false
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REPO" = "$REPO" ]; then
+            SHOULD_RUN=true
+          elif [ "$EVENT_NAME" = "push" ] && [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$REPO" ]; then
+            SHOULD_RUN=true
+          fi
+
+          echo "Resolved PR #$PR_NUMBER (head=$HEAD_REPO) should_run=$SHOULD_RUN"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+
+  #############################################################################
+  # PREVIEW (non-blocking) - Generates a preview URL and comments on the PR.
+  # Skipped entirely when preview-context says it shouldn't run, so the only
+  # check that ever appears on a PR is the matching one (no fake yellow). The
+  # actual preview-generate step never `exit 1`s — failures emit a warning,
+  # set no URL output, and the comment step posts a "preview unavailable"
+  # message instead. continue-on-error stays as belt-and-suspenders for any
+  # other unexpected failure (sync, network, rate limit at sync time, etc.).
   #############################################################################
 
   preview-docs:
     name: Preview docs (non-blocking)
-    # Run on:
-    #   1. same-repo PRs (have FERN_TOKEN), OR
-    #   2. push to copy-pr-bot mirror branches `pull-request/<N>` (also have
-    #      FERN_TOKEN, used for fork PRs after maintainer `/ok to test`).
-    # Un-mirrored fork PRs don't match either condition, so they're cleanly
-    # skipped — no fake yellow continue-on-error check on the PR.
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/'))
+    needs: preview-context
+    if: needs.preview-context.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - name: Determine PR number
-        id: pr
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          else
-            # push to copy-pr-bot mirror branch refs/heads/pull-request/<N>
-            BRANCH="${GITHUB_REF#refs/heads/}"
-            echo "number=${BRANCH#pull-request/}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout source branch
         uses: actions/checkout@v4
         with:
@@ -392,29 +435,39 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
+          # Never `exit 1` here — preview is best-effort. On failure we emit a
+          # ::warning::, leave the `url` output empty, and let the comment
+          # step post a "preview unavailable" message. This keeps the job
+          # genuinely green (so the per-job check is a real check, not the
+          # not-quite-green of `continue-on-error: true` masking failure).
           if OUTPUT=$(fern generate --docs --preview 2>&1); then
             FERN_EXIT=0
           else
             FERN_EXIT=$?
           fi
           echo "$OUTPUT"
-          if [ $FERN_EXIT -ne 0 ]; then
-            echo "::error::Fern docs preview generation failed (exit $FERN_EXIT)"
-            exit 1
-          fi
           URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K\S+') || true
           if [ -n "$URL" ]; then
-            echo "url=$URL" >> $GITHUB_OUTPUT
+            echo "url=$URL" >> "$GITHUB_OUTPUT"
+          elif [ $FERN_EXIT -ne 0 ]; then
+            echo "::warning::Fern docs preview generation failed (exit $FERN_EXIT) — preview will be unavailable for this run."
           fi
 
-      - name: Comment preview URL on PR
-        if: steps.preview.outputs.url != ''
+      - name: Comment preview status on PR
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.preview-context.outputs.pr_number }}
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
-            const prNumber = ${{ steps.pr.outputs.number }};
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const url = process.env.PREVIEW_URL;
+            const runUrl = process.env.RUN_URL;
             const commentIdentifier = '<!-- fern-docs-preview -->';
-            const body = `${commentIdentifier}\n**Fern Docs Preview:** ${{ steps.preview.outputs.url }}/dev`;
+            const body = url
+              ? `${commentIdentifier}\n**Fern Docs Preview:** ${url}/dev`
+              : `${commentIdentifier}\n**Fern Docs Preview:** generation failed — see the [Actions log](${runUrl}) for details. This does not block merge; ask a maintainer to retry if needed.`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -319,7 +319,12 @@ jobs:
           else
             BRANCH="${GITHUB_REF#refs/heads/}"
             PR_NUMBER="${BRANCH#pull-request/}"
-            HEAD_REPO=$(gh api "/repos/$REPO/pulls/$PR_NUMBER" --jq '.head.repo.full_name' 2>/dev/null || echo "")
+            # Surface lookup failures rather than silently routing as same-repo
+            # (which would skip the preview entirely, leaving no PR comment).
+            if ! HEAD_REPO=$(gh api "/repos/$REPO/pulls/$PR_NUMBER" --jq '.head.repo.full_name'); then
+              echo "::error::Unable to resolve head repo for PR #$PR_NUMBER — preview routing failed"
+              exit 1
+            fi
           fi
 
           SHOULD_RUN=false
@@ -438,10 +443,9 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
           # Never `exit 1` here — preview is best-effort. On failure we emit a
-          # ::warning::, leave the `url` output empty, and let the comment
-          # step post a "preview unavailable" message. This keeps the job
-          # genuinely green (so the per-job check is a real check, not the
-          # not-quite-green of `continue-on-error: true` masking failure).
+          # ::warning::, set `status=failed`, and let the comment step post a
+          # "preview unavailable" message. On success we set `status=success`
+          # plus the URL. This keeps the job genuinely green.
           if OUTPUT=$(fern generate --docs --preview 2>&1); then
             FERN_EXIT=0
           else
@@ -451,11 +455,19 @@ jobs:
           URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K\S+') || true
           if [ -n "$URL" ]; then
             echo "url=$URL" >> "$GITHUB_OUTPUT"
-          elif [ $FERN_EXIT -ne 0 ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          else
             echo "::warning::Fern docs preview generation failed (exit $FERN_EXIT) — preview will be unavailable for this run."
+            echo "status=failed" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Comment preview status on PR
+        # Run on success or failure of preceding steps, but skip the comment
+        # entirely when the preview step itself was skipped (has_changes=false)
+        # so we don't post a misleading "preview unavailable" on doc-untouched
+        # synced runs. Early-step failures (sync/checkout) are covered by
+        # validate-and-publish-docs being red, so no comment needed there either.
+        if: always() && steps.preview.outputs.status != ''
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ needs.preview-context.outputs.pr_number }}

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -62,6 +62,8 @@ on:
     paths:
       - 'docs/**'
       - 'fern/**'
+      # Self-validate when the workflow itself is edited.
+      - '.github/workflows/fern-docs.yml'
   push:
     branches:
       - main

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -28,9 +28,17 @@
 #    - On PRs: only validates (preview lives in a separate, non-blocking job)
 #    - Preserves versioned documentation (products[0]) from docs-website's docs.yml
 #
-# 3. PREVIEW (PRs, non-blocking): Generates a preview URL and comments on the PR.
+# 3. PREVIEW (non-blocking): Generates a preview URL and comments on the PR.
 #    - `continue-on-error: true` so flaky `fern generate --preview` failures never
 #      block PR merges. Validation correctness is enforced by job (2).
+#    - On same-repo PRs: runs on the `pull_request` event with full secret access.
+#    - On fork PRs (no secrets in `pull_request` events): skipped on the
+#      `pull_request` event, then re-runs on push to `pull-request/<N>` after a
+#      maintainer approves the PR via copy-pr-bot (`/ok to test`). The mirror
+#      branch is in the trusted org repo, so it gets `FERN_TOKEN` and can post
+#      the preview URL back to the original PR.
+#    - On un-mirrored fork PRs: simply skipped — no fake yellow continue-on-error
+#      check, just no preview link until a maintainer kicks off copy-pr-bot.
 #
 # 4. VERSION RELEASE (tags): Creates versioned documentation snapshot
 #    - Triggers on new version tags (vX.Y.Z format)
@@ -52,6 +60,10 @@ on:
   push:
     branches:
       - main
+      # copy-pr-bot mirror branches for fork PRs; pushes here run in trusted
+      # context with FERN_TOKEN, letting `preview-docs` generate previews for
+      # fork PRs after a maintainer approves via `/ok to test`.
+      - 'pull-request/*'
     tags:
       # Match only clean semver tags: vX.Y.Z
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -99,7 +111,8 @@ jobs:
     name: Validate (and publish on main) synced docs
     if: |
       github.ref_type != 'tag' &&
-      (github.event.inputs.tag == '' || github.event.inputs.tag == null)
+      (github.event.inputs.tag == '' || github.event.inputs.tag == null) &&
+      !(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/'))
     runs-on: ubuntu-latest
     steps:
       - name: Determine context
@@ -269,10 +282,29 @@ jobs:
 
   preview-docs:
     name: Preview docs (non-blocking)
-    if: github.event_name == 'pull_request'
+    # Run on:
+    #   1. same-repo PRs (have FERN_TOKEN), OR
+    #   2. push to copy-pr-bot mirror branches `pull-request/<N>` (also have
+    #      FERN_TOKEN, used for fork PRs after maintainer `/ok to test`).
+    # Un-mirrored fork PRs don't match either condition, so they're cleanly
+    # skipped — no fake yellow continue-on-error check on the PR.
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/'))
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Determine PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # push to copy-pr-bot mirror branch refs/heads/pull-request/<N>
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            echo "number=${BRANCH#pull-request/}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout source branch
         uses: actions/checkout@v4
         with:
@@ -380,7 +412,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.issue.number;
+            const prNumber = ${{ steps.pr.outputs.number }};
             const commentIdentifier = '<!-- fern-docs-preview -->';
             const body = `${commentIdentifier}\n**Fern Docs Preview:** ${{ steps.preview.outputs.url }}/dev`;
 


### PR DESCRIPTION
## Summary

Three layered changes that turn the "flaky" Fern preview check into a genuine signal:

1. **Split validation from preview** — `preview-or-publish-docs` becomes `validate-and-publish-docs` (required: sync + validate + publish-on-main) plus a parallel preview path. Validation correctness is the gating signal; preview is convenience.
2. **Wire preview into copy-pr-bot** — what looked like flake was deterministic fork-PR auth: `FERN_TOKEN` is empty in untrusted `pull_request` events from forks, so `fern generate --preview` always fails with "Authentication required." The repo already has copy-pr-bot enabled (`.github/copy-pr-bot.yaml`), so this PR teaches the preview path to also run on `push` to `pull-request/<N>` mirror branches (trusted context).
3. **`preview-context` decider + never-fail preview step + fallback comment** — a small `preview-context` job resolves the PR number and decides whether `preview-docs` should run for this event (skipping fork PRs without a mirror, and skipping mirror pushes for same-repo PRs that already ran on `pull_request`). The actual `Generate docs preview` step never `exit 1`s — failures emit a `::warning::` and the comment step posts a "preview unavailable" message with a link to the Actions run. No more silent failures, no more double previews, no more fake yellow.

Also drops a redundant `Setup Node.js` / `Install Fern CLI` pair that was conditionally re-running on `has_changes` while the unconditional setup above already covered the path.

## Why

Looking at recent failures, every "preview failed" run had `FERN_TOKEN: ` (empty) in the env block. Cross-referencing PR head repos:

| PR | head repo | `FERN_TOKEN` | result |
|---|---|---|---|
| #856 (frgud) | dferguson992 fork | empty | fail "Authentication required" |
| #864 (sm-trace-fmt) | Lokiiiiii fork | empty | fail "Authentication required" |
| #841 (nealv) | ai-dynamo same-repo | `***` | success |
| #815 (mmlu/debermudez) | ai-dynamo same-repo | `***` | success |

So the failure mode was "fork PR without secrets," not flake. The fix routes fork-PR previews through the copy-pr-bot mirror branch (which is in the trusted org repo and has secrets) after a maintainer comments `/ok to test`.

## Behavior matrix after this PR

| Trigger | `validate-and-publish-docs` | `preview-context` | `preview-docs` | `release-version` |
|---|---|---|---|---|
| Same-repo PR | required (validates) | runs (always green) | runs (parallel, posts URL) | skipped |
| Fork PR, no `/ok to test` | required (validates) | runs (decides skip) | **skipped** (no fake check) | skipped |
| Fork PR, after `/ok to test` → mirror push | skipped (already validated on `pull_request`) | runs (decides run) | runs (posts URL on the original PR) | skipped |
| Same-repo PR mirror push (copy-pr-bot also mirrors these) | skipped | runs (decides skip) | **skipped** (no duplicate run) | skipped |
| Push to `main` | required (validates + publishes) | skipped | skipped | skipped |
| Tag `vX.Y.Z` | skipped | skipped | skipped | required |

## Branch protection

Confirmed via `gh api repos/ai-dynamo/aiperf/rules/branches/main`: the only required check on `main` is `pre-commit`. The renamed fern-docs jobs are not referenced in any required-status-checks list, so this PR needs **no branch-protection-rule update**.

## Test plan

- [ ] Confirm `validate-and-publish-docs` runs and is green on this PR (same-repo branch).
- [ ] Confirm `preview-context` runs, decides `should_run=true`, and `preview-docs` runs and posts a preview URL comment.
- [ ] Wait for the next fork PR to confirm `preview-context` decides `should_run=false` on the `pull_request` event (no fake yellow check on the PR).
- [ ] On a fork PR after `/ok to test`, confirm the resulting `pull-request/<N>` push triggers `preview-context` (`should_run=true`), then `preview-docs` runs and posts the URL back to the original PR.
- [ ] Force a synthetic preview failure (e.g., revoke `FERN_TOKEN` temporarily on a test branch) and confirm the comment step posts the "preview unavailable — see Actions log" fallback message, and the job remains green.
- [ ] After merge to main, confirm push-to-`main` still triggers sync/commit-to-`docs-website` and `fern generate --docs` publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized documentation validation and publishing pipeline to run on main branch only.
  * Pull request documentation previews now automatically generated with improved error handling.
  * Enhanced preview system across all pull request types with informative fallback messaging when previews are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->