### PR TITLE
ci(test_docs): always clean up server containers, including failure paths

### DIFF
--- a/tests/ci/test_docs_end_to_end/test_runner.py
+++ b/tests/ci/test_docs_end_to_end/test_runner.py
@@ -260,6 +260,7 @@ class EndToEndTestRunner:
                     self.stop_log_monitoring.set()
                     if self.log_monitoring_thread:
                         self.log_monitoring_thread.join(timeout=2)
+                    self._stop_non_aiperf_containers(server.name)
                     return False
                 else:
                     # Process completed successfully (some servers might do this)
@@ -301,6 +302,7 @@ class EndToEndTestRunner:
             logger.error("=" * 60)
             logger.error(f"Health check failed for server: {server.name}")
             logger.error(f"Return code: {health_process.returncode}")
+            self._stop_non_aiperf_containers(server.name)
             return False
 
         logger.info("=" * 60)
@@ -359,11 +361,18 @@ class EndToEndTestRunner:
                 logger.info("=" * 60)
                 logger.info(f"AIPerf test {i + 1} passed for {server.name}")
 
-        # Cleanup: Stop all containers EXCEPT the aiperf test container
-        logger.info(
-            f"Test completed for {server.name}. Stopping all containers except aiperf test container..."
-        )
-        # Stop all containers except the aiperf test container by filtering out its name
+        self._stop_non_aiperf_containers(server.name)
+        return all_aiperf_passed
+
+    def _stop_non_aiperf_containers(self, server_name: str) -> None:
+        """Stop every container except the long-running aiperf test container.
+
+        Idempotent and safe to call from any exit path of ``_test_server`` —
+        early setup failures, health-check failures, or normal completion.
+        Without this, a failed server's container leaks into the next
+        iteration and conflicts on shared resources like port 8000.
+        """
+        logger.info(f"Cleaning up server containers for {server_name}...")
         stop_cmd = f"docker ps --format '{{{{.Names}}}}' | grep -v '^{self.aiperf_container_id}$' | xargs -r docker stop 2>/dev/null || true"
         subprocess.run(
             stop_cmd,
@@ -377,8 +386,6 @@ class EndToEndTestRunner:
         logger.info(
             "All server containers stopped, aiperf container preserved for next test"
         )
-
-        return all_aiperf_passed
 
     def _cleanup(self):
         """Cleanup all containers (nuclear approach)"""


### PR DESCRIPTION
# Always clean up server containers, including failure paths

## Summary

Move the per-server Docker cleanup in `tests/ci/test_docs_end_to_end/test_runner.py:_test_server` so it runs on **every** exit path — setup-fails-early, health-check-fails, and normal completion. Previously the cleanup only ran on the success path, so a failed server's container leaked into the next iteration and conflicted on shared resources like port 8000.

## Why

The current control flow has three exits from `_test_server`:

| Exit | Reach the cleanup block? | Effect |
|---|---|---|
| Setup process exits non-zero within `SETUP_MONITOR_TIMEOUT` | ❌ early `return False` | Container left running on port 8000 |
| Health check returns non-zero | ❌ early `return False` | Container left running on port 8000 |
| Aiperf loop completes (success or per-test failures) | ✅ falls through to cleanup | Container stopped |

When any server fails before reaching the aiperf loop, every subsequent server fails its `docker run` with:

```
docker: Error response from daemon: failed to set up container networking:
driver failed programming external connectivity on endpoint <random>:
Bind for 0.0.0.0:8000 failed: port is already allocated
```

Concrete example: in the 2026-04-29 PR run [25129046600 / job 73650026741](https://github.com/ai-dynamo/aiperf/actions/runs/25129046600/job/73650026741), default's health check failed (a separate HF-rate-limit issue, since fixed by #890). That alone should have only failed `vllm-default-openai`, but the leaked container caused `vllm-audio-openai`, `vllm-vision-openai`, and `vllm-video-openai` to all fail with port conflicts — three additional false-failure signals chasing one real one.

The cascade obscures the actual failure when triaging logs. Fixing it means each server's verdict is independent, which is what the test design clearly intends.

## Changes

`tests/ci/test_docs_end_to_end/test_runner.py` — single file, +14/-7 lines.

- **Extracted** the inline cleanup block (formerly at the end of `_test_server`) into a new `_stop_non_aiperf_containers(server_name: str)` helper. Same shell logic; just hoisted into a method.
- **Called the helper** from all three exit paths in `_test_server`:
  - Before the early `return False` on setup-fails-early.
  - Before the early `return False` on health-check-fails.
  - In place of the original inline cleanup before `return all_aiperf_passed`.

The helper is idempotent — safe to call from any of the three paths, and from any future paths added later.

## Test plan

- [ ] PR-triggered `Test Docs End-to-End` runs and completes (passes or fails on its merits, not on cascading port conflicts).
- [ ] If a future server's health check or setup fails, the next server in the iteration starts cleanly — its `docker run` succeeds, its health check is allowed to do its own thing.
- [ ] No regression in the success path — green nightlies on `main` continue to be green.

## Out of scope

- **AIMO public-dataset `TimeoutError` in aiperf's `profile_configure`** — that's the actual remaining red item on `Test Docs End-to-End` and is an aiperf source-code bug, not a CI plumbing issue. Separate ticket.
- **Opaque error wrapping in `SystemController._start_services`** — surfaces only `Failed to perform operation 'Configure Profiling'` while hiding the underlying exception. Worth a separate observability ticket; out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure cleanup logic for enhanced reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->