### PR TITLE
ci(test_docs): pass HF_TOKEN through to aiperf container

### DIFF
--- a/tests/ci/test_docs_end_to_end/test_runner.py
+++ b/tests/ci/test_docs_end_to_end/test_runner.py
@@ -138,7 +138,7 @@ class EndToEndTestRunner:
         repo_root = get_repo_root()
         fixtures_mount = f"-v {repo_root}/tests/fixtures:/fixtures:ro"
 
-        run_command = f"docker run -d --name {container_name} {fixtures_mount} --network host --entrypoint bash aiperf:test -c 'tail -f /dev/null'"
+        run_command = f"docker run -d --name {container_name} -e HF_TOKEN {fixtures_mount} --network host --entrypoint bash aiperf:test -c 'tail -f /dev/null'"
 
         result = subprocess.run(
             run_command, shell=True, capture_output=True, text=True, timeout=60


### PR DESCRIPTION
Adds `-e HF_TOKEN` to the `docker run` invocation that starts the `aiperf:test` container in `tests/ci/test_docs_end_to_end/test_runner.py`. Without this, aiperf's own HuggingFace requests (e.g. `--public-dataset aimo` downloading `AI-MO/NuminaMath-TIR`) are unauthenticated and rate-limited, causing the AIMO tutorial test to fail inside `SystemController._start_services` with an opaque `Failed to perform operation 'Configure Profiling'`.

## Why

A prior PR ([#866](https://github.com/ai-dynamo/aiperf/pull/866)) wired `HF_TOKEN` from the workflow env into the **vLLM** server containers via tutorial `docker run` lines. That fixed the model-download authentication path. But the **aiperf container** — started by `test_runner.py` separately — was never given the same passthrough, so any aiperf operation that itself reaches HF Hub (public datasets, tokenizer downloads for unfamiliar models) still hits the rate limit.

This was exposed by the [2026-05-06 nightly](https://github.com/ai-dynamo/aiperf/actions/runs/25428077671/job/74586844344): audio / vision / video all passed, but default's AIMO benchmark (`--public-dataset aimo`, test 5 of 41) failed. The aiperf container's logs include the `Warning: You are sending unauthenticated requests to the HF Hub` line, distinct from vLLM's own auth path. Once the fix is in place, the workflow's env-set `HF_TOKEN` reaches aiperf the same way `-e HF_TOKEN` already lets it reach vLLM.

## Changes

Single one-line edit in `tests/ci/test_docs_end_to_end/test_runner.py`:

```diff
-run_command = f"docker run -d --name {container_name} {fixtures_mount} --network host --entrypoint bash aiperf:test -c 'tail -f /dev/null'"
+run_command = f"docker run -d --name {container_name} -e HF_TOKEN {fixtures_mount} --network host --entrypoint bash aiperf:test -c 'tail -f /dev/null'"
```

The `-e HF_TOKEN` (no `=value`) form passes through whatever's in the parent shell's env — empty string if no secret is configured, the token value when there is one. Safe for local runs without `HF_TOKEN` set; transparent speed-up + auth when it is.

`docker exec` calls (line 321) inherit the container's env automatically, so they don't need an additional change.

## Test plan

- [ ] Next nightly `Test Docs End-to-End` shows test 5 (AIMO) passing on the default server.
- [ ] All four servers (default / audio / vision / video) report green.
- [ ] PR-triggered run on this branch picks up `Test Docs End-to-End` (since the workflow's path filter includes `tests/ci/test_docs_end_to_end/**`).

## Notes

- **Opaque error wrapping**: `SystemController._start_services` catches the underlying download/HTTP exception and only logs `Failed to perform operation 'Configure Profiling'`. The actual cause (rate-limited HF request) doesn't reach the operator. This is a separate observability/ergonomics gap; it's what made the original nightly failure take longer to diagnose than it should have. Worth a follow-up ticket but out of scope for this fix.
- **`test_runner.py` cleanup-on-failure bug** is also still open — when a server fails its health check, the per-server cleanup is skipped, leaking a Docker container on port 8000 into the next iteration. Not exercised in the AIMO failure (default's vLLM was healthy; the failure was post-health-check inside aiperf), so unrelated to this PR but flagged for completeness.

## Out of scope

- Tutorial doc updates — none needed. The user-facing `aiperf` invocation is unchanged; this only touches the CI test harness's container plumbing.
- HF_TOKEN secret management — already in place at the repo level after the audio swap PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated runtime configuration for test container initialization to enhance environment setup during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->