### PR TITLE
feat: autodetect model name

### DIFF
--- a/src/aiperf/cli_commands/profile.py
+++ b/src/aiperf/cli_commands/profile.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from cyclopts import App
 
 from aiperf.config.flags import CLIConfig
@@ -53,6 +55,28 @@ def profile(
     with exit_on_error(title="Error Running AIPerf System", show_traceback=False):
         from aiperf.config.flags.resolver import resolve_config
         from aiperf.config.loader import build_benchmark_plan
+
+        # If the user didn't provide --model/--model-names, try to discover
+        # one from the server's OpenAI-compatible model list.
+        if not cli_config.model_names:
+            import logging
+
+            from aiperf.common.models.model_autodetect import autodetect_names
+
+            if not logging.getLogger().handlers:
+                logging.basicConfig(
+                    level=logging.INFO,
+                    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                )
+
+            cli_config.model_names = asyncio.run(
+                autodetect_names(
+                    urls=cli_config.urls,
+                    headers={},
+                    timeout_s=cli_config.wait_for_model_timeout or 10.0,
+                    interval_s=cli_config.wait_for_model_interval,
+                )
+            )
 
         # ``resolve_config`` handles both paths: CLI-only (no config_file)
         # and YAML+CLI merge (YAML is the base, explicitly-set CLI flags like

--- a/src/aiperf/common/models/model_autodetect.py
+++ b/src/aiperf/common/models/model_autodetect.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Model autodetection helpers.
+
+Used by ``aiperf profile`` when ``--model/--model-names`` is omitted: poll
+``GET {base_url}/v1/models`` until a model appears (or the timeout is
+exhausted), then return the first discovered model ID.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import aiohttp
+import orjson
+
+from aiperf.common.aiperf_logger import AIPerfLogger
+from aiperf.transports.aiohttp_client import AioHttpClient
+
+_logger = AIPerfLogger(__name__)
+
+_MIN_REQUEST_TIMEOUT_S = 5.0
+
+
+def _models_url_from_base(base_url: str) -> str:
+    """Build the /v1/models URL, handling bases that already end in /v1."""
+    _base = base_url.rstrip("/")
+    return _base + ("/models" if _base.endswith("/v1") else "/v1/models")
+
+
+def _extract_ids_from_payload(body_text: str) -> list[str]:
+    try:
+        payload = orjson.loads(body_text)
+    except (orjson.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    data = payload.get("data")
+    if not isinstance(data, list):
+        return []
+    return [
+        entry["id"]
+        for entry in data
+        if isinstance(entry, dict)
+        and isinstance(entry.get("id"), str)
+        and entry.get("id")
+    ]
+
+
+def _log_and_return_chosen(ids: list[str], models_url: str) -> str:
+    chosen = ids[0]
+    if len(ids) > 1:
+        _logger.warning(
+            f"{len(ids)} models returned by {models_url}; "
+            "pass --model to select one explicitly"
+        )
+        _logger.warning(f"No --model provided; using first listed model '{chosen}'")
+    else:
+        _logger.info(f"Auto-detected model '{chosen}' from {models_url}")
+    return chosen
+
+
+def _parse_ids_from_record(record: Any) -> list[str]:
+    if record.status != 200 or not record.responses:
+        return []
+    body_text = getattr(record.responses[0], "text", None)
+    if not isinstance(body_text, str) or not body_text:
+        return []
+    return _extract_ids_from_payload(body_text)
+
+
+async def autodetect_names(
+    *,
+    urls: list[str],
+    headers: dict[str, str],
+    timeout_s: float = 10.0,
+    interval_s: float = 5.0,
+) -> list[str]:
+    """Poll ``GET {url}/v1/models`` until a model appears and return it.
+
+    Retries on transient failures (connection errors, non-200 responses, empty
+    ``data[]``) until ``timeout_s`` is exhausted.  Only the first URL is used
+    for discovery; pass ``--model`` explicitly when multiple URLs serve
+    different model sets.
+
+    Args:
+        urls: Base URLs. Only the first is used for autodetection.
+        headers: HTTP headers to attach to every request.
+        timeout_s: Total wall-clock budget. Raised as ``TimeoutError`` when
+            exhausted without a successful discovery.
+        interval_s: Pause between retries.
+
+    Returns:
+        A single-element list containing the first discovered model ID.
+
+    Raises:
+        ValueError: ``urls`` is empty.
+        TimeoutError: No model discovered within ``timeout_s``.
+    """
+    if not urls:
+        raise ValueError("Autodetection requires at least one --url base URL")
+
+    base_url = urls[0]
+    models_url = _models_url_from_base(base_url)
+    deadline = time.monotonic() + timeout_s
+    request_timeout_base = max(interval_s, _MIN_REQUEST_TIMEOUT_S)
+    attempt = 0
+
+    client = AioHttpClient(timeout=request_timeout_base)
+    try:
+        while True:
+            attempt += 1
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Timed out after {timeout_s:.1f}s auto-detecting models from "
+                    f"{models_url} (checked {attempt - 1} time(s))"
+                )
+            request_timeout = aiohttp.ClientTimeout(
+                total=min(request_timeout_base, remaining)
+            )
+            record = await client.get_request(
+                models_url, headers=headers, timeout=request_timeout
+            )
+            ids = _parse_ids_from_record(record)
+            if ids:
+                return [_log_and_return_chosen(ids, models_url)]
+
+            status_repr = (
+                record.status if record.status is not None else "connection error"
+            )
+            _logger.info(
+                f"Auto-detect probe to {models_url} returned {status_repr} "
+                f"(attempt {attempt}), retrying in {interval_s}s"
+            )
+            await asyncio.sleep(min(interval_s, max(0.0, deadline - time.monotonic())))
+    finally:
+        await client.close()

--- a/src/aiperf/common/readiness_probe.py
+++ b/src/aiperf/common/readiness_probe.py
@@ -234,7 +234,8 @@ async def _wait_models(
     when they respond at all.
     """
     deadline = time.monotonic() + timeout_s
-    models_url = url.rstrip("/") + "/v1/models"
+    _base = url.rstrip("/")
+    models_url = _base + ("/models" if _base.endswith("/v1") else "/v1/models")
     request_timeout_base = max(interval_s, _MIN_REQUEST_TIMEOUT_S)
     attempt = 0
 

--- a/tests/unit/cli_commands/test_profile.py
+++ b/tests/unit/cli_commands/test_profile.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for profile CLI command, focusing on the model autodetect path."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aiperf.cli_commands.profile import profile
+from aiperf.config.flags import CLIConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def mock_loaders() -> Generator[MagicMock, None, None]:
+    """Mock the resolve_config + build_benchmark_plan + run_benchmark path."""
+    with (
+        patch("aiperf.config.flags.resolver.resolve_config"),
+        patch("aiperf.config.loader.build_benchmark_plan"),
+        patch("aiperf.cli_runner.run_benchmark") as mock_run,
+    ):
+        yield mock_run
+
+
+@pytest.fixture
+def base_cli_config() -> CLIConfig:
+    """Return a minimal CLIConfig suitable for testing profile()."""
+    return CLIConfig(
+        model_names=["test-model"],
+        urls=["http://localhost:8000"],
+    )
+
+
+def test_profile_with_explicit_model_calls_run_benchmark(
+    base_cli_config: CLIConfig,
+    mock_loaders: MagicMock,
+) -> None:
+    """When --model is provided, autodetect is skipped and run_benchmark is called."""
+    profile(cli_config=base_cli_config)
+    mock_loaders.assert_called_once()
+
+
+def test_profile_autodetects_model_when_model_not_provided(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_loaders: MagicMock,
+) -> None:
+    """When --model is NOT provided, autodetect_names is called and its result
+    is assigned to cli_config.model_names before proceeding."""
+    # Build a CLIConfig without model_names
+    cli_config = CLIConfig(
+        model_names=[],
+        urls=["http://localhost:8000"],
+    )
+
+    async def _fake_autodetect_names(**_: object) -> list[str]:
+        return ["auto-detected-model"]
+
+    monkeypatch.setattr(
+        "aiperf.common.models.model_autodetect.autodetect_names",
+        _fake_autodetect_names,
+    )
+
+    def _fake_asyncio_run(coro: object) -> list[str]:
+        """Synchronous wrapper that just returns the coroutine result
+        without involving a real event loop."""
+        import asyncio as _asyncio
+
+        loop = _asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    monkeypatch.setattr(
+        "aiperf.cli_commands.profile.asyncio.run",
+        _fake_asyncio_run,
+    )
+
+    profile(cli_config=cli_config)
+
+    # After autodetect, model_names should be set
+    assert cli_config.model_names == ["auto-detected-model"]
+    mock_loaders.assert_called_once()

--- a/tests/unit/common/test_model_autodetect.py
+++ b/tests/unit/common/test_model_autodetect.py
@@ -9,7 +9,13 @@ from typing import Any
 import orjson
 import pytest
 
-from aiperf.common.models.model_autodetect import autodetect_names
+from aiperf.common.models.model_autodetect import (
+    _extract_ids_from_payload,
+    _log_and_return_chosen,
+    _models_url_from_base,
+    _parse_ids_from_record,
+    autodetect_names,
+)
 
 
 class _FakeRecord:
@@ -180,3 +186,173 @@ def test_autodetect_retries_on_empty_data_then_succeeds(
 def test_autodetect_raises_valueerror_on_empty_urls() -> None:
     with pytest.raises(ValueError, match="at least one --url"):
         asyncio.run(autodetect_names(urls=[], headers={}))
+
+
+def test_models_url_from_base_regular() -> None:
+    assert (
+        _models_url_from_base("http://localhost:8000")
+        == "http://localhost:8000/v1/models"
+    )
+
+
+def test_models_url_from_base_trailing_slash() -> None:
+    assert (
+        _models_url_from_base("http://localhost:8000/")
+        == "http://localhost:8000/v1/models"
+    )
+
+
+def test_models_url_from_base_already_ends_with_v1() -> None:
+    assert (
+        _models_url_from_base("http://localhost:8000/v1")
+        == "http://localhost:8000/v1/models"
+    )
+
+
+def test_models_url_from_base_already_ends_with_v1_slash() -> None:
+    assert (
+        _models_url_from_base("http://localhost:8000/v1/")
+        == "http://localhost:8000/v1/models"
+    )
+
+
+def test_extract_ids_success() -> None:
+    body = orjson.dumps({"data": [{"id": "model-a"}, {"id": "model-b"}]}).decode(
+        "utf-8"
+    )
+    assert _extract_ids_from_payload(body) == ["model-a", "model-b"]
+
+
+def test_extract_ids_malformed_json_returns_empty() -> None:
+    assert _extract_ids_from_payload("not json") == []
+
+
+def test_extract_ids_payload_is_list_not_dict_returns_empty() -> None:
+    assert _extract_ids_from_payload(orjson.dumps([1, 2, 3]).decode("utf-8")) == []
+
+
+def test_extract_ids_payload_is_str_returns_empty() -> None:
+    assert _extract_ids_from_payload(orjson.dumps("hello").decode("utf-8")) == []
+
+
+def test_extract_ids_data_is_not_list_returns_empty() -> None:
+    body = orjson.dumps({"data": "not-a-list"}).decode("utf-8")
+    assert _extract_ids_from_payload(body) == []
+
+
+def test_extract_ids_data_missing_returns_empty() -> None:
+    assert _extract_ids_from_payload(orjson.dumps({"other": 1}).decode("utf-8")) == []
+
+
+def test_extract_ids_entry_not_dict_skipped() -> None:
+    body = orjson.dumps({"data": ["not-dict", {"id": "valid"}, 123]}).decode("utf-8")
+    assert _extract_ids_from_payload(body) == ["valid"]
+
+
+def test_extract_ids_entry_id_not_string_skipped() -> None:
+    body = orjson.dumps({"data": [{"id": 123}, {"id": "valid"}]}).decode("utf-8")
+    assert _extract_ids_from_payload(body) == ["valid"]
+
+
+def test_extract_ids_entry_id_empty_string_skipped() -> None:
+    body = orjson.dumps({"data": [{"id": ""}, {"id": "valid"}]}).decode("utf-8")
+    assert _extract_ids_from_payload(body) == ["valid"]
+
+
+def test_extract_ids_entry_missing_id_key_skipped() -> None:
+    body = orjson.dumps({"data": [{"other": 1}, {"id": "valid"}]}).decode("utf-8")
+    assert _extract_ids_from_payload(body) == ["valid"]
+
+
+def test_parse_ids_non_200_status_returns_empty() -> None:
+    record = _FakeRecord(status=404, body_text=_models_body("model"))
+    assert _parse_ids_from_record(record) == []
+
+
+def test_parse_ids_no_responses_returns_empty() -> None:
+    record = type("_Record", (), {"status": 200, "responses": []})()
+    assert _parse_ids_from_record(record) == []
+
+
+def test_parse_ids_body_text_is_none_returns_empty() -> None:
+    resp = type("_Resp", (), {"text": None})()
+    record = type("_Record", (), {"status": 200, "responses": [resp]})()
+    assert _parse_ids_from_record(record) == []
+
+
+def test_parse_ids_body_text_is_empty_returns_empty() -> None:
+    resp = type("_Resp", (), {"text": ""})()
+    record = type("_Record", (), {"status": 200, "responses": [resp]})()
+    assert _parse_ids_from_record(record) == []
+
+
+def test_parse_ids_status_none_returns_empty() -> None:
+    record = _FakeRecord(status=None, body_text=_models_body("model"))
+    assert _parse_ids_from_record(record) == []
+
+
+def test_log_and_return_chosen_single_id() -> None:
+    assert _log_and_return_chosen(["model"], "http://localhost/v1/models") == "model"
+
+
+def test_log_and_return_chosen_multiple_ids() -> None:
+    assert (
+        _log_and_return_chosen(["model-a", "model-b"], "http://localhost/v1/models")
+        == "model-a"
+    )
+
+
+def test_autodetect_retry_logs_on_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify retry log messages appear after non-200 responses."""
+    import logging
+
+    caplog.set_level(logging.INFO, logger="aiperf.common.models.model_autodetect")
+    _install_fake_aiohttp(
+        monkeypatch,
+        responses=[
+            (503, "not ready"),
+            (200, _models_body("my-model")),
+        ],
+    )
+
+    asyncio.run(
+        autodetect_names(
+            urls=["http://localhost:8000"],
+            headers={},
+            timeout_s=30.0,
+            interval_s=0.001,
+        )
+    )
+
+    assert "Auto-detect probe" in caplog.text
+    assert "retrying" in caplog.text
+
+
+def test_autodetect_connection_error_status_none(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When status is None, log should say 'connection error'."""
+    import logging
+
+    caplog.set_level(logging.INFO, logger="aiperf.common.models.model_autodetect")
+    _install_fake_aiohttp(
+        monkeypatch,
+        responses=[
+            (None, "connection failed"),  # status=None simulates connection error
+            (200, _models_body("recovered-model")),
+        ],
+    )
+
+    result = asyncio.run(
+        autodetect_names(
+            urls=["http://localhost:8000"],
+            headers={},
+            timeout_s=30.0,
+            interval_s=0.001,
+        )
+    )
+
+    assert result == ["recovered-model"]
+    assert "connection error" in caplog.text

--- a/tests/unit/common/test_model_autodetect.py
+++ b/tests/unit/common/test_model_autodetect.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import orjson
+import pytest
+
+from aiperf.common.models.model_autodetect import autodetect_names
+
+
+class _FakeRecord:
+    def __init__(self, *, status: int | None, body_text: str) -> None:
+        self.status = status
+        resp = type("_Resp", (), {"text": body_text})()
+        self.responses = [resp]
+
+
+class _FakeClient:
+    """Replays a fixed sequence of (status, body) responses."""
+
+    def __init__(self, *, responses: list[tuple[int | None, str]]) -> None:
+        self._responses = list(responses)
+        self._idx = 0
+        self.urls: list[str] = []
+        self.headers: list[dict[str, str]] = []
+        self.closed = False
+
+    async def get_request(
+        self, url: str, headers: dict[str, str], **_: Any
+    ) -> _FakeRecord:
+        self.urls.append(url)
+        self.headers.append(headers)
+        status, body = self._responses[min(self._idx, len(self._responses) - 1)]
+        self._idx += 1
+        return _FakeRecord(status=status, body_text=body)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _install_fake_aiohttp(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    responses: list[tuple[int | None, str]],
+) -> _FakeClient:
+    fake = _FakeClient(responses=responses)
+
+    def _factory(*_: Any, **__: Any) -> _FakeClient:
+        return fake
+
+    monkeypatch.setattr(
+        "aiperf.common.models.model_autodetect.AioHttpClient",
+        _factory,
+    )
+    return fake
+
+
+def _models_body(*ids: str) -> str:
+    return orjson.dumps({"data": [{"id": mid} for mid in ids]}).decode("utf-8")
+
+
+def test_autodetect_picks_first_id_from_data(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="aiperf.common.models.model_autodetect")
+    fake = _install_fake_aiohttp(
+        monkeypatch, responses=[(200, _models_body("model-a", "model-b"))]
+    )
+
+    result = asyncio.run(
+        autodetect_names(
+            urls=["http://localhost:8000"],
+            headers={"Authorization": "Bearer token"},
+            timeout_s=10.0,
+        )
+    )
+
+    assert result == ["model-a"]
+    assert fake.urls == ["http://localhost:8000/v1/models"]
+    assert fake.headers[0]["Authorization"] == "Bearer token"
+    assert fake.closed is True
+    assert "2 models returned" in caplog.text
+    assert "pass --model" in caplog.text
+    assert "first listed model 'model-a'" in caplog.text
+
+
+def test_autodetect_single_model_logs_info_not_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    caplog.set_level(logging.INFO, logger="aiperf.common.models.model_autodetect")
+    _install_fake_aiohttp(monkeypatch, responses=[(200, _models_body("only-one"))])
+
+    asyncio.run(
+        autodetect_names(
+            urls=["http://localhost:8000"],
+            headers={},
+            timeout_s=10.0,
+        )
+    )
+
+    assert "Auto-detected model 'only-one'" in caplog.text
+    assert "pass --model" not in caplog.text
+
+
+def test_autodetect_timeout_exhausted_on_non_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-200 responses trigger retries until timeout -> TimeoutError."""
+    _install_fake_aiohttp(monkeypatch, responses=[(404, "not found")] * 100)
+
+    with pytest.raises(TimeoutError, match="Timed out"):
+        asyncio.run(
+            autodetect_names(
+                urls=["http://localhost:8000"],
+                headers={},
+                timeout_s=0.01,
+                interval_s=0.001,
+            )
+        )
+
+
+def test_autodetect_retries_on_non_200_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server returns 503 on first attempt, then 200 with a model -- should succeed."""
+    fake = _install_fake_aiohttp(
+        monkeypatch,
+        responses=[
+            (503, "not ready"),
+            (200, _models_body("my-model")),
+        ],
+    )
+
+    result = asyncio.run(
+        autodetect_names(
+            urls=["http://localhost:8000"],
+            headers={},
+            timeout_s=30.0,
+            interval_s=0.001,
+        )
+    )
+
+    assert result == ["my-model"]
+    assert len(fake.urls) == 2
+
+
+def test_autodetect_retries_on_empty_data_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server returns 200 but empty data[] on first attempt, model appears next."""
+    fake = _install_fake_aiohttp(
+        monkeypatch,
+        responses=[
+            (200, orjson.dumps({"data": []}).decode("utf-8")),
+            (200, _models_body("appeared-model")),
+        ],
+    )
+
+    result = asyncio.run(
+        autodetect_names(
+            urls=["http://localhost:8000"],
+            headers={},
+            timeout_s=30.0,
+            interval_s=0.001,
+        )
+    )
+
+    assert result == ["appeared-model"]
+    assert len(fake.urls) == 2
+
+
+def test_autodetect_raises_valueerror_on_empty_urls() -> None:
+    with pytest.raises(ValueError, match="at least one --url"):
+        asyncio.run(autodetect_names(urls=[], headers={}))

--- a/tests/unit/common/test_readiness_probe.py
+++ b/tests/unit/common/test_readiness_probe.py
@@ -181,3 +181,36 @@ def test_wait_for_endpoint_receives_normalized_urls_from_endpoint_config(
             f"EndpointConfig normalization is broken"
         )
     assert fake.urls[0] == "http://localhost:8000/v1/models"
+
+
+def test_wait_for_endpoint_deduplicates_v1_in_models_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test: --url http://host/v1 must probe /v1/models, not /v1/v1/models."""
+    fake = _FakeMultiClient(
+        models_payload=orjson.dumps({"data": [{"id": "served-model"}]})
+    )
+
+    monkeypatch.setattr(
+        "aiperf.transports.aiohttp_client.AioHttpClient",
+        lambda *args, **kwargs: fake,
+    )
+
+    config = CLIConfig(model_names=["served-model"], urls=["http://localhost:8000/v1"])
+
+    asyncio.run(
+        readiness_probe.wait_for_endpoint(
+            urls=config.urls,
+            model_names=config.model_names,
+            mode="models",
+            endpoint_type="chat",
+            custom_endpoint=None,
+            timeout_s=2.0,
+            interval_s=0.1,
+            headers={},
+        )
+    )
+
+    assert fake.urls[0] == "http://localhost:8000/v1/models", (
+        f"Expected /v1/models but got {fake.urls[0]!r} -- /v1 was duplicated"
+    )


### PR DESCRIPTION
## Summary

- Introduces the ability to auto-detect model name for `aiperf profile` with `GET /v1/models` from specified `--url`
- Emits a warning when multiple models are returned, selecting the first:
```
2026-05-08 15:39:47,745 - aiperf.common.models.model_autodetect - WARNING - 42 models returned by https://lightning.ai/api/v1/models; pass --model to select one explicitly
2026-05-08 15:39:47,746 - aiperf.common.models.model_autodetect - WARNING - No --model provided; using first listed model 'openai/o3'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `-m/--model-names` is now optional; the profile command will auto-detect models from the server (with retries and timeout) when omitted. Auto-detection selects the first discovered model and logs guidance.

* **Bug Fixes**
  * Fixed model-list URL handling to avoid duplicating `/v1`.
  * Auto-computed artifact directory is no longer treated as a user-provided field.

* **Documentation**
  * CLI docs updated to reflect optional model names and auto-detection.

* **Tests**
  * Added unit tests covering model autodiscovery, retry/timeout behavior, logging, and URL handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->