### PR TITLE
fix(readiness-probe): normalize scheme-less URLs in EndpointConfig

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -148,9 +148,9 @@ Enable streaming responses. When enabled, the server streams tokens incrementall
 
 #### `-u`, `--url` `<list>`
 
-Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). URLs without an `http://` or `https://` scheme have `http://` prepended automatically.
+Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). URLs that do not include a scheme (no `://`) have `http://` prepended automatically.
 <br/>_Constraints: min: 1_
-<br/>_Default: `['localhost:8000']`_
+<br/>_Default: `['http://localhost:8000']`_
 
 #### `--url-strategy` `<str>`
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -148,7 +148,7 @@ Enable streaming responses. When enabled, the server streams tokens incrementall
 
 #### `-u`, `--url` `<list>`
 
-Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`).
+Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). URLs without an `http://` or `https://` scheme have `http://` prepended automatically.
 <br/>_Constraints: min: 1_
 <br/>_Default: `['localhost:8000']`_
 

--- a/src/aiperf/common/config/config_defaults.py
+++ b/src/aiperf/common/config/config_defaults.py
@@ -39,7 +39,7 @@ class EndpointDefaults:
     CUSTOM_ENDPOINT = None
     TYPE = EndpointType.CHAT
     STREAMING = False
-    URL = "localhost:8000"
+    URL = "http://localhost:8000"
     URL_STRATEGY = URLSelectionStrategy.ROUND_ROBIN
     TIMEOUT = 6 * 60 * 60  # 6 hours, match vLLM benchmark default
     API_KEY = None

--- a/src/aiperf/common/config/config_validators.py
+++ b/src/aiperf/common/config/config_validators.py
@@ -16,16 +16,23 @@ This module provides utility functions for validating and parsing configuration 
 
 
 def normalize_http_url(url: str) -> str:
-    """Prepend ``http://`` to a URL that lacks an ``http`` or ``https`` scheme.
+    """Prepend ``http://`` to a URL that has no scheme component.
 
     aiohttp rejects URLs without a recognized scheme with NonHttpUrlClientError.
     Users commonly pass ``--url localhost:8000`` expecting an implicit scheme;
-    this normalization accepts that form. URLs already starting with
-    ``http://`` or ``https://`` are returned unchanged.
+    this normalization accepts that form.
+
+    A URL is considered to "already have a scheme" if it contains ``://`` —
+    the structural separator between scheme and authority. This is preferred
+    over ``urlsplit(url).scheme`` because urlsplit parses ``localhost:8000``
+    as scheme=``localhost``, which would defeat the normalization. The
+    ``://`` check is also case-insensitive (matches ``http://``, ``HTTPS://``,
+    ``ftp://`` etc.) and preserves the original scheme; URLs with non-HTTP
+    schemes are passed through unmodified rather than corrupted.
     """
     if not isinstance(url, str):
         return url
-    return url if url.startswith(("http://", "https://")) else f"http://{url}"
+    return url if "://" in url else f"http://{url}"
 
 
 def normalize_http_urls(urls: list[str]) -> list[str]:

--- a/src/aiperf/common/config/config_validators.py
+++ b/src/aiperf/common/config/config_validators.py
@@ -30,8 +30,6 @@ def normalize_http_url(url: str) -> str:
     ``ftp://`` etc.) and preserves the original scheme; URLs with non-HTTP
     schemes are passed through unmodified rather than corrupted.
     """
-    if not isinstance(url, str):
-        return url
     return url if "://" in url else f"http://{url}"
 
 

--- a/src/aiperf/common/config/config_validators.py
+++ b/src/aiperf/common/config/config_validators.py
@@ -15,6 +15,24 @@ This module provides utility functions for validating and parsing configuration 
 """
 
 
+def normalize_http_url(url: str) -> str:
+    """Prepend ``http://`` to a URL that lacks an ``http`` or ``https`` scheme.
+
+    aiohttp rejects URLs without a recognized scheme with NonHttpUrlClientError.
+    Users commonly pass ``--url localhost:8000`` expecting an implicit scheme;
+    this normalization accepts that form. URLs already starting with
+    ``http://`` or ``https://`` are returned unchanged.
+    """
+    if not isinstance(url, str):
+        return url
+    return url if url.startswith(("http://", "https://")) else f"http://{url}"
+
+
+def normalize_http_urls(urls: list[str]) -> list[str]:
+    """Apply :func:`normalize_http_url` to each URL in the list."""
+    return [normalize_http_url(u) for u in urls]
+
+
 def parse_str_or_list(input: Any) -> list[Any] | None:
     """
     Parses the input to ensure it is either a string, a list, or None. If the input is a string,

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -4,6 +4,7 @@
 from typing import Annotated, Literal
 
 from pydantic import (
+    AfterValidator,
     BeforeValidator,
     Field,
     SerializationInfo,
@@ -16,7 +17,10 @@ from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.common.config.base_config import BaseConfig
 from aiperf.common.config.cli_parameter import CLIParameter
 from aiperf.common.config.config_defaults import EndpointDefaults
-from aiperf.common.config.config_validators import parse_str_or_list
+from aiperf.common.config.config_validators import (
+    normalize_http_urls,
+    parse_str_or_list,
+)
 from aiperf.common.config.groups import Groups
 from aiperf.common.enums import (
     ConnectionReuseStrategy,
@@ -161,10 +165,12 @@ class EndpointConfig(BaseConfig):
         Field(
             description="Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing "
             "across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). "
-            "The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`).",
+            "The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). "
+            "URLs without an `http://` or `https://` scheme have `http://` prepended automatically.",
             min_length=1,
         ),
         BeforeValidator(parse_str_or_list),
+        AfterValidator(normalize_http_urls),
         CLIParameter(
             name=(
                 "--url",  # GenAI-Perf

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -166,8 +166,12 @@ class EndpointConfig(BaseConfig):
             description="Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing "
             "across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). "
             "The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). "
-            "URLs without an `http://` or `https://` scheme have `http://` prepended automatically.",
+            "URLs that do not include a scheme (no `://`) have `http://` prepended automatically.",
             min_length=1,
+            # Run the validator chain on the default too — without this, a
+            # bare `--wait-for-model-timeout 30` (no `--url`) would send the
+            # un-normalized default to aiohttp and reproduce the original bug.
+            validate_default=True,
         ),
         BeforeValidator(parse_str_or_list),
         AfterValidator(normalize_http_urls),

--- a/src/aiperf/common/config/user_config.py
+++ b/src/aiperf/common/config/user_config.py
@@ -44,8 +44,11 @@ def _is_localhost_url(url: str) -> bool:
     """Check if a URL points to localhost."""
     from urllib.parse import urlparse
 
-    # Handle IPv6 localhost without brackets (e.g., "::1:8000")
-    if url.startswith("::1:") or url.startswith("[::1]"):
+    # Handle IPv6 localhost without brackets (e.g. "::1:8000" or "http://::1:8000").
+    # `EndpointConfig` now prepends `http://` to scheme-less URLs, so we accept
+    # both the pre-normalization and post-normalization forms here.
+    url_without_scheme = url.removeprefix("http://").removeprefix("https://")
+    if url_without_scheme.startswith("::1:") or url_without_scheme.startswith("[::1]"):
         return True
 
     # Add scheme if missing for proper parsing

--- a/tests/unit/common/config/test_config_validators.py
+++ b/tests/unit/common/config/test_config_validators.py
@@ -7,6 +7,8 @@ import pytest
 
 from aiperf.common.config.config_validators import (
     coerce_value,
+    normalize_http_url,
+    normalize_http_urls,
     parse_str_as_numeric_dict,
     parse_str_or_dict_as_tuple_list,
     parse_str_or_list_of_positive_values,
@@ -372,3 +374,66 @@ class TestParseStrOrListOfPositiveValues:
     def test_parse_str_as_numeric_dict_invalid_dict_raises(self):
         with pytest.raises(ValueError, match="goodput dict values must be numeric"):
             parse_str_as_numeric_dict({"time_to_first_token": "fast"})
+
+
+class TestNormalizeHttpUrl:
+    """Tests for normalize_http_url and normalize_http_urls."""
+
+    @pytest.mark.parametrize(
+        "given,expected",
+        [
+            pytest.param(
+                "http://localhost:8000",
+                "http://localhost:8000",
+                id="http_scheme_passes_through",
+            ),
+            pytest.param(
+                "https://example.com",
+                "https://example.com",
+                id="https_scheme_passes_through",
+            ),
+            pytest.param(
+                "https://example.com:8443/path",
+                "https://example.com:8443/path",
+                id="https_with_port_and_path",
+            ),
+            pytest.param(
+                "localhost:8000",
+                "http://localhost:8000",
+                id="bare_host_port_gets_http",
+            ),
+            pytest.param(
+                "127.0.0.1:8000",
+                "http://127.0.0.1:8000",
+                id="ipv4_host_port_gets_http",
+            ),
+            pytest.param(
+                "example.com",
+                "http://example.com",
+                id="bare_hostname_gets_http",
+            ),
+            pytest.param(
+                "httpbin.org",
+                "http://httpbin.org",
+                id="hostname_starting_with_http_letters_still_normalized",
+            ),
+        ],
+    )
+    def test_normalize_http_url(self, given: str, expected: str) -> None:
+        assert normalize_http_url(given) == expected
+
+    def test_normalize_http_urls_applies_to_each_element(self) -> None:
+        urls = ["http://server1:8000", "server2:8000", "https://server3"]
+        assert normalize_http_urls(urls) == [
+            "http://server1:8000",
+            "http://server2:8000",
+            "https://server3",
+        ]
+
+    def test_normalize_http_urls_empty_list_returns_empty(self) -> None:
+        assert normalize_http_urls([]) == []
+
+    def test_normalize_http_url_non_string_passes_through(self) -> None:
+        # AfterValidator may run after pydantic coerces; non-strings should not crash here.
+        # The actual type enforcement happens via the list[str] field annotation.
+        assert normalize_http_url(None) is None  # type: ignore[arg-type]

--- a/tests/unit/common/config/test_config_validators.py
+++ b/tests/unit/common/config/test_config_validators.py
@@ -417,6 +417,26 @@ class TestNormalizeHttpUrl:
                 "http://httpbin.org",
                 id="hostname_starting_with_http_letters_still_normalized",
             ),
+            pytest.param(
+                "HTTP://host:8000",
+                "HTTP://host:8000",
+                id="uppercase_scheme_preserved_not_corrupted",
+            ),
+            pytest.param(
+                "Https://example.com",
+                "Https://example.com",
+                id="mixed_case_scheme_preserved_not_corrupted",
+            ),
+            pytest.param(
+                "ftp://host",
+                "ftp://host",
+                id="non_http_scheme_preserved_not_corrupted",
+            ),
+            pytest.param(
+                "ws://host:8080/socket",
+                "ws://host:8080/socket",
+                id="websocket_scheme_preserved_not_corrupted",
+            ),
         ],
     )
     def test_normalize_http_url(self, given: str, expected: str) -> None:

--- a/tests/unit/common/config/test_config_validators.py
+++ b/tests/unit/common/config/test_config_validators.py
@@ -452,8 +452,3 @@ class TestNormalizeHttpUrl:
 
     def test_normalize_http_urls_empty_list_returns_empty(self) -> None:
         assert normalize_http_urls([]) == []
-
-    def test_normalize_http_url_non_string_passes_through(self) -> None:
-        # AfterValidator may run after pydantic coerces; non-strings should not crash here.
-        # The actual type enforcement happens via the list[str] field annotation.
-        assert normalize_http_url(None) is None  # type: ignore[arg-type]

--- a/tests/unit/common/config/test_endpoint_config.py
+++ b/tests/unit/common/config/test_endpoint_config.py
@@ -171,6 +171,30 @@ class TestURLSchemeNormalization:
             "http://server3",
         ]
 
+    def test_default_url_is_normalized(self):
+        """The default `EndpointDefaults.URL` is scheme-less; with
+        `validate_default=True` the AfterValidator runs on it too, so a
+        config built without `--url` (e.g. just `--wait-for-model-timeout 30`)
+        still yields a well-formed URL.
+        """
+        config = EndpointConfig(model_names=["gpt2"])  # no urls= argument
+        assert all(u.startswith(("http://", "https://")) for u in config.urls), (
+            f"Default URLs were not normalized: {config.urls}"
+        )
+
+    def test_uppercase_scheme_not_corrupted(self):
+        """Pre-existing schemes are preserved regardless of case (no
+        ``http://`` is prepended to ``HTTP://host``)."""
+        config = EndpointConfig(model_names=["gpt2"], urls=["HTTP://host:8000"])
+        assert config.urls == ["HTTP://host:8000"]
+
+    def test_non_http_scheme_not_corrupted(self):
+        """A non-http(s) scheme is left alone — the validator should not
+        produce ``http://ftp://host``. aiohttp will reject it downstream,
+        which is the correct error behavior."""
+        config = EndpointConfig(model_names=["gpt2"], urls=["ftp://host:21"])
+        assert config.urls == ["ftp://host:21"]
+
 
 class TestWaitForModelValidation:
     """Tests for the readiness-probe flag coherence + bounds validation.

--- a/tests/unit/common/config/test_endpoint_config.py
+++ b/tests/unit/common/config/test_endpoint_config.py
@@ -136,6 +136,42 @@ class TestMultiURLSupport:
             EndpointConfig(model_names=["gpt2"], urls=[])
 
 
+class TestURLSchemeNormalization:
+    """Regression tests for the readiness-probe scheme normalization bug.
+
+    Previously, a URL like ``localhost:8000`` worked for benchmark requests
+    (transport prepended ``http://``) but broke the readiness probe path,
+    which passed the raw URL to aiohttp and got NonHttpUrlClientError.
+    The fix centralizes scheme normalization in EndpointConfig so every
+    consumer receives a well-formed URL.
+    """
+
+    def test_bare_host_port_gets_http_prepended(self):
+        """`localhost:8000` should normalize to `http://localhost:8000`."""
+        config = EndpointConfig(model_names=["gpt2"], urls=["localhost:8000"])
+        assert config.urls == ["http://localhost:8000"]
+        assert config.url == "http://localhost:8000"
+
+    def test_existing_http_url_unchanged(self):
+        config = EndpointConfig(model_names=["gpt2"], urls=["http://localhost:8000"])
+        assert config.urls == ["http://localhost:8000"]
+
+    def test_existing_https_url_unchanged(self):
+        config = EndpointConfig(model_names=["gpt2"], urls=["https://example.com:8443"])
+        assert config.urls == ["https://example.com:8443"]
+
+    def test_mixed_list_normalized_per_element(self):
+        config = EndpointConfig(
+            model_names=["gpt2"],
+            urls=["server1:8000", "https://server2:8443", "server3"],
+        )
+        assert config.urls == [
+            "http://server1:8000",
+            "https://server2:8443",
+            "http://server3",
+        ]
+
+
 class TestWaitForModelValidation:
     """Tests for the readiness-probe flag coherence + bounds validation.
 

--- a/tests/unit/common/config/test_user_config.py
+++ b/tests/unit/common/config/test_user_config.py
@@ -495,6 +495,51 @@ class TestGPUTelemetryConfig:
         with pytest.raises(ValueError, match="Invalid GPU telemetry item"):
             make_config(gpu_telemetry=[invalid_item])
 
+
+class TestIsLocalhostUrl:
+    """Direct tests for the `_is_localhost_url` private helper.
+
+    `EndpointConfig` now prepends `http://` to scheme-less URLs (fix for the
+    readiness-probe bug). This helper has to recognize both the pre- and
+    post-normalization forms — including the IPv6-without-brackets edge case
+    that pre-existed the fix and would otherwise have regressed.
+    """
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            # localhost / 127.0.0.1 — common forms
+            pytest.param("localhost", True, id="bare_localhost"),
+            pytest.param("localhost:8000", True, id="localhost_port"),
+            pytest.param("http://localhost", True, id="localhost_http"),
+            pytest.param("http://localhost:8000", True, id="localhost_http_port"),
+            pytest.param("https://localhost:8443", True, id="localhost_https_port"),
+            pytest.param("127.0.0.1", True, id="bare_127"),
+            pytest.param("127.0.0.1:8000", True, id="127_port"),
+            pytest.param("http://127.0.0.1:8000", True, id="127_http_port"),
+            # IPv6 ::1 with brackets — well-formed
+            pytest.param("[::1]:8000", True, id="ipv6_bracketed_port"),
+            pytest.param("http://[::1]:8000", True, id="ipv6_bracketed_http"),
+            pytest.param("https://[::1]:8443", True, id="ipv6_bracketed_https"),
+            # IPv6 ::1 without brackets — pre- and post-normalization forms
+            pytest.param("::1:8000", True, id="ipv6_bare_pre_normalization"),
+            pytest.param("http://::1:8000", True, id="ipv6_bare_post_normalization"),
+            pytest.param(
+                "https://::1:8443", True, id="ipv6_bare_https_post_normalization"
+            ),
+            # External hosts — must NOT match localhost
+            pytest.param("remote-server:8000", False, id="remote_host"),
+            pytest.param("http://remote-server:8000", False, id="remote_host_http"),
+            pytest.param("192.168.1.100:8000", False, id="lan_ipv4"),
+            pytest.param("http://192.168.1.100:8000", False, id="lan_ipv4_http"),
+            pytest.param("http://example.com", False, id="public_dns"),
+        ],
+    )
+    def test_is_localhost_url(self, url: str, expected: bool) -> None:
+        from aiperf.common.config.user_config import _is_localhost_url
+
+        assert _is_localhost_url(url) is expected
+
     def test_unknown_item_with_valid_items_raises_error(self):
         """Test that unknown items mixed with valid items still raise an error."""
         with pytest.raises(ValueError, match="Invalid GPU telemetry item"):

--- a/tests/unit/common/test_readiness_probe.py
+++ b/tests/unit/common/test_readiness_probe.py
@@ -85,3 +85,99 @@ def test_wait_inference_dedicated_template_does_not_warn(
     assert "no dedicated request template" not in caplog.text
     assert client.posted_urls == ["http://server/v1/embeddings"]
     assert client.payloads == [{"input": "Lo", "model": "embedder"}]
+
+
+class _FakeReadyRecord:
+    """A get_request response that the probe treats as 'server live'."""
+
+    status: int = 200
+    error: None = None
+    responses: list[Any]
+
+    def __init__(self, body: str) -> None:
+        text_resp = type("_Resp", (), {"text": body})()
+        self.responses = [text_resp]
+
+
+class _FakeMultiClient:
+    """Captures every URL passed to get_request/post_request for assertion."""
+
+    def __init__(self, models_payload: bytes | None = None) -> None:
+        self.urls: list[str] = []
+        self._models_payload = models_payload or orjson.dumps(
+            {"data": [{"id": "served-model"}]}
+        )
+
+    async def get_request(
+        self, url: str, headers: dict[str, str], timeout: object
+    ) -> _FakeReadyRecord:
+        del headers, timeout
+        self.urls.append(url)
+        return _FakeReadyRecord(self._models_payload.decode("utf-8"))
+
+    async def post_request(
+        self,
+        request_url: str,
+        payload: bytes,
+        headers: dict[str, str],
+        timeout: object,
+    ) -> _FakeRecord:
+        del payload, headers, timeout
+        self.urls.append(request_url)
+        return _FakeRecord()
+
+    async def close(self) -> None:
+        return None
+
+
+def test_wait_for_endpoint_receives_normalized_urls_from_endpoint_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test: the readiness probe must see scheme-prefixed URLs.
+
+    Before the fix, `EndpointConfig(urls=["localhost:8000"]).urls` returned
+    the raw string and `wait_for_endpoint` passed `localhost:8000/v1/models`
+    to aiohttp, which raised NonHttpUrlClientError.
+
+    This test wires `EndpointConfig` to a fake aiohttp client and asserts
+    every URL the client sees is well-formed (starts with `http://` or
+    `https://`).
+    """
+    from aiperf.common.config import EndpointConfig
+
+    fake = _FakeMultiClient(
+        models_payload=orjson.dumps({"data": [{"id": "served-model"}]})
+    )
+
+    # `wait_for_endpoint` constructs `AioHttpClient` internally — patch the
+    # import so it returns our fake instead.
+    monkeypatch.setattr(
+        "aiperf.transports.aiohttp_client.AioHttpClient",
+        lambda *args, **kwargs: fake,
+    )
+
+    config = EndpointConfig(model_names=["served-model"], urls=["localhost:8000"])
+    assert config.urls == ["http://localhost:8000"], (
+        "EndpointConfig must prepend http:// to scheme-less URLs"
+    )
+
+    asyncio.run(
+        readiness_probe.wait_for_endpoint(
+            urls=config.urls,
+            model_names=config.model_names,
+            mode="models",
+            endpoint_type="chat",
+            custom_endpoint=None,
+            timeout_s=2.0,
+            interval_s=0.1,
+            headers={},
+        )
+    )
+
+    assert fake.urls, "wait_for_endpoint should have made at least one request"
+    for url in fake.urls:
+        assert url.startswith(("http://", "https://")), (
+            f"URL {url!r} reached the HTTP client without a scheme — "
+            f"EndpointConfig normalization is broken"
+        )
+    assert fake.urls[0] == "http://localhost:8000/v1/models"


### PR DESCRIPTION
- `aiperf profile --url localhost:8000 --wait-for-model-timeout 120` failed with `NonHttpUrlClientError` because the readiness probe passed the raw URL to aiohttp without prepending `http://`. The main benchmark transport already normalized URLs, so the bug only surfaced when the probe was enabled.
- Fix centralizes URL normalization in `EndpointConfig` via an `AfterValidator` on the `urls` field — all consumers (probe, transport, future code) now receive scheme-prefixed URLs from a single source of truth.
- `_is_localhost_url` patched to recognize IPv6-without-brackets in both pre- and post-normalization forms, preserving prior behavior.

## Repro (before/after)

**Before:**
```
$ aiperf profile --url localhost:8000 --wait-for-model-timeout 120 --request-count 10
... INFO Waiting for endpoint readiness ...
... ERROR Error in aiohttp request: NonHttpUrlClientError(URL('localhost:8000'))
TimeoutError: Timed out after 120.0s probing localhost:8000 ... (checked 24 time(s))
```

**After:**
```
$ aiperf profile --url localhost:8000 --wait-for-model-timeout 30 --request-count 5
... benchmark completes in 15.4s, all 5 requests succeed, metrics computed correctly
```

## Why `EndpointConfig` over `readiness_probe.py`?
A local fix in `readiness_probe.py` would only patch this one path and leave the asymmetry: transport normalizes, probe normalizes (post-patch), and any future code path consuming `endpoint.urls` would have to remember to do it again. Centralizing in the config validator means there is one place where the contract lives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL scheme normalization: URLs without a scheme will automatically get "http://" prepended.
  * Improved IPv6 localhost detection for endpoint handling.

* **Bug Fixes**
  * Default endpoint now includes an explicit scheme (e.g., "http://localhost:8000") to avoid ambiguous URLs.

* **Documentation**
  * Updated aiperf profile --url docs to describe automatic URL scheme normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->