### PR TITLE
fix: fail fast on unimplemented benchmark/grader names (AIP-892)

### DIFF
--- a/src/aiperf/common/config/accuracy_config.py
+++ b/src/aiperf/common/config/accuracy_config.py
@@ -3,17 +3,73 @@
 
 from typing import Annotated
 
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Field, model_validator
 
 from aiperf.common.config.base_config import BaseConfig
 from aiperf.common.config.cli_parameter import CLIParameter
 from aiperf.common.config.config_validators import parse_str_or_list
 from aiperf.common.config.groups import Groups
-from aiperf.plugin.enums import AccuracyBenchmarkType, AccuracyGraderType
+from aiperf.plugin import plugins
+from aiperf.plugin.enums import (
+    AccuracyBenchmarkType,
+    AccuracyGraderType,
+    PluginType,
+)
+
+
+def _list_implemented(category: PluginType) -> list[str]:
+    """Names of plugins in ``category`` whose metadata does not flag them as stubs.
+
+    A plugin is treated as implemented when ``metadata.is_implemented`` is
+    truthy or absent (the default). Stubs explicitly opt out with
+    ``is_implemented: false`` in plugins.yaml so the
+    ``AccuracyConfig`` validator can reject them before any service starts.
+    """
+    return sorted(
+        entry.name
+        for entry in plugins.list_entries(category)
+        if entry.metadata.get("is_implemented", True)
+    )
+
+
+def _check_implemented(category: PluginType, name: str, *, flag_name: str) -> None:
+    """Raise ``ValueError`` if ``name`` resolves to a stub plugin.
+
+    Why: registering stubs in plugins.yaml makes them visible to the CLI
+    enum so we can keep their names stable across releases, but running
+    them would only surface ``NotImplementedError`` deep inside async
+    dataset loading. We fail at config-validation time instead, with a
+    message that lists what IS available.
+    """
+    metadata = plugins.get_metadata(category, name)
+    if metadata.get("is_implemented", True):
+        return
+    available = _list_implemented(category)
+    raise ValueError(
+        f"{flag_name} '{name}' is registered but not yet implemented "
+        f"in this release. Available: {', '.join(available) or '(none)'}."
+    )
 
 
 class AccuracyConfig(BaseConfig):
     """Configuration for accuracy benchmarking mode."""
+
+    @model_validator(mode="after")
+    def _reject_stub_plugins(self) -> "AccuracyConfig":
+        """Reject benchmark/grader names that point at unimplemented stubs."""
+        if self.benchmark is not None:
+            _check_implemented(
+                PluginType.ACCURACY_BENCHMARK,
+                str(self.benchmark),
+                flag_name="--accuracy-benchmark",
+            )
+        if self.grader is not None:
+            _check_implemented(
+                PluginType.ACCURACY_GRADER,
+                str(self.grader),
+                flag_name="--accuracy-grader",
+            )
+        return self
 
     benchmark: Annotated[
         AccuracyBenchmarkType | None,

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1017,12 +1017,16 @@ accuracy_grader:
     description: |
       Exact match grader that compares extracted answers against ground truth
       using exact string matching. Suitable for factual Q&A and classification tasks.
+    metadata:
+      is_implemented: false
 
   math:
     class: aiperf.accuracy.graders.math:MathGrader
     description: |
       Math grader that evaluates mathematical expressions for equivalence.
       Handles symbolic comparison, numeric tolerance, and expression normalization.
+    metadata:
+      is_implemented: false
 
   multiple_choice:
     class: aiperf.accuracy.graders.multiple_choice:MultipleChoiceGrader
@@ -1035,6 +1039,8 @@ accuracy_grader:
     description: |
       Code execution grader that runs generated code in a sandboxed environment
       and compares output against expected results.
+    metadata:
+      is_implemented: false
 
 # =============================================================================
 # Accuracy Benchmarks
@@ -1060,6 +1066,7 @@ accuracy_benchmark:
     metadata:
       default_grader: math
       default_n_shots: 0
+      is_implemented: false
 
   hellaswag:
     class: aiperf.accuracy.benchmarks.hellaswag:HellaSwagBenchmark
@@ -1068,6 +1075,7 @@ accuracy_benchmark:
     metadata:
       default_grader: multiple_choice
       default_n_shots: 0
+      is_implemented: false
 
   bigbench:
     class: aiperf.accuracy.benchmarks.bigbench:BigBenchBenchmark
@@ -1077,6 +1085,7 @@ accuracy_benchmark:
     metadata:
       default_grader: exact_match
       default_n_shots: 3
+      is_implemented: false
 
   aime24:
     class: aiperf.accuracy.benchmarks.aime24:AIME24Benchmark
@@ -1085,6 +1094,7 @@ accuracy_benchmark:
     metadata:
       default_grader: math
       default_n_shots: 0
+      is_implemented: false
 
   aime25:
     class: aiperf.accuracy.benchmarks.aime25:AIME25Benchmark
@@ -1093,6 +1103,7 @@ accuracy_benchmark:
     metadata:
       default_grader: math
       default_n_shots: 0
+      is_implemented: false
 
   math_500:
     class: aiperf.accuracy.benchmarks.math_500:Math500Benchmark
@@ -1102,6 +1113,7 @@ accuracy_benchmark:
     metadata:
       default_grader: math
       default_n_shots: 0
+      is_implemented: false
 
   gpqa_diamond:
     class: aiperf.accuracy.benchmarks.gpqa_diamond:GPQADiamondBenchmark
@@ -1111,6 +1123,7 @@ accuracy_benchmark:
     metadata:
       default_grader: multiple_choice
       default_n_shots: 0
+      is_implemented: false
 
   lcb_codegeneration:
     class: aiperf.accuracy.benchmarks.lcb_codegeneration:LCBCodeGenerationBenchmark
@@ -1120,6 +1133,7 @@ accuracy_benchmark:
     metadata:
       default_grader: code_execution
       default_n_shots: 0
+      is_implemented: false
 
 # =============================================================================
 # Communication Backends

--- a/tests/unit/accuracy/test_accuracy_config.py
+++ b/tests/unit/accuracy/test_accuracy_config.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validation tests for ``AccuracyConfig``.
+
+Exercises the ``_reject_stub_plugins`` model validator that surfaces
+``--accuracy-benchmark`` / ``--accuracy-grader`` errors at config-parse
+time instead of letting an unimplemented stub raise
+``NotImplementedError`` deep inside async dataset loading.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from pytest import param
+
+from aiperf.common.config.accuracy_config import AccuracyConfig
+
+# Stub names match the ``is_implemented: false`` entries in plugins.yaml.
+# Update both lists together when a follow-up branch lands an
+# implementation (and remove the ``is_implemented: false`` from the YAML).
+STUB_BENCHMARKS = (
+    "aime",
+    "hellaswag",
+    "bigbench",
+    "aime24",
+    "aime25",
+    "math_500",
+    "gpqa_diamond",
+    "lcb_codegeneration",
+)
+STUB_GRADERS = ("exact_match", "math", "code_execution")
+
+
+class TestAcceptsImplemented:
+    def test_no_benchmark_set_is_valid(self) -> None:
+        cfg = AccuracyConfig()
+        assert cfg.benchmark is None
+        assert cfg.grader is None
+        assert cfg.enabled is False
+
+    def test_implemented_benchmark_passes(self) -> None:
+        cfg = AccuracyConfig(benchmark="mmlu")
+        assert str(cfg.benchmark) == "mmlu"
+        assert cfg.enabled is True
+
+    def test_implemented_grader_override_passes(self) -> None:
+        cfg = AccuracyConfig(benchmark="mmlu", grader="multiple_choice")
+        assert str(cfg.grader) == "multiple_choice"
+
+
+class TestRejectsStubBenchmark:
+    @pytest.mark.parametrize(
+        "name",
+        [param(n, id=n) for n in STUB_BENCHMARKS],
+    )  # fmt: skip
+    def test_stub_benchmark_rejected(self, name: str) -> None:
+        with pytest.raises(ValidationError) as exc:
+            AccuracyConfig(benchmark=name)
+        msg = str(exc.value)
+        assert "--accuracy-benchmark" in msg
+        assert name in msg
+        assert "not yet implemented" in msg
+        assert "Available:" in msg
+        # ``mmlu`` is the one always-implemented benchmark; the message
+        # must surface at least that as a usable alternative.
+        assert "mmlu" in msg.split("Available:")[-1]
+
+    def test_hyphenated_stub_name_also_rejected(self) -> None:
+        """Reproduces the original bug: ``--accuracy-benchmark lcb-codegeneration``
+        used the hyphen-tolerant enum lookup and reached the loader."""
+        with pytest.raises(ValidationError) as exc:
+            AccuracyConfig(benchmark="lcb-codegeneration")
+        msg = str(exc.value)
+        # Enum normalization runs first → message references the canonical
+        # snake-case form, not the user's hyphenated input.
+        assert "lcb_codegeneration" in msg
+        assert "not yet implemented" in msg
+
+    def test_uppercase_stub_name_also_rejected(self) -> None:
+        """Case-insensitive enum lookup must not bypass the validator."""
+        with pytest.raises(ValidationError) as exc:
+            AccuracyConfig(benchmark="HELLASWAG")
+        assert "hellaswag" in str(exc.value)
+
+
+class TestRejectsStubGrader:
+    @pytest.mark.parametrize(
+        "name",
+        [param(n, id=n) for n in STUB_GRADERS],
+    )  # fmt: skip
+    def test_stub_grader_override_rejected(self, name: str) -> None:
+        with pytest.raises(ValidationError) as exc:
+            AccuracyConfig(benchmark="mmlu", grader=name)
+        msg = str(exc.value)
+        assert "--accuracy-grader" in msg
+        assert name in msg
+        assert "not yet implemented" in msg
+        # ``multiple_choice`` is the one always-implemented grader.
+        assert "multiple_choice" in msg.split("Available:")[-1]
+
+    def test_grader_unset_falls_back_to_default(self) -> None:
+        """Leaving ``grader`` unset must not trigger the stub check.
+
+        AccuracyConfig stays neutral about which grader the benchmark
+        defaults to — the dataset loader resolves that. This test pins
+        that behavior so the validator never blocks the default-grader
+        path even when the default itself is currently a stub (e.g.
+        ``aime`` defaulting to ``math``).
+        """
+        cfg = AccuracyConfig(benchmark="mmlu")
+        assert cfg.grader is None


### PR DESCRIPTION
Closes https://github.com/ai-dynamo/aiperf/issues/885




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now prevents selection of unimplemented benchmarks and graders, displaying helpful error messages with available options.
  * Marked several benchmarks and graders as not yet implemented to prevent premature usage.

* **Tests**
  * Added comprehensive test coverage for configuration validation of accuracy plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->