### PR TITLE
fix(server-metrics): auto-disable on incompatible endpoint + probe /prometheus/metrics fallback

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,6 +136,7 @@ The Server Metrics Manager collects metrics from Prometheus-compatible endpoints
 - Supporting custom Prometheus endpoints via `--server-metrics` flag
 - Parsing any metrics exposed in Prometheus format (gauges, counters, histograms)
 - Typical metrics collected: inference server KV cache usage, request counts, latencies, batch sizes, model-specific metrics, and server resource metrics
+- Auto-detecting non-Prometheus endpoints (e.g. TRT-LLM serves an iteration-stats JSON array at `/metrics` by default), probing `<base>/prometheus/metrics` once as a fallback, and disabling collection for that endpoint after a single warning if neither path yields parseable Prometheus data — see [Server Metrics Compatibility & auto-disable](server-metrics/server-metrics.md#compatibility--auto-disable)
 - Exporting server metrics alongside benchmark results
 
 ## How AIPerf Works

--- a/docs/server-metrics/server-metrics-reference.md
+++ b/docs/server-metrics/server-metrics-reference.md
@@ -456,6 +456,9 @@ For disaggregated prefill/decode deployments, these metrics track KV cache trans
 
 TensorRT-LLM (trtllm) is NVIDIA's high-performance inference engine optimized for NVIDIA GPUs. These metrics focus on request latency and completion tracking.
 
+> [!IMPORTANT]
+> **TRT-LLM exposes Prometheus at a non-standard path.** By default `trtllm-serve` serves an iteration-stats JSON array at `/metrics` (not Prometheus exposition format). The metrics below are only available when the server is launched with `return_perf_metrics: true` in `extra_llm_api_options.yaml`, which mounts the proper Prometheus exposition at `/prometheus/metrics`. AIPerf detects the JSON response on `/metrics`, probes the alt path automatically, and swaps the collector's URL on success — see [Compatibility & auto-disable](server-metrics.md#compatibility--auto-disable).
+
 ### Request Latency
 
 | Metric | Type | Unit | Labels | Histogram Buckets | Description |

--- a/docs/server-metrics/server-metrics.md
+++ b/docs/server-metrics/server-metrics.md
@@ -73,6 +73,17 @@ AIPerf automatically collects metrics from Prometheus-compatible endpoints expos
 | `trtllm:request_queue_time_seconds` | histogram | Queue wait (`stats.p99_estimate`) |
 | `trtllm:request_success` | counter | Completed requests (`stats.rate`) |
 
+> [!IMPORTANT]
+> **TRT-LLM server-side setup is required.** Unlike vLLM and SGLang, `trtllm-serve` does not expose Prometheus exposition format at `/metrics` by default — the default `/metrics` returns an iteration-stats JSON array (`application/json`), which is not parseable as Prometheus. Two consequences:
+>
+> 1. **Enable Prometheus on the server.** Pass `return_perf_metrics: true` in your `extra_llm_api_options.yaml`. This mounts the proper Prometheus exposition at `/prometheus/metrics` (a non-standard path).
+> 2. **AIPerf auto-detects and falls back.** When AIPerf hits `/metrics` and gets `application/json`, it automatically probes `<base>/prometheus/metrics` once. If the alt path serves Prometheus, AIPerf swaps the URL and continues — no manual override needed. If the alt path also fails (e.g. `return_perf_metrics` was not set), the collector auto-disables for the remainder of the run with a single warning.
+>
+> Example `extra_llm_api_options.yaml` snippet:
+> ```yaml
+> return_perf_metrics: true
+> ```
+
 </Accordion>
 
 ## Quick Start
@@ -92,7 +103,7 @@ aiperf profile \
 AIPerf automatically:
 1. Discovers the `/metrics` endpoint on your inference server (base URL + `/metrics`)
 2. Tests endpoint reachability before profiling starts
-3. Captures baseline metrics before warmup period begins (reference point for deltas)
+3. Captures baseline metrics before warmup period begins (reference point for deltas) — also where AIPerf first parses the response and validates it as Prometheus exposition format; see [Compatibility & auto-disable](#compatibility--auto-disable) for what happens when an endpoint returns non-Prometheus content
 4. Collects metrics at configurable intervals during warmup and profiling
 5. Performs final scrape after profiling completes (captures end state)
 6. Exports selected formats (default: JSON + CSV):
@@ -153,6 +164,27 @@ aiperf profile --model MODEL ... --server-metrics-formats json csv jsonl parquet
 | **JSON/CSV** (default) | Summary statistics, CI/CD thresholds | Small |
 | **Parquet** | SQL queries, pandas/DuckDB analytics | Compressed |
 | **JSONL** | Debugging, raw Prometheus snapshots | 10-100x larger |
+
+## Compatibility & auto-disable
+
+AIPerf scrapes `/metrics` at ~3 Hz and parses the response as Prometheus exposition format. When a server speaks something else at that path (most commonly TRT-LLM, which serves an iteration-stats JSON array), AIPerf does not retry-and-spam — it detects the mismatch on the first scrape and disables collection for that endpoint with a single log line. This avoids the failure mode where parse errors at the scrape interval inflate run time by 10×+.
+
+**Detection.** A response is treated as non-Prometheus when either:
+- the HTTP `Content-Type` is `application/json` (the response body is never read in this case — the rejection is cheaper than parsing); or
+- the body fails to parse as Prometheus exposition format (`prometheus_client.parser.text_string_to_metric_families` raises `ValueError` — e.g. a server returns `text/plain` with garbage, or a JSON body without a content-type).
+
+**TRT-LLM `/prometheus/metrics` fallback.** Before disabling, AIPerf probes `<base>/prometheus/metrics` exactly once — TRT-LLM mounts the proper Prometheus path there when launched with `return_perf_metrics: true` (see the TRT-LLM entry in the [Quick Reference table](#quick-reference) above). If the probe succeeds, the collector swaps its URL there and the run continues with the alt endpoint. The probe is only attempted when the configured URL ends with exactly `/metrics`; URLs ending with anything else (e.g. `/prometheus/metrics`, `/v1/metrics`, `/api/metrics`) are left untouched.
+
+**On auto-disable.** A single `WARNING` is emitted naming the endpoint and the suppression flag. Subsequent scrape cycles short-circuit, the collector emits no further log noise, and the rest of the benchmark proceeds normally — other configured endpoints (DCGM telemetry, additional `--server-metrics` URLs) are unaffected.
+
+```text
+WARNING  Disabling server metrics collection for http://127.0.0.1:60000/metrics:
+         endpoint 'http://127.0.0.1:60000/metrics' returned non-Prometheus
+         content-type 'application/json'; expected text/plain (Prometheus
+         exposition format). To suppress this warning, pass --no-server-metrics.
+```
+
+**To suppress the warning entirely**, pass `--no-server-metrics` — collection is skipped, no probe is attempted, no warning is logged.
 
 ## Configuration
 
@@ -499,6 +531,7 @@ AIPerf automatically infers units from metric names and descriptions using stand
 | OOM crashes | `vllm:kv_cache_usage_perc` approaching 1.0 | Reduce `max_model_len` or increase `gpu_memory_utilization` |
 | Low throughput | `vllm:num_requests_running` vs `vllm:num_requests_waiting` | Low both = client bottleneck; high waiting = server bottleneck |
 | Endpoint unreachable | `curl http://localhost:8000/metrics` | Check server running, network, firewall; use explicit `--server-metrics` URL |
+| `WARNING ... non-Prometheus content-type 'application/json'` | `curl -i <base>/metrics` shows `Content-Type: application/json` | Server isn't serving Prometheus at `/metrics`. For TRT-LLM, set `return_perf_metrics: true` in `extra_llm_api_options.yaml` so AIPerf's auto-probe finds `/prometheus/metrics`. To silence the warning entirely, pass `--no-server-metrics`. See [Compatibility & auto-disable](#compatibility--auto-disable). |
 
 ---
 

--- a/src/aiperf/common/exceptions.py
+++ b/src/aiperf/common/exceptions.py
@@ -107,6 +107,19 @@ class DatasetGeneratorError(AIPerfError):
     """Generic dataset generator error."""
 
 
+class IncompatibleMetricsEndpointError(AIPerfError):
+    """Raised when an HTTP metrics endpoint returns content that cannot be
+    interpreted as Prometheus exposition format (e.g. a JSON body, or text
+    that fails the Prometheus parser). Indicates a structural mismatch the
+    collector cannot recover from by retrying — the affected collector should
+    auto-disable rather than spam parse errors at the configured interval.
+
+    A representative trigger is the TensorRT-LLM ``/metrics`` endpoint, which
+    serves an iteration-stats JSON array (``application/json``) at the same
+    path Prometheus scrapers expect.
+    """
+
+
 class InitializationError(AIPerfError):
     """Exception raised when something fails to initialize."""
 

--- a/src/aiperf/common/mixins/base_metrics_collector_mixin.py
+++ b/src/aiperf/common/mixins/base_metrics_collector_mixin.py
@@ -16,6 +16,7 @@ from typing import Generic, TypeVar
 
 import aiohttp
 
+from aiperf.common.exceptions import IncompatibleMetricsEndpointError
 from aiperf.common.hooks import background_task, on_init, on_stop
 from aiperf.common.mixins import AIPerfLifecycleMixin
 from aiperf.common.models import ErrorDetails
@@ -213,6 +214,10 @@ class BaseMetricsCollectorMixin(AIPerfLifecycleMixin, ABC, Generic[TRecord]):
         self._trace_timing: dict[object, HttpTraceTiming] = {}
         # Hash of last response for deduplication
         self._last_response_hash: int | None = None
+        # Set when the endpoint is determined to be structurally non-Prometheus
+        # (see IncompatibleMetricsEndpointError). Subsequent collection cycles
+        # short-circuit so we don't spam parse failures at the scrape interval.
+        self._endpoint_disabled: bool = False
         super().__init__(**kwargs)
 
     @property
@@ -426,11 +431,35 @@ class BaseMetricsCollectorMixin(AIPerfLifecycleMixin, ABC, Generic[TRecord]):
         - Logs errors if no callback configured
         - Prevents exceptions from crashing the background collection task
 
+        IncompatibleMetricsEndpointError is treated as a terminal classification
+        for the endpoint: the collector is marked disabled, a single warning is
+        logged, the error is reported once via the error callback, and all
+        subsequent calls short-circuit. This avoids the "30min benchmark
+        becomes 8hr" failure mode where a non-Prometheus endpoint (e.g. the
+        TRT-LLM iteration-stats JSON at /metrics) drove the scrape loop into
+        a parse-error spiral.
+
         This error handling enables collectors to recover from transient failures
         (network blips, server restarts) and continue collecting on the next interval.
         """
+        if self._endpoint_disabled:
+            return
         try:
             await self._collect_and_process_metrics()
+        except IncompatibleMetricsEndpointError as e:
+            self._endpoint_disabled = True
+            self.warning(
+                f"Disabling server metrics collection for {self._endpoint_url}: "
+                f"{e}. To suppress this warning, pass --no-server-metrics."
+            )
+            if self._error_callback:
+                try:
+                    await self._error_callback(
+                        ErrorDetails.from_exception(e),
+                        self.id,
+                    )
+                except Exception as callback_error:
+                    self.error(f"Failed to send error via callback: {callback_error}")
         except Exception as e:
             if self._error_callback:
                 try:
@@ -488,6 +517,17 @@ class BaseMetricsCollectorMixin(AIPerfLifecycleMixin, ABC, Generic[TRecord]):
                 self._endpoint_url, trace_request_ctx=trace_ctx
             ) as response:
                 response.raise_for_status()
+                content_type = response.headers.get("content-type", "").lower()
+                # Prometheus exposition is text/plain; servers like TRT-LLM
+                # serve a JSON iteration-stats array at /metrics, which the
+                # Prometheus parser cannot interpret. Reject up front so the
+                # caller can auto-disable instead of looping on parse errors.
+                if content_type.startswith("application/json"):
+                    raise IncompatibleMetricsEndpointError(
+                        f"endpoint {self._endpoint_url!r} returned non-Prometheus "
+                        f"content-type {content_type!r}; expected text/plain "
+                        f"(Prometheus exposition format)"
+                    )
                 text = await response.text()
 
             timing = self._trace_timing.pop(trace_ctx, HttpTraceTiming())

--- a/src/aiperf/common/mixins/base_metrics_collector_mixin.py
+++ b/src/aiperf/common/mixins/base_metrics_collector_mixin.py
@@ -447,6 +447,14 @@ class BaseMetricsCollectorMixin(AIPerfLifecycleMixin, ABC, Generic[TRecord]):
         try:
             await self._collect_and_process_metrics()
         except IncompatibleMetricsEndpointError as e:
+            # `_collect_metrics_loop` fires `execute_async` every interval
+            # without awaiting prior cycles; under TRT-LLM /metrics latency
+            # several scrape coroutines can be in flight when the first one
+            # raises, all reaching this except block. Synchronously
+            # check-and-set the flag (no awaits before the set) so only the
+            # first arrival logs and notifies — the rest short-circuit.
+            if self._endpoint_disabled:
+                return
             self._endpoint_disabled = True
             self.warning(
                 f"Disabling server metrics collection for {self._endpoint_url}: "

--- a/src/aiperf/server_metrics/data_collector.py
+++ b/src/aiperf/server_metrics/data_collector.py
@@ -181,8 +181,17 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
     async def _probe_prometheus_fallback_or_reraise(self) -> None:
         """Attempt ``<base>/prometheus/metrics`` once. On success, swap the
         collector's URL and dispatch the record from the alt endpoint. On
-        failure, restore the original URL and re-raise so the base mixin
-        can auto-disable.
+        failure, restore the original URL and re-raise as
+        ``IncompatibleMetricsEndpointError`` so the base mixin can auto-disable.
+
+        Probe failures from any cause — 404 (path not mounted because
+        ``return_perf_metrics`` is unset), connection-refused, transient HTTP
+        errors, or another non-Prometheus body at the alt path — are all
+        funneled into ``IncompatibleMetricsEndpointError``. Without this
+        translation, a 404 on ``/prometheus/metrics`` would surface as
+        ``aiohttp.ClientResponseError`` and bypass the auto-disable wrapper,
+        causing the collector to keep retrying the (still-broken) original
+        URL on every subsequent scrape interval.
         """
         self._prometheus_fallback_attempted = True
         original_url = self._endpoint_url
@@ -197,9 +206,18 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         self._last_response_hash = None
         try:
             await self._fetch_parse_send()
-        except Exception:
+        except IncompatibleMetricsEndpointError:
             self._endpoint_url = original_url
             raise
+        except Exception as e:
+            self._endpoint_url = original_url
+            raise IncompatibleMetricsEndpointError(
+                f"Prometheus fallback {candidate_url!r} also failed ({e!r}); "
+                f"original endpoint {original_url!r} returned non-Prometheus "
+                f"content. For TRT-LLM, set 'return_perf_metrics: true' in "
+                f"extra_llm_api_options.yaml to enable Prometheus exposition "
+                f"at /prometheus/metrics."
+            ) from e
         self.info(
             f"Prometheus fallback succeeded; collector swapped to {candidate_url!r}."
         )

--- a/src/aiperf/server_metrics/data_collector.py
+++ b/src/aiperf/server_metrics/data_collector.py
@@ -11,6 +11,7 @@ from prometheus_client.parser import text_string_to_metric_families
 
 from aiperf.common.enums import PrometheusMetricType
 from aiperf.common.environment import Environment
+from aiperf.common.exceptions import IncompatibleMetricsEndpointError
 from aiperf.common.mixins import BaseMetricsCollectorMixin
 from aiperf.common.mixins.base_metrics_collector_mixin import FetchResult
 from aiperf.common.models import ErrorDetails
@@ -119,6 +120,10 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         # Keep track of metrics we have already seen (logged once) to avoid spamming the logs
         self._seen_metadata_metrics = set()
         self._seen_summary_metrics = set()
+        # When True, the active endpoint URL has already been swapped (or the
+        # probe was attempted unsuccessfully) — never probe twice for the same
+        # collector instance.
+        self._prometheus_fallback_attempted: bool = False
 
     async def _collect_and_process_metrics(self) -> None:
         """Collect metrics from Prometheus endpoint and process them into ServerMetricsRecord objects.
@@ -130,16 +135,74 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         2. Parses Prometheus-format data into ServerMetricsRecord objects
         3. Sends records via callback (via mixin's _send_records_via_callback)
 
+        On the first IncompatibleMetricsEndpointError (typical trigger:
+        TRT-LLM serves an iteration-stats JSON array at ``/metrics``), the
+        collector probes ``<base>/prometheus/metrics`` once. If that path
+        returns valid Prometheus exposition, the collector swaps its
+        endpoint URL there and continues — the user gets metrics without
+        having to manually move the URL. If the fallback also fails, the
+        original IncompatibleMetricsEndpointError propagates so the base
+        mixin's ``collect_and_process_metrics`` wrapper can auto-disable.
+
         Uses HTTP trace timing to capture precise request lifecycle timestamps for
         accurate correlation with client request timestamps.
 
         Raises:
-            Exception: Any exception from fetch or parse is logged and re-raised
+            IncompatibleMetricsEndpointError: When neither the original URL
+                nor the ``/prometheus/metrics`` fallback yields parseable
+                Prometheus data. The base mixin catches this and disables
+                the collector for the remainder of the run.
         """
+        try:
+            await self._fetch_parse_send()
+        except IncompatibleMetricsEndpointError:
+            if not self._should_probe_prometheus_fallback():
+                raise
+            await self._probe_prometheus_fallback_or_reraise()
+
+    async def _fetch_parse_send(self) -> None:
+        """Single fetch+parse+dispatch cycle against the current endpoint URL."""
         fetch_result = await self._fetch_metrics_text()
         record = self._parse_metrics_to_records(fetch_result)
         if record:
             await self._send_records_via_callback([record])
+
+    def _should_probe_prometheus_fallback(self) -> bool:
+        """The fallback probe runs at most once and only when the active URL
+        ends with ``/metrics`` (so we have a deterministic alternate path to
+        try). URLs that already point at ``/prometheus/metrics`` or that use
+        a non-standard suffix are left untouched."""
+        return (
+            not self._prometheus_fallback_attempted
+            and self._endpoint_url.endswith("/metrics")
+            and not self._endpoint_url.endswith("/prometheus/metrics")
+        )
+
+    async def _probe_prometheus_fallback_or_reraise(self) -> None:
+        """Attempt ``<base>/prometheus/metrics`` once. On success, swap the
+        collector's URL and dispatch the record from the alt endpoint. On
+        failure, restore the original URL and re-raise so the base mixin
+        can auto-disable.
+        """
+        self._prometheus_fallback_attempted = True
+        original_url = self._endpoint_url
+        candidate_url = original_url.removesuffix("/metrics") + "/prometheus/metrics"
+        self.info(
+            f"Endpoint {original_url!r} returned non-Prometheus content; "
+            f"probing fallback {candidate_url!r} (TRT-LLM compatibility path)."
+        )
+        self._endpoint_url = candidate_url
+        # Reset response-hash dedup so the alt endpoint's first response is
+        # not mistaken for a duplicate of the previous /metrics body.
+        self._last_response_hash = None
+        try:
+            await self._fetch_parse_send()
+        except Exception:
+            self._endpoint_url = original_url
+            raise
+        self.info(
+            f"Prometheus fallback succeeded; collector swapped to {candidate_url!r}."
+        )
 
     def _parse_metrics_to_records(
         self, fetch_result: FetchResult
@@ -159,7 +222,9 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
             ServerMetricsRecord | None: ServerMetricsRecord containing complete snapshot.
                 Returns None if fetch_result.text is empty
         Raises:
-            ValueError: If parsing fails
+            IncompatibleMetricsEndpointError: If the body cannot be parsed as
+                Prometheus exposition format (e.g. TRT-LLM serves an
+                iteration-stats JSON array at the same path).
         """
         trace_timing = fetch_result.trace_timing
 
@@ -222,8 +287,11 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
                         samples=samples,
                     )
         except ValueError as e:
-            self.warning(f"Failed to parse Prometheus metrics - invalid format: {e!r}")
-            raise
+            body_preview = (fetch_result.text or "")[:200]
+            raise IncompatibleMetricsEndpointError(
+                f"endpoint did not return valid Prometheus exposition format "
+                f"({e}); body sample: {body_preview!r}"
+            ) from e
 
         # Suppress empty snapshots to reduce I/O noise
         if not metrics_dict:

--- a/tests/unit/common/mixins/test_base_metrics_collector_mixin.py
+++ b/tests/unit/common/mixins/test_base_metrics_collector_mixin.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -139,6 +140,33 @@ class TestAutoDisableOnIncompatibleEndpoint:
         # subsequent cycles short-circuited at the disabled gate, so no
         # additional error callbacks fired (no parse-error spam).
         assert collector.calls == 1
+        assert error_cb.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_log_disable_warning_only_once(self) -> None:
+        """The real-world trigger: `_collect_metrics_loop` calls
+        ``execute_async(self.collect_and_process_metrics())`` every interval
+        without awaiting prior cycles, so multiple scrape coroutines can
+        be in flight when the first one raises. Every concurrent call
+        will reach the except block, but the warning + error_callback
+        must fire exactly once across the cohort.
+        """
+        error_cb = AsyncMock()
+        collector = _RaisingCollector(
+            endpoint_url="http://localhost:9999/metrics",
+            collection_interval=0.1,
+            reachability_timeout=1.0,
+            error_callback=error_cb,
+        )
+
+        await asyncio.gather(
+            *(collector.collect_and_process_metrics() for _ in range(8))
+        )
+
+        assert collector._endpoint_disabled is True
+        # Concurrent cohort all raised, but only the first arrival into
+        # the except block flipped the flag; subsequent arrivals saw the
+        # disabled check and short-circuited before logging.
         assert error_cb.await_count == 1
 
 

--- a/tests/unit/common/mixins/test_base_metrics_collector_mixin.py
+++ b/tests/unit/common/mixins/test_base_metrics_collector_mixin.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aiperf.common.exceptions import IncompatibleMetricsEndpointError
 from aiperf.common.mixins.base_metrics_collector_mixin import (
     BaseMetricsCollectorMixin,
 )
@@ -70,3 +71,110 @@ class TestTrustEnvPassedToSessions:
             assert mock_session_class.call_count == 2
             for call in mock_session_class.call_args_list:
                 assert call[1]["trust_env"] == trust_env_value
+
+
+class _RaisingCollector(BaseMetricsCollectorMixin[dict]):
+    """Concrete subclass whose `_collect_and_process_metrics` always raises
+    IncompatibleMetricsEndpointError, simulating the TRT-LLM JSON `/metrics`
+    bug as it would surface from either fetch-side content-type rejection
+    or parser-side reclassification."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.calls: int = 0
+
+    async def _collect_and_process_metrics(self) -> None:
+        self.calls += 1
+        raise IncompatibleMetricsEndpointError(
+            f"endpoint {self._endpoint_url!r} returned non-Prometheus content"
+        )
+
+
+class TestAutoDisableOnIncompatibleEndpoint:
+    """The collector should permanently disable itself after one
+    IncompatibleMetricsEndpointError instead of re-failing every scrape
+    interval (the failure mode that turned a 30min benchmark into 8hrs)."""
+
+    @pytest.mark.asyncio
+    async def test_first_failure_disables_collector_and_invokes_callback_once(
+        self,
+    ) -> None:
+        error_cb = AsyncMock()
+        collector = _RaisingCollector(
+            endpoint_url="http://localhost:9999/metrics",
+            collection_interval=0.1,
+            reachability_timeout=1.0,
+            error_callback=error_cb,
+        )
+
+        await collector.collect_and_process_metrics()
+
+        assert collector._endpoint_disabled is True
+        assert collector.calls == 1
+        assert error_cb.await_count == 1
+        # The callback receives ErrorDetails describing the underlying
+        # IncompatibleMetricsEndpointError, not the bare exception.
+        (error_details, collector_id), _ = error_cb.await_args
+        assert collector_id == collector.id
+        assert "Incompatible" in error_details.type or "Incompatible" in str(
+            error_details
+        )
+
+    @pytest.mark.asyncio
+    async def test_subsequent_calls_short_circuit_after_disable(self) -> None:
+        error_cb = AsyncMock()
+        collector = _RaisingCollector(
+            endpoint_url="http://localhost:9999/metrics",
+            collection_interval=0.1,
+            reachability_timeout=1.0,
+            error_callback=error_cb,
+        )
+
+        # Three successive scrape cycles
+        await collector.collect_and_process_metrics()
+        await collector.collect_and_process_metrics()
+        await collector.collect_and_process_metrics()
+
+        # The underlying _collect_and_process_metrics ran exactly once;
+        # subsequent cycles short-circuited at the disabled gate, so no
+        # additional error callbacks fired (no parse-error spam).
+        assert collector.calls == 1
+        assert error_cb.await_count == 1
+
+
+class TestFetchRejectsJsonContentType:
+    """Sanity check on the fetch-side guard: a 200 response with
+    `application/json` content-type must raise
+    IncompatibleMetricsEndpointError before the body is read, even though
+    the status is OK. This is what differentiates the TRT-LLM /metrics bug
+    from a transient network issue."""
+
+    @pytest.mark.asyncio
+    async def test_application_json_response_raises_incompatible(self) -> None:
+        collector = ConcreteCollector(
+            endpoint_url="http://localhost:9999/metrics",
+            collection_interval=0.1,
+            reachability_timeout=1.0,
+        )
+
+        # Build a mock aiohttp response context manager whose `headers` mimics
+        # TRT-LLM's `/metrics` (Content-Type: application/json, body `[]`).
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = AsyncMock(return_value="[]")
+        response_cm = MagicMock()
+        response_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        response_cm.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.closed = False
+        mock_session.get = MagicMock(return_value=response_cm)
+        collector._session = mock_session
+
+        with pytest.raises(IncompatibleMetricsEndpointError):
+            await collector._fetch_metrics_text()
+
+        # The body should never have been read — Content-Type rejection is
+        # cheaper than full parse and avoids any work on a bad endpoint.
+        mock_response.text.assert_not_awaited()

--- a/tests/unit/gpu_telemetry/test_telemetry_data_collector.py
+++ b/tests/unit/gpu_telemetry/test_telemetry_data_collector.py
@@ -272,6 +272,7 @@ class TestHttpCommunication:
             # Mock successful response with sample data
             mock_response = AsyncMock()
             mock_response.status = 200
+            mock_response.headers = {"Content-Type": "text/plain; version=0.0.4"}
             mock_response.text.return_value = sample_dcgm_data
             mock_response.raise_for_status = Mock(return_value=None)
             mock_get.return_value.__aenter__.return_value = mock_response
@@ -344,6 +345,7 @@ class TestCollectionLifecycle:
             # Mock successful response
             mock_response = AsyncMock()
             mock_response.status = 200
+            mock_response.headers = {"Content-Type": "text/plain; version=0.0.4"}
             mock_response.text.side_effect = faker.generate
             mock_response.raise_for_status = Mock(return_value=None)
             mock_get.return_value.__aenter__.return_value = mock_response
@@ -407,6 +409,7 @@ class TestCollectionLifecycle:
         with patch("aiohttp.ClientSession.get") as mock_get:
             mock_response = AsyncMock()
             mock_response.status = 200
+            mock_response.headers = {"Content-Type": "text/plain; version=0.0.4"}
             # Use side_effect to generate different data each time to avoid deduplication
             mock_response.text.side_effect = faker.generate
             mock_response.raise_for_status = Mock(return_value=None)
@@ -598,6 +601,7 @@ class TestDataProcessingEdgeCases:
         with patch("aiohttp.ClientSession.get") as mock_get:
             mock_response = AsyncMock()
             mock_response.status = 200
+            mock_response.headers = {"Content-Type": "text/plain; version=0.0.4"}
             mock_response.text.side_effect = faker.generate
             mock_response.raise_for_status = Mock(return_value=None)
             mock_get.return_value.__aenter__.return_value = mock_response
@@ -619,6 +623,7 @@ class TestDataProcessingEdgeCases:
         with patch("aiohttp.ClientSession.get") as mock_get:
             mock_response = AsyncMock()
             mock_response.status = 200
+            mock_response.headers = {"Content-Type": "text/plain; version=0.0.4"}
             mock_response.text.return_value = "# HELP comment\n# TYPE comment"
             mock_response.raise_for_status = Mock(return_value=None)
             mock_get.return_value.__aenter__.return_value = mock_response

--- a/tests/unit/gpu_telemetry/test_telemetry_integration.py
+++ b/tests/unit/gpu_telemetry/test_telemetry_integration.py
@@ -141,6 +141,7 @@ DCGM_FI_DEV_FB_TOTAL{gpu="1",UUID="GPU-9876fedc-ba09-8765-4321-fedcba098765",dev
             mock_context_manager = AsyncMock()
             mock_response = AsyncMock()
             mock_response.status = 200
+            mock_response.headers = {"Content-Type": "text/plain; version=0.0.4"}
             mock_response.raise_for_status = Mock()
 
             if "node1" in str(url):
@@ -298,6 +299,7 @@ DCGM_FI_DEV_FB_TOTAL{gpu="1",UUID="GPU-9876fedc-ba09-8765-4321-fedcba098765",dev
             mock_context_manager = AsyncMock()
             mock_response = AsyncMock()
             mock_response.status = 200
+            mock_response.headers = {"Content-Type": "text/plain; version=0.0.4"}
             mock_response.raise_for_status = Mock()
             mock_response.text.return_value = mock_dcgm_response_node1
 
@@ -354,6 +356,7 @@ DCGM_FI_DEV_FB_TOTAL{gpu="1",UUID="GPU-9876fedc-ba09-8765-4321-fedcba098765",dev
             mock_context_manager = AsyncMock()
             mock_response = AsyncMock()
             mock_response.status = 200
+            mock_response.headers = {"Content-Type": "text/plain; version=0.0.4"}
             mock_response.raise_for_status = Mock()
             mock_response.text.return_value = "# No metrics available\n"
 
@@ -403,6 +406,7 @@ DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{gpu="0",UUID="GPU-test-1234",device="nvidia
             mock_context_manager = AsyncMock()
             mock_response_obj = AsyncMock()
             mock_response_obj.status = 200
+            mock_response_obj.headers = {"Content-Type": "text/plain; version=0.0.4"}
             mock_response_obj.raise_for_status = Mock()
             mock_response_obj.text.return_value = mock_response
 

--- a/tests/unit/server_metrics/test_server_metrics_data_collector.py
+++ b/tests/unit/server_metrics/test_server_metrics_data_collector.py
@@ -7,6 +7,7 @@ import aiohttp
 import pytest
 
 from aiperf.common.enums import PrometheusMetricType
+from aiperf.common.exceptions import IncompatibleMetricsEndpointError
 from aiperf.common.mixins.base_metrics_collector_mixin import (
     FetchResult,
     HttpTraceTiming,
@@ -201,15 +202,28 @@ http_requests_total{method="GET",status="404"} 5.0
             record = collector._parse_metrics_to_records(make_fetch_result(empty_data))
             assert record is None
 
-    def test_parse_invalid_format_raises_error(self):
-        """Test that invalid Prometheus format raises ValueError."""
+    def test_parse_invalid_format_raises_incompatible(self):
+        """Invalid Prometheus exposition format is reclassified as
+        IncompatibleMetricsEndpointError so the collector auto-disables
+        instead of looping on parse failures every scrape interval."""
         collector = ServerMetricsDataCollector("http://localhost:8081/metrics")
 
         # Invalid TYPE directive without metric name
         invalid_format = "# HELP comment\n# TYPE comment"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(IncompatibleMetricsEndpointError):
             collector._parse_metrics_to_records(make_fetch_result(invalid_format))
+
+    def test_parse_trtllm_iteration_stats_json_raises_incompatible(self):
+        """The TRT-LLM iteration-stats JSON body (``[]`` or a JSON array of
+        iteration objects) at /metrics is the canonical trigger for this
+        bug class — must produce IncompatibleMetricsEndpointError, not a
+        bare ValueError."""
+        collector = ServerMetricsDataCollector("http://localhost:8081/metrics")
+
+        for json_body in ("[]", '[{"iter": 1, "numActiveRequests": 0}]'):
+            with pytest.raises(IncompatibleMetricsEndpointError):
+                collector._parse_metrics_to_records(make_fetch_result(json_body))
 
     def test_parse_incomplete_histogram(self):
         """Test that incomplete histograms (missing sum/count) still create samples with None values."""
@@ -267,6 +281,141 @@ test_counter{label="a"} 30.0
 
         assert len(samples) == 1
         assert samples[0].value == 30.0
+
+
+class TestPrometheusFallbackProbe:
+    """When the configured /metrics path returns non-Prometheus content,
+    the collector should probe `<base>/prometheus/metrics` once, swap the
+    URL there on success, and fall through to auto-disable on failure.
+
+    This is the TRT-LLM compatibility path: ``return_perf_metrics: true``
+    mounts Prometheus exposition at the non-standard /prometheus/metrics
+    location while the default /metrics still serves iteration-stats JSON.
+    """
+
+    PROM_BODY = "# HELP up Whether the target is up\n# TYPE up gauge\nup 1.0\n"
+    JSON_BODY = "[]"
+
+    @pytest.mark.asyncio
+    async def test_probe_swaps_url_on_successful_prometheus_fallback(self) -> None:
+        collector = ServerMetricsDataCollector(
+            endpoint_url="http://server:60000/metrics"
+        )
+        # Original /metrics raises Incompatible (JSON path), then the probe
+        # at /prometheus/metrics succeeds with valid Prom exposition.
+        fetch_results = [
+            IncompatibleMetricsEndpointError("/metrics returned application/json"),
+            FetchResult(
+                text=self.PROM_BODY,
+                trace_timing=HttpTraceTiming(
+                    start_ns=1, start_perf_ns=0, first_byte_perf_ns=1, end_perf_ns=2
+                ),
+            ),
+        ]
+
+        async def fake_fetch() -> FetchResult:
+            value = fetch_results.pop(0)
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        sent: list = []
+
+        async def fake_send(records: list) -> None:
+            sent.append(records)
+
+        with (
+            patch.object(collector, "_fetch_metrics_text", side_effect=fake_fetch),
+            patch.object(
+                collector, "_send_records_via_callback", side_effect=fake_send
+            ),
+        ):
+            await collector._collect_and_process_metrics()
+
+        assert collector._endpoint_url == "http://server:60000/prometheus/metrics"
+        assert collector._prometheus_fallback_attempted is True
+        # The fallback attempt produced a record from the alt endpoint.
+        assert len(sent) == 1 and len(sent[0]) == 1
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_restores_url_and_reraises(self) -> None:
+        collector = ServerMetricsDataCollector(
+            endpoint_url="http://server:60000/metrics"
+        )
+
+        # Original /metrics raises Incompatible, then the probe at
+        # /prometheus/metrics ALSO raises (e.g. 404 or also JSON).
+        async def fake_fetch() -> FetchResult:
+            raise IncompatibleMetricsEndpointError("simulated probe failure")
+
+        with (
+            patch.object(collector, "_fetch_metrics_text", side_effect=fake_fetch),
+            pytest.raises(IncompatibleMetricsEndpointError),
+        ):
+            await collector._collect_and_process_metrics()
+
+        # URL must be restored so it shows up correctly in logs / status messages
+        assert collector._endpoint_url == "http://server:60000/metrics"
+        assert collector._prometheus_fallback_attempted is True
+
+    @pytest.mark.asyncio
+    async def test_probe_runs_at_most_once_per_collector(self) -> None:
+        collector = ServerMetricsDataCollector(
+            endpoint_url="http://server:60000/metrics"
+        )
+
+        async def always_incompatible() -> FetchResult:
+            raise IncompatibleMetricsEndpointError("never works")
+
+        with patch.object(
+            collector, "_fetch_metrics_text", side_effect=always_incompatible
+        ) as mock_fetch:
+            with pytest.raises(IncompatibleMetricsEndpointError):
+                await collector._collect_and_process_metrics()
+            # Two fetches: the original and the one fallback attempt.
+            assert mock_fetch.await_count == 2
+
+            mock_fetch.reset_mock()
+            with pytest.raises(IncompatibleMetricsEndpointError):
+                await collector._collect_and_process_metrics()
+            # Second cycle must not re-probe — single fetch on the original URL.
+            assert mock_fetch.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_probe_when_url_already_targets_prometheus_path(self) -> None:
+        collector = ServerMetricsDataCollector(
+            endpoint_url="http://server:60000/prometheus/metrics"
+        )
+
+        async def fake_fetch() -> FetchResult:
+            raise IncompatibleMetricsEndpointError("already on prometheus path")
+
+        with patch.object(
+            collector, "_fetch_metrics_text", side_effect=fake_fetch
+        ) as mock_fetch:
+            with pytest.raises(IncompatibleMetricsEndpointError):
+                await collector._collect_and_process_metrics()
+            # Only one fetch; the probe is skipped because we're already on
+            # /prometheus/metrics — there's no further alt path to try.
+            assert mock_fetch.await_count == 1
+        assert collector._prometheus_fallback_attempted is False
+
+    @pytest.mark.asyncio
+    async def test_no_probe_when_url_does_not_end_with_metrics(self) -> None:
+        collector = ServerMetricsDataCollector(
+            endpoint_url="http://server:60000/custom/path"
+        )
+
+        async def fake_fetch() -> FetchResult:
+            raise IncompatibleMetricsEndpointError("non-standard path")
+
+        with patch.object(
+            collector, "_fetch_metrics_text", side_effect=fake_fetch
+        ) as mock_fetch:
+            with pytest.raises(IncompatibleMetricsEndpointError):
+                await collector._collect_and_process_metrics()
+            assert mock_fetch.await_count == 1
+        assert collector._prometheus_fallback_attempted is False
 
 
 class TestAsyncLifecycle:

--- a/tests/unit/server_metrics/test_server_metrics_data_collector.py
+++ b/tests/unit/server_metrics/test_server_metrics_data_collector.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
@@ -357,6 +357,49 @@ class TestPrometheusFallbackProbe:
         # URL must be restored so it shows up correctly in logs / status messages
         assert collector._endpoint_url == "http://server:60000/metrics"
         assert collector._prometheus_fallback_attempted is True
+
+    @pytest.mark.asyncio
+    async def test_probe_404_translates_to_incompatible_endpoint_error(self) -> None:
+        """The realistic TRT-LLM-without-`return_perf_metrics` case:
+        ``/metrics`` returns JSON, ``/prometheus/metrics`` returns 404
+        (i.e. ``aiohttp.ClientResponseError``, NOT
+        ``IncompatibleMetricsEndpointError``). The probe failure must be
+        translated to ``IncompatibleMetricsEndpointError`` so the base
+        mixin's auto-disable wrapper triggers — otherwise the collector
+        would keep scraping the broken original URL every interval.
+        """
+        collector = ServerMetricsDataCollector(
+            endpoint_url="http://server:60000/metrics"
+        )
+        call_count = {"n": 0}
+
+        async def fake_fetch() -> FetchResult:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # First call (against /metrics): JSON body → Incompatible
+                raise IncompatibleMetricsEndpointError("/metrics returned JSON")
+            # Second call (against /prometheus/metrics): 404 → ClientResponseError
+            raise aiohttp.ClientResponseError(
+                request_info=MagicMock(),
+                history=(),
+                status=404,
+                message="Not Found",
+            )
+
+        with (
+            patch.object(collector, "_fetch_metrics_text", side_effect=fake_fetch),
+            pytest.raises(IncompatibleMetricsEndpointError) as exc_info,
+        ):
+            await collector._collect_and_process_metrics()
+
+        # The 404 (a ClientResponseError) was translated, not bubbled up raw —
+        # so the auto-disable wrapper will catch it.
+        assert "Prometheus fallback" in str(exc_info.value)
+        assert "return_perf_metrics" in str(exc_info.value)
+        # And the chained __cause__ preserves the original 404 for diagnostics.
+        assert isinstance(exc_info.value.__cause__, aiohttp.ClientResponseError)
+        # URL restored to the original.
+        assert collector._endpoint_url == "http://server:60000/metrics"
 
     @pytest.mark.asyncio
     async def test_probe_runs_at_most_once_per_collector(self) -> None:


### PR DESCRIPTION
## Summary

- Auto-disables the server-metrics collector when an endpoint returns non-Prometheus content (canonical trigger: TRT-LLM serves an iteration-stats JSON array at `/metrics` by default), instead of looping on parse failures every 333ms — the failure mode that turned a 30-minute benchmark into ~8 hours.
- Probes `<base>/prometheus/metrics` exactly once before disabling. TRT-LLM mounts the proper Prometheus exposition there when launched with `return_perf_metrics: true`; on success the collector swaps URL and continues, on failure it falls through to the auto-disable.
- Adds the typed `IncompatibleMetricsEndpointError`, drives detection from both the HTTP `Content-Type` (cheap reject before reading the body) and the existing `text_string_to_metric_families` parser raising `ValueError` (catches servers that send JSON without a content-type), and wraps `BaseMetricsCollectorMixin.collect_and_process_metrics` to short-circuit after the first failure with a single WARNING and one error-callback notification — no further log noise for the rest of the run.

## Why

Source: TRT-LLM team bug `[B] 6062537: [TensorRT-LLM][v1.3.0rc10][perf] Prometheus metrics scraping at /metrics degrades AIPerf benchmark from 30min to 8hrs`. AIPerf scraped `/metrics`, got `[]` (or a JSON iter-stats array), the parser raised `ValueError('invalid metric name:[]')`, and the loop re-fired every 333ms. Hundreds of warnings per second + a ZMQ error-message per cycle to RecordsManager dominated CPU on the records side.

## Behaviour matrix

| TRT-LLM config (`extra_llm_api_options.yaml`) | `/metrics` body | `/prometheus/metrics` | What AIPerf does (after this PR) |
|---|---|---|---|
| `return_perf_metrics: false`, `enable_iter_perf_stats: false` (default) | always `[]` | 404 | warn once, disable that endpoint, run continues |
| `return_perf_metrics: false`, `enable_iter_perf_stats: true` | populated iter-stats JSON | 404 | warn once, disable that endpoint, run continues *(addressed by a follow-up PR that ingests the JSON natively — see Out of scope)* |
| `return_perf_metrics: true`, `enable_iter_perf_stats: true` (default once Prom enabled) | always `[]` (drainer eats stats) | populated Prom | swap URL to `/prometheus/metrics`, run continues |
| `return_perf_metrics: true`, `enable_iter_perf_stats: false` | always `[]` | populated Prom | swap URL to `/prometheus/metrics`, run continues |

Verified end-to-end locally on `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc7` with Qwen/Qwen2.5-0.5B-Instruct: log went from hundreds of `Failed to parse Prometheus metrics — invalid format: ValueError('invalid metric name:[]')` lines per second to a single `WARNING Disabling server metrics collection for http://127.0.0.1:60000/metrics: ...` line followed by silence.

## Out of scope (deferred to follow-up)

- Native ingestion of the TRT-LLM iteration-stats JSON as a new collector type (`TrtllmIterationStatsCollector`). The schema and a captured payload are documented in this branch's investigation notes; the iter-stats stream carries genuinely more information than `/prometheus/metrics` (per-iteration `iterLatencyMS`, `numActiveRequests`/`numQueuedRequests`, full `kvCacheStats`, `inflightBatchingStats`, `specDecodingStats`, per-request `requestStats[]`) and is worth a separate PR. This PR's auto-disable is a clean foundation for that work — the new collector would override `_collect_and_process_metrics` instead of relying on the JSON path being routed through the Prometheus parser.

## What changed

**Production (3 files, +118 / −7):**
- `src/aiperf/common/exceptions.py` — adds `IncompatibleMetricsEndpointError(AIPerfError)` with a docstring that names the canonical trigger and the expected handler behaviour (auto-disable, not retry).
- `src/aiperf/common/mixins/base_metrics_collector_mixin.py` — fetch-side Content-Type guard (rejects `application/json` before reading the body); `collect_and_process_metrics` now distinguishes `IncompatibleMetricsEndpointError` from transient errors and sets `_endpoint_disabled` so subsequent cycles short-circuit.
- `src/aiperf/server_metrics/data_collector.py` — converts parser `ValueError` to `IncompatibleMetricsEndpointError` (preserving body preview + `from e` chain); adds `_should_probe_prometheus_fallback` / `_probe_prometheus_fallback_or_reraise` driving the one-shot URL swap with restoration on probe failure.

**Tests (4 files, +272 / −0):**
- `tests/unit/server_metrics/test_server_metrics_data_collector.py` — parser reclassification tests (`[]`, populated iter-stats array, invalid Prom format) + new `TestPrometheusFallbackProbe` class (URL swap on success; URL restored + reraise on failure; probe runs at most once per collector; skipped on `/prometheus/metrics` and on non-`/metrics` URLs).
- `tests/unit/common/mixins/test_base_metrics_collector_mixin.py` — `TestAutoDisableOnIncompatibleEndpoint` (first failure disables + invokes callback once; subsequent cycles short-circuit) + `TestFetchRejectsJsonContentType` (Content-Type rejection happens before the body is read).
- `tests/unit/gpu_telemetry/test_telemetry_data_collector.py`, `tests/unit/gpu_telemetry/test_telemetry_integration.py` — nine existing mock-response sites updated to set `headers={"Content-Type": "text/plain; version=0.0.4"}` (previously they left `.headers` as an `AsyncMock`, which surfaced as a coroutine once the mixin started reading it).

**Docs (3 files, +39 / −1):**
- `docs/server-metrics/server-metrics.md` — TRT-LLM accordion now carries the `return_perf_metrics: true` setup note; new `## Compatibility & auto-disable` section with the example WARNING line + suppression flag; troubleshooting row for the new warning.
- `docs/server-metrics/server-metrics-reference.md` — `## TensorRT-LLM` section gains an IMPORTANT callout cross-linking to the compatibility section.
- `docs/architecture.md` — Server Metrics Manager bullets gain an auto-detect line.

## Test plan

- [x] CI: `make check-ergonomics` and `make check-ruff-baselined` clean (locally: `0 new` on each); full `pytest -n auto tests/unit/` 8806 pass / 8 skipped after the follow-up commit (8804 originally; +2 regression tests added below).
- [x] Manual: launch `trtllm-serve Qwen/Qwen2.5-0.5B-Instruct` without `return_perf_metrics` and confirm `aiperf profile --url localhost:60000 ...` logs exactly one WARNING line then proceeds silently to completion. *(Caught two bugs on first run; see [follow-up comment](#issuecomment-4364790631) and commit `a08c92e3`.)*
- [x] Manual: launch the same with `return_perf_metrics: true` in `extra_llm_api_options.yaml` and confirm the log shows `INFO Endpoint '...' returned non-Prometheus content; probing fallback '.../prometheus/metrics' (TRT-LLM compatibility path).` followed by `INFO Prometheus fallback succeeded; ...` and a normally populated `server_metrics_export.json`.
- [x] Manual: confirm the new code paths are inert against a server that serves valid Prometheus at `/metrics` natively (used `aiperf_mock_server` as a vLLM-shape stand-in: 0 probes, 0 disables, 0 warnings, 10 metric families exported normally).
- [x] Manual: launch with `--no-server-metrics` and confirm zero server-metrics activity (no probe, no warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection and fallback handling for non-Prometheus metrics endpoints with one-time probe of alternative paths.
  * Auto-disable of metrics collection with warnings when endpoints return incompatible formats.

* **Documentation**
  * Expanded Server Metrics Manager guide on compatibility detection and fallback behavior.
  * Added TensorRT-LLM setup requirements clarifying default non-standard metrics format.
  * Updated Troubleshooting section with endpoint compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
