### PR TITLE
feat: Addressing outputs format for benchmarking jobs

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -691,6 +691,11 @@ Include HTTP trace data (timestamps, chunks, headers, socket info) in profile_ex
 Display HTTP trace timing metrics in the console at the end of the benchmark. Shows detailed timing breakdown: blocked, DNS, connecting, sending, waiting (TTFB), receiving, and total duration following k6 naming conventions.
 <br/>_Flag (no value required)_
 
+#### `--export-outputs-json`
+
+Export per-request model responses to outputs.json for downstream post-processing.
+<br/>_Flag (no value required)_
+
 ### Tokenizer
 
 #### `--tokenizer` `<str>`

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -170,6 +170,7 @@ class OutputDefaults:
     LOG_FOLDER = Path("logs")
     LOG_FILE = Path("aiperf.log")
     INPUTS_JSON_FILE = Path("inputs.json")
+    OUTPUTS_JSON_FILE = Path("outputs.json")
     PROFILE_EXPORT_AIPERF_CSV_FILE = Path("profile_export_aiperf.csv")
     PROFILE_EXPORT_AIPERF_JSON_FILE = Path("profile_export_aiperf.json")
     PROFILE_EXPORT_AIPERF_TIMESLICES_CSV_FILE = Path(

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -167,6 +167,7 @@ class TurnDelayDefaults:
 class OutputDefaults:
     ARTIFACT_DIRECTORY = Path("./artifacts")
     RAW_RECORDS_FOLDER = Path("raw_records")
+    OUTPUT_FRAGMENTS_FOLDER = Path("output_fragments")
     LOG_FOLDER = Path("logs")
     LOG_FILE = Path("aiperf.log")
     INPUTS_JSON_FILE = Path("inputs.json")

--- a/src/aiperf/common/config/output_config.py
+++ b/src/aiperf/common/config/output_config.py
@@ -187,6 +187,10 @@ class OutputConfig(BaseConfig):
         return self.artifact_directory / self._profile_export_csv_file
 
     @property
+    def outputs_json_file(self) -> Path:
+        return self.artifact_directory / OutputDefaults.OUTPUTS_JSON_FILE
+
+    @property
     def profile_export_json_file(self) -> Path:
         return self.artifact_directory / self._profile_export_json_file
 

--- a/src/aiperf/common/config/output_config.py
+++ b/src/aiperf/common/config/output_config.py
@@ -104,6 +104,17 @@ class OutputConfig(BaseConfig):
         ),
     ] = OutputDefaults.SHOW_TRACE_TIMING
 
+    export_outputs_json: Annotated[
+        bool,
+        Field(
+            description="Export per-request model responses to outputs.json for downstream post-processing.",
+        ),
+        CLIParameter(
+            name="--export-outputs-json",
+            group=Groups.OUTPUT,
+        ),
+    ] = False
+
     _profile_export_csv_file: Path = OutputDefaults.PROFILE_EXPORT_AIPERF_CSV_FILE
     _profile_export_json_file: Path = OutputDefaults.PROFILE_EXPORT_AIPERF_JSON_FILE
     _profile_export_timeslices_csv_file: Path = (
@@ -129,6 +140,15 @@ class OutputConfig(BaseConfig):
     _server_metrics_export_parquet_file: Path = (
         OutputDefaults.SERVER_METRICS_EXPORT_PARQUET_FILE
     )
+
+    @model_validator(mode="after")
+    def validate_export_outputs_json(self) -> Self:
+        """Validate that export_outputs_json is compatible with the export level."""
+        if self.export_outputs_json and self.export_level == ExportLevel.SUMMARY:
+            raise ValueError(
+                "--export-outputs-json requires --export-level records or raw"
+            )
+        return self
 
     @model_validator(mode="after")
     def set_export_filenames(self) -> Self:

--- a/src/aiperf/exporters/outputs_json_exporter.py
+++ b/src/aiperf/exporters/outputs_json_exporter.py
@@ -6,20 +6,30 @@ import asyncio
 import aiofiles
 import orjson
 
+from aiperf.common.config.config_defaults import OutputDefaults
 from aiperf.common.enums import CreditPhase
 from aiperf.common.mixins import AIPerfLoggerMixin
-from aiperf.common.models.record_models import MetricRecordInfo
+from aiperf.common.models.record_models import MetricRecordInfo, RawRecordInfo
 from aiperf.exporters.exporter_config import ExporterConfig, FileExportInfo
 
 
 class OutputsJsonExporter(AIPerfLoggerMixin):
-    """Exports per-request output metadata to outputs.json for downstream post-processing."""
+    """Exports per-request output metadata and response text to outputs.json.
+
+    When raw records are available (--export-level raw), includes the full
+    response text for downstream safety/accuracy evaluation. Otherwise,
+    includes metrics only.
+    """
 
     def __init__(self, exporter_config: ExporterConfig, **kwargs) -> None:
         super().__init__(**kwargs)
         self._user_config = exporter_config.user_config
         self._file_path = self._user_config.output.outputs_json_file
         self._jsonl_path = self._user_config.output.profile_export_jsonl_file
+        self._raw_records_dir = (
+            self._user_config.output.artifact_directory
+            / OutputDefaults.RAW_RECORDS_FOLDER
+        )
 
     def get_export_info(self) -> FileExportInfo:
         """Return export metadata for logging."""
@@ -29,14 +39,19 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
         )
 
     async def export(self) -> None:
-        """Read per-request records from the JSONL file and write outputs.json."""
+        """Read per-request records and write outputs.json with response text when available."""
         if not self._jsonl_path.exists():
             self.debug(
                 f"JSONL file not found, skipping outputs.json export: {self._jsonl_path}"
             )
             return
 
-        records: list[dict] = await asyncio.to_thread(self._read_and_parse_records)
+        # Load raw records for response text (if available)
+        raw_responses = await asyncio.to_thread(self._load_raw_responses)
+
+        records: list[dict] = await asyncio.to_thread(
+            self._read_and_parse_records, raw_responses
+        )
         records.sort(key=lambda r: r["session_num"])
 
         output = {
@@ -50,7 +65,32 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
             await f.write(content)
         self.info(f"Exported {len(records)} records to {self._file_path}")
 
-    def _read_and_parse_records(self) -> list[dict]:
+    def _load_raw_responses(self) -> dict[int, str]:
+        """Load response text from raw record files, keyed by session_num."""
+        responses: dict[int, str] = {}
+        if not self._raw_records_dir.exists():
+            return responses
+
+        for raw_file in self._raw_records_dir.glob("*.jsonl"):
+            with open(raw_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        raw = RawRecordInfo.model_validate_json(line)
+                    except (ValueError, KeyError) as e:
+                        self.debug(f"Skipping malformed raw record: {e}")
+                        continue
+                    if raw.metadata.benchmark_phase != CreditPhase.PROFILING:
+                        continue
+                    text = self._extract_response_text(raw)
+                    if text:
+                        responses[raw.metadata.session_num] = text
+
+        return responses
+
+    def _read_and_parse_records(self, raw_responses: dict[int, str]) -> list[dict]:
         """Read JSONL and parse profiling records (runs in thread pool)."""
         records: list[dict] = []
         with open(self._jsonl_path) as f:
@@ -61,8 +101,23 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
                 record = MetricRecordInfo.model_validate_json(line)
                 if record.metadata.benchmark_phase != CreditPhase.PROFILING:
                     continue
-                records.append(self._build_output_entry(record))
+                entry = self._build_output_entry(record)
+                # Attach response text from raw records if available
+                session_num = record.metadata.session_num
+                entry["response_text"] = raw_responses.get(session_num)
+                records.append(entry)
         return records
+
+    @staticmethod
+    def _extract_response_text(raw: RawRecordInfo) -> str | None:
+        """Extract concatenated response text from raw record responses."""
+        parts: list[str] = []
+        for resp in raw.responses:
+            if hasattr(resp, "text") and resp.text:
+                parts.append(resp.text)
+            elif hasattr(resp, "data") and resp.data:
+                parts.append(str(resp.data))
+        return "".join(parts) if parts else None
 
     @staticmethod
     def _build_output_entry(record: MetricRecordInfo) -> dict:
@@ -80,5 +135,6 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
             "request_start_ns": record.metadata.request_start_ns,
             "request_end_ns": record.metadata.request_end_ns,
             "metrics": metrics,
+            "response_text": None,
             "error": record.error.model_dump() if record.error else None,
         }

--- a/src/aiperf/exporters/outputs_json_exporter.py
+++ b/src/aiperf/exporters/outputs_json_exporter.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import orjson
+
+from aiperf.common.enums import CreditPhase
+from aiperf.common.mixins import AIPerfLoggerMixin
+from aiperf.common.models.record_models import MetricRecordInfo
+from aiperf.exporters.exporter_config import ExporterConfig, FileExportInfo
+
+
+class OutputsJsonExporter(AIPerfLoggerMixin):
+    """Exports per-request output metadata to outputs.json for downstream post-processing."""
+
+    def __init__(self, exporter_config: ExporterConfig, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._user_config = exporter_config.user_config
+        self._file_path = self._user_config.output.outputs_json_file
+        self._jsonl_path = self._user_config.output.profile_export_jsonl_file
+
+    def get_export_info(self) -> FileExportInfo:
+        return FileExportInfo(
+            export_type="Outputs JSON",
+            file_path=self._file_path,
+        )
+
+    async def export(self) -> None:
+        """Read per-request records from the JSONL file and write outputs.json."""
+        if not self._jsonl_path.exists():
+            self.debug(
+                f"JSONL file not found, skipping outputs.json export: {self._jsonl_path}"
+            )
+            return
+
+        records: list[dict] = []
+        with open(self._jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                record = MetricRecordInfo.model_validate_json(line)
+                if record.metadata.benchmark_phase != CreditPhase.PROFILING:
+                    continue
+                records.append(self._build_output_entry(record))
+
+        records.sort(key=lambda r: r["session_num"])
+
+        output = {
+            "schema_version": "1.0",
+            "data": records,
+        }
+
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+        content = orjson.dumps(output, option=orjson.OPT_INDENT_2)
+        self._file_path.write_bytes(content)
+        self.info(f"Exported {len(records)} records to {self._file_path}")
+
+    @staticmethod
+    def _build_output_entry(record: MetricRecordInfo) -> dict:
+        """Extract relevant fields from a MetricRecordInfo into the outputs.json schema."""
+        metrics: dict = {}
+        for key in ("output_token_count", "output_sequence_length", "request_latency"):
+            if key in record.metrics:
+                metrics[key] = record.metrics[key].value
+
+        return {
+            "session_num": record.metadata.session_num,
+            "conversation_id": record.metadata.conversation_id,
+            "turn_index": record.metadata.turn_index,
+            "x_request_id": record.metadata.x_request_id,
+            "request_start_ns": record.metadata.request_start_ns,
+            "request_end_ns": record.metadata.request_end_ns,
+            "metrics": metrics,
+            "error": record.error.model_dump() if record.error else None,
+        }

--- a/src/aiperf/exporters/outputs_json_exporter.py
+++ b/src/aiperf/exporters/outputs_json_exporter.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+
+import aiofiles
 import orjson
 
 from aiperf.common.enums import CreditPhase
@@ -19,6 +22,7 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
         self._jsonl_path = self._user_config.output.profile_export_jsonl_file
 
     def get_export_info(self) -> FileExportInfo:
+        """Return export metadata for logging."""
         return FileExportInfo(
             export_type="Outputs JSON",
             file_path=self._file_path,
@@ -32,6 +36,22 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
             )
             return
 
+        records: list[dict] = await asyncio.to_thread(self._read_and_parse_records)
+        records.sort(key=lambda r: r["session_num"])
+
+        output = {
+            "schema_version": "1.0",
+            "data": records,
+        }
+
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+        content = orjson.dumps(output, option=orjson.OPT_INDENT_2)
+        async with aiofiles.open(self._file_path, "wb") as f:
+            await f.write(content)
+        self.info(f"Exported {len(records)} records to {self._file_path}")
+
+    def _read_and_parse_records(self) -> list[dict]:
+        """Read JSONL and parse profiling records (runs in thread pool)."""
         records: list[dict] = []
         with open(self._jsonl_path) as f:
             for line in f:
@@ -42,18 +62,7 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
                 if record.metadata.benchmark_phase != CreditPhase.PROFILING:
                     continue
                 records.append(self._build_output_entry(record))
-
-        records.sort(key=lambda r: r["session_num"])
-
-        output = {
-            "schema_version": "1.0",
-            "data": records,
-        }
-
-        self._file_path.parent.mkdir(parents=True, exist_ok=True)
-        content = orjson.dumps(output, option=orjson.OPT_INDENT_2)
-        self._file_path.write_bytes(content)
-        self.info(f"Exported {len(records)} records to {self._file_path}")
+        return records
 
     @staticmethod
     def _build_output_entry(record: MetricRecordInfo) -> dict:

--- a/src/aiperf/exporters/outputs_json_exporter.py
+++ b/src/aiperf/exporters/outputs_json_exporter.py
@@ -1,34 +1,46 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+"""Aggregator that merges output fragments with metrics into final outputs.json."""
 
-import asyncio
+import contextlib
 
 import aiofiles
 import orjson
 
 from aiperf.common.config.config_defaults import OutputDefaults
 from aiperf.common.enums import CreditPhase
+from aiperf.common.exceptions import DataExporterDisabled
 from aiperf.common.mixins import AIPerfLoggerMixin
-from aiperf.common.models.record_models import MetricRecordInfo, RawRecordInfo
+from aiperf.common.models.record_models import MetricRecordInfo
 from aiperf.exporters.exporter_config import ExporterConfig, FileExportInfo
 
 
 class OutputsJsonExporter(AIPerfLoggerMixin):
-    """Exports per-request output metadata and response text to outputs.json.
+    """Aggregates per-processor output fragment files and merges with metrics from profile_export.jsonl.
 
-    When raw records are available (--export-level raw), includes the full
-    response text for downstream safety/accuracy evaluation. Otherwise,
-    includes metrics only.
+    Self-disables unless --export-outputs-json is set.
     """
+
+    _METRIC_ALLOWLIST = (
+        "output_token_count",
+        "output_sequence_length",
+        "request_latency",
+    )
 
     def __init__(self, exporter_config: ExporterConfig, **kwargs) -> None:
         super().__init__(**kwargs)
         self._user_config = exporter_config.user_config
+
+        if not self._user_config.output.export_outputs_json:
+            raise DataExporterDisabled(
+                "OutputsJsonExporter is disabled (--export-outputs-json not set)"
+            )
+
         self._file_path = self._user_config.output.outputs_json_file
         self._jsonl_path = self._user_config.output.profile_export_jsonl_file
-        self._raw_records_dir = (
+        self._fragments_dir = (
             self._user_config.output.artifact_directory
-            / OutputDefaults.RAW_RECORDS_FOLDER
+            / OutputDefaults.OUTPUT_FRAGMENTS_FOLDER
         )
 
     def get_export_info(self) -> FileExportInfo:
@@ -39,19 +51,31 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
         )
 
     async def export(self) -> None:
-        """Read per-request records and write outputs.json with response text when available."""
-        if not self._jsonl_path.exists():
-            self.debug(
-                f"JSONL file not found, skipping outputs.json export: {self._jsonl_path}"
-            )
+        """Read fragment files, merge with metrics, and write final outputs.json."""
+        fragment_files = list(self._fragments_dir.glob("output_fragments_*.jsonl"))
+        if not fragment_files:
+            self.debug("No output fragment files found, skipping outputs.json export")
             return
 
-        # Load raw records for response text (if available)
-        raw_responses = await asyncio.to_thread(self._load_raw_responses)
+        fragments = self._read_fragments(fragment_files)
+        metrics_map = self._build_metrics_map()
 
-        records: list[dict] = await asyncio.to_thread(
-            self._read_and_parse_records, raw_responses
-        )
+        records: list[dict] = []
+        for frag in fragments:
+            key = f"{frag['session_num']}:{frag.get('turn_index', 0)}"
+            metrics = metrics_map.get(key, {})
+            entry = {
+                "session_num": frag["session_num"],
+                "conversation_id": frag.get("conversation_id"),
+                "turn_index": frag.get("turn_index"),
+                "x_request_id": frag.get("x_request_id"),
+                "request_start_ns": frag.get("request_start_ns"),
+                "request_end_ns": frag.get("request_end_ns"),
+                "metrics": metrics,
+                "response_text": frag.get("response_text"),
+            }
+            records.append(entry)
+
         records.sort(key=lambda r: r["session_num"])
 
         output = {
@@ -63,39 +87,30 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
         content = orjson.dumps(output, option=orjson.OPT_INDENT_2)
         async with aiofiles.open(self._file_path, "wb") as f:
             await f.write(content)
+
         self.info(f"Exported {len(records)} records to {self._file_path}")
 
-    def _load_raw_responses(self) -> dict[str, str]:
-        """Load response text from raw record files, keyed by session_num:turn_index."""
-        responses: dict[str, str] = {}
-        if not self._raw_records_dir.exists():
-            return responses
+        self._cleanup_fragments(fragment_files)
 
-        for raw_file in self._raw_records_dir.glob("*.jsonl"):
-            with open(raw_file) as f:
+    def _read_fragments(self, fragment_files: list) -> list[dict]:
+        """Read all fragment JSONL files and return parsed dicts."""
+        fragments: list[dict] = []
+        for file in fragment_files:
+            with open(file) as f:
                 for line in f:
                     line = line.strip()
                     if not line:
                         continue
-                    try:
-                        raw = RawRecordInfo.model_validate_json(line)
-                    except (ValueError, KeyError) as e:
-                        self.debug(f"Skipping malformed raw record: {e}")
-                        continue
-                    if raw.metadata.benchmark_phase != CreditPhase.PROFILING:
-                        continue
-                    text = self._extract_response_text(raw)
-                    if text:
-                        key = (
-                            f"{raw.metadata.session_num}:{raw.metadata.turn_index or 0}"
-                        )
-                        responses[key] = text
+                    fragments.append(orjson.loads(line))
+        return fragments
 
-        return responses
+    def _build_metrics_map(self) -> dict[str, dict]:
+        """Read profile_export.jsonl and build a metrics map keyed by session_num:turn_index."""
+        metrics_map: dict[str, dict] = {}
+        if not self._jsonl_path.exists():
+            self.debug("profile_export.jsonl not found, metrics will be empty")
+            return metrics_map
 
-    def _read_and_parse_records(self, raw_responses: dict[str, str]) -> list[dict]:
-        """Read JSONL and parse profiling records (runs in thread pool)."""
-        records: list[dict] = []
         with open(self._jsonl_path) as f:
             for line in f:
                 line = line.strip()
@@ -104,39 +119,18 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
                 record = MetricRecordInfo.model_validate_json(line)
                 if record.metadata.benchmark_phase != CreditPhase.PROFILING:
                     continue
-                entry = self._build_output_entry(record)
                 key = f"{record.metadata.session_num}:{record.metadata.turn_index or 0}"
-                entry["response_text"] = raw_responses.get(key)
-                records.append(entry)
-        return records
+                metrics: dict = {}
+                for metric_key in self._METRIC_ALLOWLIST:
+                    if metric_key in record.metrics:
+                        metrics[metric_key] = record.metrics[metric_key].value
+                metrics_map[key] = metrics
 
-    @staticmethod
-    def _extract_response_text(raw: RawRecordInfo) -> str | None:
-        """Extract concatenated response text from raw record responses."""
-        parts: list[str] = []
-        for resp in raw.responses:
-            if hasattr(resp, "text") and resp.text:
-                parts.append(resp.text)
-            elif hasattr(resp, "data") and resp.data:
-                parts.append(str(resp.data))
-        return "".join(parts) if parts else None
+        return metrics_map
 
-    @staticmethod
-    def _build_output_entry(record: MetricRecordInfo) -> dict:
-        """Extract relevant fields from a MetricRecordInfo into the outputs.json schema."""
-        metrics: dict = {}
-        for key in ("output_token_count", "output_sequence_length", "request_latency"):
-            if key in record.metrics:
-                metrics[key] = record.metrics[key].value
-
-        return {
-            "session_num": record.metadata.session_num,
-            "conversation_id": record.metadata.conversation_id,
-            "turn_index": record.metadata.turn_index,
-            "x_request_id": record.metadata.x_request_id,
-            "request_start_ns": record.metadata.request_start_ns,
-            "request_end_ns": record.metadata.request_end_ns,
-            "metrics": metrics,
-            "response_text": None,
-            "error": record.error.model_dump() if record.error else None,
-        }
+    def _cleanup_fragments(self, fragment_files: list) -> None:
+        """Remove fragment files and directory."""
+        for file in fragment_files:
+            file.unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            self._fragments_dir.rmdir()

--- a/src/aiperf/exporters/outputs_json_exporter.py
+++ b/src/aiperf/exporters/outputs_json_exporter.py
@@ -65,9 +65,9 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
             await f.write(content)
         self.info(f"Exported {len(records)} records to {self._file_path}")
 
-    def _load_raw_responses(self) -> dict[int, str]:
-        """Load response text from raw record files, keyed by session_num."""
-        responses: dict[int, str] = {}
+    def _load_raw_responses(self) -> dict[str, str]:
+        """Load response text from raw record files, keyed by session_num:turn_index."""
+        responses: dict[str, str] = {}
         if not self._raw_records_dir.exists():
             return responses
 
@@ -86,11 +86,14 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
                         continue
                     text = self._extract_response_text(raw)
                     if text:
-                        responses[raw.metadata.session_num] = text
+                        key = (
+                            f"{raw.metadata.session_num}:{raw.metadata.turn_index or 0}"
+                        )
+                        responses[key] = text
 
         return responses
 
-    def _read_and_parse_records(self, raw_responses: dict[int, str]) -> list[dict]:
+    def _read_and_parse_records(self, raw_responses: dict[str, str]) -> list[dict]:
         """Read JSONL and parse profiling records (runs in thread pool)."""
         records: list[dict] = []
         with open(self._jsonl_path) as f:
@@ -102,9 +105,8 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
                 if record.metadata.benchmark_phase != CreditPhase.PROFILING:
                     continue
                 entry = self._build_output_entry(record)
-                # Attach response text from raw records if available
-                session_num = record.metadata.session_num
-                entry["response_text"] = raw_responses.get(session_num)
+                key = f"{record.metadata.session_num}:{record.metadata.turn_index or 0}"
+                entry["response_text"] = raw_responses.get(key)
                 records.append(entry)
         return records
 

--- a/src/aiperf/exporters/outputs_json_exporter.py
+++ b/src/aiperf/exporters/outputs_json_exporter.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Aggregator that merges output fragments with metrics into final outputs.json."""
 
-import contextlib
-
 import aiofiles
 import orjson
 
@@ -76,7 +74,7 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
             }
             records.append(entry)
 
-        records.sort(key=lambda r: r["session_num"])
+        records.sort(key=lambda r: (r["session_num"], r.get("turn_index") or 0))
 
         output = {
             "schema_version": "1.0",
@@ -132,5 +130,9 @@ class OutputsJsonExporter(AIPerfLoggerMixin):
         """Remove fragment files and directory."""
         for file in fragment_files:
             file.unlink(missing_ok=True)
-        with contextlib.suppress(OSError):
+        try:
             self._fragments_dir.rmdir()
+        except OSError:
+            self.debug(
+                f"Could not remove fragments directory (may not be empty): {self._fragments_dir}"
+            )

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -75,7 +75,7 @@ TransportType = plugins.create_enum(PluginType.TRANSPORT, "TransportType", modul
 
 RecordProcessorTypeStr: TypeAlias = str
 RecordProcessorType = plugins.create_enum(PluginType.RECORD_PROCESSOR, "RecordProcessorType", module=__name__)
-"""Dynamic enum for record processor. Example: RecordProcessorType.ACCURACY_RECORD, RecordProcessorType.METRIC_RECORD, RecordProcessorType.RAW_RECORD_WRITER"""
+"""Dynamic enum for record processor. Example: RecordProcessorType.ACCURACY_RECORD, RecordProcessorType.OUTPUTS_JSON, RecordProcessorType.RAW_RECORD_WRITER"""
 
 ResultsProcessorTypeStr: TypeAlias = str
 ResultsProcessorType = plugins.create_enum(PluginType.RESULTS_PROCESSOR, "ResultsProcessorType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -819,6 +819,10 @@ data_exporter:
       CSV exporter for accuracy benchmarking results. Exports per-problem grading
       details for offline analysis. Self-disables when accuracy mode is off.
 
+  outputs_json:
+    class: aiperf.exporters.outputs_json_exporter:OutputsJsonExporter
+    description: Exports per-request output metadata to outputs.json for downstream post-processing.
+
 # =============================================================================
 # Console Exporters
 # =============================================================================

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -700,6 +700,12 @@ record_processor:
       Accuracy record processor that grades LLM responses against ground truth
       for accuracy benchmarking. Self-disables when accuracy mode is off.
 
+  outputs_json:
+    class: aiperf.post_processors.outputs_json_record_processor:OutputsJsonRecordProcessor
+    description: |
+      Outputs JSON record processor that captures model response text per request.
+      Enabled when --export-outputs-json is set. Writes per-processor fragment files.
+
 # =============================================================================
 # Results Processors
 # =============================================================================
@@ -821,7 +827,9 @@ data_exporter:
 
   outputs_json:
     class: aiperf.exporters.outputs_json_exporter:OutputsJsonExporter
-    description: Exports per-request output metadata to outputs.json for downstream post-processing.
+    description: |
+      Aggregates per-processor output fragment files and merges with metrics
+      into final outputs.json. Enabled when --export-outputs-json is set.
 
 # =============================================================================
 # Console Exporters

--- a/src/aiperf/post_processors/outputs_json_record_processor.py
+++ b/src/aiperf/post_processors/outputs_json_record_processor.py
@@ -55,6 +55,10 @@ class OutputsJsonRecordProcessor(BufferedJSONLWriterMixin[OutputFragment]):
         )
         output_dir.mkdir(parents=True, exist_ok=True)
 
+        # Clear stale fragments from previous failed runs
+        for stale in output_dir.glob("output_fragments_*.jsonl"):
+            stale.unlink(missing_ok=True)
+
         safe_id = (
             (service_id or "processor")
             .replace("/", "_")

--- a/src/aiperf/post_processors/outputs_json_record_processor.py
+++ b/src/aiperf/post_processors/outputs_json_record_processor.py
@@ -55,10 +55,6 @@ class OutputsJsonRecordProcessor(BufferedJSONLWriterMixin[OutputFragment]):
         )
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Clear stale fragments from previous failed runs
-        for stale in output_dir.glob("output_fragments_*.jsonl"):
-            stale.unlink(missing_ok=True)
-
         safe_id = (
             (service_id or "processor")
             .replace("/", "_")
@@ -66,6 +62,9 @@ class OutputsJsonRecordProcessor(BufferedJSONLWriterMixin[OutputFragment]):
             .replace(" ", "_")
         )
         output_file = output_dir / f"output_fragments_{safe_id}.jsonl"
+
+        # Clear own file from a previous failed run (safe: each processor has a unique ID)
+        output_file.unlink(missing_ok=True)
 
         super().__init__(
             output_file=output_file,

--- a/src/aiperf/post_processors/outputs_json_record_processor.py
+++ b/src/aiperf/post_processors/outputs_json_record_processor.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Record processor that captures model response text per request for outputs.json export."""
+
+from pydantic import Field
+
+from aiperf.common.config import UserConfig
+from aiperf.common.config.config_defaults import OutputDefaults
+from aiperf.common.environment import Environment
+from aiperf.common.exceptions import PostProcessorDisabled
+from aiperf.common.mixins import BufferedJSONLWriterMixin
+from aiperf.common.models import MetricRecordMetadata, ParsedResponseRecord
+from aiperf.common.models.base_models import AIPerfBaseModel
+
+
+class OutputFragment(AIPerfBaseModel):
+    """A single output fragment capturing response text and request identifiers."""
+
+    session_num: int = Field(description="The session number of the request.")
+    turn_index: int = Field(description="The turn index within the conversation.")
+    conversation_id: str = Field(description="The conversation identifier.")
+    x_request_id: str = Field(description="The unique request identifier.")
+    response_text: str | None = Field(
+        default=None,
+        description="The concatenated generated text from the model response.",
+    )
+    request_start_ns: int = Field(description="Request start timestamp in nanoseconds.")
+    request_end_ns: int = Field(description="Request end timestamp in nanoseconds.")
+
+
+class OutputsJsonRecordProcessor(BufferedJSONLWriterMixin[OutputFragment]):
+    """Captures model response text per request and writes fragment files.
+
+    Enabled when --export-outputs-json is set. Writes per-processor fragment
+    files that are later aggregated by the OutputsJsonExporter.
+    """
+
+    def __init__(
+        self,
+        service_id: str | None,
+        user_config: UserConfig,
+        **kwargs,
+    ) -> None:
+        self.user_config = user_config
+
+        if not self.user_config.output.export_outputs_json:
+            raise PostProcessorDisabled(
+                "OutputsJsonRecordProcessor is disabled (--export-outputs-json not set)"
+            )
+
+        output_dir = (
+            user_config.output.artifact_directory
+            / OutputDefaults.OUTPUT_FRAGMENTS_FOLDER
+        )
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        safe_id = (
+            (service_id or "processor")
+            .replace("/", "_")
+            .replace(":", "_")
+            .replace(" ", "_")
+        )
+        output_file = output_dir / f"output_fragments_{safe_id}.jsonl"
+
+        super().__init__(
+            output_file=output_file,
+            batch_size=Environment.RECORD.EXPORT_BATCH_SIZE,
+            service_id=service_id,
+            user_config=user_config,
+            **kwargs,
+        )
+
+        self.info(f"OutputsJsonRecordProcessor initialized: {self.output_file}")
+
+    async def process_record(
+        self, record: ParsedResponseRecord, metadata: MetricRecordMetadata
+    ) -> None:
+        """Extract response text and write an output fragment."""
+        parts: list[str] = []
+        for resp in record.content_responses:
+            if resp.data:
+                text = resp.data.get_text()
+                if text:
+                    parts.append(text)
+        response_text = "".join(parts) or None
+
+        fragment = OutputFragment(
+            session_num=metadata.session_num,
+            turn_index=metadata.turn_index or 0,
+            conversation_id=metadata.conversation_id or "",
+            x_request_id=metadata.x_request_id or "",
+            response_text=response_text,
+            request_start_ns=metadata.request_start_ns or 0,
+            request_end_ns=metadata.request_end_ns or 0,
+        )
+
+        await self.buffered_write(fragment)

--- a/src/aiperf/post_processors/outputs_json_record_processor.py
+++ b/src/aiperf/post_processors/outputs_json_record_processor.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from aiperf.common.config import UserConfig
 from aiperf.common.config.config_defaults import OutputDefaults
+from aiperf.common.enums import CreditPhase
 from aiperf.common.environment import Environment
 from aiperf.common.exceptions import PostProcessorDisabled
 from aiperf.common.mixins import BufferedJSONLWriterMixin
@@ -76,6 +77,9 @@ class OutputsJsonRecordProcessor(BufferedJSONLWriterMixin[OutputFragment]):
         self, record: ParsedResponseRecord, metadata: MetricRecordMetadata
     ) -> None:
         """Extract response text and write an output fragment."""
+        if metadata.benchmark_phase != CreditPhase.PROFILING:
+            return
+
         parts: list[str] = []
         for resp in record.content_responses:
             if resp.data:

--- a/tests/unit/exporters/test_outputs_json_exporter.py
+++ b/tests/unit/exporters/test_outputs_json_exporter.py
@@ -7,33 +7,51 @@ from unittest.mock import MagicMock
 import orjson
 import pytest
 
+from aiperf.common.config.config_defaults import OutputDefaults
+from aiperf.common.exceptions import DataExporterDisabled
 from aiperf.exporters.outputs_json_exporter import OutputsJsonExporter
 
 
-def _make_record(
+def _make_fragment(
     session_num: int,
-    benchmark_phase: str = "profiling",
-    x_request_id: str = "req-1",
-    conversation_id: str = "conv-1",
     turn_index: int = 0,
+    conversation_id: str = "conv-1",
+    x_request_id: str = "req-1",
+    response_text: str | None = "Hello, world!",
     request_start_ns: int = 1000000000,
     request_end_ns: int = 2000000000,
+) -> dict:
+    """Build an output fragment dict suitable for JSONL serialization."""
+    return {
+        "session_num": session_num,
+        "turn_index": turn_index,
+        "conversation_id": conversation_id,
+        "x_request_id": x_request_id,
+        "response_text": response_text,
+        "request_start_ns": request_start_ns,
+        "request_end_ns": request_end_ns,
+    }
+
+
+def _make_profile_record(
+    session_num: int,
+    turn_index: int = 0,
+    benchmark_phase: str = "profiling",
     output_token_count: int = 42,
     request_latency: float = 1000.0,
-    error: dict | None = None,
 ) -> dict:
-    """Build a MetricRecordInfo dict suitable for JSONL serialization."""
+    """Build a MetricRecordInfo dict suitable for profile_export.jsonl."""
     return {
         "metadata": {
             "session_num": session_num,
-            "x_request_id": x_request_id,
+            "x_request_id": "req-1",
             "x_correlation_id": None,
-            "conversation_id": conversation_id,
+            "conversation_id": "conv-1",
             "turn_index": turn_index,
             "credit_issued_ns": None,
-            "request_start_ns": request_start_ns,
+            "request_start_ns": 1000000000,
             "request_ack_ns": None,
-            "request_end_ns": request_end_ns,
+            "request_end_ns": 2000000000,
             "worker_id": "worker-1",
             "record_processor_id": "proc-1",
             "benchmark_phase": benchmark_phase,
@@ -44,12 +62,13 @@ def _make_record(
             "request_latency": {"value": request_latency, "unit": "ms"},
         },
         "trace_data": None,
-        "error": error,
+        "error": None,
     }
 
 
 def _write_jsonl(path: Path, records: list[dict]) -> None:
     """Write records as JSONL to the given path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "wb") as f:
         for record in records:
             f.write(orjson.dumps(record) + b"\n")
@@ -58,22 +77,53 @@ def _write_jsonl(path: Path, records: list[dict]) -> None:
 def _make_exporter(tmp_path: Path) -> OutputsJsonExporter:
     """Create an OutputsJsonExporter with mocked config pointing to tmp_path."""
     config = MagicMock()
+    config.user_config.output.export_outputs_json = True
     config.user_config.output.outputs_json_file = tmp_path / "outputs.json"
     config.user_config.output.profile_export_jsonl_file = (
         tmp_path / "profile_export.jsonl"
     )
+    config.user_config.output.artifact_directory = tmp_path
     return OutputsJsonExporter(config)
 
 
 class TestOutputsJsonExporter:
+    def test_disabled_when_flag_not_set(self, tmp_path: Path) -> None:
+        """Exporter raises DataExporterDisabled when export_outputs_json is False."""
+        config = MagicMock()
+        config.user_config.output.export_outputs_json = False
+        with pytest.raises(DataExporterDisabled):
+            OutputsJsonExporter(config)
+
     @pytest.mark.asyncio
-    async def test_export_produces_valid_outputs_json(self, tmp_path: Path) -> None:
-        """Warmup records are filtered; only profiling records appear in outputs.json."""
-        records = [
-            _make_record(session_num=0, benchmark_phase="warmup"),
-            _make_record(session_num=1, benchmark_phase="profiling"),
+    async def test_export_no_fragments_skips(self, tmp_path: Path) -> None:
+        """When no fragment files exist, export completes without error and no outputs.json is produced."""
+        exporter = _make_exporter(tmp_path)
+        await exporter.export()
+
+        outputs_file = tmp_path / "outputs.json"
+        assert not outputs_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_export_merges_fragments_with_metrics(self, tmp_path: Path) -> None:
+        """Fragments are merged with metrics from profile_export.jsonl."""
+        fragments_dir = tmp_path / OutputDefaults.OUTPUT_FRAGMENTS_FOLDER
+        fragments_dir.mkdir(parents=True)
+
+        fragments = [
+            _make_fragment(session_num=1, response_text="Hello"),
+            _make_fragment(session_num=2, response_text="World"),
         ]
-        _write_jsonl(tmp_path / "profile_export.jsonl", records)
+        _write_jsonl(fragments_dir / "output_fragments_proc1.jsonl", fragments)
+
+        profile_records = [
+            _make_profile_record(
+                session_num=1, output_token_count=10, request_latency=500.0
+            ),
+            _make_profile_record(
+                session_num=2, output_token_count=20, request_latency=800.0
+            ),
+        ]
+        _write_jsonl(tmp_path / "profile_export.jsonl", profile_records)
 
         exporter = _make_exporter(tmp_path)
         await exporter.export()
@@ -83,28 +133,32 @@ class TestOutputsJsonExporter:
 
         data = orjson.loads(outputs_file.read_bytes())
         assert data["schema_version"] == "1.0"
-        assert len(data["data"]) == 1
-        assert data["data"][0]["session_num"] == 1
+        assert len(data["data"]) == 2
 
-    @pytest.mark.asyncio
-    async def test_export_missing_jsonl_skips_gracefully(self, tmp_path: Path) -> None:
-        """When the JSONL file does not exist, export completes without error and no outputs.json is produced."""
-        exporter = _make_exporter(tmp_path)
-        await exporter.export()
+        entry1 = data["data"][0]
+        assert entry1["session_num"] == 1
+        assert entry1["response_text"] == "Hello"
+        assert entry1["metrics"]["output_token_count"] == 10
+        assert entry1["metrics"]["request_latency"] == 500.0
 
-        outputs_file = tmp_path / "outputs.json"
-        assert not outputs_file.exists()
+        entry2 = data["data"][1]
+        assert entry2["session_num"] == 2
+        assert entry2["response_text"] == "World"
+        assert entry2["metrics"]["output_token_count"] == 20
 
     @pytest.mark.asyncio
     async def test_export_sorts_by_session_num(self, tmp_path: Path) -> None:
-        """Records in outputs.json are sorted by session_num ascending regardless of input order."""
-        records = [
-            _make_record(session_num=5),
-            _make_record(session_num=2),
-            _make_record(session_num=9),
-            _make_record(session_num=1),
+        """Records in outputs.json are sorted by session_num ascending."""
+        fragments_dir = tmp_path / OutputDefaults.OUTPUT_FRAGMENTS_FOLDER
+        fragments_dir.mkdir(parents=True)
+
+        fragments = [
+            _make_fragment(session_num=5),
+            _make_fragment(session_num=2),
+            _make_fragment(session_num=9),
+            _make_fragment(session_num=1),
         ]
-        _write_jsonl(tmp_path / "profile_export.jsonl", records)
+        _write_jsonl(fragments_dir / "output_fragments_proc1.jsonl", fragments)
 
         exporter = _make_exporter(tmp_path)
         await exporter.export()
@@ -114,38 +168,84 @@ class TestOutputsJsonExporter:
         assert session_nums == [1, 2, 5, 9]
 
     @pytest.mark.asyncio
-    async def test_export_extracts_correct_fields(self, tmp_path: Path) -> None:
-        """Verify all expected fields are correctly extracted from a MetricRecordInfo record."""
-        records = [
-            _make_record(
-                session_num=3,
-                x_request_id="req-abc",
-                conversation_id="conv-xyz",
-                turn_index=2,
-                request_start_ns=5000000000,
-                request_end_ns=6000000000,
-                output_token_count=100,
-                request_latency=500.0,
-                error={"error_type": "timeout", "message": "request timed out"},
-            ),
-        ]
-        _write_jsonl(tmp_path / "profile_export.jsonl", records)
+    async def test_export_handles_missing_profile_jsonl(self, tmp_path: Path) -> None:
+        """When profile_export.jsonl is missing, metrics are empty but export succeeds."""
+        fragments_dir = tmp_path / OutputDefaults.OUTPUT_FRAGMENTS_FOLDER
+        fragments_dir.mkdir(parents=True)
+
+        fragments = [_make_fragment(session_num=1, response_text="test")]
+        _write_jsonl(fragments_dir / "output_fragments_proc1.jsonl", fragments)
 
         exporter = _make_exporter(tmp_path)
         await exporter.export()
 
         data = orjson.loads((tmp_path / "outputs.json").read_bytes())
         assert len(data["data"]) == 1
+        assert data["data"][0]["metrics"] == {}
+        assert data["data"][0]["response_text"] == "test"
 
-        entry = data["data"][0]
-        assert entry["session_num"] == 3
-        assert entry["conversation_id"] == "conv-xyz"
-        assert entry["turn_index"] == 2
-        assert entry["x_request_id"] == "req-abc"
-        assert entry["request_start_ns"] == 5000000000
-        assert entry["request_end_ns"] == 6000000000
-        assert entry["metrics"]["output_token_count"] == 100
-        assert entry["metrics"]["request_latency"] == 500.0
-        assert entry["error"] is not None
-        assert entry["error"]["error_type"] == "timeout"
-        assert entry["error"]["message"] == "request timed out"
+    @pytest.mark.asyncio
+    async def test_export_filters_warmup_from_metrics(self, tmp_path: Path) -> None:
+        """Warmup records in profile_export.jsonl are not included in the metrics map."""
+        fragments_dir = tmp_path / OutputDefaults.OUTPUT_FRAGMENTS_FOLDER
+        fragments_dir.mkdir(parents=True)
+
+        fragments = [_make_fragment(session_num=1)]
+        _write_jsonl(fragments_dir / "output_fragments_proc1.jsonl", fragments)
+
+        profile_records = [
+            _make_profile_record(
+                session_num=1, benchmark_phase="warmup", output_token_count=99
+            ),
+            _make_profile_record(
+                session_num=1, benchmark_phase="profiling", output_token_count=42
+            ),
+        ]
+        _write_jsonl(tmp_path / "profile_export.jsonl", profile_records)
+
+        exporter = _make_exporter(tmp_path)
+        await exporter.export()
+
+        data = orjson.loads((tmp_path / "outputs.json").read_bytes())
+        assert data["data"][0]["metrics"]["output_token_count"] == 42
+
+    @pytest.mark.asyncio
+    async def test_export_cleans_up_fragments(self, tmp_path: Path) -> None:
+        """Fragment files and directory are removed after export."""
+        fragments_dir = tmp_path / OutputDefaults.OUTPUT_FRAGMENTS_FOLDER
+        fragments_dir.mkdir(parents=True)
+
+        fragments = [_make_fragment(session_num=1)]
+        _write_jsonl(fragments_dir / "output_fragments_proc1.jsonl", fragments)
+
+        exporter = _make_exporter(tmp_path)
+        await exporter.export()
+
+        assert not (fragments_dir / "output_fragments_proc1.jsonl").exists()
+        assert not fragments_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_export_aggregates_multiple_fragment_files(
+        self, tmp_path: Path
+    ) -> None:
+        """Multiple fragment files from different processors are aggregated."""
+        fragments_dir = tmp_path / OutputDefaults.OUTPUT_FRAGMENTS_FOLDER
+        fragments_dir.mkdir(parents=True)
+
+        _write_jsonl(
+            fragments_dir / "output_fragments_proc1.jsonl",
+            [_make_fragment(session_num=1, response_text="from proc1")],
+        )
+        _write_jsonl(
+            fragments_dir / "output_fragments_proc2.jsonl",
+            [_make_fragment(session_num=2, response_text="from proc2")],
+        )
+
+        exporter = _make_exporter(tmp_path)
+        await exporter.export()
+
+        data = orjson.loads((tmp_path / "outputs.json").read_bytes())
+        assert len(data["data"]) == 2
+        texts = {r["session_num"]: r["response_text"] for r in data["data"]}
+        assert texts[1] == "from proc1"
+        assert texts[2] == "from proc2"

--- a/tests/unit/exporters/test_outputs_json_exporter.py
+++ b/tests/unit/exporters/test_outputs_json_exporter.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import orjson
+import pytest
+
+from aiperf.exporters.outputs_json_exporter import OutputsJsonExporter
+
+
+def _make_record(
+    session_num: int,
+    benchmark_phase: str = "profiling",
+    x_request_id: str = "req-1",
+    conversation_id: str = "conv-1",
+    turn_index: int = 0,
+    request_start_ns: int = 1000000000,
+    request_end_ns: int = 2000000000,
+    output_token_count: int = 42,
+    request_latency: float = 1000.0,
+    error: dict | None = None,
+) -> dict:
+    """Build a MetricRecordInfo dict suitable for JSONL serialization."""
+    return {
+        "metadata": {
+            "session_num": session_num,
+            "x_request_id": x_request_id,
+            "x_correlation_id": None,
+            "conversation_id": conversation_id,
+            "turn_index": turn_index,
+            "credit_issued_ns": None,
+            "request_start_ns": request_start_ns,
+            "request_ack_ns": None,
+            "request_end_ns": request_end_ns,
+            "worker_id": "worker-1",
+            "record_processor_id": "proc-1",
+            "benchmark_phase": benchmark_phase,
+            "was_cancelled": False,
+        },
+        "metrics": {
+            "output_token_count": {"value": output_token_count, "unit": "tokens"},
+            "request_latency": {"value": request_latency, "unit": "ms"},
+        },
+        "trace_data": None,
+        "error": error,
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    """Write records as JSONL to the given path."""
+    with open(path, "wb") as f:
+        for record in records:
+            f.write(orjson.dumps(record) + b"\n")
+
+
+def _make_exporter(tmp_path: Path) -> OutputsJsonExporter:
+    """Create an OutputsJsonExporter with mocked config pointing to tmp_path."""
+    config = MagicMock()
+    config.user_config.output.outputs_json_file = tmp_path / "outputs.json"
+    config.user_config.output.profile_export_jsonl_file = (
+        tmp_path / "profile_export.jsonl"
+    )
+    return OutputsJsonExporter(config)
+
+
+class TestOutputsJsonExporter:
+    @pytest.mark.asyncio
+    async def test_export_produces_valid_outputs_json(self, tmp_path: Path) -> None:
+        """Warmup records are filtered; only profiling records appear in outputs.json."""
+        records = [
+            _make_record(session_num=0, benchmark_phase="warmup"),
+            _make_record(session_num=1, benchmark_phase="profiling"),
+        ]
+        _write_jsonl(tmp_path / "profile_export.jsonl", records)
+
+        exporter = _make_exporter(tmp_path)
+        await exporter.export()
+
+        outputs_file = tmp_path / "outputs.json"
+        assert outputs_file.exists()
+
+        data = orjson.loads(outputs_file.read_bytes())
+        assert data["schema_version"] == "1.0"
+        assert len(data["data"]) == 1
+        assert data["data"][0]["session_num"] == 1
+
+    @pytest.mark.asyncio
+    async def test_export_missing_jsonl_skips_gracefully(self, tmp_path: Path) -> None:
+        """When the JSONL file does not exist, export completes without error and no outputs.json is produced."""
+        exporter = _make_exporter(tmp_path)
+        await exporter.export()
+
+        outputs_file = tmp_path / "outputs.json"
+        assert not outputs_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_export_sorts_by_session_num(self, tmp_path: Path) -> None:
+        """Records in outputs.json are sorted by session_num ascending regardless of input order."""
+        records = [
+            _make_record(session_num=5),
+            _make_record(session_num=2),
+            _make_record(session_num=9),
+            _make_record(session_num=1),
+        ]
+        _write_jsonl(tmp_path / "profile_export.jsonl", records)
+
+        exporter = _make_exporter(tmp_path)
+        await exporter.export()
+
+        data = orjson.loads((tmp_path / "outputs.json").read_bytes())
+        session_nums = [r["session_num"] for r in data["data"]]
+        assert session_nums == [1, 2, 5, 9]
+
+    @pytest.mark.asyncio
+    async def test_export_extracts_correct_fields(self, tmp_path: Path) -> None:
+        """Verify all expected fields are correctly extracted from a MetricRecordInfo record."""
+        records = [
+            _make_record(
+                session_num=3,
+                x_request_id="req-abc",
+                conversation_id="conv-xyz",
+                turn_index=2,
+                request_start_ns=5000000000,
+                request_end_ns=6000000000,
+                output_token_count=100,
+                request_latency=500.0,
+                error={"error_type": "timeout", "message": "request timed out"},
+            ),
+        ]
+        _write_jsonl(tmp_path / "profile_export.jsonl", records)
+
+        exporter = _make_exporter(tmp_path)
+        await exporter.export()
+
+        data = orjson.loads((tmp_path / "outputs.json").read_bytes())
+        assert len(data["data"]) == 1
+
+        entry = data["data"][0]
+        assert entry["session_num"] == 3
+        assert entry["conversation_id"] == "conv-xyz"
+        assert entry["turn_index"] == 2
+        assert entry["x_request_id"] == "req-abc"
+        assert entry["request_start_ns"] == 5000000000
+        assert entry["request_end_ns"] == 6000000000
+        assert entry["metrics"]["output_token_count"] == 100
+        assert entry["metrics"]["request_latency"] == 500.0
+        assert entry["error"] is not None
+        assert entry["error"]["error_type"] == "timeout"
+        assert entry["error"]["message"] == "request timed out"

--- a/tests/unit/post_processors/test_outputs_json_record_processor.py
+++ b/tests/unit/post_processors/test_outputs_json_record_processor.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for OutputsJsonRecordProcessor."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from pydantic import ValidationError
+
+from aiperf.common.config import EndpointConfig, OutputConfig, UserConfig
+from aiperf.common.enums import ExportLevel
+from aiperf.common.exceptions import PostProcessorDisabled
+from aiperf.common.models.record_models import (
+    MetricRecordMetadata,
+    ParsedResponseRecord,
+)
+from aiperf.plugin.enums import EndpointType
+from aiperf.post_processors.outputs_json_record_processor import (
+    OutputsJsonRecordProcessor,
+)
+from tests.unit.post_processors.conftest import aiperf_lifecycle
+
+
+class TestOutputsJsonRecordProcessorDisabled:
+    """Tests for OutputsJsonRecordProcessor disabled state."""
+
+    def test_disabled_when_flag_not_set(self, tmp_path: Path) -> None:
+        """Raises PostProcessorDisabled when export_outputs_json is False."""
+        config = UserConfig(
+            endpoint=EndpointConfig(
+                model_names=["test-model"],
+                type=EndpointType.CHAT,
+                streaming=False,
+            ),
+            output=OutputConfig(
+                artifact_directory=tmp_path,
+                export_outputs_json=False,
+            ),
+        )
+
+        with pytest.raises(PostProcessorDisabled):
+            OutputsJsonRecordProcessor(
+                service_id="processor-1",
+                user_config=config,
+            )
+
+
+class TestOutputsJsonRecordProcessorProcessRecord:
+    """Tests for OutputsJsonRecordProcessor process_record method."""
+
+    @pytest.mark.asyncio
+    async def test_process_record_writes_fragment(self, tmp_path: Path) -> None:
+        """Creates a mock ParsedResponseRecord with content_responses, calls process_record, verifies fragment is written."""
+        config = UserConfig(
+            endpoint=EndpointConfig(
+                model_names=["test-model"],
+                type=EndpointType.CHAT,
+                streaming=False,
+            ),
+            output=OutputConfig(
+                artifact_directory=tmp_path,
+                export_outputs_json=True,
+                export_level=ExportLevel.RECORDS,
+            ),
+        )
+
+        record = MagicMock(spec=ParsedResponseRecord)
+        resp1 = MagicMock()
+        resp1.data.get_text.return_value = "Hello "
+        resp2 = MagicMock()
+        resp2.data.get_text.return_value = "world!"
+        type(record).content_responses = PropertyMock(return_value=[resp1, resp2])
+
+        metadata = MetricRecordMetadata(
+            session_num=0,
+            request_start_ns=1000000000,
+            request_end_ns=2000000000,
+            worker_id="worker-1",
+            record_processor_id="proc-1",
+            benchmark_phase="profiling",
+        )
+
+        processor = OutputsJsonRecordProcessor(
+            service_id="processor-1",
+            user_config=config,
+        )
+        async with aiperf_lifecycle(processor) as proc:
+            await proc.process_record(record, metadata)
+
+        assert proc.lines_written == 1
+
+    @pytest.mark.asyncio
+    async def test_process_record_extracts_response_text(self, tmp_path: Path) -> None:
+        """Verifies response text is concatenated from content_responses."""
+        import orjson
+
+        config = UserConfig(
+            endpoint=EndpointConfig(
+                model_names=["test-model"],
+                type=EndpointType.CHAT,
+                streaming=False,
+            ),
+            output=OutputConfig(
+                artifact_directory=tmp_path,
+                export_outputs_json=True,
+                export_level=ExportLevel.RECORDS,
+            ),
+        )
+
+        record = MagicMock(spec=ParsedResponseRecord)
+        resp1 = MagicMock()
+        resp1.data.get_text.return_value = "Hello "
+        resp2 = MagicMock()
+        resp2.data.get_text.return_value = "world!"
+        type(record).content_responses = PropertyMock(return_value=[resp1, resp2])
+
+        metadata = MetricRecordMetadata(
+            session_num=0,
+            request_start_ns=1000000000,
+            request_end_ns=2000000000,
+            worker_id="worker-1",
+            record_processor_id="proc-1",
+            benchmark_phase="profiling",
+        )
+
+        processor = OutputsJsonRecordProcessor(
+            service_id="processor-1",
+            user_config=config,
+        )
+        async with aiperf_lifecycle(processor) as proc:
+            await proc.process_record(record, metadata)
+
+        # Read the written fragment file and verify response_text
+        output_file = proc.output_file
+        content = output_file.read_bytes()
+        fragment = orjson.loads(content.strip())
+        assert fragment["response_text"] == "Hello world!"
+
+    @pytest.mark.asyncio
+    async def test_process_record_null_response_text_when_no_content(
+        self, tmp_path: Path
+    ) -> None:
+        """When content_responses is empty, response_text is None."""
+        import orjson
+
+        config = UserConfig(
+            endpoint=EndpointConfig(
+                model_names=["test-model"],
+                type=EndpointType.CHAT,
+                streaming=False,
+            ),
+            output=OutputConfig(
+                artifact_directory=tmp_path,
+                export_outputs_json=True,
+                export_level=ExportLevel.RECORDS,
+            ),
+        )
+
+        record = MagicMock(spec=ParsedResponseRecord)
+        type(record).content_responses = PropertyMock(return_value=[])
+
+        metadata = MetricRecordMetadata(
+            session_num=0,
+            request_start_ns=1000000000,
+            request_end_ns=2000000000,
+            worker_id="worker-1",
+            record_processor_id="proc-1",
+            benchmark_phase="profiling",
+        )
+
+        processor = OutputsJsonRecordProcessor(
+            service_id="processor-1",
+            user_config=config,
+        )
+        async with aiperf_lifecycle(processor) as proc:
+            await proc.process_record(record, metadata)
+
+        # Read the written fragment file and verify response_text is absent (exclude_none=True)
+        output_file = proc.output_file
+        content = output_file.read_bytes()
+        fragment = orjson.loads(content.strip())
+        assert "response_text" not in fragment
+
+
+class TestOutputConfigExportOutputsJsonValidation:
+    """Tests for OutputConfig validation of export_outputs_json."""
+
+    def test_export_outputs_json_with_summary_raises(self) -> None:
+        """export_outputs_json=True with export_level=summary raises ValueError."""
+        with pytest.raises(ValidationError, match="export-outputs-json"):
+            OutputConfig(
+                export_outputs_json=True,
+                export_level=ExportLevel.SUMMARY,
+            )


### PR DESCRIPTION
Closes issue #882

## Summary

Adds an `outputs.json` artifact that persists model responses for every benchmark run, enabling downstream post-processing without modifying AIPerf internals. Each record in `outputs.json` is joinable to the corresponding input in `inputs.json` via `session_num`.

Closes #882

## Motivation

Today users can inspect the generated workload through `inputs.json`, but have no equivalent artifact for what the model returned. This limits workflows like custom quality evaluation, safety checks, response comparison across configurations, and accuracy auditing.

## Implementation

- **New data exporter** (`src/aiperf/exporters/outputs_json_exporter.py`): Reads from the existing `profile_export.jsonl`, filters to profiling phase, extracts per-request metadata and metrics, writes structured `outputs.json`
- **Unconditional**: Always produced when JSONL exists (no export level gating)
- **Registered** in `plugins.yaml` under `data_exporter` as `outputs_json`
- **Config**: Added `OUTPUTS_JSON_FILE` to `OutputDefaults` and `outputs_json_file` property to output config

## Schema

```json
{
  "schema_version": "1.0",
  "data": [
    {
      "session_num": 0,
      "conversation_id": "session-abc",
      "turn_index": 0,
      "x_request_id": "req-123",
      "request_start_ns": 1714500000000000000,
      "request_end_ns": 1714500001234000000,
      "metrics": {
        "output_token_count": 42,
        "output_sequence_length": 42,
        "request_latency": 1234.5
      },
      "error": null
    }
  ]
}
```

## Join Key

`outputs.json[i].session_num` maps to `inputs.json.data[session_num]` for deterministic request/response pairing across all endpoint types.

## Example Usage

```bash
# Run benchmark
aiperf profile --model my-model --url http://localhost:8080 --request-count 100

# outputs.json is automatically produced in the artifact directory
cat artifacts/outputs.json | python -c "
import json, sys
data = json.load(sys.stdin)
print(f'{len(data[\"data\"])} responses captured')
print(f'First response: {data[\"data\"][0][\"metrics\"]}')
"
```

## Files Changed

| File | Change |
|------|--------|
| `src/aiperf/common/config/config_defaults.py` | Added `OUTPUTS_JSON_FILE` |
| `src/aiperf/common/config/output_config.py` | Added `outputs_json_file` property |
| `src/aiperf/exporters/outputs_json_exporter.py` | New exporter (reads JSONL, writes outputs.json) |
| `src/aiperf/plugin/plugins.yaml` | Registered `outputs_json` data exporter |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an exporter that writes outputs.json with per-request output metadata (token counts, sequence lengths, request latency, optional error text); entries sorted by session and skipped when input is missing.
  * Configurable outputs.json location so export destination can be targeted.
* **Tests**
  * Added unit tests for filtering, sorting, field extraction, and missing-input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->