### PR TITLE
feat(rankings): multimodal support for Cohere ranking endpoint

### DIFF
--- a/docs/tutorials/rankings.md
+++ b/docs/tutorials/rankings.md
@@ -164,12 +164,38 @@ structured documents with `content` parts for text and media. AIPerf pairs
 `passages`, `images`, and `videos` by index, so each non-empty modality must have
 the same number of entries.
 
+For synthetic rankings inputs, AIPerf generates one image or video per synthetic
+passage when image or video generation is enabled. This keeps the generated
+multimodal documents index-paired.
+
+Run AIPerf with synthetic multimodal rankings inputs:
+
+```bash
+aiperf profile \
+    -m nvidia/llama-nemotron-rerank-vl-1b-v2 \
+    --endpoint-type cohere_rankings \
+    --custom-endpoint /rerank \
+    --url localhost:8080 \
+    --request-count 10 \
+    --rankings-passages-mean 4 \
+    --rankings-passages-stddev 0 \
+    --rankings-passages-prompt-token-mean 32 \
+    --rankings-passages-prompt-token-stddev 0 \
+    --rankings-query-prompt-token-mean 16 \
+    --rankings-query-prompt-token-stddev 0 \
+    --image-width-mean 224 \
+    --image-width-stddev 0 \
+    --image-height-mean 224 \
+    --image-height-stddev 0 \
+    --image-batch-size 1
+```
+
 You can supply images as `data:` URLs (as in the example below), using the usual
 `data:image/<subtype>;base64,<payload>` form, or as absolute `http://` or
 `https://` URLs to a reachable image resource when the rerank server fetches media
 from the network.
 
-Create a multimodal rankings file:
+To use custom multimodal inputs, create a rankings file:
 
 ```bash
 cat <<EOF > multimodal-rankings.jsonl
@@ -178,15 +204,12 @@ cat <<EOF > multimodal-rankings.jsonl
 EOF
 ```
 
-Run AIPerf against a vLLM server. AIPerf keeps `/v2/rerank` as the default Cohere
-path; vLLM examples commonly expose `/rerank`, so override the endpoint path when
-needed:
+Run AIPerf against a vLLM server.
 
 ```bash
 aiperf profile \
-    -m jinaai/jina-reranker-m0 \
+    -m nvidia/llama-nemotron-rerank-vl-1b-v2 \
     --endpoint-type cohere_rankings \
-    --custom-endpoint /rerank \
     --url localhost:8080 \
     --input-file ./multimodal-rankings.jsonl \
     --custom-dataset-type single_turn \

--- a/docs/tutorials/rankings.md
+++ b/docs/tutorials/rankings.md
@@ -155,3 +155,40 @@ aiperf profile \
     --custom-dataset-type single_turn \
     --request-count 10
 ```
+
+### Profile vLLM Vision Rerank Models
+
+The `cohere_rankings` endpoint also supports vLLM multimodal rerank documents.
+Text-only requests keep the standard Cohere shape, while multimodal requests use
+structured documents with `content` parts for text and media. AIPerf pairs
+`passages`, `images`, and `videos` by index, so each non-empty modality must have
+the same number of entries.
+
+You can supply images as `data:` URLs (as in the example below), using the usual
+`data:image/<subtype>;base64,<payload>` form, or as absolute `http://` or
+`https://` URLs to a reachable image resource when the rerank server fetches media
+from the network.
+
+Create a multimodal rankings file:
+
+```bash
+cat <<EOF > multimodal-rankings.jsonl
+{"texts":[{"name":"query","contents":["Retrieve the beach image"]},{"name":"passages","contents":["A beach at sunset"]}],"images":[{"name":"image_url","contents":["data:image/png;base64,<BASE64_IMAGE>"]}]}
+{"texts":[{"name":"query","contents":["Retrieve the skyline image"]},{"name":"passages","contents":["A city skyline at night"]}],"images":[{"name":"image_url","contents":["data:image/png;base64,<BASE64_IMAGE>"]}]}
+EOF
+```
+
+Run AIPerf against a vLLM server. AIPerf keeps `/v2/rerank` as the default Cohere
+path; vLLM examples commonly expose `/rerank`, so override the endpoint path when
+needed:
+
+```bash
+aiperf profile \
+    -m jinaai/jina-reranker-m0 \
+    --endpoint-type cohere_rankings \
+    --custom-endpoint /rerank \
+    --url localhost:8080 \
+    --input-file ./multimodal-rankings.jsonl \
+    --custom-dataset-type single_turn \
+    --request-count 10
+```

--- a/src/aiperf/dataset/composer/synthetic_rankings.py
+++ b/src/aiperf/dataset/composer/synthetic_rankings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from aiperf.common import random_generator as rng
 from aiperf.common.config import InputDefaults, UserConfig
-from aiperf.common.models import Conversation, Text, Turn
+from aiperf.common.models import Conversation, Image, Text, Turn, Video
 from aiperf.common.session_id_generator import SessionIDGenerator
 from aiperf.common.tokenizer import Tokenizer
 from aiperf.dataset.composer.base import BaseDatasetComposer
@@ -88,9 +88,46 @@ class SyntheticRankingsDatasetComposer(BaseDatasetComposer):
             passages.contents.append(passage_text)
 
         turn.texts.extend([query, passages])
+        if self.include_image:
+            turn.images.append(self._generate_image_payloads(count=num_passages))
+        if self.include_video:
+            turn.videos.append(self._generate_video_payloads(count=num_passages))
+
         self._finalize_turn(turn)
 
         self.debug(
             lambda: f"[rankings] query_len={len(query_text)} chars, passages={num_passages}"
         )
         return turn
+
+    def _generate_image_payloads(self, count: int) -> Image:
+        """Generate one synthetic image per ranking passage."""
+        image = Image(name="image_url")
+        for _ in range(count):
+            image.contents.append(self.image_generator.generate())
+        return image
+
+    def _generate_video_payloads(self, count: int) -> Video:
+        """Generate one synthetic video per ranking passage."""
+        video = Video(name="video_url")
+        for _ in range(count):
+            data = self.video_generator.generate()
+            if data:
+                video.contents.append(data)
+        return video
+
+    @property
+    def include_image(self) -> bool:
+        return (
+            self.config.input.image.batch_size > 0
+            and self.config.input.image.width.mean > 0
+            and self.config.input.image.height.mean > 0
+        )
+
+    @property
+    def include_video(self) -> bool:
+        return bool(
+            self.config.input.video.batch_size > 0
+            and self.config.input.video.width
+            and self.config.input.video.height
+        )

--- a/src/aiperf/endpoints/base_rankings_endpoint.py
+++ b/src/aiperf/endpoints/base_rankings_endpoint.py
@@ -15,6 +15,7 @@ from aiperf.common.models import (
 )
 from aiperf.common.types import RequestOutputT
 from aiperf.endpoints.base_endpoint import BaseEndpoint
+from aiperf.plugin import plugins
 
 
 class BaseRankingsEndpoint(BaseEndpoint):
@@ -182,8 +183,6 @@ class BaseRankingsEndpoint(BaseEndpoint):
         endpoint_type: str,
     ) -> None:
         """Reject media inputs that the selected rankings endpoint does not support."""
-        from aiperf.plugin import plugins
-
         endpoint_metadata = plugins.get_endpoint_metadata(endpoint_type)
         unsupported = []
         if images and not endpoint_metadata.supports_images:

--- a/src/aiperf/endpoints/base_rankings_endpoint.py
+++ b/src/aiperf/endpoints/base_rankings_endpoint.py
@@ -3,6 +3,7 @@
 
 
 from abc import abstractmethod
+from collections.abc import Sequence
 from typing import Any
 
 from aiperf.common.models import (
@@ -10,7 +11,9 @@ from aiperf.common.models import (
     ParsedResponse,
     RankingsResponseData,
     RequestInfo,
+    Turn,
 )
+from aiperf.common.types import RequestOutputT
 from aiperf.endpoints.base_endpoint import BaseEndpoint
 
 
@@ -19,7 +22,14 @@ class BaseRankingsEndpoint(BaseEndpoint):
 
     @abstractmethod
     def build_payload(
-        self, query_text: str, passages: list[str], model_name: str
+        self,
+        query_text: str,
+        passages: Sequence[str],
+        model_name: str,
+        *,
+        images: Sequence[str] = (),
+        videos: Sequence[str] = (),
+        audios: Sequence[str] = (),
     ) -> dict[str, Any]:
         """Build payload based on the endpoint"""
 
@@ -27,7 +37,7 @@ class BaseRankingsEndpoint(BaseEndpoint):
     def extract_rankings(self, json_obj: dict[str, Any]) -> list[dict[str, Any]]:
         """Parse ranking results into a list."""
 
-    def format_payload(self, request_info: RequestInfo) -> dict[str, Any]:
+    def format_payload(self, request_info: RequestInfo) -> RequestOutputT:
         """Format payload for a rankings request.
 
         Accepts texts with specific names:
@@ -54,6 +64,43 @@ class BaseRankingsEndpoint(BaseEndpoint):
 
         if turn.max_tokens:
             self.warning("Max_tokens is provided but is not supported for rankings.")
+
+        query_texts, passage_texts = self._extract_rankings_texts(turn)
+        images, videos, audios = self._extract_media_contents(turn)
+        query_text = self._select_query_text(query_texts)
+
+        self._validate_media_support(
+            images=images,
+            videos=videos,
+            audios=audios,
+            endpoint_type=model_endpoint.endpoint.type,
+        )
+        self._warn_if_no_documents(
+            passage_texts=passage_texts,
+            images=images,
+            videos=videos,
+            audios=audios,
+        )
+
+        extra = model_endpoint.endpoint.extra or []
+        model_name = turn.model or model_endpoint.primary_model_name
+
+        payload = self.build_payload(
+            query_text,
+            passage_texts,
+            model_name,
+            images=images,
+            videos=videos,
+            audios=audios,
+        )
+        if extra:
+            payload.update(extra)
+
+        self.trace(lambda: f"Formatted rankings payload: {payload}")
+        return payload
+
+    def _extract_rankings_texts(self, turn: Turn) -> tuple[list[str], list[str]]:
+        """Extract query and passage texts from the rankings turn."""
         query_texts = []
         passage_texts = []
 
@@ -68,6 +115,34 @@ class BaseRankingsEndpoint(BaseEndpoint):
                         f"Ignoring text with name '{text.name}' - rankings expects 'query'/'queries' and 'passages'"
                     )
 
+        return query_texts, passage_texts
+
+    def _extract_media_contents(
+        self, turn: Turn
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Extract non-empty image, video, and audio contents from the turn."""
+        images = [
+            image_content
+            for image in turn.images
+            for image_content in image.contents
+            if image_content
+        ]
+        videos = [
+            video_content
+            for video in turn.videos
+            for video_content in video.contents
+            if video_content
+        ]
+        audios = [
+            audio_content
+            for audio in turn.audios
+            for audio_content in audio.contents
+            if audio_content
+        ]
+        return images, videos, audios
+
+    def _select_query_text(self, query_texts: list[str]) -> str:
+        """Select the single query used for the rankings request."""
         if not query_texts:
             raise ValueError(
                 "Rankings request requires a text with name 'query' or 'queries'. "
@@ -79,23 +154,51 @@ class BaseRankingsEndpoint(BaseEndpoint):
                 f"Multiple query texts found, using the first one. Found {len(query_texts)} queries."
             )
 
-        query_text = query_texts[0]
+        return query_texts[0]
 
-        if not passage_texts:
-            self.warning(
-                "Rankings request has query but no passages to rank. "
-                "Consider adding a Text object with name='passages' containing texts to rank."
+    def _warn_if_no_documents(
+        self,
+        *,
+        passage_texts: Sequence[str],
+        images: Sequence[str],
+        videos: Sequence[str],
+        audios: Sequence[str],
+    ) -> None:
+        """Warn when the request has no rankable text or media documents."""
+        if passage_texts or images or videos or audios:
+            return
+
+        self.warning(
+            "Rankings request has query but no passages to rank. "
+            "Consider adding a Text object with name='passages' containing texts to rank."
+        )
+
+    def _validate_media_support(
+        self,
+        *,
+        images: Sequence[str],
+        videos: Sequence[str],
+        audios: Sequence[str],
+        endpoint_type: str,
+    ) -> None:
+        """Reject media inputs that the selected rankings endpoint does not support."""
+        from aiperf.plugin import plugins
+
+        endpoint_metadata = plugins.get_endpoint_metadata(endpoint_type)
+        unsupported = []
+        if images and not endpoint_metadata.supports_images:
+            unsupported.append("image")
+        if videos and not endpoint_metadata.supports_videos:
+            unsupported.append("video")
+        if audios and not endpoint_metadata.supports_audio:
+            unsupported.append("audio")
+
+        if unsupported:
+            media_names = ", ".join(unsupported)
+            raise ValueError(
+                f"Rankings endpoint '{endpoint_type}' does not support "
+                f"{media_names} input."
             )
-
-        extra = model_endpoint.endpoint.extra or []
-        model_name = turn.model or model_endpoint.primary_model_name
-
-        payload = self.build_payload(query_text, passage_texts, model_name)
-        if extra:
-            payload.update(extra)
-
-        self.trace(lambda: f"Formatted rankings payload: {payload}")
-        return payload
 
     def parse_response(
         self, response: InferenceServerResponse

--- a/src/aiperf/endpoints/cohere_rankings.py
+++ b/src/aiperf/endpoints/cohere_rankings.py
@@ -1,24 +1,130 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Sequence
 from typing import Any
 
 from aiperf.endpoints.base_rankings_endpoint import BaseRankingsEndpoint
+
+CohereDocument = str | dict[str, list[dict[str, Any]]]
 
 
 class CohereRankingsEndpoint(BaseRankingsEndpoint):
     """Cohere Rankings Endpoint."""
 
     def build_payload(
-        self, query_text: str, passages: list[str], model_name: str
+        self,
+        query_text: str,
+        passages: Sequence[str],
+        model_name: str,
+        *,
+        images: Sequence[str] = (),
+        videos: Sequence[str] = (),
+        audios: Sequence[str] = (),
     ) -> dict[str, Any]:
         """Build payload to match Cohere Rankings API schema."""
+        if audios:
+            raise ValueError("Cohere rankings does not support audio input.")
+
         payload = {
             "model": model_name,
             "query": query_text,
-            "documents": passages,
+            "documents": self._build_documents(
+                passages=passages,
+                images=images,
+                videos=videos,
+            ),
         }
         return payload
+
+    def _build_documents(
+        self,
+        *,
+        passages: Sequence[str],
+        images: Sequence[str],
+        videos: Sequence[str],
+    ) -> list[CohereDocument]:
+        """Build Cohere/vLLM rerank documents from index-paired modalities."""
+        self._validate_document_counts(
+            passages=passages,
+            images=images,
+            videos=videos,
+        )
+
+        if not images and not videos:
+            return list(passages)
+
+        document_count = self._document_count(
+            passages=passages,
+            images=images,
+            videos=videos,
+        )
+        documents: list[CohereDocument] = []
+        for index in range(document_count):
+            content: list[dict[str, Any]] = []
+            if passages:
+                content.append({"type": "text", "text": passages[index]})
+            if images:
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": images[index]},
+                    }
+                )
+            if videos:
+                content.append(
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": videos[index]},
+                    }
+                )
+            documents.append({"content": content})
+        return documents
+
+    def _validate_document_counts(
+        self,
+        *,
+        passages: Sequence[str],
+        images: Sequence[str],
+        videos: Sequence[str],
+    ) -> None:
+        """Ensure non-empty document modalities can be paired by index."""
+        counts = {
+            "passages": len(passages),
+            "images": len(images),
+            "videos": len(videos),
+        }
+        non_zero_counts = {name: count for name, count in counts.items() if count}
+        if not non_zero_counts:
+            return
+
+        expected_count = next(iter(non_zero_counts.values()))
+        mismatches = {
+            name: count
+            for name, count in non_zero_counts.items()
+            if count != expected_count
+        }
+        if mismatches:
+            counts_str = ", ".join(
+                f"{name}={count}" for name, count in non_zero_counts.items()
+            )
+            raise ValueError(
+                "Cohere rankings multimodal documents must be index-paired "
+                f"with matching non-zero counts. Got {counts_str}."
+            )
+
+    def _document_count(
+        self,
+        *,
+        passages: Sequence[str],
+        images: Sequence[str],
+        videos: Sequence[str],
+    ) -> int:
+        """Return the number of multimodal documents after count validation."""
+        for contents in (passages, images, videos):
+            if contents:
+                return len(contents)
+        return 0
 
     def extract_rankings(self, json_obj: dict[str, Any]) -> list[dict[str, Any]]:
         """Extract ranking results from Cohere Rankings API response."""

--- a/src/aiperf/endpoints/hf_tei_rankings.py
+++ b/src/aiperf/endpoints/hf_tei_rankings.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Sequence
 from typing import Any
 
 from aiperf.endpoints.base_rankings_endpoint import BaseRankingsEndpoint
@@ -10,9 +11,17 @@ class HFTeiRankingsEndpoint(BaseRankingsEndpoint):
     """HuggingFace TEI Rankings Endpoint."""
 
     def build_payload(
-        self, query_text: str, passages: list[str], model_name: str
+        self,
+        query_text: str,
+        passages: Sequence[str],
+        model_name: str,
+        *,
+        images: Sequence[str] = (),
+        videos: Sequence[str] = (),
+        audios: Sequence[str] = (),
     ) -> dict[str, Any]:
         """Build payload to match Huggingface TEI Rankings API schema."""
+        _ = images, videos, audios
         payload = {
             "query": query_text,
             "texts": passages,

--- a/src/aiperf/endpoints/nim_rankings.py
+++ b/src/aiperf/endpoints/nim_rankings.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from collections.abc import Sequence
 from typing import Any
 
 from aiperf.endpoints.base_rankings_endpoint import BaseRankingsEndpoint
@@ -14,9 +15,17 @@ class NIMRankingsEndpoint(BaseRankingsEndpoint):
     returning their relevance scores."""
 
     def build_payload(
-        self, query_text: str, passages: list[str], model_name: str
+        self,
+        query_text: str,
+        passages: Sequence[str],
+        model_name: str,
+        *,
+        images: Sequence[str] = (),
+        videos: Sequence[str] = (),
+        audios: Sequence[str] = (),
     ) -> dict[str, Any]:
         """Build payload to match NIM rankings API schema."""
+        _ = images, videos, audios
         payload = {
             "model": model_name,
             "query": {"text": query_text},

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -215,6 +215,8 @@ endpoint:
       supports_streaming: false
       produces_tokens: false
       tokenizes_input: true
+      supports_images: true
+      supports_videos: true
       metrics_title: Ranking Metrics
 
   completions:

--- a/tests/aiperf_mock_server/models.py
+++ b/tests/aiperf_mock_server/models.py
@@ -126,7 +126,7 @@ class CohereRerankRequest(BaseModel):
     """Request model for Cohere /v2/rerank endpoint."""
 
     query: str
-    documents: list[str]
+    documents: list[str | dict[str, Any]]
     model: str = "cohere-reranker"
 
     @property
@@ -135,7 +135,37 @@ class CohereRerankRequest(BaseModel):
 
     @property
     def passage_texts(self) -> list[str]:
-        return self.documents
+        return [self._document_to_text(document) for document in self.documents]
+
+    def _document_to_text(self, document: str | dict[str, Any]) -> str:
+        """Convert text or multimodal Cohere documents into mock scoring text."""
+        if isinstance(document, str):
+            return document
+
+        content = document.get("content", [])
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return ""
+
+        parts = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            match item.get("type"):
+                case "text":
+                    parts.append(str(item.get("text", "")))
+                case "image_url":
+                    parts.append(self._media_url_text(item, "image_url"))
+                case "video_url":
+                    parts.append(self._media_url_text(item, "video_url"))
+        return "\n".join(part for part in parts if part)
+
+    def _media_url_text(self, item: dict[str, Any], key: str) -> str:
+        media = item.get(key, {})
+        if isinstance(media, dict):
+            return str(media.get("url", ""))
+        return str(media)
 
 
 class TGIParameters(BaseModel):

--- a/tests/component_integration/endpoints/test_rankings_endpoint.py
+++ b/tests/component_integration/endpoints/test_rankings_endpoint.py
@@ -10,7 +10,10 @@ from tests.component_integration.conftest import (
     ComponentIntegrationTestDefaults as defaults,
 )
 from tests.harness.utils import AIPerfCLI
-from tests.integration.utils import create_rankings_dataset
+from tests.integration.utils import (
+    create_multimodal_rankings_dataset,
+    create_rankings_dataset,
+)
 
 
 @pytest.mark.component_integration
@@ -67,6 +70,26 @@ class TestRankingsEndpoint:
             f"""
             aiperf profile \
                 --model BAAI/bge-reranker-base \
+                --endpoint-type cohere_rankings \
+                --input-file {dataset_path} \
+                --custom-dataset-type single_turn \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.request_count == defaults.request_count
+
+    def test_cohere_rankings_multimodal(self, cli: AIPerfCLI, tmp_path: Path):
+        """Test multimodal Cohere Rankings endpoint payloads."""
+        dataset_path = create_multimodal_rankings_dataset(tmp_path, 5)
+
+        result = cli.run_sync(
+            f"""
+            aiperf profile \
+                --model jinaai/jina-reranker-m0 \
                 --endpoint-type cohere_rankings \
                 --input-file {dataset_path} \
                 --custom-dataset-type single_turn \

--- a/tests/component_integration/endpoints/test_rankings_endpoint.py
+++ b/tests/component_integration/endpoints/test_rankings_endpoint.py
@@ -124,3 +124,31 @@ class TestRankingsEndpoint:
         )
 
         assert result.request_count == defaults.request_count
+
+    def test_synthetic_cohere_rankings_multimodal(self, cli: AIPerfCLI):
+        """Synthetic multimodal dataset test for Cohere Rankings endpoint."""
+        result = cli.run_sync(
+            f"""
+            aiperf profile \
+                --model jinaai/jina-reranker-m0 \
+                --tokenizer gpt2 \
+                --endpoint-type cohere_rankings \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --rankings-passages-mean 2 \
+                --rankings-passages-stddev 0 \
+                --rankings-passages-prompt-token-mean 16 \
+                --rankings-passages-prompt-token-stddev 0 \
+                --rankings-query-prompt-token-mean 8 \
+                --rankings-query-prompt-token-stddev 0 \
+                --image-width-mean 8 \
+                --image-width-stddev 0 \
+                --image-height-mean 8 \
+                --image-height-stddev 0 \
+                --image-batch-size 1 \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.request_count == defaults.request_count

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -143,6 +143,28 @@ def create_rankings_dataset(tmp_path: Path, num_entries: int) -> Path:
     return dataset_path
 
 
+def create_multimodal_rankings_dataset(tmp_path: Path, num_entries: int) -> Path:
+    """Create a Cohere/vLLM multimodal rankings dataset for testing."""
+    dataset_path = tmp_path / "multimodal_rankings.jsonl"
+    image_data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
+    with open(dataset_path, "w") as f:
+        for i in range(num_entries):
+            entry = {
+                "texts": [
+                    {"name": "query", "contents": [f"What is shown in image {i}?"]},
+                    {"name": "passages", "contents": [f"Image passage {i}"]},
+                ],
+                "images": [
+                    {
+                        "name": "image_url",
+                        "contents": [image_data_url],
+                    }
+                ],
+            }
+            f.write(orjson.dumps(entry).decode("utf-8") + "\n")
+    return dataset_path
+
+
 def _check_mp4_fragmentation(video_bytes: bytes) -> bool:
     """Check if MP4 video is fragmented by looking for moof (movie fragment) boxes.
 

--- a/tests/unit/dataset/composer/test_synthetic_rankings_composer.py
+++ b/tests/unit/dataset/composer/test_synthetic_rankings_composer.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
-
+from unittest.mock import patch
 
 from aiperf.common.models import Conversation, Turn
 from aiperf.dataset.composer.synthetic_rankings import SyntheticRankingsDatasetComposer
@@ -94,3 +94,71 @@ def test_rankings_specific_token_options(synthetic_config, mock_tokenizer):
         # Query and passages should have content
         assert len(query.contents) == 1
         assert len(passages.contents) >= 1
+
+
+def test_synthetic_images_and_videos_match_passage_count(
+    synthetic_config, mock_tokenizer
+):
+    """Synthetic rankings media should be generated per passage for paired docs."""
+    synthetic_config.input.rankings.passages.mean = 3
+    synthetic_config.input.rankings.passages.stddev = 0
+    synthetic_config.input.image.width.mean = 8
+    synthetic_config.input.image.height.mean = 8
+    synthetic_config.input.image.batch_size = 1
+    synthetic_config.input.video.width = 8
+    synthetic_config.input.video.height = 8
+    synthetic_config.input.video.batch_size = 1
+
+    composer = SyntheticRankingsDatasetComposer(synthetic_config, mock_tokenizer)
+
+    with (
+        patch.object(
+            composer.image_generator,
+            "generate",
+            side_effect=lambda: "data:image/png;base64,test",
+        ) as generate_image,
+        patch.object(
+            composer.video_generator,
+            "generate",
+            side_effect=lambda: "data:video/webm;base64,test",
+        ) as generate_video,
+    ):
+        dataset = composer.create_dataset()
+
+    expected_media_count = synthetic_config.input.conversation.num_dataset_entries * 3
+    assert generate_image.call_count == expected_media_count
+    assert generate_video.call_count == expected_media_count
+
+    for conversation in dataset:
+        turn = conversation.turns[0]
+        passage_count = len(turn.texts[1].contents)
+
+        assert len(turn.images) == 1
+        assert turn.images[0].name == "image_url"
+        assert len(turn.images[0].contents) == passage_count
+
+        assert len(turn.videos) == 1
+        assert turn.videos[0].name == "video_url"
+        assert len(turn.videos[0].contents) == passage_count
+
+
+def test_synthetic_rankings_media_batch_size_zero_disables_media(
+    synthetic_config, mock_tokenizer
+):
+    """Batch size zero disables synthetic rankings media even with dimensions set."""
+    synthetic_config.input.rankings.passages.mean = 2
+    synthetic_config.input.rankings.passages.stddev = 0
+    synthetic_config.input.image.width.mean = 8
+    synthetic_config.input.image.height.mean = 8
+    synthetic_config.input.image.batch_size = 0
+    synthetic_config.input.video.width = 8
+    synthetic_config.input.video.height = 8
+    synthetic_config.input.video.batch_size = 0
+
+    composer = SyntheticRankingsDatasetComposer(synthetic_config, mock_tokenizer)
+    dataset = composer.create_dataset()
+
+    for conversation in dataset:
+        turn = conversation.turns[0]
+        assert turn.images == []
+        assert turn.videos == []

--- a/tests/unit/dataset/composer/test_synthetic_rankings_composer.py
+++ b/tests/unit/dataset/composer/test_synthetic_rankings_composer.py
@@ -142,6 +142,23 @@ def test_synthetic_images_and_videos_match_passage_count(
         assert len(turn.videos[0].contents) == passage_count
 
 
+def test_generate_video_payloads_skips_empty_generated_video(
+    synthetic_config, mock_tokenizer
+):
+    """Empty generated videos are omitted from synthetic video payloads."""
+    composer = SyntheticRankingsDatasetComposer(synthetic_config, mock_tokenizer)
+
+    with patch.object(
+        composer.video_generator,
+        "generate",
+        side_effect=["data:video/webm;base64,test", ""],
+    ):
+        video = composer._generate_video_payloads(count=2)
+
+    assert video.name == "video_url"
+    assert video.contents == ["data:video/webm;base64,test"]
+
+
 def test_synthetic_rankings_media_batch_size_zero_disables_media(
     synthetic_config, mock_tokenizer
 ):

--- a/tests/unit/endpoints/test_cohere_rankings_endpoint.py
+++ b/tests/unit/endpoints/test_cohere_rankings_endpoint.py
@@ -5,9 +5,11 @@ import logging
 
 import pytest
 
-from aiperf.common.models import Text, Turn
+from aiperf.common.models import Audio, Image, Text, Turn, Video
 from aiperf.endpoints.cohere_rankings import CohereRankingsEndpoint
+from aiperf.plugin import plugins
 from aiperf.plugin.enums import EndpointType
+from aiperf.plugin.schema.schemas import EndpointMetadata
 from tests.unit.endpoints.conftest import (
     create_endpoint_with_mock_transport,
     create_model_endpoint,
@@ -58,6 +60,16 @@ class TestCohereRankingsEndpoint:
         assert payload["query"] == "What is deep learning?"
         assert len(payload["documents"]) == 3
         assert "Deep learning uses neural networks." in payload["documents"][0]
+
+    def test_build_payload_legacy_signature(self, converter):
+        """Test that direct text-only build_payload calls remain compatible."""
+        payload = converter.build_payload("What is AI?", ["AI passage"], "test-model")
+
+        assert payload == {
+            "model": "test-model",
+            "query": "What is AI?",
+            "documents": ["AI passage"],
+        }
 
     def test_format_payload_single_passage(self, converter, model_endpoint):
         """Test payload formatting with single passage."""
@@ -112,6 +124,143 @@ class TestCohereRankingsEndpoint:
         assert "no passages to rank" in caplog.text
         assert payload["query"] == "What is AI?"
         assert payload["documents"] == []
+
+    def test_format_payload_single_passage_with_image(self, converter, model_endpoint):
+        """Test multimodal document formatting with one passage and one image."""
+        image_url = "data:image/png;base64,img1"
+        turn = Turn(
+            texts=[
+                Text(name="query", contents=["Find the relevant image"]),
+                Text(name="passages", contents=["A beach at sunset"]),
+            ],
+            images=[Image(contents=[image_url])],
+            model="test-model",
+        )
+
+        payload = converter.format_payload(
+            create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        )
+
+        assert payload["documents"] == [
+            {
+                "content": [
+                    {"type": "text", "text": "A beach at sunset"},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ]
+            }
+        ]
+
+    def test_format_payload_multiple_index_paired_modalities(
+        self, converter, model_endpoint
+    ):
+        """Test that passages, images, and videos are paired by index."""
+        images = ["data:image/png;base64,img1", "data:image/png;base64,img2"]
+        videos = ["data:video/mp4;base64,vid1", "data:video/mp4;base64,vid2"]
+        turn = Turn(
+            texts=[
+                Text(name="query", contents=["Find relevant media"]),
+                Text(name="passages", contents=["First document", "Second document"]),
+            ],
+            images=[Image(contents=images)],
+            videos=[Video(contents=videos)],
+            model="test-model",
+        )
+
+        payload = converter.format_payload(
+            create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        )
+
+        assert payload["documents"] == [
+            {
+                "content": [
+                    {"type": "text", "text": "First document"},
+                    {"type": "image_url", "image_url": {"url": images[0]}},
+                    {"type": "video_url", "video_url": {"url": videos[0]}},
+                ]
+            },
+            {
+                "content": [
+                    {"type": "text", "text": "Second document"},
+                    {"type": "image_url", "image_url": {"url": images[1]}},
+                    {"type": "video_url", "video_url": {"url": videos[1]}},
+                ]
+            },
+        ]
+
+    def test_format_payload_image_only_documents(self, converter, model_endpoint):
+        """Test image-only documents."""
+        images = ["data:image/png;base64,img1", "data:image/png;base64,img2"]
+        turn = Turn(
+            texts=[Text(name="query", contents=["Find relevant images"])],
+            images=[Image(contents=images)],
+            model="test-model",
+        )
+
+        payload = converter.format_payload(
+            create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        )
+
+        assert payload["documents"] == [
+            {"content": [{"type": "image_url", "image_url": {"url": images[0]}}]},
+            {"content": [{"type": "image_url", "image_url": {"url": images[1]}}]},
+        ]
+
+    def test_format_payload_video_only_documents(self, converter, model_endpoint):
+        """Test video-only documents."""
+        videos = ["data:video/mp4;base64,vid1", "data:video/mp4;base64,vid2"]
+        turn = Turn(
+            texts=[Text(name="query", contents=["Find relevant videos"])],
+            videos=[Video(contents=videos)],
+            model="test-model",
+        )
+
+        payload = converter.format_payload(
+            create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        )
+
+        assert payload["documents"] == [
+            {"content": [{"type": "video_url", "video_url": {"url": videos[0]}}]},
+            {"content": [{"type": "video_url", "video_url": {"url": videos[1]}}]},
+        ]
+
+    def test_format_payload_multimodal_count_mismatch_raises(
+        self, converter, model_endpoint
+    ):
+        """Test that non-zero modality counts must match."""
+        turn = Turn(
+            texts=[
+                Text(name="query", contents=["Find relevant media"]),
+                Text(name="passages", contents=["First document", "Second document"]),
+            ],
+            images=[Image(contents=["data:image/png;base64,img1"])],
+            model="test-model",
+        )
+
+        with pytest.raises(ValueError, match="matching non-zero counts"):
+            converter.format_payload(
+                create_request_info(model_endpoint=model_endpoint, turns=[turn])
+            )
+
+    def test_format_payload_audio_rejected(self, converter, model_endpoint):
+        """Test that audio input is rejected for Cohere rankings."""
+        turn = Turn(
+            texts=[Text(name="query", contents=["Find relevant audio"])],
+            audios=[Audio(contents=["wav,b64audio"])],
+            model="test-model",
+        )
+
+        with pytest.raises(ValueError, match="does not support audio input"):
+            converter.format_payload(
+                create_request_info(model_endpoint=model_endpoint, turns=[turn])
+            )
+
+    def test_metadata_declares_multimodal_support(self):
+        """Test that Cohere rankings metadata declares image and video support."""
+        metadata = plugins.get_endpoint_metadata(EndpointType.COHERE_RANKINGS)
+        assert isinstance(metadata, EndpointMetadata)
+        assert metadata.supports_images is True
+        assert metadata.supports_videos is True
+        assert metadata.supports_audio is False
 
     def test_format_payload_no_query(self, converter, model_endpoint):
         """Test with no query text (should raise error)."""

--- a/tests/unit/endpoints/test_cohere_rankings_endpoint.py
+++ b/tests/unit/endpoints/test_cohere_rankings_endpoint.py
@@ -71,6 +71,20 @@ class TestCohereRankingsEndpoint:
             "documents": ["AI passage"],
         }
 
+    def test_build_payload_direct_audio_rejected(self, converter):
+        """Test direct Cohere payload construction rejects audio input."""
+        with pytest.raises(ValueError, match="does not support audio input"):
+            converter.build_payload(
+                "What is AI?",
+                ["AI passage"],
+                "test-model",
+                audios=["wav,b64audio"],
+            )
+
+    def test_document_count_empty_inputs_returns_zero(self, converter):
+        """Test empty multimodal inputs produce zero documents."""
+        assert converter._document_count(passages=[], images=[], videos=[]) == 0
+
     def test_format_payload_single_passage(self, converter, model_endpoint):
         """Test payload formatting with single passage."""
         turn = Turn(

--- a/tests/unit/endpoints/test_hf_tei_rankings_endpoint.py
+++ b/tests/unit/endpoints/test_hf_tei_rankings_endpoint.py
@@ -5,7 +5,7 @@ import logging
 
 import pytest
 
-from aiperf.common.models import Text, Turn
+from aiperf.common.models import Audio, Image, Text, Turn, Video
 from aiperf.endpoints.hf_tei_rankings import HFTeiRankingsEndpoint
 from aiperf.plugin.enums import EndpointType
 from tests.unit.endpoints.conftest import (
@@ -203,3 +203,38 @@ class TestHFTeiRankingsEndpoint:
         assert payload["top_k"] == 5
         assert payload["return_scores"] is True
         assert payload["query"] == "Test query"
+
+    @pytest.mark.parametrize(
+        "turn_kwargs,expected_error",
+        [
+            (
+                {"images": [Image(contents=["data:image/png;base64,img1"])]},
+                "does not support image input",
+            ),
+            (
+                {"videos": [Video(contents=["data:video/mp4;base64,vid1"])]},
+                "does not support video input",
+            ),
+            (
+                {"audios": [Audio(contents=["wav,b64audio"])]},
+                "does not support audio input",
+            ),
+        ],
+    )
+    def test_format_payload_unsupported_media_rejected(
+        self, converter, model_endpoint, turn_kwargs, expected_error
+    ):
+        """Test that base rankings validation rejects unsupported media."""
+        turn = Turn(
+            texts=[
+                Text(name="query", contents=["What is AI?"]),
+                Text(name="passages", contents=["AI definition"]),
+            ],
+            model="test-model",
+            **turn_kwargs,
+        )
+
+        with pytest.raises(ValueError, match=expected_error):
+            converter.format_payload(
+                create_request_info(model_endpoint=model_endpoint, turns=[turn])
+            )

--- a/tests/unit/endpoints/test_nim_rankings_endpoint.py
+++ b/tests/unit/endpoints/test_nim_rankings_endpoint.py
@@ -5,7 +5,7 @@ import logging
 
 import pytest
 
-from aiperf.common.models import Text, Turn
+from aiperf.common.models import Audio, Image, Text, Turn, Video
 from aiperf.endpoints.nim_rankings import NIMRankingsEndpoint
 from aiperf.plugin.enums import EndpointType
 from tests.unit.endpoints.conftest import (
@@ -288,3 +288,38 @@ class TestNIMRankingsEndpoint:
         assert payload["query"] == {"text": "What is AI?"}
         assert len(payload["passages"]) == 1
         assert payload["passages"][0] == {"text": "AI definition"}
+
+    @pytest.mark.parametrize(
+        "turn_kwargs,expected_error",
+        [
+            (
+                {"images": [Image(contents=["data:image/png;base64,img1"])]},
+                "does not support image input",
+            ),
+            (
+                {"videos": [Video(contents=["data:video/mp4;base64,vid1"])]},
+                "does not support video input",
+            ),
+            (
+                {"audios": [Audio(contents=["wav,b64audio"])]},
+                "does not support audio input",
+            ),
+        ],
+    )
+    def test_format_payload_unsupported_media_rejected(
+        self, converter, model_endpoint, turn_kwargs, expected_error
+    ):
+        """Test that base rankings validation rejects unsupported media."""
+        turn = Turn(
+            texts=[
+                Text(name="query", contents=["What is AI?"]),
+                Text(name="passages", contents=["AI definition"]),
+            ],
+            model="test-model",
+            **turn_kwargs,
+        )
+
+        with pytest.raises(ValueError, match=expected_error):
+            converter.format_payload(
+                create_request_info(model_endpoint=model_endpoint, turns=[turn])
+            )

--- a/tests/unit/server/test_models.py
+++ b/tests/unit/server/test_models.py
@@ -5,6 +5,7 @@
 import pytest
 from aiperf_mock_server.models import (
     ChatCompletionRequest,
+    CohereRerankRequest,
     CompletionRequest,
     EmbeddingRequest,
     Message,
@@ -87,3 +88,46 @@ class TestRankingRequest:
             ],
         )
         assert req.passage_texts == ["passage 1", "passage 2"]
+
+
+class TestCohereRerankRequest:
+    """Tests for Cohere rerank request model."""
+
+    def test_text_documents_as_passage_texts(self):
+        req = CohereRerankRequest(
+            model="test",
+            query="query",
+            documents=["passage 1", "passage 2"],
+        )
+
+        assert req.passage_texts == ["passage 1", "passage 2"]
+
+    def test_structured_documents_as_passage_texts(self):
+        req = CohereRerankRequest(
+            model="test",
+            query="query",
+            documents=[
+                {
+                    "content": [
+                        {"type": "text", "text": "city skyline"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,img1"},
+                        },
+                    ]
+                },
+                {
+                    "content": [
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": "data:video/mp4;base64,vid1"},
+                        }
+                    ]
+                },
+            ],
+        )
+
+        assert req.passage_texts == [
+            "city skyline\ndata:image/png;base64,img1",
+            "data:video/mp4;base64,vid1",
+        ]


### PR DESCRIPTION
Add multimodal input support to the `cohere_rankings` endpoint for vLLM’s vision rerank API, including structured text, image, and video document payload formatting. See:
  https://docs.vllm.ai/en/latest/examples/pooling/score/#vision-rerank-api-online

  We already have text-only Cohere rerank support. This keeps the existing text-only payload shape unchanged, while switching to structured Cohere documents when media is present.

  ### Changes
  - Extend the shared rankings base endpoint to pass media inputs into endpoint-specific payload builders.
  - Add multimodal payload support to `cohere_rankings` for text, image, and video rerank documents.
  - Add synthetic multimodal ranking dataset generation
  - Add validation, mock server support, tests, and documentation for multimodal rankings inputs.

  ### Example usage
  Set up a vLLM server:
  ```bash
vllm serve nvidia/llama-nemotron-rerank-vl-1b-v2 \
    --runner pooling \
    --trust-remote-code \
    --chat-template "$(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/pooling/score/template/nemotron-vl-rerank.jinja)"
```

Run AIPerf with synthetic multimodal rankings inputs:
```bash
aiperf profile \
      -m nvidia/llama-nemotron-rerank-vl-1b-v2 \
      --endpoint-type cohere_rankings \
      --custom-endpoint /rerank \
      --url localhost:8000 \
      --request-count 10 \
      --rankings-passages-mean 4 \
      --rankings-passages-stddev 0 \
      --rankings-passages-prompt-token-mean 32 \
      --rankings-passages-prompt-token-stddev 0 \
      --rankings-query-prompt-token-mean 16 \
      --rankings-query-prompt-token-stddev 0 \
      --image-width-mean 224 \
      --image-width-stddev 0 \
      --image-height-mean 224 \
      --image-height-stddev 0 \
      --image-batch-size 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multimodal reranking: Cohere Rankings now supports ranking with text, images, and videos (index-aligned across modalities) and synthetic multimodal dataset generation.

* **Documentation**
  * Added vLLM multimodal reranking guidance, CLI examples, and instructions for JSONL inputs with base64 image data.

* **Tests**
  * Expanded unit and integration tests to cover multimodal payloads, dataset composition, and endpoint metadata.

* **Bug Fixes / Validation**
  * Added media count validations and explicit rejection of unsupported audio inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->