### PR TITLE
feat: add request concurrency layer for per-turn slot limiting

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -720,13 +720,18 @@ The grace period in seconds to wait for responses after benchmark duration ends.
 <br/>_Constraints: ≥ 0_
 <br/>_Default: `30.0`_
 
-#### `--concurrency` `<str>`
+#### `--concurrency`, `--session-concurrency` `<str>`
 
-Number of concurrent requests to maintain OR list of concurrency values for parameter sweep. AIPerf issues a new request immediately when one completes, maintaining this level of in-flight requests. Can be combined with `--request-rate` to control the request rate. When a list is provided (e.g., [10, 20, 30]), AIPerf runs benchmarks sequentially for each value.
+Number of concurrent sessions (conversations) to maintain. A slot is held from a session's first turn until its final turn completes — for single-turn datasets this equals concurrent requests; for multi-turn datasets it caps active conversations. Pair with `--request-concurrency` to additionally cap simultaneous in-flight requests across sessions, or with `--request-rate` to control issuance rate. Accepts a single value or comma-separated list (e.g. `10,20,30`) for parameter sweep.
 
 #### `--prefill-concurrency` `<int>`
 
 Max concurrent requests waiting for first token (prefill phase). Limits how many requests can be in the prefill/prompt-processing stage simultaneously.
+<br/>_Constraints: ≥ 1_
+
+#### `--request-concurrency` `<int>`
+
+Max concurrent request streams (prefill + decode) across all sessions. Acquired every turn, released on credit return. Independent of `--concurrency` (session) — pair them to keep many sessions alive while capping in-flight requests, e.g. `--session-concurrency 100 --request-concurrency 10`. If not set, request concurrency is unlimited.
 <br/>_Constraints: ≥ 1_
 
 #### `--request-rate` `<float>`
@@ -775,6 +780,11 @@ The concurrency value to use for the warmup phase. If not set, it will use the `
 The prefill concurrency value to use for the warmup phase. If not set, it will use the `--prefill-concurrency` value.
 <br/>_Constraints: ≥ 1_
 
+#### `--warmup-request-concurrency` `<int>`
+
+The request concurrency value to use for the warmup phase. If not set, it will use the `--request-concurrency` value.
+<br/>_Constraints: ≥ 1_
+
 #### `--warmup-request-rate` `<float>`
 
 The request rate to use for the warmup phase. If not set, it will use the `--request-rate` value.
@@ -820,6 +830,11 @@ Duration in seconds to ramp session concurrency from 1 to target. Useful for gra
 Duration in seconds to ramp prefill concurrency from 1 to target.
 <br/>_Constraints: > 0_
 
+#### `--request-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp request concurrency from 1 to target.
+<br/>_Constraints: > 0_
+
 #### `--warmup-concurrency-ramp-duration` `<float>`
 
 Duration in seconds to ramp warmup session concurrency from 1 to target. If not set, uses `--concurrency-ramp-duration` value.
@@ -828,6 +843,11 @@ Duration in seconds to ramp warmup session concurrency from 1 to target. If not 
 #### `--warmup-prefill-concurrency-ramp-duration` `<float>`
 
 Duration in seconds to ramp warmup prefill concurrency from 1 to target. If not set, uses `--prefill-concurrency-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-request-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup request concurrency from 1 to target. If not set, uses `--request-concurrency-ramp-duration` value.
 <br/>_Constraints: > 0_
 
 #### `--request-rate-ramp-duration` `<float>`

--- a/src/aiperf/common/config/loadgen_config.py
+++ b/src/aiperf/common/config/loadgen_config.py
@@ -174,14 +174,18 @@ class LoadGeneratorConfig(BaseConfig):
     concurrency: Annotated[
         Any,  # CLI accepts string, validator converts to Union[int, list[int], None]
         Field(
-            description="Number of concurrent requests to maintain OR list of concurrency values for parameter sweep. "
-            "AIPerf issues a new request immediately when one completes, maintaining this level of in-flight requests. "
-            "Can be combined with `--request-rate` to control the request rate. "
-            "When a list is provided (e.g., [10, 20, 30]), AIPerf runs benchmarks sequentially for each value.",
+            description="Number of concurrent sessions (conversations) to maintain. "
+            "A slot is held from a session's first turn until its final turn completes — "
+            "for single-turn datasets this equals concurrent requests; "
+            "for multi-turn datasets it caps active conversations. "
+            "Pair with `--request-concurrency` to additionally cap simultaneous in-flight requests across sessions, "
+            "or with `--request-rate` to control issuance rate. "
+            "Accepts a single value or comma-separated list (e.g. `10,20,30`) for parameter sweep.",
         ),
         CLIParameter(
             name=(
                 "--concurrency",  # GenAI-Perf
+                "--session-concurrency",
             ),
             group=_CLI_GROUP,
         ),
@@ -238,6 +242,22 @@ class LoadGeneratorConfig(BaseConfig):
         ),
         CLIParameter(
             name=("--prefill-concurrency",),
+            group=_CLI_GROUP,
+        ),
+    ] = None
+
+    request_concurrency: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Max concurrent request streams (prefill + decode) across all sessions. "
+            "Acquired every turn, released on credit return. "
+            "Independent of `--concurrency` (session) — pair them to keep many sessions alive "
+            "while capping in-flight requests, e.g. `--session-concurrency 100 --request-concurrency 10`. "
+            "If not set, request concurrency is unlimited.",
+        ),
+        CLIParameter(
+            name=("--request-concurrency",),
             group=_CLI_GROUP,
         ),
     ] = None
@@ -371,6 +391,19 @@ class LoadGeneratorConfig(BaseConfig):
         ),
     ] = None
 
+    warmup_request_concurrency: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="The request concurrency value to use for the warmup phase. "
+            "If not set, it will use the `--request-concurrency` value.",
+        ),
+        CLIParameter(
+            name=("--warmup-request-concurrency",),
+            group=_CLI_GROUP,
+        ),
+    ] = None
+
     warmup_request_rate: Annotated[
         float | None,
         Field(
@@ -495,6 +528,18 @@ class LoadGeneratorConfig(BaseConfig):
         ),
     ] = None
 
+    request_concurrency_ramp_duration: Annotated[
+        float | None,
+        Field(
+            gt=0,
+            description="Duration in seconds to ramp request concurrency from 1 to target.",
+        ),
+        CLIParameter(
+            name=("--request-concurrency-ramp-duration",),
+            group=_CLI_GROUP,
+        ),
+    ] = None
+
     warmup_concurrency_ramp_duration: Annotated[
         float | None,
         Field(
@@ -517,6 +562,19 @@ class LoadGeneratorConfig(BaseConfig):
         ),
         CLIParameter(
             name=("--warmup-prefill-concurrency-ramp-duration",),
+            group=_CLI_GROUP,
+        ),
+    ] = None
+
+    warmup_request_concurrency_ramp_duration: Annotated[
+        float | None,
+        Field(
+            gt=0,
+            description="Duration in seconds to ramp warmup request concurrency from 1 to target. "
+            "If not set, uses `--request-concurrency-ramp-duration` value.",
+        ),
+        CLIParameter(
+            name=("--warmup-request-concurrency-ramp-duration",),
             group=_CLI_GROUP,
         ),
     ] = None
@@ -744,6 +802,7 @@ class LoadGeneratorConfig(BaseConfig):
         # Warmup load parameters
         self.warmup_concurrency = None
         self.warmup_prefill_concurrency = None
+        self.warmup_request_concurrency = None
         self.warmup_request_rate = None
         self.warmup_arrival_pattern = None
 
@@ -753,6 +812,7 @@ class LoadGeneratorConfig(BaseConfig):
         # Warmup ramp parameters
         self.warmup_concurrency_ramp_duration = None
         self.warmup_prefill_concurrency_ramp_duration = None
+        self.warmup_request_concurrency_ramp_duration = None
         self.warmup_request_rate_ramp_duration = None
 
     @model_validator(mode="after")

--- a/src/aiperf/credit/callback_handler.py
+++ b/src/aiperf/credit/callback_handler.py
@@ -198,6 +198,7 @@ class CreditCallbackHandler:
 
         Slot release rules:
         - Session slot: Released when conversation ends (final turn)
+        - Request slot: Released on every return
         - Prefill slot: Released if TTFT never arrived (error/cancellation path)
         - On final return: Cleanup in-flight sessions
 
@@ -224,6 +225,9 @@ class CreditCallbackHandler:
                 )
                 for _ in range(in_flight):
                     concurrency.release_session_slot(phase)
+
+        # Release request slot unconditionally (every return)
+        concurrency.release_request_slot(phase)
 
         # Prefill slot is normally released on TTFT. If the request failed or was
         # cancelled before first token, we release here to prevent slot leaks.

--- a/src/aiperf/credit/issuer.py
+++ b/src/aiperf/credit/issuer.py
@@ -5,7 +5,7 @@
 Handles credit issuance with concurrency control and stop condition checking.
 
 Key responsibilities:
-- Acquire concurrency slots (session + prefill)
+- Acquire concurrency slots (session + request + prefill)
 - Check stop conditions after slot acquisition
 - Atomic credit numbering via progress tracker
 - Create and send Credit to router
@@ -34,7 +34,7 @@ class CreditIssuer:
     """Issues credits with concurrency control and stop condition checking.
 
     Single point of contact for credit issuance operations:
-    - Acquire concurrency slots (session on first turn, prefill on every turn)
+    - Acquire concurrency slots (session → request → prefill)
     - Check stop conditions AFTER slot acquisition (prevents races)
     - Atomic credit numbering via progress tracker
     - Create and send Credit to router
@@ -42,8 +42,9 @@ class CreditIssuer:
 
     Concurrency contract:
     - Session slot: Acquired on first turn only
-    - Prefill slot: Acquired on every turn
-    - Slots are released on failure to maintain symmetry
+    - Request slot: Acquired on every turn, released on credit return
+    - Prefill slot: Acquired on every turn, released on TTFT (or return on failure)
+    - Slots are released symmetrically on failure
 
     Used by timing strategies to issue credits without knowing about
     concurrency or routing internals.
@@ -102,16 +103,17 @@ class CreditIssuer:
 
         Note:
             For first turns (turn_index == 0), acquires session slot first.
-            For all turns, acquires prefill slot.
+            For all turns, acquires request and prefill slots.
             Slots are released automatically on failure.
 
         Flow:
             1. Acquire session slot (first turn only)
-            2. Acquire prefill slot (all turns)
-            3. Atomic numbering via increment_sent
-            4. Calculate cancellation delay
-            5. Create and send Credit
-            6. If final credit: freeze counts + set event
+            2. Acquire request slot (all turns)
+            3. Acquire prefill slot (all turns)
+            4. Atomic numbering via increment_sent
+            5. Calculate cancellation delay
+            6. Create and send Credit
+            7. If final credit: freeze counts + set event
         """
         is_first_turn = turn.turn_index == 0
 
@@ -133,13 +135,21 @@ class CreditIssuer:
             if not acquired:
                 return False
 
+        # Request concurrency: one slot per request stream, released on credit return.
+        acquired = await self._concurrency_manager.acquire_request_slot(
+            self._phase, can_proceed_fn
+        )
+        if not acquired:
+            if is_first_turn:
+                self._concurrency_manager.release_session_slot(self._phase)
+            return False
+
         # Prefill concurrency: one slot per request, released when TTFT arrives.
-        # Limits concurrent prompt processing which is the GPU-intensive phase.
         acquired = await self._concurrency_manager.acquire_prefill_slot(
             self._phase, can_proceed_fn
         )
         if not acquired:
-            # CRITICAL: Release session slot if we acquired it to maintain symmetry
+            self._concurrency_manager.release_request_slot(self._phase)
             if is_first_turn:
                 self._concurrency_manager.release_session_slot(self._phase)
             return False
@@ -181,11 +191,19 @@ class CreditIssuer:
             if not acquired:
                 return None  # No slot - credit not issued
 
+        acquired = self._concurrency_manager.try_acquire_request_slot(
+            self._phase, can_proceed_fn
+        )
+        if not acquired:
+            if is_first_turn:
+                self._concurrency_manager.release_session_slot(self._phase)
+            return None  # No slot - credit not issued
+
         acquired = self._concurrency_manager.try_acquire_prefill_slot(
             self._phase, can_proceed_fn
         )
         if not acquired:
-            # CRITICAL: Release session slot if we acquired it to maintain symmetry
+            self._concurrency_manager.release_request_slot(self._phase)
             if is_first_turn:
                 self._concurrency_manager.release_session_slot(self._phase)
             return None  # No slot - credit not issued

--- a/src/aiperf/timing/concurrency.py
+++ b/src/aiperf/timing/concurrency.py
@@ -15,7 +15,10 @@ import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.common.enums import CreditPhase
+
+_logger = AIPerfLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -156,12 +159,29 @@ class DynamicConcurrencyLimit:
 
         If there is outstanding debt (from a limit decrease), this release is
         absorbed by the debt instead of freeing a slot for other acquirers.
+
+        If neither debt nor an in-flight slot is available to release (the pool
+        is already at full capacity), the call is a no-op and emits a warning.
+        This guards against double-release / release-without-acquire bugs that
+        would otherwise inflate the pool above its configured limit, since
+        asyncio.Semaphore has no upper bound on its value.
         """
         self.stats.release_count += 1
         if self._debt > 0:
             self._debt -= 1
-        else:
-            self._semaphore.release()
+            return
+        if self._semaphore._value >= self._current_limit:
+            # No in-flight slot to release — refusing would silently corrupt
+            # the limit. Surface it instead.
+            _logger.warning(
+                "Spurious release on DynamicConcurrencyLimit (limit=%d, "
+                "available=%d, debt=0): no in-flight slot to release. "
+                "Refusing to inflate pool.",
+                self._current_limit,
+                self._semaphore._value,
+            )
+            return
+        self._semaphore.release()
 
     def try_acquire(self) -> bool:
         """Try to acquire a concurrency slot without blocking.
@@ -203,6 +223,17 @@ class GlobalPhaseConcurrencyLimiter:
         of in-flight requests from previous phases. This layered approach
         ensures new phases respect their limits while allowing old phases
         to complete gracefully.
+
+    Cross-phase global pool:
+        The global limit is **shared** across all configured phases — each
+        configure_for_phase(phase, limit) call resets the global pool size to
+        `limit`. With multiple phases configured (e.g. WARMUP + PROFILING)
+        the most-recent configure wins. This is by design: phases are meant
+        to run sequentially, with the previous phase draining before the next
+        starts. release_stuck_slots(phase) frees only that phase's per-phase
+        slots, but its global slots also go back to the shared pool. Code
+        that runs phases concurrently would see them contend for the shared
+        global capacity.
     """
 
     def __init__(self) -> None:
@@ -388,11 +419,13 @@ class GlobalPhaseConcurrencyLimiter:
 
 
 class ConcurrencyManager:
-    """Manager for session and prefill concurrency limits.
+    """Manager for session, request, and prefill concurrency limits.
 
-    Supports two independent concurrency dimensions:
+    Supports three independent concurrency dimensions:
     - Session concurrency: Limits concurrent sessions (conversations). A slot is
       acquired on first turn and released on final turn or phase cleanup.
+    - Request concurrency: Limits concurrent request streams (prefill + decode).
+      A slot is acquired on every turn and released when the credit is returned.
     - Prefill concurrency: Limits requests waiting for first token (prefill phase).
       A slot is acquired on every turn and released when TTFT is received.
 
@@ -403,10 +436,11 @@ class ConcurrencyManager:
     def __init__(self) -> None:
         """Initialize the concurrency manager.
 
-        Note: By default, both session and prefill concurrency limiting is disabled.
+        Note: By default, session, request, and prefill concurrency limiting is disabled.
         They will be enabled or disabled based on the phase config.
         """
         self._session_limiter = GlobalPhaseConcurrencyLimiter()
+        self._request_limiter = GlobalPhaseConcurrencyLimiter()
         self._prefill_limiter = GlobalPhaseConcurrencyLimiter()
 
     def configure_for_phase(
@@ -414,12 +448,13 @@ class ConcurrencyManager:
         phase: CreditPhase,
         concurrency: int | None,
         prefill_concurrency: int | None,
+        request_concurrency: int | None = None,
     ) -> None:
         """Configure concurrency limits for a new phase.
 
-        Must be called before acquiring slots for a phase. Configures both
-        session and prefill limiters unconditionally - each limiter internally
-        enables/disables based on whether the limit is None.
+        Must be called before acquiring slots for a phase. Configures all
+        limiters unconditionally - each limiter internally enables/disables
+        based on whether the limit is None.
 
         Args:
             phase: The phase to configure
@@ -427,8 +462,11 @@ class ConcurrencyManager:
                 If None, session concurrency limiting is disabled globally.
             prefill_concurrency: Maximum concurrent prefill slots for this phase.
                 If None, prefill concurrency limiting is disabled globally.
+            request_concurrency: Maximum concurrent request slots for this phase.
+                If None, request concurrency limiting is disabled globally.
         """
         self._session_limiter.configure_for_phase(phase, concurrency)
+        self._request_limiter.configure_for_phase(phase, request_concurrency)
         self._prefill_limiter.configure_for_phase(phase, prefill_concurrency)
 
     def session_slot_available(self, phase: CreditPhase) -> bool:
@@ -493,6 +531,63 @@ class ConcurrencyManager:
         if self._session_limiter.enabled:
             self._session_limiter.release(phase)
 
+    def request_slot_available(self, phase: CreditPhase) -> bool:
+        """Check if a request slot is available without blocking.
+
+        Returns True when concurrency limiting is disabled (no limit configured).
+        """
+        if not self._request_limiter.enabled:
+            return True
+        return self._request_limiter.slot_available(phase)
+
+    async def acquire_request_slot(
+        self, phase: CreditPhase, can_proceed_fn: Callable[[], bool]
+    ) -> bool:
+        """Acquire a request concurrency slot.
+
+        Request slots limit total concurrent request streams (prefill + decode).
+        Released when the credit is returned.
+
+        Args:
+            phase: The credit phase to acquire the slot for.
+            can_proceed_fn: Callback that returns True if the operation should proceed.
+
+        Returns:
+            True if slot was acquired and can_proceed_fn returned True, False otherwise.
+        """
+        if not self._request_limiter.enabled:
+            return can_proceed_fn()
+        return await self._request_limiter.acquire(phase, can_proceed_fn)
+
+    def try_acquire_request_slot(
+        self, phase: CreditPhase, can_proceed_fn: Callable[[], bool]
+    ) -> bool:
+        """Try to acquire a request concurrency slot without blocking.
+
+        Args:
+            phase: The credit phase to acquire the slot for.
+            can_proceed_fn: Callback that returns True if the operation should proceed.
+
+        Returns:
+            True if slot was acquired, False if no slot available or
+            can_proceed_fn returned False.
+        """
+        if not self._request_limiter.enabled:
+            return can_proceed_fn()
+        return self._request_limiter.try_acquire(phase, can_proceed_fn)
+
+    def release_request_slot(self, phase: CreditPhase) -> None:
+        """Release a request concurrency slot.
+
+        Called when a credit is returned (every return). No-op if request
+        concurrency is disabled.
+
+        Args:
+            phase: The credit phase to release the slot for.
+        """
+        if self._request_limiter.enabled:
+            self._request_limiter.release(phase)
+
     async def acquire_prefill_slot(
         self, phase: CreditPhase, can_proceed_fn: Callable[[], bool]
     ) -> bool:
@@ -550,7 +645,7 @@ class ConcurrencyManager:
         if self._prefill_limiter.enabled:
             self._prefill_limiter.release(phase)
 
-    def release_stuck_slots(self, phase: CreditPhase) -> tuple[int, int]:
+    def release_stuck_slots(self, phase: CreditPhase) -> tuple[int, int, int]:
         """Release all stuck slots for a phase during force-completion.
 
         Called when cancel drain timeout expires and credits will never return.
@@ -560,7 +655,7 @@ class ConcurrencyManager:
             phase: The phase to release stuck slots for.
 
         Returns:
-            Tuple of (session_slots_released, prefill_slots_released)
+            Tuple of (session_slots_released, request_slots_released, prefill_slots_released)
         """
         session_released = 0
         if self._session_limiter.enabled:
@@ -568,13 +663,19 @@ class ConcurrencyManager:
             for _ in range(session_released):
                 self._session_limiter.release(phase)
 
+        request_released = 0
+        if self._request_limiter.enabled:
+            request_released = self._request_limiter.get_held_slots(phase)
+            for _ in range(request_released):
+                self._request_limiter.release(phase)
+
         prefill_released = 0
         if self._prefill_limiter.enabled:
             prefill_released = self._prefill_limiter.get_held_slots(phase)
             for _ in range(prefill_released):
                 self._prefill_limiter.release(phase)
 
-        return session_released, prefill_released
+        return session_released, request_released, prefill_released
 
     def get_session_stats(
         self, phase: CreditPhase | None = None
@@ -605,6 +706,19 @@ class ConcurrencyManager:
         self._session_limiter._global_limit.set_limit(limit)
         if phase in self._session_limiter._phase_limits:
             self._session_limiter._phase_limits[phase].set_limit(limit)
+
+    def set_request_limit(self, phase: CreditPhase, limit: int) -> None:
+        """Set request concurrency limit for both global and phase.
+
+        Args:
+            phase: The phase whose limit should be adjusted along with global.
+            limit: The new concurrency limit.
+        """
+        if not self._request_limiter.enabled:
+            return
+        self._request_limiter._global_limit.set_limit(limit)
+        if phase in self._request_limiter._phase_limits:
+            self._request_limiter._phase_limits[phase].set_limit(limit)
 
     def set_prefill_limit(self, phase: CreditPhase, limit: int) -> None:
         """Set prefill concurrency limit for both global and phase.

--- a/src/aiperf/timing/config.py
+++ b/src/aiperf/timing/config.py
@@ -120,6 +120,13 @@ class CreditPhaseConfig(AIPerfBaseModel):
         "This is the max number of requests that can be waiting for the first token at once. "
         "If None, the prefill concurrency is unlimited.",
     )
+    request_concurrency: int | None = Field(
+        default=None,
+        gt=0,
+        description="The max number of concurrent request streams (prefill + decode). "
+        "Acquired every turn, released on credit return. "
+        "If None, request concurrency is unlimited.",
+    )
     request_rate: float | None = Field(
         default=None, gt=0, description="The request rate of the credit phase."
     )
@@ -161,6 +168,12 @@ class CreditPhaseConfig(AIPerfBaseModel):
         gt=0,
         description="Duration in seconds to ramp prefill concurrency from 1 to target. "
         "If None, prefill concurrency starts at target immediately.",
+    )
+    request_concurrency_ramp_duration_sec: float | None = Field(
+        default=None,
+        gt=0,
+        description="Duration in seconds to ramp request concurrency from 1 to target. "
+        "If None, request concurrency starts at target immediately.",
     )
     request_rate_ramp_duration_sec: float | None = Field(
         default=None,
@@ -210,6 +223,9 @@ def _build_warmup_config(user_config: UserConfig) -> CreditPhaseConfig | None:
     prefill_concurrency = (
         loadgen.warmup_prefill_concurrency or loadgen.prefill_concurrency
     )
+    request_concurrency = (
+        loadgen.warmup_request_concurrency or loadgen.request_concurrency
+    )
     if request_rate is None or arrival_pattern is None:
         arrival_pattern = ArrivalPattern.CONCURRENCY_BURST
         if concurrency is None and prefill_concurrency is None:
@@ -225,6 +241,7 @@ def _build_warmup_config(user_config: UserConfig) -> CreditPhaseConfig | None:
         expected_num_sessions=loadgen.warmup_num_sessions,
         concurrency=concurrency,
         prefill_concurrency=prefill_concurrency,
+        request_concurrency=request_concurrency,
         request_rate=request_rate,
         arrival_pattern=arrival_pattern,
         arrival_smoothness=loadgen.arrival_smoothness,
@@ -232,6 +249,7 @@ def _build_warmup_config(user_config: UserConfig) -> CreditPhaseConfig | None:
         grace_period_sec=loadgen.warmup_grace_period if loadgen.warmup_grace_period is not None else float('inf'),
         concurrency_ramp_duration_sec=loadgen.warmup_concurrency_ramp_duration or loadgen.concurrency_ramp_duration,
         prefill_concurrency_ramp_duration_sec=loadgen.warmup_prefill_concurrency_ramp_duration or loadgen.prefill_concurrency_ramp_duration,
+        request_concurrency_ramp_duration_sec=loadgen.warmup_request_concurrency_ramp_duration or loadgen.request_concurrency_ramp_duration,
         request_rate_ramp_duration_sec=loadgen.warmup_request_rate_ramp_duration or loadgen.request_rate_ramp_duration,
     )  # fmt: skip
 
@@ -255,6 +273,7 @@ def _build_profiling_config(user_config: UserConfig) -> CreditPhaseConfig:
         expected_num_sessions=input.conversation.num,
         concurrency=loadgen.concurrency,
         prefill_concurrency=loadgen.prefill_concurrency,
+        request_concurrency=loadgen.request_concurrency,
         request_rate=loadgen.request_rate or loadgen.user_centric_rate,
         arrival_pattern=loadgen.arrival_pattern,
         arrival_smoothness=loadgen.arrival_smoothness,
@@ -262,6 +281,7 @@ def _build_profiling_config(user_config: UserConfig) -> CreditPhaseConfig:
         num_users=loadgen.num_users,
         concurrency_ramp_duration_sec=loadgen.concurrency_ramp_duration,
         prefill_concurrency_ramp_duration_sec=loadgen.prefill_concurrency_ramp_duration,
+        request_concurrency_ramp_duration_sec=loadgen.request_concurrency_ramp_duration,
         request_rate_ramp_duration_sec=loadgen.request_rate_ramp_duration,
         # Fixed schedule config
         auto_offset_timestamps=input.fixed_schedule_auto_offset,

--- a/src/aiperf/timing/phase/runner.py
+++ b/src/aiperf/timing/phase/runner.py
@@ -225,6 +225,7 @@ class PhaseRunner(TaskManagerMixin):
                 self._config.phase,
                 self._config.concurrency,
                 self._config.prefill_concurrency,
+                self._config.request_concurrency,
             )
 
             await strategy.setup_phase()
@@ -313,45 +314,24 @@ class PhaseRunner(TaskManagerMixin):
         self._rampers = []
         config = self._config
 
-        # Session concurrency ramper (stepped mode)
-        if config.concurrency_ramp_duration_sec and config.concurrency:
-            self.info(
-                f"Starting session concurrency ramp: 1 → {config.concurrency} "
-                f"over {config.concurrency_ramp_duration_sec}s"
-            )
-            ramp_config = RampConfig(
-                ramp_type=RampType.LINEAR,
-                start=1,
-                target=config.concurrency,
-                duration_sec=config.concurrency_ramp_duration_sec,
-            )
-
-            def setter(limit: float) -> None:
-                return self._concurrency_manager.set_session_limit(
-                    config.phase, int(limit)
-                )
-
-            self._rampers.append(Ramper(setter=setter, config=ramp_config))
-
-        # Prefill concurrency ramper (stepped mode)
-        if config.prefill_concurrency_ramp_duration_sec and config.prefill_concurrency:
-            self.info(
-                f"Starting prefill concurrency ramp: 1 → {config.prefill_concurrency} "
-                f"over {config.prefill_concurrency_ramp_duration_sec}s"
-            )
-            ramp_config = RampConfig(
-                ramp_type=RampType.LINEAR,
-                start=1,
-                target=config.prefill_concurrency,
-                duration_sec=config.prefill_concurrency_ramp_duration_sec,
-            )
-
-            def setter(limit: float) -> None:
-                return self._concurrency_manager.set_prefill_limit(
-                    config.phase, int(limit)
-                )
-
-            self._rampers.append(Ramper(setter=setter, config=ramp_config))
+        self._add_concurrency_ramper(
+            "session",
+            config.concurrency,
+            config.concurrency_ramp_duration_sec,
+            self._concurrency_manager.set_session_limit,
+        )
+        self._add_concurrency_ramper(
+            "prefill",
+            config.prefill_concurrency,
+            config.prefill_concurrency_ramp_duration_sec,
+            self._concurrency_manager.set_prefill_limit,
+        )
+        self._add_concurrency_ramper(
+            "request",
+            config.request_concurrency,
+            config.request_concurrency_ramp_duration_sec,
+            self._concurrency_manager.set_request_limit,
+        )
 
         # Request rate ramper (continuous mode via update_interval)
         if config.request_rate_ramp_duration_sec and config.request_rate:
@@ -381,6 +361,32 @@ class PhaseRunner(TaskManagerMixin):
                     f"Strategy {strategy.__class__.__name__} does not implement RateSettableProtocol. "
                     "Request rate will be fixed at the target value."
                 )
+
+    def _add_concurrency_ramper(
+        self,
+        label: str,
+        target: int | None,
+        duration_sec: float | None,
+        limit_setter: Callable[[CreditPhase, int], None],
+    ) -> None:
+        """Append a stepped LINEAR ramper from 1 → target if both target and duration are set."""
+        if not (duration_sec and target):
+            return
+        phase = self._config.phase
+        self.info(
+            f"Starting {label} concurrency ramp: 1 → {target} over {duration_sec}s"
+        )
+        ramp_config = RampConfig(
+            ramp_type=RampType.LINEAR,
+            start=1,
+            target=target,
+            duration_sec=duration_sec,
+        )
+
+        def setter(limit: float) -> None:
+            return limit_setter(phase, int(limit))
+
+        self._rampers.append(Ramper(setter=setter, config=ramp_config))
 
     def _format_phase_started(self, stats: CreditPhaseStats) -> str:
         """Format a concise log message for phase start."""
@@ -546,13 +552,13 @@ class PhaseRunner(TaskManagerMixin):
 
     def _release_stuck_slots(self) -> None:
         """Release concurrency slots for credits that will never return."""
-        session_released, prefill_released = (
+        session_released, request_released, prefill_released = (
             self._concurrency_manager.release_stuck_slots(self._config.phase)
         )
-        if session_released or prefill_released:
+        if session_released or request_released or prefill_released:
             self.warning(
                 f"Released stuck slots for phase {self._config.phase}: "
-                f"session={session_released}, prefill={prefill_released}"
+                f"session={session_released}, request={request_released}, prefill={prefill_released}"
             )
 
     async def _wait_for_event_with_timeout(

--- a/tests/unit/credit/test_callback_handler.py
+++ b/tests/unit/credit/test_callback_handler.py
@@ -26,6 +26,7 @@ def mock_concurrency():
     """Mock concurrency manager."""
     mock = MagicMock()
     mock.release_session_slot = MagicMock()
+    mock.release_request_slot = MagicMock()
     mock.release_prefill_slot = MagicMock()
     return mock
 
@@ -208,6 +209,54 @@ class TestCreditReturnBasicFlow:
         await registered_handler.on_credit_return("worker-1", credit_return)
 
         mock_concurrency.release_session_slot.assert_not_called()
+
+
+# =============================================================================
+# Test: Credit Return - Request Slot Release
+# =============================================================================
+
+
+class TestCreditReturnRequestSlotRelease:
+    """Tests for request slot release in credit returns."""
+
+    async def test_request_slot_released_on_every_return_non_final(
+        self, registered_handler, mock_concurrency
+    ):
+        """Request slot is released on every credit return, not just final turn."""
+        credit = make_credit(turn_index=0, num_turns=3)  # Non-final
+        credit_return = make_credit_return(credit)
+
+        await registered_handler.on_credit_return("worker-1", credit_return)
+
+        mock_concurrency.release_request_slot.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
+
+    async def test_request_slot_released_on_final_turn(
+        self, registered_handler, mock_concurrency
+    ):
+        """Request slot is released on final turn alongside session slot."""
+        credit = make_credit(turn_index=2, num_turns=3)  # Final turn
+        credit_return = make_credit_return(credit)
+
+        await registered_handler.on_credit_return("worker-1", credit_return)
+
+        mock_concurrency.release_request_slot.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
+
+    async def test_request_slot_released_on_cancelled_return(
+        self, registered_handler, mock_concurrency
+    ):
+        """Request slot is released even when the credit was cancelled."""
+        credit = make_credit(turn_index=0, num_turns=3)
+        credit_return = make_credit_return(credit, cancelled=True)
+
+        await registered_handler.on_credit_return("worker-1", credit_return)
+
+        mock_concurrency.release_request_slot.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
 
 
 # =============================================================================

--- a/tests/unit/credit/test_issuer.py
+++ b/tests/unit/credit/test_issuer.py
@@ -44,8 +44,10 @@ def mock_concurrency():
     """Mock concurrency manager."""
     mock = MagicMock()
     mock.acquire_session_slot = AsyncMock(return_value=True)
+    mock.acquire_request_slot = AsyncMock(return_value=True)
     mock.acquire_prefill_slot = AsyncMock(return_value=True)
     mock.release_session_slot = MagicMock()
+    mock.release_request_slot = MagicMock()
     return mock
 
 
@@ -205,14 +207,33 @@ class TestSlotAcquisitionFailures:
         result = await credit_issuer.issue_credit(turn)
 
         assert result is False
+        mock_concurrency.acquire_request_slot.assert_not_called()
         mock_concurrency.acquire_prefill_slot.assert_not_called()
         mock_router.send_credit.assert_not_called()
 
-    async def test_first_turn_releases_session_slot_when_prefill_fails(
+    async def test_first_turn_releases_session_slot_when_request_slot_fails(
         self, credit_issuer, mock_concurrency, mock_router
     ):
-        """First turn should release session slot if prefill acquisition fails."""
+        """First turn should release session slot if request slot acquisition fails."""
         mock_concurrency.acquire_session_slot.return_value = True
+        mock_concurrency.acquire_request_slot.return_value = False
+        turn = make_turn(turn_index=0)
+
+        result = await credit_issuer.issue_credit(turn)
+
+        assert result is False
+        mock_concurrency.release_session_slot.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
+        mock_concurrency.acquire_prefill_slot.assert_not_called()
+        mock_router.send_credit.assert_not_called()
+
+    async def test_first_turn_releases_session_and_request_slot_when_prefill_fails(
+        self, credit_issuer, mock_concurrency, mock_router
+    ):
+        """First turn should release session and request slots if prefill acquisition fails."""
+        mock_concurrency.acquire_session_slot.return_value = True
+        mock_concurrency.acquire_request_slot.return_value = True
         mock_concurrency.acquire_prefill_slot.return_value = False
         turn = make_turn(turn_index=0)
 
@@ -220,6 +241,9 @@ class TestSlotAcquisitionFailures:
 
         assert result is False
         mock_concurrency.release_session_slot.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
+        mock_concurrency.release_request_slot.assert_called_once_with(
             CreditPhase.PROFILING
         )
         mock_router.send_credit.assert_not_called()
@@ -236,6 +260,9 @@ class TestSlotAcquisitionFailures:
         assert result is False
         mock_concurrency.acquire_session_slot.assert_not_called()
         mock_concurrency.release_session_slot.assert_not_called()
+        mock_concurrency.release_request_slot.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
         mock_router.send_credit.assert_not_called()
 
 

--- a/tests/unit/timing/conftest.py
+++ b/tests/unit/timing/conftest.py
@@ -562,12 +562,14 @@ def mock_credit_router() -> MagicMock:
 @pytest.fixture
 def mock_concurrency_manager() -> MagicMock:
     m = MagicMock()
-    m.configure_for_phase = m.release_session_slot = m.release_prefill_slot = (
-        MagicMock()
+    m.configure_for_phase = m.release_session_slot = m.release_request_slot = (
+        m.release_prefill_slot
+    ) = MagicMock()
+    m.set_session_limit = m.set_request_limit = m.set_prefill_limit = MagicMock()
+    m.acquire_session_slot = m.acquire_request_slot = m.acquire_prefill_slot = (
+        _async_true
     )
-    m.set_session_limit = m.set_prefill_limit = MagicMock()
-    m.acquire_session_slot = m.acquire_prefill_slot = _async_true
-    m.release_stuck_slots = MagicMock(return_value=(0, 0))
+    m.release_stuck_slots = MagicMock(return_value=(0, 0, 0))
     m.get_session_stats = m.get_prefill_stats = MagicMock(return_value=None)
     return m
 

--- a/tests/unit/timing/phase/conftest.py
+++ b/tests/unit/timing/phase/conftest.py
@@ -42,7 +42,7 @@ def mock_credit_router() -> MagicMock:
 def mock_credit_manager() -> MagicMock:
     m = MagicMock()
     m.configure_for_phase = MagicMock()
-    m.release_stuck_slots = MagicMock(return_value=(0, 0))
+    m.release_stuck_slots = MagicMock(return_value=(0, 0, 0))
     return m
 
 

--- a/tests/unit/timing/phase/test_runner.py
+++ b/tests/unit/timing/phase/test_runner.py
@@ -64,10 +64,13 @@ def mock_conc_mgr() -> MagicMock:
     m = MagicMock()
     m.configure_for_phase = MagicMock()
     m.acquire_session_slot = AsyncMock(return_value=True)
+    m.acquire_request_slot = AsyncMock(return_value=True)
     m.acquire_prefill_slot = AsyncMock(return_value=True)
-    m.release_session_slot = m.release_prefill_slot = MagicMock()
-    m.set_session_limit = m.set_prefill_limit = MagicMock()
-    m.release_stuck_slots = MagicMock(return_value=(0, 0))
+    m.release_session_slot = m.release_request_slot = m.release_prefill_slot = (
+        MagicMock()
+    )
+    m.set_session_limit = m.set_request_limit = m.set_prefill_limit = MagicMock()
+    m.release_stuck_slots = MagicMock(return_value=(0, 0, 0))
     return m
 
 
@@ -261,7 +264,7 @@ class TestPhaseRunnerLifecycle:
             r._progress.all_credits_returned_event.set()
             await r.run(is_final_phase=True)
             conc.configure_for_phase.assert_called_once_with(
-                c.phase, c.concurrency, c.prefill_concurrency
+                c.phase, c.concurrency, c.prefill_concurrency, c.request_concurrency
             )
 
     async def test_run_publishes_start_and_complete(

--- a/tests/unit/timing/test_concurrency.py
+++ b/tests/unit/timing/test_concurrency.py
@@ -69,11 +69,17 @@ class TestDynamicConcurrencyLimit:
         lim.release()
         assert lim.effective_slots == 1
 
-    def test_release_without_acquire(self) -> None:
+    def test_release_without_acquire_is_noop(self) -> None:
+        """Spurious release on a full pool is refused, not absorbed.
+
+        Previously this inflated the pool above its configured limit because
+        asyncio.Semaphore has no upper bound; release() now guards against
+        callers that double-release or release without a matching acquire.
+        """
         lim = DynamicConcurrencyLimit()
         lim.set_limit(10)
         lim.release()
-        assert lim.effective_slots == 11
+        assert lim.effective_slots == 10
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("acq,dec,inc,exp_debt,exp_slots", [(50, 25, 60, 0, 10), (50, 25, 35, 15, 0), (50, 25, 50, 0, 0)])  # fmt: skip
@@ -432,19 +438,56 @@ class TestConcurrencyManager:
         m.release_prefill_slot(P)
 
     @pytest.mark.asyncio
+    async def test_acquire_request_slot_disabled_calls_check(self) -> None:
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, None)
+        called = False
+
+        def chk() -> bool:
+            nonlocal called
+            called = True
+            return True
+
+        assert await m.acquire_request_slot(P, chk) is True and called
+
+    @pytest.mark.asyncio
+    async def test_acquire_request_slot_enabled(self) -> None:
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, None, request_concurrency=5)
+        assert await m.acquire_request_slot(P, lambda: True) is True
+
+    def test_release_request_slot_disabled_noop(self) -> None:
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, None)
+        m.release_request_slot(P)
+
+    @pytest.mark.asyncio
+    async def test_request_limiter_blocks_at_limit(self) -> None:
+        """Acquiring up to the limit succeeds non-blocking; further try_acquire fails until release."""
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, None, request_concurrency=2)
+        assert m.try_acquire_request_slot(P, lambda: True) is True
+        assert m.try_acquire_request_slot(P, lambda: True) is True
+        assert m.try_acquire_request_slot(P, lambda: True) is False
+        m.release_request_slot(P)
+        assert m.try_acquire_request_slot(P, lambda: True) is True
+
+    @pytest.mark.asyncio
     async def test_release_stuck_slots_returns_counts(self) -> None:
         m = ConcurrencyManager()
-        m.configure_for_phase(P, 10, 5)
+        m.configure_for_phase(P, 10, 5, request_concurrency=4)
         for _ in range(3):
             await m.acquire_session_slot(P, lambda: True)
         for _ in range(2):
+            await m.acquire_request_slot(P, lambda: True)
+        for _ in range(2):
             await m.acquire_prefill_slot(P, lambda: True)
-        assert m.release_stuck_slots(P) == (3, 2)
+        assert m.release_stuck_slots(P) == (3, 2, 2)
 
     def test_release_stuck_slots_disabled_returns_zero(self) -> None:
         m = ConcurrencyManager()
         m.configure_for_phase(P, None, None)
-        assert m.release_stuck_slots(P) == (0, 0)
+        assert m.release_stuck_slots(P) == (0, 0, 0)
 
     def test_get_session_stats_disabled_returns_none(self) -> None:
         m = ConcurrencyManager()
@@ -487,6 +530,165 @@ class TestConcurrencyManager:
         m = ConcurrencyManager()
         m.configure_for_phase(P, None, None)
         m.set_prefill_limit(P, 10)
+
+
+class TestRequestConcurrencyAdversarial:
+    """Adversarial tests for the request concurrency dimension.
+
+    Cover concurrent races, slot leaks under stop-condition rejection,
+    interaction with the other two dimensions (most-restrictive wins),
+    phase isolation in stuck-slot release, and capacity recovery.
+    """
+
+    @pytest.mark.asyncio
+    async def test_blocking_acquires_never_exceed_limit(self) -> None:
+        """N coroutines racing for K<N slots: at any moment, at most K hold a slot."""
+        LIMIT, RACERS = 3, 10
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, None, request_concurrency=LIMIT)
+
+        in_flight = 0
+        max_in_flight = 0
+        gate = asyncio.Event()
+
+        async def racer() -> None:
+            nonlocal in_flight, max_in_flight
+            await m.acquire_request_slot(P, lambda: True)
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await gate.wait()
+            in_flight -= 1
+            m.release_request_slot(P)
+
+        tasks = [asyncio.create_task(racer()) for _ in range(RACERS)]
+        # Give the first wave time to acquire and block on the gate
+        for _ in range(20):
+            await asyncio.sleep(0)
+        assert in_flight == LIMIT
+        assert max_in_flight == LIMIT
+        # Releasing the gate lets each finisher hand off to a waiter
+        gate.set()
+        await asyncio.gather(*tasks)
+        assert in_flight == 0
+        assert max_in_flight == LIMIT  # never exceeded across the whole run
+
+    @pytest.mark.asyncio
+    async def test_stop_condition_after_acquire_releases_slot(self) -> None:
+        """can_proceed_fn returning False post-acquire must NOT leak a slot."""
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, None, request_concurrency=1)
+
+        # First call returns True (let the acquire complete the global step),
+        # second call returns False (rejecting after the phase step) — the
+        # limiter must release everything it took.
+        toggle = iter([True, False])
+        assert await m.acquire_request_slot(P, lambda: next(toggle)) is False
+
+        # If the slot leaked, this acquire would block forever; it must succeed.
+        assert (
+            await asyncio.wait_for(m.acquire_request_slot(P, lambda: True), timeout=0.5)
+            is True
+        )
+        m.release_request_slot(P)
+
+    @pytest.mark.asyncio
+    async def test_most_restrictive_dimension_wins(self) -> None:
+        """With session=10, request=2, prefill=10 — only 2 turns can be in flight."""
+        m = ConcurrencyManager()
+        m.configure_for_phase(
+            P, concurrency=10, prefill_concurrency=10, request_concurrency=2
+        )
+
+        async def issue_turn() -> bool:
+            if not await m.acquire_session_slot(P, lambda: True):
+                return False
+            if not await m.acquire_request_slot(P, lambda: True):
+                m.release_session_slot(P)
+                return False
+            if not await m.acquire_prefill_slot(P, lambda: True):
+                m.release_request_slot(P)
+                m.release_session_slot(P)
+                return False
+            return True
+
+        # Two turns can land immediately; the third must block on request limit.
+        assert await issue_turn()
+        assert await issue_turn()
+        third = asyncio.create_task(issue_turn())
+        await asyncio.sleep(0.05)
+        assert not third.done(), "third turn should be blocked on request limit"
+
+        # Releasing one request slot unblocks exactly one waiter.
+        m.release_request_slot(P)
+        assert await asyncio.wait_for(third, timeout=0.5)
+
+    @pytest.mark.asyncio
+    async def test_release_stuck_slots_restores_capacity(self) -> None:
+        """After stuck-slot release, the limiter accepts the full original limit again."""
+        LIMIT = 4
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, None, request_concurrency=LIMIT)
+
+        # Fill to the limit, then "lose" the slots (simulating credits that never return).
+        for _ in range(LIMIT):
+            await m.acquire_request_slot(P, lambda: True)
+        assert m.try_acquire_request_slot(P, lambda: True) is False
+
+        released = m.release_stuck_slots(P)
+        assert released == (0, LIMIT, 0)
+
+        # Capacity restored — should accept LIMIT new acquires immediately.
+        for i in range(LIMIT):
+            assert m.try_acquire_request_slot(P, lambda: True) is True, f"slot {i}"
+        assert m.try_acquire_request_slot(P, lambda: True) is False
+
+    @pytest.mark.asyncio
+    async def test_release_stuck_slots_phase_scoped(self) -> None:
+        """release_stuck_slots(WARMUP) frees only WARMUP-held phase slots.
+
+        Note: the global limit is intentionally shared across phases (the last
+        configure_for_phase resets it), so this test only stays within the
+        shared budget. The semantic we verify is: phase-scoped slot accounting
+        — release_stuck_slots(W) does not pop a slot from the PROFILING phase
+        semaphore, only the WARMUP one.
+        """
+        m = ConcurrencyManager()
+        m.configure_for_phase(W, None, None, request_concurrency=2)
+        m.configure_for_phase(P, None, None, request_concurrency=2)
+
+        # 1 in W, 1 in P — total 2, fits the (now P-set) global cap of 2.
+        await m.acquire_request_slot(W, lambda: True)
+        await m.acquire_request_slot(P, lambda: True)
+
+        # Release WARMUP only — frees its phase slot AND its global slot.
+        assert m.release_stuck_slots(W) == (0, 1, 0)
+
+        # PROFILING's held slot is untouched: it still holds 1.
+        assert m.try_acquire_request_slot(P, lambda: True) is True  # 2nd P slot
+        # And now the (shared) global is full again.
+        assert m.try_acquire_request_slot(P, lambda: True) is False
+
+    @pytest.mark.asyncio
+    async def test_extra_release_is_refused_not_inflated(self) -> None:
+        """A double-release must NOT inflate the pool above its configured limit.
+
+        asyncio.Semaphore has no upper bound, so DynamicConcurrencyLimit.release()
+        explicitly guards against spurious releases; the third release here is
+        a no-op (and emits a warning) rather than freeing a phantom slot.
+        """
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, None, request_concurrency=2)
+
+        await m.acquire_request_slot(P, lambda: True)
+        await m.acquire_request_slot(P, lambda: True)
+        m.release_request_slot(P)
+        m.release_request_slot(P)
+        m.release_request_slot(P)  # spurious — pool already at full capacity
+
+        # Configured limit is 2 → exactly two slots should be acquirable.
+        assert m.try_acquire_request_slot(P, lambda: True) is True
+        assert m.try_acquire_request_slot(P, lambda: True) is True
+        assert m.try_acquire_request_slot(P, lambda: True) is False
 
 
 class TestConcurrencyStats:


### PR DESCRIPTION
## Summary

- Adds a third concurrency limiter (`_request_limiter` in `ConcurrencyManager`) that gates **every turn** on the wire, while `--concurrency` (session) only gates first-turn admission of a conversation. Acquisition order is session → request → prefill, with symmetric rollback on partial failure.
- New CLI flags: `--request-concurrency`, `--warmup-request-concurrency`, `--request-concurrency-ramp-duration`, `--warmup-request-concurrency-ramp-duration`, plus a `--session-concurrency` alias for `--concurrency`.
- `PhaseRunner` gains a request-concurrency ramper and three duplicate concurrency-ramper blocks were collapsed into a single `_add_concurrency_ramper` helper. `release_stuck_slots` now returns the full `(session, request, prefill)` triple. Concurrency release path refuses spurious releases and documents the cross-phase global pool semantics.

## Why

`--concurrency` only holds a slot from a session's first turn until its final turn completes — for multi-turn conversations, all subsequent turns fire freely once a session is admitted. Operators benchmarking against a backend that throttles per-in-flight-request need a knob that caps total simultaneous in-flight request streams across all sessions. Pair `--session-concurrency 100 --request-concurrency 10` to keep 100 conversations alive while only 10 are decoding at any moment.

## Verification

- `make test-all`: 8824 unit + 217 component_integration + 133 integration — all pass.
- End-to-end against the in-repo mock server (single-turn, 200 requests):
  - `--concurrency 50` (baseline): 266.5 req/s, peak in-flight = 50
  - `--concurrency 50 --request-concurrency 5`: 27.4 req/s, peak in-flight = 5
- Multi-turn (50 conversations × 5 turns):
  - Baseline: peak in-flight = 50
  - With `--request-concurrency 5`: peak in-flight = **5 across all turns** (not just first turns)
- Peak concurrent in-flight verified by reconstructing the timeline from `request_start_ns`/`request_end_ns` in `profile_export.jsonl`.

## Test plan

- [ ] CI: unit + component_integration + integration all green
- [ ] Smoke: `aiperf profile ... --concurrency 100 --request-concurrency 10` against any chat backend, verify request throughput ≈ `request-concurrency / avg_request_latency`
- [ ] Smoke: multi-turn run, confirm peak in-flight in `profile_export.jsonl` ≤ `--request-concurrency`
- [ ] Smoke: `--warmup-request-concurrency` differs from steady-state value, confirm ramp transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--request-concurrency` and `--warmup-request-concurrency` CLI options to control request-level concurrency independently from session concurrency
  * Added `--request-concurrency-ramp-duration` and `--warmup-request-concurrency-ramp-duration` options for gradual request concurrency scaling

* **Documentation**
  * Updated CLI documentation clarifying session vs request concurrency semantics and their coordination in load generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->