### PR TITLE
fix: stop setting HF_HUB_OFFLINE in parent process

### DIFF
--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -249,8 +249,18 @@ async def preload_tokenizers(
 
 
 def _enable_hf_offline_mode(logger: AIPerfLogger | None = None) -> None:
-    """Set HF environment variables so spawned processes never make network calls."""
-    os.environ["HF_HUB_OFFLINE"] = "1"
-    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    """No-op: workers set HF_HUB_OFFLINE on init themselves.
+
+    Previously this set HF_HUB_OFFLINE=1 / TRANSFORMERS_OFFLINE=1 in the
+    parent process so spawned children would inherit them. That mutation
+    also affected same-process consumers that legitimately need HF online
+    (e.g. ``dataset_manager`` loading a public HF dataset right after the
+    tokenizer preload finishes), causing ``OfflineModeIsEnabled``.
+
+    Worker init functions in ``dataset/loader/parallel_convert.py``,
+    ``dataset/loader/weka_parallel_convert.py``, and
+    ``dataset/generator/parallel_decode.py`` already re-set these vars
+    on ``_init_worker``, so the parent-side mutation was redundant.
+    """
     if logger:
-        logger.debug("Enabled HF offline mode for child processes")
+        logger.debug("HF offline mode set per-worker on init (no parent mutation)")

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 import time
 from typing import TYPE_CHECKING


### PR DESCRIPTION
## Summary

`_enable_hf_offline_mode` in `src/aiperf/common/tokenizer_validator.py` mutated the parent process's `os.environ` to set `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` so child workers would inherit them. The intent — skip HF network calls in workers when the tokenizer is already cached — is sound, but the mutation also affects same-process consumers that legitimately need HF online.

In particular, when `dataset_manager` tries to load a public HF dataset *after* the tokenizer preload finishes, it sees the parent's `HF_HUB_OFFLINE=1` and fails:

```
DatasetLoaderError: Failed to load HuggingFace dataset 'semianalysisai/cc-traces-weka-042026':
Couldn't reach 'semianalysisai/cc-traces-weka-042026' on the Hub (OfflineModeIsEnabled)
```

The parent-side mutation is also redundant — worker init functions in `parallel_convert.py:87`, `weka_parallel_convert.py:189`, and `parallel_decode.py:58` already re-set these env vars in their `_init_worker`, so children get offline mode regardless of parent state.

This PR neuters the parent-side env mutation while leaving the call structure intact (so any future plumbing through this hook still has a place). Updated the docstring to explain the trap and preserved a debug log line.

## Test plan
- [ ] Run an `inferencex-agentx-mvp` profile against a server with a locally-cached `--tokenizer` and a public HF dataset (e.g. `--public-dataset semianalysis_cc_traces_weka`) — dataset_manager should fetch successfully instead of erroring with `OfflineModeIsEnabled`.
- [ ] Confirm worker subprocesses still hit local cache only (no network) — they re-set the env in `_init_worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/aiperf/pull/899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->