### PR TITLE
fix(dataset): extract images from HF Image(decode=False) byte dicts

### DIFF
--- a/src/aiperf/dataset/loader/base_hf_dataset.py
+++ b/src/aiperf/dataset/loader/base_hf_dataset.py
@@ -86,13 +86,13 @@ class BaseHFDatasetLoader(BasePublicDatasetLoader):
         abort the loader.
         """
         value = row.get(image_column)
-        candidates = value if isinstance(value, list) else [value]
-        for candidate in candidates:
-            if isinstance(candidate, PILImage.Image):
-                return [self._pil_to_image(candidate)]
-            if isinstance(candidate, dict) and candidate.get("bytes"):
+        items = value if isinstance(value, list) else [value]
+        for item in items:
+            if isinstance(item, PILImage.Image):
+                return [self._pil_to_image(item)]
+            if isinstance(item, dict) and item.get("bytes"):
                 try:
-                    pil = PILImage.open(io.BytesIO(candidate["bytes"]))
+                    pil = PILImage.open(io.BytesIO(item["bytes"]))
                     return [self._pil_to_image(pil)]
                 except (OSError, PILImage.UnidentifiedImageError):
                     continue

--- a/src/aiperf/dataset/loader/base_hf_dataset.py
+++ b/src/aiperf/dataset/loader/base_hf_dataset.py
@@ -73,15 +73,21 @@ class BaseHFDatasetLoader(BasePublicDatasetLoader):
     def _extract_images(self, row: dict[str, Any], image_column: str) -> list[Image]:
         """Extract images from a dataset row column.
 
-        Handles both a single PIL Image and a list of PIL Images,
-        returning the first valid image found.
+        Handles HF-decoded PIL Images and undecoded ``{"bytes": ..., "path": ...}``
+        dicts — datasets declared with ``Image(decode=False)`` (e.g. VisionArena)
+        return raw byte dicts. Returns the first valid image found, scalar or
+        list-wrapped.
         """
         value = row.get(image_column)
-        if isinstance(value, PILImage.Image):
-            return [self._pil_to_image(value)]
-        if isinstance(value, list):
-            pil = next((v for v in value if isinstance(v, PILImage.Image)), None)
-            if pil:
+        candidates = value if isinstance(value, list) else [value]
+        for candidate in candidates:
+            if isinstance(candidate, PILImage.Image):
+                return [self._pil_to_image(candidate)]
+            if isinstance(candidate, dict) and candidate.get("bytes"):
+                try:
+                    pil = PILImage.open(io.BytesIO(candidate["bytes"]))
+                except (OSError, PILImage.UnidentifiedImageError):
+                    continue
                 return [self._pil_to_image(pil)]
         return []
 

--- a/src/aiperf/dataset/loader/base_hf_dataset.py
+++ b/src/aiperf/dataset/loader/base_hf_dataset.py
@@ -111,6 +111,10 @@ class BaseHFDatasetLoader(BasePublicDatasetLoader):
 
         Handles URL strings and dicts with raw bytes (HF video format).
         URL strings are passed through directly; bytes are base64-encoded.
+
+        Scalar-only: if a future dataset declares ``Sequence(Video(decode=False))``,
+        mirror ``_extract_images``' list-unwrap loop here to avoid the same
+        silent-empty regression that motivated this file's image fix.
         """
         value = row.get(video_column)
         if isinstance(value, str) and value:

--- a/src/aiperf/dataset/loader/base_hf_dataset.py
+++ b/src/aiperf/dataset/loader/base_hf_dataset.py
@@ -79,23 +79,31 @@ class BaseHFDatasetLoader(BasePublicDatasetLoader):
         with ``Image(decode=False)``, e.g. VisionArena, return raw byte dicts).
 
         Path-only dicts (``bytes is None``) aren't handled — VisionArena (the
-        dataset that motivated this fix) embeds bytes inline. The byte-decode
-        path catches both header-detection errors (``UnidentifiedImageError``)
-        and load-time errors raised when ``_pil_to_image`` re-encodes
-        (``OSError`` from truncated payloads), so a single bad image doesn't
-        abort the loader.
+        dataset that motivated this fix) embeds bytes inline; we log a debug
+        message so an operator pointing aiperf at a path-only dataset can see
+        why ``inputs.json`` is text-only. Both branches are wrapped in the same
+        ``try`` so header-detection errors (``UnidentifiedImageError``) and
+        load-time errors raised when ``_pil_to_image`` re-encodes (``OSError``
+        from truncated payloads) skip the bad image instead of aborting the
+        loader.
         """
         value = row.get(image_column)
         items = value if isinstance(value, list) else [value]
         for item in items:
-            if isinstance(item, PILImage.Image):
-                return [self._pil_to_image(item)]
-            if isinstance(item, dict) and item.get("bytes"):
-                try:
+            try:
+                if isinstance(item, PILImage.Image):
+                    return [self._pil_to_image(item)]
+                if not isinstance(item, dict):
+                    continue
+                if item.get("bytes"):
                     pil = PILImage.open(io.BytesIO(item["bytes"]))
                     return [self._pil_to_image(pil)]
-                except (OSError, PILImage.UnidentifiedImageError):
-                    continue
+                if item.get("path"):
+                    self.debug(
+                        f"path-only HF image dict not supported: {item.get('path')}"
+                    )
+            except (OSError, PILImage.UnidentifiedImageError):
+                continue
         return []
 
     def _extract_videos(self, row: dict[str, Any], video_column: str) -> list[Video]:

--- a/src/aiperf/dataset/loader/base_hf_dataset.py
+++ b/src/aiperf/dataset/loader/base_hf_dataset.py
@@ -78,11 +78,12 @@ class BaseHFDatasetLoader(BasePublicDatasetLoader):
         and undecoded ``{"bytes": ..., "path": ...}`` dicts (datasets declared
         with ``Image(decode=False)``, e.g. VisionArena, return raw byte dicts).
 
-        Path-only dicts (``bytes is None``) aren't handled — VisionArena and
-        other in-repo datasets embed bytes inline. The byte-decode path catches
-        both header-detection errors (``UnidentifiedImageError``) and load-time
-        errors raised when ``_pil_to_image`` re-encodes (``OSError`` from
-        truncated payloads), so a single bad image doesn't abort the loader.
+        Path-only dicts (``bytes is None``) aren't handled — VisionArena (the
+        dataset that motivated this fix) embeds bytes inline. The byte-decode
+        path catches both header-detection errors (``UnidentifiedImageError``)
+        and load-time errors raised when ``_pil_to_image`` re-encodes
+        (``OSError`` from truncated payloads), so a single bad image doesn't
+        abort the loader.
         """
         value = row.get(image_column)
         candidates = value if isinstance(value, list) else [value]

--- a/src/aiperf/dataset/loader/base_hf_dataset.py
+++ b/src/aiperf/dataset/loader/base_hf_dataset.py
@@ -73,10 +73,16 @@ class BaseHFDatasetLoader(BasePublicDatasetLoader):
     def _extract_images(self, row: dict[str, Any], image_column: str) -> list[Image]:
         """Extract images from a dataset row column.
 
-        Handles HF-decoded PIL Images and undecoded ``{"bytes": ..., "path": ...}``
-        dicts — datasets declared with ``Image(decode=False)`` (e.g. VisionArena)
-        return raw byte dicts. Returns the first valid image found, scalar or
-        list-wrapped.
+        Accepts scalar or list-wrapped values; returns the first valid image as
+        a single-element list, or ``[]`` if none. Handles HF-decoded PIL Images
+        and undecoded ``{"bytes": ..., "path": ...}`` dicts (datasets declared
+        with ``Image(decode=False)``, e.g. VisionArena, return raw byte dicts).
+
+        Path-only dicts (``bytes is None``) aren't handled — VisionArena and
+        other in-repo datasets embed bytes inline. The byte-decode path catches
+        both header-detection errors (``UnidentifiedImageError``) and load-time
+        errors raised when ``_pil_to_image`` re-encodes (``OSError`` from
+        truncated payloads), so a single bad image doesn't abort the loader.
         """
         value = row.get(image_column)
         candidates = value if isinstance(value, list) else [value]
@@ -86,9 +92,9 @@ class BaseHFDatasetLoader(BasePublicDatasetLoader):
             if isinstance(candidate, dict) and candidate.get("bytes"):
                 try:
                     pil = PILImage.open(io.BytesIO(candidate["bytes"]))
+                    return [self._pil_to_image(pil)]
                 except (OSError, PILImage.UnidentifiedImageError):
                     continue
-                return [self._pil_to_image(pil)]
         return []
 
     def _extract_videos(self, row: dict[str, Any], video_column: str) -> list[Video]:

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -368,6 +368,40 @@ class TestHFConversationDatasetLoader:
         assert conversations[0].turns[0].images == []
         assert len(conversations[1].turns[0].images) == 1
 
+    async def test_skips_truncated_pil_image_at_load_time(self, user_config):
+        # Lazy PIL Image (from PILImage.open on truncated bytes) passes the
+        # isinstance(PILImage.Image) check but raises OSError when _pil_to_image
+        # forces re-encode. Locks in the symmetric try/except on the PIL branch
+        # so HF decode=True datasets carrying a corrupt lazy image are also
+        # skipped instead of aborting the loader.
+        full = _jpeg_bytes(256, 256)
+        truncated_pil = PILImage.open(io.BytesIO(full[: int(len(full) * 0.95)]))
+        good_pil = _make_pil_image()
+        loader = HFConversationDatasetLoader(
+            user_config=user_config,
+            hf_dataset_name="lmarena-ai/VisionArena-Chat",
+            hf_split="train",
+            conversation_column="conversation",
+            message_content_key="content",
+            image_column="images",
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [{"role": "user", "content": "Truncated PIL"}],
+                    "images": [truncated_pil],
+                },
+                {
+                    "conversation": [{"role": "user", "content": "Good"}],
+                    "images": [good_pil],
+                },
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 2
+        assert conversations[0].turns[0].images == []
+        assert len(conversations[1].turns[0].images) == 1
+
     async def test_no_images_when_image_column_not_set(self, loader):
         data = {
             "dataset": [{"conversation": [{"role": "user", "content": "Text only"}]}]

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -315,6 +315,28 @@ class TestHFConversationDatasetLoader:
         conversations = await loader.convert_to_conversations(data)
         assert conversations[0].turns[0].images == []
 
+    async def test_path_only_dict_returns_no_images(self, user_config):
+        # Locks in the documented "not handled" contract for path-only HF dicts
+        # (bytes is None, path is a string). Update if path-only is ever supported.
+        loader = HFConversationDatasetLoader(
+            user_config=user_config,
+            hf_dataset_name="lmarena-ai/VisionArena-Chat",
+            hf_split="train",
+            conversation_column="conversation",
+            message_content_key="content",
+            image_column="images",
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [{"role": "user", "content": "Path only"}],
+                    "images": [{"bytes": None, "path": "/tmp/some_image.jpg"}],
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert conversations[0].turns[0].images == []
+
     async def test_skips_truncated_image_at_load_time(self, user_config):
         # Truncated valid JPEG: header passes PILImage.open (lazy) but the
         # subsequent re-encode in _pil_to_image raises OSError. Locks in the

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -315,6 +315,37 @@ class TestHFConversationDatasetLoader:
         conversations = await loader.convert_to_conversations(data)
         assert conversations[0].turns[0].images == []
 
+    async def test_skips_truncated_image_at_load_time(self, user_config):
+        # Truncated valid JPEG: header passes PILImage.open (lazy) but the
+        # subsequent re-encode in _pil_to_image raises OSError. Locks in the
+        # widened try/except so one corrupt row can't abort the full loader run.
+        full = _jpeg_bytes(256, 256)
+        truncated = full[: int(len(full) * 0.95)]
+        loader = HFConversationDatasetLoader(
+            user_config=user_config,
+            hf_dataset_name="lmarena-ai/VisionArena-Chat",
+            hf_split="train",
+            conversation_column="conversation",
+            message_content_key="content",
+            image_column="images",
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [{"role": "user", "content": "Truncated"}],
+                    "images": [{"bytes": truncated, "path": None}],
+                },
+                {
+                    "conversation": [{"role": "user", "content": "Good"}],
+                    "images": [{"bytes": full, "path": None}],
+                },
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert len(conversations) == 2
+        assert conversations[0].turns[0].images == []
+        assert len(conversations[1].turns[0].images) == 1
+
     async def test_no_images_when_image_column_not_set(self, loader):
         data = {
             "dataset": [{"conversation": [{"role": "user", "content": "Text only"}]}]

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import io
+
 import pytest
 from PIL import Image as PILImage
+from pytest import param
 
 from aiperf.common.config import EndpointConfig, UserConfig
 from aiperf.common.models import Conversation
@@ -12,6 +15,12 @@ from aiperf.plugin.enums import DatasetSamplingStrategy
 
 def _make_pil_image(width: int = 4, height: int = 4) -> PILImage.Image:
     return PILImage.new("RGB", (width, height), color=(255, 0, 0))
+
+
+def _jpeg_bytes(width: int = 4, height: int = 4) -> bytes:
+    buf = io.BytesIO()
+    _make_pil_image(width, height).save(buf, format="JPEG")
+    return buf.getvalue()
 
 
 @pytest.fixture
@@ -241,6 +250,70 @@ class TestHFConversationDatasetLoader:
         }
         conversations = await loader.convert_to_conversations(data)
         assert len(conversations[0].turns[0].images) == 1
+
+    @pytest.mark.parametrize(
+        "images_value",
+        [
+            param(
+                {"bytes": _jpeg_bytes(), "path": None},
+                id="undecoded-bytes-dict-scalar",
+            ),
+            param(
+                [{"bytes": _jpeg_bytes(), "path": None}],
+                id="undecoded-bytes-dict-list",
+            ),
+            param(
+                [
+                    {"bytes": _jpeg_bytes(), "path": None},
+                    {"bytes": _jpeg_bytes(8, 8), "path": None},
+                ],
+                id="undecoded-bytes-dict-list-multiple",
+            ),
+        ],
+    )  # fmt: skip
+    async def test_attaches_image_from_undecoded_hf_dict(
+        self, user_config, images_value
+    ):
+        loader = HFConversationDatasetLoader(
+            user_config=user_config,
+            hf_dataset_name="lmarena-ai/VisionArena-Chat",
+            hf_split="train",
+            conversation_column="conversation",
+            message_content_key="content",
+            image_column="images",
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [{"role": "user", "content": "What is this?"}],
+                    "images": images_value,
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        turn = conversations[0].turns[0]
+        assert len(turn.images) == 1
+        assert turn.images[0].contents[0].startswith("data:image/jpeg;base64,")
+
+    async def test_skips_corrupt_image_bytes(self, user_config):
+        loader = HFConversationDatasetLoader(
+            user_config=user_config,
+            hf_dataset_name="lmarena-ai/VisionArena-Chat",
+            hf_split="train",
+            conversation_column="conversation",
+            message_content_key="content",
+            image_column="images",
+        )
+        data = {
+            "dataset": [
+                {
+                    "conversation": [{"role": "user", "content": "Bad image"}],
+                    "images": [{"bytes": b"not-a-real-image", "path": None}],
+                }
+            ]
+        }
+        conversations = await loader.convert_to_conversations(data)
+        assert conversations[0].turns[0].images == []
 
     async def test_no_images_when_image_column_not_set(self, loader):
         data = {

--- a/tests/unit/dataset/loader/test_hf_conversation_loader.py
+++ b/tests/unit/dataset/loader/test_hf_conversation_loader.py
@@ -330,7 +330,7 @@ class TestHFConversationDatasetLoader:
             "dataset": [
                 {
                     "conversation": [{"role": "user", "content": "Path only"}],
-                    "images": [{"bytes": None, "path": "/tmp/some_image.jpg"}],
+                    "images": [{"bytes": None, "path": "some_image.jpg"}],
                 }
             ]
         }

--- a/tests/unit/dataset/loader/test_hf_image_feature_schemas.py
+++ b/tests/unit/dataset/loader/test_hf_image_feature_schemas.py
@@ -9,6 +9,7 @@ unit tests didn't match what HF actually emitted (``[{"bytes": ...}, ...]``).
 """
 
 import io
+from typing import Any
 
 import pytest
 from datasets import Dataset, Sequence
@@ -33,7 +34,7 @@ def user_config() -> UserConfig:
     return UserConfig(endpoint=EndpointConfig(model_names=["test-model"]))
 
 
-def _vision_arena_dataset(image_feature) -> Dataset:
+def _vision_arena_dataset(image_feature: Any) -> Dataset:
     """Build a VisionArena-shaped Dataset with the given Image feature.
 
     Schema matches lmarena-ai/VisionArena-Chat:
@@ -54,7 +55,7 @@ class TestHFConversationLoaderRealSchemas:
     """Run HFConversationDatasetLoader against real HF Datasets so the row
     shapes are produced by the actual ``datasets`` library, not by us."""
 
-    async def _loader(self, user_config: UserConfig) -> HFConversationDatasetLoader:
+    def _loader(self, user_config: UserConfig) -> HFConversationDatasetLoader:
         return HFConversationDatasetLoader(
             user_config=user_config,
             hf_dataset_name="lmarena-ai/VisionArena-Chat",
@@ -73,7 +74,7 @@ class TestHFConversationLoaderRealSchemas:
         dataset = _vision_arena_dataset(Sequence(HFImage(decode=False)))
         assert str(dataset.features["images"]) == "List(Image(mode=None, decode=False))"
 
-        loader = await self._loader(user_config)
+        loader = self._loader(user_config)
         conversations = await loader.convert_to_conversations({"dataset": dataset})
 
         assert len(conversations) == 1
@@ -89,7 +90,7 @@ class TestHFConversationLoaderRealSchemas:
         dataset = _vision_arena_dataset(Sequence(HFImage(decode=False)))
         streaming = dataset.to_iterable_dataset()
 
-        loader = await self._loader(user_config)
+        loader = self._loader(user_config)
         conversations = await loader.convert_to_conversations({"dataset": streaming})
 
         assert len(conversations[0].turns[0].images) == 1
@@ -99,7 +100,7 @@ class TestHFConversationLoaderRealSchemas:
         PIL Images; the unified loop must handle both shapes."""
         dataset = _vision_arena_dataset(Sequence(HFImage(decode=True)))
 
-        loader = await self._loader(user_config)
+        loader = self._loader(user_config)
         conversations = await loader.convert_to_conversations({"dataset": dataset})
 
         turn = conversations[0].turns[0]

--- a/tests/unit/dataset/loader/test_hf_image_feature_schemas.py
+++ b/tests/unit/dataset/loader/test_hf_image_feature_schemas.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests that exercise the real HuggingFace ``datasets`` library against the
+loaders, so the dataset row shapes come from HF's own feature decoding rather
+than hand-rolled mocks. Catches schema-shape surprises like the VisionArena
+``Image(decode=False)`` regression where handcrafted ``[PIL, PIL]`` lists in
+unit tests didn't match what HF actually emitted (``[{"bytes": ...}, ...]``).
+"""
+
+import io
+
+import pytest
+from datasets import Dataset, Sequence
+from datasets import Image as HFImage
+from PIL import Image as PILImage
+
+from aiperf.common.config import EndpointConfig, UserConfig
+from aiperf.dataset.loader.hf_conversation import HFConversationDatasetLoader
+from aiperf.dataset.loader.hf_instruction_response import (
+    HFInstructionResponseDatasetLoader,
+)
+
+
+def _jpeg_bytes(width: int = 4, height: int = 4) -> bytes:
+    buf = io.BytesIO()
+    PILImage.new("RGB", (width, height), color=(255, 0, 0)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def user_config() -> UserConfig:
+    return UserConfig(endpoint=EndpointConfig(model_names=["test-model"]))
+
+
+def _vision_arena_dataset(image_feature) -> Dataset:
+    """Build a VisionArena-shaped Dataset with the given Image feature.
+
+    Schema matches lmarena-ai/VisionArena-Chat:
+    ``conversation: List(List({content, role}))``,
+    ``images: <feature>``.
+    """
+    ds = Dataset.from_dict(
+        {
+            "conversation": [[[{"role": "user", "content": "What is this?"}]]],
+            "images": [[{"bytes": _jpeg_bytes(), "path": None}]],
+        }
+    )
+    return ds.cast_column("images", image_feature)
+
+
+@pytest.mark.asyncio
+class TestHFConversationLoaderRealSchemas:
+    """Run HFConversationDatasetLoader against real HF Datasets so the row
+    shapes are produced by the actual ``datasets`` library, not by us."""
+
+    async def _loader(self, user_config: UserConfig) -> HFConversationDatasetLoader:
+        return HFConversationDatasetLoader(
+            user_config=user_config,
+            hf_dataset_name="lmarena-ai/VisionArena-Chat",
+            hf_split="train",
+            conversation_column="conversation",
+            message_content_key="content",
+            image_column="images",
+        )
+
+    async def test_vision_arena_schema_decode_false_yields_image(self, user_config):
+        """The original bug: List(Image(decode=False)) → list[dict] from HF.
+
+        Pre-fix, _extract_images returned [] for this shape and inputs.json
+        was text-only.
+        """
+        dataset = _vision_arena_dataset(Sequence(HFImage(decode=False)))
+        assert str(dataset.features["images"]) == "List(Image(mode=None, decode=False))"
+
+        loader = await self._loader(user_config)
+        conversations = await loader.convert_to_conversations({"dataset": dataset})
+
+        assert len(conversations) == 1
+        turn = conversations[0].turns[0]
+        assert len(turn.images) == 1, (
+            "vision_arena schema must yield image content; this regression slipped "
+            "past hand-rolled-dict tests because the real HF row shape was unknown."
+        )
+        assert turn.images[0].contents[0].startswith("data:image/jpeg;base64,")
+
+    async def test_vision_arena_schema_decode_false_streaming(self, user_config):
+        """Streaming flag must not change image extraction behavior."""
+        dataset = _vision_arena_dataset(Sequence(HFImage(decode=False)))
+        streaming = dataset.to_iterable_dataset()
+
+        loader = await self._loader(user_config)
+        conversations = await loader.convert_to_conversations({"dataset": streaming})
+
+        assert len(conversations[0].turns[0].images) == 1
+
+    async def test_decode_true_list_schema_still_works(self, user_config):
+        """Regression coverage: Sequence(Image(decode=True)) keeps yielding
+        PIL Images; the unified loop must handle both shapes."""
+        dataset = _vision_arena_dataset(Sequence(HFImage(decode=True)))
+
+        loader = await self._loader(user_config)
+        conversations = await loader.convert_to_conversations({"dataset": dataset})
+
+        turn = conversations[0].turns[0]
+        assert len(turn.images) == 1
+        assert turn.images[0].contents[0].startswith("data:image/jpeg;base64,")
+
+
+@pytest.mark.asyncio
+class TestHFInstructionResponseLoaderRealSchemas:
+    """MMStar-style: scalar Image(decode=True). Regression coverage so the
+    common decoded-PIL path never breaks while we evolve the loader."""
+
+    async def test_mmstar_schema_decode_true_yields_image(self, user_config):
+        ds = Dataset.from_dict(
+            {
+                "question": ["Describe this image."],
+                "image": [{"bytes": _jpeg_bytes(), "path": None}],
+            }
+        ).cast_column("image", HFImage(decode=True))
+        assert str(ds.features["image"]) == "Image(mode=None, decode=True)"
+
+        loader = HFInstructionResponseDatasetLoader(
+            user_config=user_config,
+            hf_dataset_name="Lin-Chen/MMStar",
+            hf_split="val",
+            prompt_column="question",
+            image_column="image",
+        )
+        conversations = await loader.convert_to_conversations({"dataset": ds})
+
+        turn = conversations[0].turns[0]
+        assert len(turn.images) == 1
+        assert turn.images[0].contents[0].startswith("data:image/jpeg;base64,")


### PR DESCRIPTION
## Summary

- HuggingFace datasets declared with `Sequence(Image(decode=False))` (e.g. `lmarena-ai/VisionArena-Chat`) emit `[{"bytes": ..., "path": ...}]` rows. The previous `_extract_images` only recognized scalar PIL Images and `[PIL, ...]` lists, so VisionArena rows produced text-only `inputs.json` with no image content reaching the model.
- Unify scalar/list dispatch and add a byte-dict branch that decodes via `PIL.Image.open(io.BytesIO(...))`. Wrap both header-detection (`UnidentifiedImageError`) and load-time (`OSError` from re-encode in `_pil_to_image`) failures so a single corrupt row can't abort the whole loader run.
- Lock in regression coverage with `tests/unit/dataset/loader/test_hf_image_feature_schemas.py` — drives the real `datasets` library against the loader so future feature-shape changes can't slip past hand-rolled mocks again.

Multi-image-per-turn (multiple images in a single list) is intentionally out of scope — VisionArena-Chat is single-image-per-row in practice. Tracked separately for MMMU-style datasets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved image extraction to accept decoded images and HF-style inline byte objects, returning the first successfully decoded image and ignoring path-only entries.
  * Extraction now skips per-image decode/open failures (including truncated or corrupt images) without aborting processing.

* **Tests**
  * Added extensive tests covering byte-encoded images, decoded image objects, truncated/corrupt inputs, path-only cases, various HF image feature schemas, and streaming datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->