### PR TITLE
feat(endpoints): add image_edit endpoint for OpenAI-compatible image-to-image (FLUX.2)

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -138,7 +138,7 @@ Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default,
 #### `--endpoint-type` `<str>`
 
 The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
-<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `template`]_
+<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `template`]_
 <br/>_Default: `chat`_
 
 #### `--streaming`

--- a/docs/plugins/plugin-system.md
+++ b/docs/plugins/plugin-system.md
@@ -372,6 +372,7 @@ pkg = plugins.get_package_metadata("aiperf")  # PackageInfo(version, author, ...
 | `embeddings` | `EmbeddingsEndpoint` | OpenAI Embeddings API |
 | `hf_tei_rankings` | `HFTeiRankingsEndpoint` | HuggingFace TEI Rankings |
 | `huggingface_generate` | `HuggingFaceGenerateEndpoint` | HuggingFace TGI |
+| `image_edit` | `ImageEditEndpoint` | OpenAI Image Edit (image-to-image) API; multipart upload of reference image + prompt to `/v1/images/edits`. Compatible with SGLang FLUX.2 unified diffusion serving. |
 | `image_generation` | `ImageGenerationEndpoint` | OpenAI Image Generation API |
 | `nim_embeddings` | `NIMEmbeddingsEndpoint` | NVIDIA NIM Embeddings |
 | `nim_rankings` | `NIMRankingsEndpoint` | NVIDIA NIM Rankings |

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -371,7 +371,9 @@ class EndpointConfig(BaseConfig):
     @model_validator(mode="after")
     def validate_request_content_type(self) -> Self:
         """Auto-default to multipart for requires_form_data endpoints, and
-        reject explicit non-JSON content types on endpoints that don't support it.
+        reject content-type/endpoint combinations that the transport cannot
+        serialize (JSON on multipart-only endpoints, or multipart on JSON-only
+        endpoints).
         """
         from aiperf.plugin import plugins
 
@@ -381,6 +383,15 @@ class EndpointConfig(BaseConfig):
             if metadata.requires_form_data:
                 self.request_content_type = RequestContentType.MULTIPART_FORM_DATA
             return self
+
+        if (
+            self.request_content_type == RequestContentType.APPLICATION_JSON
+            and metadata.requires_form_data
+        ):
+            raise ValueError(
+                f"--endpoint-type {self.type} requires multipart/form-data; "
+                f"application/json is not supported on this endpoint."
+            )
 
         if self.request_content_type == RequestContentType.APPLICATION_JSON:
             return self

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -370,21 +370,26 @@ class EndpointConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_request_content_type(self) -> Self:
-        """Validate that multipart/form-data is only used with endpoints that support it."""
-        if (
-            self.request_content_type is None
-            or self.request_content_type == RequestContentType.APPLICATION_JSON
-        ):
-            return self
-
+        """Auto-default to multipart for requires_form_data endpoints, and
+        reject explicit non-JSON content types on endpoints that don't support it.
+        """
         from aiperf.plugin import plugins
 
         metadata = plugins.get_endpoint_metadata(self.type)
+
+        if self.request_content_type is None:
+            if metadata.requires_form_data:
+                self.request_content_type = RequestContentType.MULTIPART_FORM_DATA
+            return self
+
+        if self.request_content_type == RequestContentType.APPLICATION_JSON:
+            return self
+
         if not metadata.requires_form_data:
             raise ValueError(
                 f"--request-content-type {self.request_content_type} is only supported for "
-                f"endpoint types that support form-data encoding (e.g., video_generation), "
-                f"but --endpoint-type {self.type} does not support it."
+                f"endpoint types that support form-data encoding (e.g., image_edit, "
+                f"video_generation), but --endpoint-type {self.type} does not support it."
             )
         return self
 

--- a/src/aiperf/common/config/endpoint_config.py
+++ b/src/aiperf/common/config/endpoint_config.py
@@ -390,7 +390,8 @@ class EndpointConfig(BaseConfig):
         ):
             raise ValueError(
                 f"--endpoint-type {self.type} requires multipart/form-data; "
-                f"application/json is not supported on this endpoint."
+                f"application/json is not supported on this endpoint. "
+                f"Omit --request-content-type to use the auto-default."
             )
 
         if self.request_content_type == RequestContentType.APPLICATION_JSON:

--- a/src/aiperf/endpoints/openai_image_edit.py
+++ b/src/aiperf/endpoints/openai_image_edit.py
@@ -1,7 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-import base64
-import binascii
 from typing import Any
 
 from aiperf.common.models import (
@@ -22,23 +20,27 @@ _MIME_BY_EXT: dict[str, str] = {
     "bmp": "image/bmp",
 }
 
-# Keys derived from turn data or expected as binary uploads that
-# --extra-inputs must not overwrite.
+# Keys protected from --extra-inputs (turn-derived or binary uploads).
 _RESERVED_PAYLOAD_KEYS: frozenset[str] = frozenset({"prompt", "image", "url", "mask"})
 
+# Base64-encoded magic-byte prefixes. PNG bytes `\x89PNG\r\n\x1a\n` -> `iVBORw0KGgo`,
+# JPEG `\xff\xd8\xff` -> `/9j/`, GIF87a/89a -> `R0lGODdh`/`R0lGODlh`, RIFF -> `UklGR`
+# (reported as WebP — image_edit inputs are image-only), BMP `BM` -> `Qk`.
+_MIME_BY_B64_PREFIX: tuple[tuple[str, str], ...] = (
+    ("iVBORw0KGgo", "image/png"),
+    ("/9j/", "image/jpeg"),
+    ("R0lGODlh", "image/gif"),
+    ("R0lGODdh", "image/gif"),
+    ("UklGR", "image/webp"),
+    ("Qk", "image/bmp"),
+)
 
-def _sniff_mime_from_magic_bytes(image_bytes: bytes) -> str | None:
-    """Detect MIME type from the magic bytes of a raw base64-decoded image."""
-    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
-        return "image/png"
-    if image_bytes.startswith(b"\xff\xd8\xff"):
-        return "image/jpeg"
-    if image_bytes.startswith(b"RIFF") and image_bytes[8:12] == b"WEBP":
-        return "image/webp"
-    if image_bytes.startswith((b"GIF87a", b"GIF89a")):
-        return "image/gif"
-    if image_bytes.startswith(b"BM"):
-        return "image/bmp"
+
+def _sniff_mime_from_b64_prefix(b64: str) -> str | None:
+    """Return the MIME type implied by a base64-encoded image's leading characters."""
+    for prefix, mime in _MIME_BY_B64_PREFIX:
+        if b64.startswith(prefix):
+            return mime
     return None
 
 
@@ -46,10 +48,9 @@ class ImageEditEndpoint(BaseEndpoint):
     """OpenAI Image Edit (image-to-image) endpoint.
 
     Multipart upload of a reference image plus text prompt. Compatible with
-    SGLang's /v1/images/edits and FLUX.2 unified diffusion serving.
-
-    See: https://platform.openai.com/docs/api-reference/images/createEdit
-    See: https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+    SGLang's /v1/images/edits and FLUX.2 unified diffusion serving. The
+    ``url`` form-field path (HTTP/HTTPS reference image) is an SGLang
+    extension; stock OpenAI ``/v1/images/edits`` only accepts file uploads.
     """
 
     def format_payload(self, request_info: RequestInfo) -> dict[str, Any]:
@@ -87,18 +88,19 @@ class ImageEditEndpoint(BaseEndpoint):
             "n": 1,
         }
 
-        if image_content.startswith(("http://", "https://")):
+        if image_content.lower().startswith(("http://", "https://")):
             payload["url"] = image_content
         else:
             payload["image"] = self._build_image_field(image_content)
 
-        for key, value in model_endpoint.endpoint.extra or []:
-            if key in _RESERVED_PAYLOAD_KEYS:
-                self.warning(
-                    f"--extra-inputs {key!r} is managed by the endpoint and was ignored."
-                )
-                continue
-            payload[key] = value
+        if model_endpoint.endpoint.extra:
+            for key, value in model_endpoint.endpoint.extra:
+                if key in _RESERVED_PAYLOAD_KEYS:
+                    self.warning(
+                        f"--extra-inputs {key!r} is managed by the endpoint and was ignored."
+                    )
+                    continue
+                payload[key] = value
 
         self.trace(lambda: f"Formatted image edit payload keys: {list(payload)}")
         return payload
@@ -115,24 +117,22 @@ class ImageEditEndpoint(BaseEndpoint):
                 raise ValueError(
                     "Malformed data URL for image content (missing comma)."
                 ) from exc
-            if header.startswith("data:") and ";" in header:
+            if ";" in header:
                 candidate = header.removeprefix("data:").split(";", 1)[0]
-                # Only honor the data URL MIME when it actually claims an image,
-                # so a malformed `data:text/html;base64,...` cannot poison the
-                # outgoing multipart Content-Type.
+                # Only honor `image/*` MIME claims; a malformed
+                # `data:text/html;base64,...` falls back to sniffing.
                 if candidate.startswith("image/"):
                     explicit_mime = candidate
 
-        try:
-            image_bytes = base64.b64decode(b64, validate=True)
-        except (binascii.Error, ValueError) as exc:
+        mime = explicit_mime or _sniff_mime_from_b64_prefix(b64)
+        if mime is None:
             raise ValueError(
-                "Image content is not valid base64; expected a data URL or "
-                "raw base64 image (PNG/JPEG/WebP/GIF/BMP)."
-            ) from exc
+                "Image content is not a recognized image format; expected a "
+                "data URL or raw base64 image (PNG/JPEG/WebP/GIF/BMP)."
+            )
 
-        mime = explicit_mime or _sniff_mime_from_magic_bytes(image_bytes) or "image/png"
-        ext = mime.split("/", 1)[1] if "/" in mime else "png"
+        # Strip subtype suffix (e.g., `svg+xml` -> `svg`) so the filename is clean.
+        ext = mime.split("/", 1)[1].split("+", 1)[0] if "/" in mime else "png"
         filename_ext = "jpg" if ext == "jpeg" else ext
         return {
             "b64_data": b64,

--- a/src/aiperf/endpoints/openai_image_edit.py
+++ b/src/aiperf/endpoints/openai_image_edit.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import base64
+import binascii
+from typing import Any
+
+from aiperf.common.models import (
+    ImageDataItem,
+    ImageResponseData,
+    InferenceServerResponse,
+    ParsedResponse,
+    RequestInfo,
+)
+from aiperf.endpoints.base_endpoint import BaseEndpoint
+
+_MIME_BY_EXT: dict[str, str] = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "webp": "image/webp",
+    "gif": "image/gif",
+    "bmp": "image/bmp",
+}
+
+# Keys derived from turn data that --extra-inputs must not overwrite.
+_RESERVED_PAYLOAD_KEYS: frozenset[str] = frozenset({"prompt", "image", "url"})
+
+
+def _sniff_mime_from_magic_bytes(image_bytes: bytes) -> str | None:
+    """Detect MIME type from the magic bytes of a raw base64-decoded image."""
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if image_bytes.startswith(b"RIFF") and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    if image_bytes.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if image_bytes.startswith(b"BM"):
+        return "image/bmp"
+    return None
+
+
+class ImageEditEndpoint(BaseEndpoint):
+    """OpenAI Image Edit (image-to-image) endpoint.
+
+    Multipart upload of a reference image plus text prompt. Compatible with
+    SGLang's /v1/images/edits and FLUX.2 unified diffusion serving.
+
+    See: https://platform.openai.com/docs/api-reference/images/createEdit
+    See: https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+    """
+
+    def format_payload(self, request_info: RequestInfo) -> dict[str, Any]:
+        """Format an OpenAI Image Edit multipart payload from RequestInfo.
+
+        The image stays base64-encoded in the payload so it survives
+        ``model_dump(mode="json")`` upstream; the transport layer decodes
+        it just before emitting multipart bytes.
+
+        ``mask`` is not supported via ``--extra-inputs`` because the server
+        expects it as a binary file upload, not a Form string.
+        """
+        if not request_info.turns:
+            raise ValueError("Image edit endpoint requires at least one turn.")
+
+        turn = request_info.turns[0]
+        model_endpoint = request_info.model_endpoint
+
+        if not turn.texts or not turn.texts[0].contents:
+            raise ValueError("Image edit endpoint requires text prompt in first turn.")
+        if not turn.images or not turn.images[0].contents:
+            raise ValueError(
+                "Image edit endpoint requires a reference image in turn.images[0]."
+            )
+
+        prompt = turn.texts[0].contents[0]
+        image_content = turn.images[0].contents[0]
+        if not image_content:
+            raise ValueError("Reference image content is empty.")
+
+        payload: dict[str, Any] = {
+            "prompt": prompt,
+            "model": turn.model or model_endpoint.primary_model_name,
+            "response_format": "b64_json",
+            "n": 1,
+        }
+
+        if image_content.startswith(("http://", "https://")):
+            payload["url"] = image_content
+        else:
+            payload["image"] = self._build_image_field(image_content)
+
+        for key, value in model_endpoint.endpoint.extra or []:
+            if key in _RESERVED_PAYLOAD_KEYS:
+                self.warning(
+                    f"--extra-inputs {key!r} is managed by the endpoint and was ignored."
+                )
+                continue
+            payload[key] = value
+
+        self.trace(lambda: f"Formatted image edit payload keys: {list(payload)}")
+        return payload
+
+    @staticmethod
+    def _build_image_field(content: str) -> dict[str, Any]:
+        """Decode a data URL or raw base64 string into a multipart file descriptor."""
+        b64 = content
+        explicit_mime: str | None = None
+        if content.startswith("data:"):
+            try:
+                header, b64 = content.split(",", 1)
+            except ValueError as exc:
+                raise ValueError(
+                    "Malformed data URL for image content (missing comma)."
+                ) from exc
+            if header.startswith("data:") and ";" in header:
+                explicit_mime = header.removeprefix("data:").split(";", 1)[0] or None
+
+        try:
+            image_bytes = base64.b64decode(b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(
+                "Image content is not valid base64; expected a data URL or "
+                "raw base64 image (PNG/JPEG/WebP/GIF/BMP)."
+            ) from exc
+
+        mime = explicit_mime or _sniff_mime_from_magic_bytes(image_bytes) or "image/png"
+        ext = mime.split("/", 1)[1] if "/" in mime else "png"
+        filename_ext = "jpg" if ext == "jpeg" else ext
+        return {
+            "b64_data": b64,
+            "filename": f"image.{filename_ext}",
+            "content_type": _MIME_BY_EXT.get(ext, mime),
+        }
+
+    def parse_response(
+        self, response: InferenceServerResponse
+    ) -> ParsedResponse | None:
+        """Parse an OpenAI Image Edit response."""
+        json_obj = response.get_json()
+        if not json_obj:
+            self.debug(
+                lambda: f"No JSON object found in response: {response.get_raw()}"
+            )
+            return None
+
+        images: list[ImageDataItem] = []
+        for item in json_obj.get("data", []) or []:
+            images.append(
+                ImageDataItem(
+                    url=item.get("url"),
+                    b64_json=item.get("b64_json"),
+                    revised_prompt=item.get("revised_prompt"),
+                )
+            )
+
+        response_data = ImageResponseData(
+            images=images,
+            size=json_obj.get("size"),
+            quality=json_obj.get("quality"),
+            output_format=json_obj.get("output_format"),
+            background=json_obj.get("background"),
+        )
+
+        usage = json_obj.get("usage") or None
+        return ParsedResponse(perf_ns=response.perf_ns, data=response_data, usage=usage)

--- a/src/aiperf/endpoints/openai_image_edit.py
+++ b/src/aiperf/endpoints/openai_image_edit.py
@@ -22,8 +22,9 @@ _MIME_BY_EXT: dict[str, str] = {
     "bmp": "image/bmp",
 }
 
-# Keys derived from turn data that --extra-inputs must not overwrite.
-_RESERVED_PAYLOAD_KEYS: frozenset[str] = frozenset({"prompt", "image", "url"})
+# Keys derived from turn data or expected as binary uploads that
+# --extra-inputs must not overwrite.
+_RESERVED_PAYLOAD_KEYS: frozenset[str] = frozenset({"prompt", "image", "url", "mask"})
 
 
 def _sniff_mime_from_magic_bytes(image_bytes: bytes) -> str | None:
@@ -115,7 +116,12 @@ class ImageEditEndpoint(BaseEndpoint):
                     "Malformed data URL for image content (missing comma)."
                 ) from exc
             if header.startswith("data:") and ";" in header:
-                explicit_mime = header.removeprefix("data:").split(";", 1)[0] or None
+                candidate = header.removeprefix("data:").split(";", 1)[0]
+                # Only honor the data URL MIME when it actually claims an image,
+                # so a malformed `data:text/html;base64,...` cannot poison the
+                # outgoing multipart Content-Type.
+                if candidate.startswith("image/"):
+                    explicit_mime = candidate
 
         try:
             image_bytes = base64.b64decode(b64, validate=True)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -310,6 +310,24 @@ endpoint:
       tokenizes_input: true
       metrics_title: Image Generation Metrics
 
+  image_edit:
+    class: aiperf.endpoints.openai_image_edit:ImageEditEndpoint
+    description: |
+      OpenAI Image Edit (image-to-image) endpoint. Edits an input image using
+      a text prompt. Compatible with SGLang's /v1/images/edits and FLUX.2
+      unified diffusion serving. Uses multipart/form-data request encoding
+      because the input image is uploaded as a file field. Use
+      --endpoint-type image_edit.
+    metadata:
+      endpoint_path: /v1/images/edits
+      supports_streaming: false
+      produces_tokens: false
+      produces_images: true
+      supports_images: true
+      tokenizes_input: true
+      requires_form_data: true
+      metrics_title: Image Edit Metrics
+
   video_generation:
     class: aiperf.endpoints.openai_video_generation:VideoGenerationEndpoint
     description: |

--- a/src/aiperf/plugin/schema/plugins.schema.json
+++ b/src/aiperf/plugin/schema/plugins.schema.json
@@ -906,7 +906,7 @@
             },
             "requires_form_data": {
               "default": false,
-              "description": "Whether endpoint supports multipart/form-data request encoding.",
+              "description": "True for endpoints that require multipart/form-data (binary uploads), e.g., video_generation, image_edit. EndpointConfig consumes this flag to auto-select the request encoding.",
               "title": "Requires Form Data",
               "type": "boolean"
             },

--- a/src/aiperf/plugin/schema/schemas.py
+++ b/src/aiperf/plugin/schema/schemas.py
@@ -280,7 +280,11 @@ class EndpointMetadata(BaseModel):
     )
     requires_form_data: bool = Field(
         default=False,
-        description="Whether endpoint supports multipart/form-data request encoding.",
+        description=(
+            "True for endpoints that require multipart/form-data (binary uploads), "
+            "e.g., video_generation, image_edit. EndpointConfig consumes this flag "
+            "to auto-select the request encoding."
+        ),
     )
     requires_inline_media: bool = Field(
         default=False,

--- a/src/aiperf/transports/aiohttp_client.py
+++ b/src/aiperf/transports/aiohttp_client.py
@@ -27,6 +27,27 @@ if TYPE_CHECKING:
     from aiperf.transports.base_transports import FirstTokenCallback
 
 
+def _expected_request_body_size(data: Any) -> int | None:
+    """Return the byte length of an HTTP request body, or None if unknown.
+
+    The aiohttp trace callback uses this to fire ``on_request_sent`` once
+    ``bytes_sent`` reaches the expected total. For multipart bodies (image_edit,
+    video_generation) the size is not directly len-able, so we serialize the
+    FormData payload once and read its computed size.
+    """
+    if isinstance(data, bytes):
+        return len(data)
+    if isinstance(data, aiohttp.FormData):
+        try:
+            return data().size
+        except (ValueError, TypeError, AttributeError):
+            # Misshapen FormData: aiohttp raises during __call__ when a field's
+            # value type is not supported. Fall back to None so a single bad
+            # request doesn't block the cancellation path for the whole run.
+            return None
+    return None
+
+
 class AioHttpClient(AIPerfLoggerMixin):
     """A high-performance HTTP client for communicating with HTTP based REST APIs using aiohttp.
 
@@ -97,9 +118,11 @@ class AioHttpClient(AIPerfLoggerMixin):
             trace_data=trace_data,
         )
 
-        # Create trace config for comprehensive timing
-        # Pass expected body size for chunk-based completion detection
-        expected_request_body_size = len(data) if isinstance(data, bytes) else None
+        # Create trace config for comprehensive timing.
+        # The trace fires `on_request_sent` once `bytes_sent` reaches this size, so
+        # the cancellation timer can start. Without it, multipart bodies wait until
+        # the send-timeout safety net and surface as RequestSendTimeout.
+        expected_request_body_size = _expected_request_body_size(data)
         collect_chunks = self.collect_trace_chunks
         trace_config = create_aiohttp_trace_config(
             record.trace_data,

--- a/src/aiperf/transports/aiohttp_client.py
+++ b/src/aiperf/transports/aiohttp_client.py
@@ -38,12 +38,11 @@ def _expected_request_body_size(data: Any) -> int | None:
     if isinstance(data, bytes):
         return len(data)
     if isinstance(data, aiohttp.FormData):
+        # TODO: compute size analytically from `data._fields` to avoid the
+        # extra MultipartWriter materialization that session.request() will do.
         try:
             return data().size
         except (ValueError, TypeError, AttributeError):
-            # Misshapen FormData: aiohttp raises during __call__ when a field's
-            # value type is not supported. Fall back to None so a single bad
-            # request doesn't block the cancellation path for the whole run.
             return None
     return None
 

--- a/src/aiperf/transports/aiohttp_transport.py
+++ b/src/aiperf/transports/aiohttp_transport.py
@@ -418,8 +418,13 @@ class AioHttpTransport(BaseTransport):
         File fields are encoded as ``{"b64_data": <str>, "filename": <str>,
         "content_type": <str>}``. Keeping bytes base64-encoded in the payload
         lets it stay JSON-serialisable upstream; decoding happens here.
+
+        ``default_to_multipart=True`` forces multipart/form-data even when the
+        payload happens to be text-only (e.g., image_edit with a `url` field
+        instead of an inline image), so the wire format always matches the
+        endpoint's declared `requires_form_data` contract.
         """
-        form_data = aiohttp.FormData()
+        form_data = aiohttp.FormData(default_to_multipart=True)
         for key, value in payload.items():
             if value is None:
                 continue

--- a/src/aiperf/transports/aiohttp_transport.py
+++ b/src/aiperf/transports/aiohttp_transport.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import time
 from collections.abc import Mapping
 from typing import Any
@@ -272,7 +274,15 @@ class AioHttpTransport(BaseTransport):
         try:
             url = self.build_url(request_info)
             headers = self.build_headers(request_info)
-            json_bytes = orjson.dumps(payload)
+            use_form_data = (
+                request_info.model_endpoint.endpoint.request_content_type
+                == RequestContentType.MULTIPART_FORM_DATA
+            )
+            body: bytes | aiohttp.FormData = (
+                self._build_form_data(payload)
+                if use_form_data
+                else orjson.dumps(payload)
+            )
 
             match reuse_strategy:
                 case ConnectionReuseStrategy.NEVER:
@@ -311,7 +321,7 @@ class AioHttpTransport(BaseTransport):
 
             record = await self.aiohttp_client.post_request(
                 url,
-                json_bytes,
+                body,
                 headers,
                 cancel_after_ns=request_info.cancel_after_ns,
                 first_token_callback=first_token_callback,
@@ -405,19 +415,31 @@ class AioHttpTransport(BaseTransport):
     def _build_form_data(payload: dict[str, Any]) -> aiohttp.FormData:
         """Build multipart form data from a payload dict.
 
-        Args:
-            payload: Key-value pairs to encode as form fields
-
-        Returns:
-            aiohttp.FormData ready for submission
+        File fields are encoded as ``{"b64_data": <str>, "filename": <str>,
+        "content_type": <str>}``. Keeping bytes base64-encoded in the payload
+        lets it stay JSON-serialisable upstream; decoding happens here.
         """
         form_data = aiohttp.FormData()
         for key, value in payload.items():
-            if value is not None:
-                str_value = (
-                    str(value).lower() if isinstance(value, bool) else str(value)
+            if value is None:
+                continue
+            if isinstance(value, dict) and isinstance(value.get("b64_data"), str):
+                try:
+                    file_bytes = base64.b64decode(value["b64_data"], validate=True)
+                except (binascii.Error, ValueError) as exc:
+                    raise ValueError(
+                        f"Field {key!r}: 'b64_data' is not valid base64."
+                    ) from exc
+                form_data.add_field(
+                    key,
+                    file_bytes,
+                    filename=value.get("filename") or key,
+                    content_type=value.get("content_type")
+                    or "application/octet-stream",
                 )
-                form_data.add_field(key, str_value)
+                continue
+            str_value = str(value).lower() if isinstance(value, bool) else str(value)
+            form_data.add_field(key, str_value)
         return form_data
 
     async def _submit_video_job(

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -777,29 +777,25 @@ async def image_generation(
         return ORJSONResponse(_build_image_response_data(ctx, req))
 
 
-_FORM_REQUIRED = Form(...)
-_FORM_NONE = Form(None)
-_FORM_DEFAULT_MODEL = Form("black-forest-labs/FLUX.2-klein-4B")
-_FORM_N_DEFAULT = Form(1)
-_FORM_B64_JSON = Form("b64_json")
-_FILE_NONE = File(None)
-
-
+# Each parameter calls Form/File fresh so FastAPI builds an independent
+# FieldInfo per parameter (alias resolution, validators, etc.) — sharing a
+# single instance across multiple parameters lets state leak between them.
+# B008 is the FastAPI-idiomatic exception to "no function calls in defaults".
 @app.post("/v1/images/edits", response_model=None)
 @with_error_injection
 async def image_edits(
     request: Request,
-    prompt: str = _FORM_REQUIRED,
-    image: UploadFile | None = _FILE_NONE,
-    url: str | None = _FORM_NONE,
-    model: str = _FORM_DEFAULT_MODEL,
-    n: int = _FORM_N_DEFAULT,
-    response_format: str = _FORM_B64_JSON,
-    size: str | None = _FORM_NONE,
-    num_inference_steps: int | None = _FORM_NONE,
-    guidance_scale: float | None = _FORM_NONE,
-    true_cfg_scale: float | None = _FORM_NONE,
-    seed: int | None = _FORM_NONE,
+    prompt: str = Form(...),  # noqa: B008
+    image: UploadFile | None = File(None),  # noqa: B008
+    url: str | None = Form(None),  # noqa: B008
+    model: str = Form("black-forest-labs/FLUX.2-klein-4B"),  # noqa: B008
+    n: int = Form(1),  # noqa: B008
+    response_format: str = Form("b64_json"),  # noqa: B008
+    size: str | None = Form(None),  # noqa: B008
+    num_inference_steps: int | None = Form(None),  # noqa: B008
+    guidance_scale: float | None = Form(None),  # noqa: B008
+    true_cfg_scale: float | None = Form(None),  # noqa: B008
+    seed: int | None = Form(None),  # noqa: B008
 ) -> ORJSONResponse:
     """Mock OpenAI Image Edit endpoint.
 

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -58,7 +58,7 @@ from aiperf_mock_server.utils import (
     stream_tgi_completion,
     with_error_injection,
 )
-from fastapi import FastAPI, HTTPException, Response
+from fastapi import FastAPI, File, Form, HTTPException, Response, UploadFile
 from fastapi.responses import ORJSONResponse, PlainTextResponse, StreamingResponse
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
 from starlette.requests import Request
@@ -775,6 +775,76 @@ async def image_generation(
     with track_llm_request(ctx, req.model, endpoint):
         await ctx.latency_sim.wait_for_tokens(len(ctx.tokens))
         return ORJSONResponse(_build_image_response_data(ctx, req))
+
+
+_FORM_REQUIRED = Form(...)
+_FORM_NONE = Form(None)
+_FORM_DEFAULT_MODEL = Form("black-forest-labs/FLUX.2-klein-4B")
+_FORM_N_DEFAULT = Form(1)
+_FORM_B64_JSON = Form("b64_json")
+_FILE_NONE = File(None)
+
+
+@app.post("/v1/images/edits", response_model=None)
+@with_error_injection
+async def image_edits(
+    request: Request,
+    prompt: str = _FORM_REQUIRED,
+    image: UploadFile | None = _FILE_NONE,
+    url: str | None = _FORM_NONE,
+    model: str = _FORM_DEFAULT_MODEL,
+    n: int = _FORM_N_DEFAULT,
+    response_format: str = _FORM_B64_JSON,
+    size: str | None = _FORM_NONE,
+    num_inference_steps: int | None = _FORM_NONE,
+    guidance_scale: float | None = _FORM_NONE,
+    true_cfg_scale: float | None = _FORM_NONE,
+    seed: int | None = _FORM_NONE,
+) -> ORJSONResponse:
+    """Mock OpenAI Image Edit endpoint.
+
+    Drains the uploaded image so multipart parsing is exercised, then
+    returns a deterministic b64-encoded JPEG.
+    """
+    endpoint = "/v1/images/edits"
+    if image is None and not url:
+        raise HTTPException(
+            status_code=422, detail="Field 'image' or 'url' is required"
+        )
+
+    if image is not None:
+        upload_bytes = await image.read()
+        upload_size = len(upload_bytes)
+    else:
+        upload_size = 0
+
+    start_time = request.state.start_time
+    mock_req = ChatCompletionRequest(
+        model=model, messages=[{"role": "user", "content": prompt}]
+    )
+    ctx = make_ctx(mock_req, endpoint, start_time)
+
+    img_req = ImageGenerationRequest(
+        prompt=prompt,
+        model=model,
+        n=n,
+        response_format=response_format,
+        size=size,
+    )
+
+    with track_llm_request(ctx, model, endpoint):
+        await ctx.latency_sim.wait_for_tokens(len(ctx.tokens))
+        body = _build_image_response_data(ctx, img_req)
+        body["input_image_bytes"] = upload_size
+        if num_inference_steps is not None:
+            body["num_inference_steps"] = num_inference_steps
+        if guidance_scale is not None:
+            body["guidance_scale"] = guidance_scale
+        if true_cfg_scale is not None:
+            body["true_cfg_scale"] = true_cfg_scale
+        if seed is not None:
+            body["seed"] = seed
+        return ORJSONResponse(body)
 
 
 # ============================================================================

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -788,7 +788,7 @@ async def image_edits(
     prompt: str = Form(...),  # noqa: B008
     image: UploadFile | None = File(None),  # noqa: B008
     url: str | None = Form(None),  # noqa: B008
-    model: str = Form("black-forest-labs/FLUX.2-klein-4B"),  # noqa: B008
+    model: str = Form("mock-model"),  # noqa: B008
     n: int = Form(1),  # noqa: B008
     response_format: str = Form("b64_json"),  # noqa: B008
     size: str | None = Form(None),  # noqa: B008

--- a/tests/aiperf_mock_server/pyproject.toml
+++ b/tests/aiperf_mock_server/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "cyclopts>=3.0.0",
     "orjson>=3.9.0",
-    "prometheus-client>=0.20.0"
+    "prometheus-client>=0.20.0",
+    "python-multipart>=0.0.7", # Required for FastAPI Form/File parsing on /v1/images/edits
 ]
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/tests/component_integration/endpoints/test_image_edit_endpoint.py
+++ b/tests/component_integration/endpoints/test_image_edit_endpoint.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for /v1/images/edits endpoint (image_edit endpoint type)."""
+
+import pytest
+
+from tests.component_integration.conftest import (
+    ComponentIntegrationTestDefaults as defaults,
+)
+from tests.harness.utils import AIPerfCLI
+
+
+@pytest.mark.component_integration
+class TestImageEditEndpoint:
+    """End-to-end smoke tests for the image_edit endpoint."""
+
+    def test_synthetic_image_edit(self, cli: AIPerfCLI):
+        """Image edit with synthetic prompt and reference image."""
+        result = cli.run_sync(
+            f"""
+            aiperf profile \
+                --model black-forest-labs/FLUX.2-klein-4B \
+                --tokenizer gpt2 \
+                --endpoint-type image_edit \
+                --image-batch-size 1 \
+                --image-width-mean 64 \
+                --image-height-mean 64 \
+                --synthetic-input-tokens-mean 50 \
+                --synthetic-input-tokens-stddev 10 \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+        assert result.request_count == defaults.request_count
+        assert (
+            not hasattr(result.json, "time_to_first_token")
+            or result.json.time_to_first_token is None
+        )
+
+    def test_image_edit_with_extra_inputs(self, cli: AIPerfCLI):
+        """--extra-inputs flow through to multipart form fields."""
+        result = cli.run_sync(
+            f"""
+            aiperf profile \
+                --model black-forest-labs/FLUX.2-klein-4B \
+                --tokenizer gpt2 \
+                --endpoint-type image_edit \
+                --image-batch-size 1 \
+                --image-width-mean 64 \
+                --image-height-mean 64 \
+                --extra-inputs size:512x512 num_inference_steps:4 guidance_scale:1.0 \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+        assert result.request_count == defaults.request_count

--- a/tests/harness/fake_transport.py
+++ b/tests/harness/fake_transport.py
@@ -355,6 +355,14 @@ class FakeTransport(BaseTransport):
                     self._do_simple,
                     build_response=_build_image_response_data,
                 )
+            case EndpointType.IMAGE_EDIT:
+                return await self._dispatch(
+                    payload,
+                    endpoint_type,
+                    ImageGenerationRequest,
+                    self._do_simple,
+                    build_response=_build_image_response_data,
+                )
             case EndpointType.IMAGE_RETRIEVAL:
                 return await self._do_image_retrieval(payload)
             case EndpointType.HUGGINGFACE_GENERATE:

--- a/tests/unit/common/config/test_endpoint_config.py
+++ b/tests/unit/common/config/test_endpoint_config.py
@@ -302,16 +302,16 @@ class TestRequestContentTypeAutoDefault:
         )
         assert config.request_content_type is None
 
-    def test_explicit_json_override_preserved(self):
-        """Explicit application/json on a multipart-required endpoint is left as-is."""
+    def test_explicit_json_on_multipart_endpoint_rejected(self):
+        """application/json must not silently bypass multipart on requires_form_data endpoints."""
         from aiperf.common.enums import RequestContentType
 
-        config = EndpointConfig(
-            model_names=["any"],
-            type=EndpointType.IMAGE_EDIT,
-            request_content_type=RequestContentType.APPLICATION_JSON,
-        )
-        assert config.request_content_type == RequestContentType.APPLICATION_JSON
+        with pytest.raises(ValueError, match="requires multipart/form-data"):
+            EndpointConfig(
+                model_names=["any"],
+                type=EndpointType.IMAGE_EDIT,
+                request_content_type=RequestContentType.APPLICATION_JSON,
+            )
 
     def test_explicit_multipart_on_chat_rejected(self):
         """Explicit multipart on a JSON-only endpoint still raises."""

--- a/tests/unit/common/config/test_endpoint_config.py
+++ b/tests/unit/common/config/test_endpoint_config.py
@@ -269,3 +269,57 @@ class TestWaitForModelValidation:
                 wait_for_model_timeout=60.0,
                 wait_for_model_mode="something-else",  # type: ignore[arg-type]
             )
+
+
+class TestRequestContentTypeAutoDefault:
+    """Auto-default request_content_type for endpoints declaring requires_form_data."""
+
+    def test_image_edit_defaults_to_multipart(self):
+        """image_edit endpoint metadata.requires_form_data is True -> multipart default."""
+        from aiperf.common.enums import RequestContentType
+
+        config = EndpointConfig(
+            model_names=["black-forest-labs/FLUX.2-klein-4B"],
+            type=EndpointType.IMAGE_EDIT,
+        )
+        assert config.request_content_type == RequestContentType.MULTIPART_FORM_DATA
+
+    def test_video_generation_defaults_to_multipart(self):
+        """Same auto-default applies to other requires_form_data endpoints."""
+        from aiperf.common.enums import RequestContentType
+
+        config = EndpointConfig(
+            model_names=["any"],
+            type=EndpointType.VIDEO_GENERATION,
+        )
+        assert config.request_content_type == RequestContentType.MULTIPART_FORM_DATA
+
+    def test_chat_endpoint_keeps_default_none(self):
+        """JSON-only endpoints (requires_form_data=False) stay at None."""
+        config = EndpointConfig(
+            model_names=["gpt2"],
+            type=EndpointType.CHAT,
+        )
+        assert config.request_content_type is None
+
+    def test_explicit_json_override_preserved(self):
+        """Explicit application/json on a multipart-required endpoint is left as-is."""
+        from aiperf.common.enums import RequestContentType
+
+        config = EndpointConfig(
+            model_names=["any"],
+            type=EndpointType.IMAGE_EDIT,
+            request_content_type=RequestContentType.APPLICATION_JSON,
+        )
+        assert config.request_content_type == RequestContentType.APPLICATION_JSON
+
+    def test_explicit_multipart_on_chat_rejected(self):
+        """Explicit multipart on a JSON-only endpoint still raises."""
+        from aiperf.common.enums import RequestContentType
+
+        with pytest.raises(ValueError, match="does not support it"):
+            EndpointConfig(
+                model_names=["gpt2"],
+                type=EndpointType.CHAT,
+                request_content_type=RequestContentType.MULTIPART_FORM_DATA,
+            )

--- a/tests/unit/common/config/test_endpoint_config.py
+++ b/tests/unit/common/config/test_endpoint_config.py
@@ -323,3 +323,27 @@ class TestRequestContentTypeAutoDefault:
                 type=EndpointType.CHAT,
                 request_content_type=RequestContentType.MULTIPART_FORM_DATA,
             )
+
+    def test_explicit_json_on_chat_passes_through(self):
+        """Explicit application/json on a JSON-native endpoint is preserved as-is."""
+        from aiperf.common.enums import RequestContentType
+
+        config = EndpointConfig(
+            model_names=["gpt2"],
+            type=EndpointType.CHAT,
+            request_content_type=RequestContentType.APPLICATION_JSON,
+        )
+        assert config.request_content_type == RequestContentType.APPLICATION_JSON
+
+    def test_explicit_multipart_on_image_edit_passes_through(self):
+        """Explicit multipart on a requires_form_data endpoint is accepted as-is
+        (the auto-default branch is bypassed when the user already set the value).
+        """
+        from aiperf.common.enums import RequestContentType
+
+        config = EndpointConfig(
+            model_names=["any"],
+            type=EndpointType.IMAGE_EDIT,
+            request_content_type=RequestContentType.MULTIPART_FORM_DATA,
+        )
+        assert config.request_content_type == RequestContentType.MULTIPART_FORM_DATA

--- a/tests/unit/endpoints/test_image_edit_endpoint.py
+++ b/tests/unit/endpoints/test_image_edit_endpoint.py
@@ -33,12 +33,14 @@ class TestImageEditEndpoint:
 
     @pytest.fixture
     def model_endpoint(self):
+        """ModelEndpointInfo configured for IMAGE_EDIT against FLUX.2-Klein-4B."""
         return create_model_endpoint(
             EndpointType.IMAGE_EDIT, model_name="black-forest-labs/FLUX.2-klein-4B"
         )
 
     @pytest.fixture
     def endpoint(self, model_endpoint):
+        """ImageEditEndpoint instance backed by a mock transport."""
         return create_endpoint_with_mock_transport(ImageEditEndpoint, model_endpoint)
 
     # ===== format_payload =====
@@ -214,17 +216,20 @@ class TestImageEditEndpoint:
         assert payload["image"]["filename"].endswith(".png")
 
     def test_format_payload_no_turns_raises(self, endpoint, model_endpoint):
+        """Missing turns raises a clear ValueError instead of indexing into an empty list."""
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
         with pytest.raises(ValueError, match="requires at least one turn"):
             endpoint.format_payload(request_info)
 
     def test_format_payload_no_text_raises(self, endpoint, model_endpoint):
+        """Turn without a text prompt is rejected up front."""
         turn = Turn(texts=[], images=[Image(contents=[_PNG_DATA_URL])])
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
         with pytest.raises(ValueError, match="requires text prompt"):
             endpoint.format_payload(request_info)
 
     def test_format_payload_no_image_raises(self, endpoint, model_endpoint):
+        """Turn without a reference image is rejected up front."""
         turn = Turn(texts=[Text(contents=["edit"])], images=[])
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
         with pytest.raises(ValueError, match="requires a reference image"):
@@ -241,6 +246,7 @@ class TestImageEditEndpoint:
             endpoint.format_payload(request_info)
 
     def test_format_payload_invalid_base64_raises(self, endpoint, model_endpoint):
+        """Non-base64 image content surfaces a clear decode error."""
         turn = Turn(
             texts=[Text(contents=["edit"])],
             images=[Image(contents=["not!base64!data"])],
@@ -250,6 +256,7 @@ class TestImageEditEndpoint:
             endpoint.format_payload(request_info)
 
     def test_format_payload_malformed_data_url_raises(self, endpoint, model_endpoint):
+        """Data URL without a comma separator is rejected before b64 decode."""
         turn = Turn(
             texts=[Text(contents=["edit"])],
             images=[Image(contents=["data:image/png;base64"])],
@@ -286,6 +293,7 @@ class TestImageEditEndpoint:
     def test_parse_response_image_formats(
         self, endpoint, json_data, expected_b64, expected_url
     ):
+        """parse_response handles b64_json, url, and revised_prompt entries."""
         mock_response = create_mock_response(json_data=json_data)
         parsed = endpoint.parse_response(mock_response)
 
@@ -295,6 +303,7 @@ class TestImageEditEndpoint:
         assert parsed.data.images[0].url == expected_url
 
     def test_parse_response_metadata_fields(self, endpoint):
+        """Top-level size/quality/output_format/background flow through to ImageResponseData."""
         json_data = {
             "data": [{"b64_json": "img"}],
             "size": "1024x1024",
@@ -312,17 +321,20 @@ class TestImageEditEndpoint:
         assert parsed.data.background == "transparent"
 
     def test_parse_response_no_json_returns_none(self, endpoint):
+        """Non-JSON response bodies return None instead of raising."""
         mock_response = create_mock_response(json_data=None)
         mock_response.get_raw.return_value = ""
         assert endpoint.parse_response(mock_response) is None
 
     def test_parse_response_empty_data_returns_no_images(self, endpoint):
+        """An empty `data` array produces a parsed response with zero images."""
         mock_response = create_mock_response(json_data={"data": []})
         parsed = endpoint.parse_response(mock_response)
         assert parsed is not None
         assert parsed.data.images == []
 
     def test_parse_response_perf_ns_preserved(self, endpoint):
+        """perf_ns from the raw response is preserved on the ParsedResponse."""
         mock_response = create_mock_response(
             perf_ns=999_888_777, json_data={"data": [{"b64_json": "x"}]}
         )
@@ -347,6 +359,7 @@ class TestSniffMimeFromMagicBytes:
         ],
     )  # fmt: skip
     def test_magic_bytes_dispatch(self, magic, expected):
+        """Each supported image format dispatches to the matching MIME, unknown returns None."""
         from aiperf.endpoints.openai_image_edit import _sniff_mime_from_magic_bytes
 
         assert _sniff_mime_from_magic_bytes(magic) == expected

--- a/tests/unit/endpoints/test_image_edit_endpoint.py
+++ b/tests/unit/endpoints/test_image_edit_endpoint.py
@@ -9,7 +9,11 @@ import pytest
 from pydantic import TypeAdapter
 
 from aiperf.common.models import Image, Text, Turn
-from aiperf.endpoints.openai_image_edit import ImageEditEndpoint
+from aiperf.common.models.model_endpoint_info import ModelEndpointInfo
+from aiperf.endpoints.openai_image_edit import (
+    ImageEditEndpoint,
+    _sniff_mime_from_magic_bytes,
+)
 from aiperf.plugin.enums import EndpointType
 from tests.unit.endpoints.conftest import (
     create_endpoint_with_mock_transport,
@@ -32,20 +36,20 @@ class TestImageEditEndpoint:
     """Tests for ImageEditEndpoint format_payload + parse_response."""
 
     @pytest.fixture
-    def model_endpoint(self):
+    def model_endpoint(self) -> ModelEndpointInfo:
         """ModelEndpointInfo configured for IMAGE_EDIT against FLUX.2-Klein-4B."""
         return create_model_endpoint(
             EndpointType.IMAGE_EDIT, model_name="black-forest-labs/FLUX.2-klein-4B"
         )
 
     @pytest.fixture
-    def endpoint(self, model_endpoint):
+    def endpoint(self, model_endpoint: ModelEndpointInfo) -> ImageEditEndpoint:
         """ImageEditEndpoint instance backed by a mock transport."""
         return create_endpoint_with_mock_transport(ImageEditEndpoint, model_endpoint)
 
     # ===== format_payload =====
 
-    def test_format_payload_with_data_url_image(self, endpoint, model_endpoint):
+    def test_format_payload_with_data_url_image(self, endpoint, model_endpoint) -> None:
         """Data URL image content keeps the base64 string in the payload."""
         turn = Turn(
             texts=[Text(contents=["Make the cat blue"])],
@@ -68,7 +72,7 @@ class TestImageEditEndpoint:
 
     def test_format_payload_payload_is_json_serialisable(
         self, endpoint, model_endpoint
-    ):
+    ) -> None:
         """Regression: payload must remain JSON-serialisable.
 
         Raw bytes here break DatasetManager._generate_inputs_json_file
@@ -84,7 +88,9 @@ class TestImageEditEndpoint:
         TypeAdapter(dict).dump_python(payload, mode="json")
         orjson.dumps(payload)
 
-    def test_format_payload_with_raw_base64_image(self, endpoint, model_endpoint):
+    def test_format_payload_with_raw_base64_image(
+        self, endpoint, model_endpoint
+    ) -> None:
         """A raw base64 string (no data URL prefix) sniffs MIME from magic bytes."""
         turn = Turn(
             texts=[Text(contents=["Edit prompt"])],
@@ -99,7 +105,7 @@ class TestImageEditEndpoint:
 
     def test_format_payload_raw_base64_jpeg_sniffed_from_magic_bytes(
         self, endpoint, model_endpoint
-    ):
+    ) -> None:
         """JPEG content without data URL prefix is detected via FFD8FF magic bytes."""
         jpeg_bytes = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9"
         b64 = base64.b64encode(jpeg_bytes).decode("ascii")
@@ -114,7 +120,7 @@ class TestImageEditEndpoint:
         assert payload["image"]["content_type"] == "image/jpeg"
         assert payload["image"]["filename"].endswith(".jpg")
 
-    def test_format_payload_with_http_url_image(self, endpoint, model_endpoint):
+    def test_format_payload_with_http_url_image(self, endpoint, model_endpoint) -> None:
         """An http(s) URL is passed through as the multipart `url` field, no decode."""
         turn = Turn(
             texts=[Text(contents=["edit"])],
@@ -129,7 +135,7 @@ class TestImageEditEndpoint:
 
     def test_format_payload_jpeg_data_url_uses_jpg_filename(
         self, endpoint, model_endpoint
-    ):
+    ) -> None:
         """JPEG data URLs round-trip with a `.jpg` filename and image/jpeg type."""
         b64 = base64.b64encode(b"\xff\xd8\xff\xd9").decode("ascii")
         turn = Turn(
@@ -144,7 +150,7 @@ class TestImageEditEndpoint:
         assert payload["image"]["content_type"] == "image/jpeg"
         assert payload["image"]["b64_data"] == b64
 
-    def test_format_payload_extra_inputs_merged_after_image(self, endpoint):
+    def test_format_payload_extra_inputs_merged_after_image(self, endpoint) -> None:
         """Extra inputs (size, num_inference_steps, guidance_scale, ...) are merged in."""
         model_endpoint = create_model_endpoint(
             EndpointType.IMAGE_EDIT,
@@ -170,7 +176,7 @@ class TestImageEditEndpoint:
         assert payload["guidance_scale"] == 4.0
         assert payload["seed"] == 42
 
-    def test_format_payload_extra_inputs_cannot_overwrite_reserved(self):
+    def test_format_payload_extra_inputs_cannot_overwrite_reserved(self) -> None:
         """Reserved keys (prompt, image, url, mask) are protected from --extra-inputs."""
         model_endpoint = create_model_endpoint(
             EndpointType.IMAGE_EDIT,
@@ -200,7 +206,7 @@ class TestImageEditEndpoint:
 
     def test_format_payload_non_image_data_url_mime_ignored(
         self, endpoint, model_endpoint
-    ):
+    ) -> None:
         """Data URLs that claim a non-image MIME type fall back to magic-byte sniff."""
         b64 = base64.b64encode(_PNG_BYTES).decode("ascii")
         turn = Turn(
@@ -217,7 +223,7 @@ class TestImageEditEndpoint:
 
     def test_format_payload_data_url_without_mime_metadata_sniffs(
         self, endpoint, model_endpoint
-    ):
+    ) -> None:
         """A bare ``data:,<b64>`` URL (no MIME / no semicolon) falls back to magic-byte sniff."""
         b64 = base64.b64encode(_PNG_BYTES).decode("ascii")
         turn = Turn(
@@ -231,27 +237,29 @@ class TestImageEditEndpoint:
         assert payload["image"]["content_type"] == "image/png"
         assert payload["image"]["b64_data"] == b64
 
-    def test_format_payload_no_turns_raises(self, endpoint, model_endpoint):
+    def test_format_payload_no_turns_raises(self, endpoint, model_endpoint) -> None:
         """Missing turns raises a clear ValueError instead of indexing into an empty list."""
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
         with pytest.raises(ValueError, match="requires at least one turn"):
             endpoint.format_payload(request_info)
 
-    def test_format_payload_no_text_raises(self, endpoint, model_endpoint):
+    def test_format_payload_no_text_raises(self, endpoint, model_endpoint) -> None:
         """Turn without a text prompt is rejected up front."""
         turn = Turn(texts=[], images=[Image(contents=[_PNG_DATA_URL])])
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
         with pytest.raises(ValueError, match="requires text prompt"):
             endpoint.format_payload(request_info)
 
-    def test_format_payload_no_image_raises(self, endpoint, model_endpoint):
+    def test_format_payload_no_image_raises(self, endpoint, model_endpoint) -> None:
         """Turn without a reference image is rejected up front."""
         turn = Turn(texts=[Text(contents=["edit"])], images=[])
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
         with pytest.raises(ValueError, match="requires a reference image"):
             endpoint.format_payload(request_info)
 
-    def test_format_payload_empty_image_content_raises(self, endpoint, model_endpoint):
+    def test_format_payload_empty_image_content_raises(
+        self, endpoint, model_endpoint
+    ) -> None:
         """Empty string in turn.images[0].contents[0] raises a clear error."""
         turn = Turn(
             texts=[Text(contents=["edit"])],
@@ -261,7 +269,9 @@ class TestImageEditEndpoint:
         with pytest.raises(ValueError, match="content is empty"):
             endpoint.format_payload(request_info)
 
-    def test_format_payload_invalid_base64_raises(self, endpoint, model_endpoint):
+    def test_format_payload_invalid_base64_raises(
+        self, endpoint, model_endpoint
+    ) -> None:
         """Non-base64 image content surfaces a clear decode error."""
         turn = Turn(
             texts=[Text(contents=["edit"])],
@@ -271,7 +281,9 @@ class TestImageEditEndpoint:
         with pytest.raises(ValueError, match="not valid base64"):
             endpoint.format_payload(request_info)
 
-    def test_format_payload_malformed_data_url_raises(self, endpoint, model_endpoint):
+    def test_format_payload_malformed_data_url_raises(
+        self, endpoint, model_endpoint
+    ) -> None:
         """Data URL without a comma separator is rejected before b64 decode."""
         turn = Turn(
             texts=[Text(contents=["edit"])],
@@ -308,7 +320,7 @@ class TestImageEditEndpoint:
     )  # fmt: skip
     def test_parse_response_image_formats(
         self, endpoint, json_data, expected_b64, expected_url
-    ):
+    ) -> None:
         """parse_response handles b64_json, url, and revised_prompt entries."""
         mock_response = create_mock_response(json_data=json_data)
         parsed = endpoint.parse_response(mock_response)
@@ -318,7 +330,7 @@ class TestImageEditEndpoint:
         assert parsed.data.images[0].b64_json == expected_b64
         assert parsed.data.images[0].url == expected_url
 
-    def test_parse_response_metadata_fields(self, endpoint):
+    def test_parse_response_metadata_fields(self, endpoint) -> None:
         """Top-level size/quality/output_format/background flow through to ImageResponseData."""
         json_data = {
             "data": [{"b64_json": "img"}],
@@ -336,20 +348,20 @@ class TestImageEditEndpoint:
         assert parsed.data.output_format == "png"
         assert parsed.data.background == "transparent"
 
-    def test_parse_response_no_json_returns_none(self, endpoint):
+    def test_parse_response_no_json_returns_none(self, endpoint) -> None:
         """Non-JSON response bodies return None instead of raising."""
         mock_response = create_mock_response(json_data=None)
         mock_response.get_raw.return_value = ""
         assert endpoint.parse_response(mock_response) is None
 
-    def test_parse_response_empty_data_returns_no_images(self, endpoint):
+    def test_parse_response_empty_data_returns_no_images(self, endpoint) -> None:
         """An empty `data` array produces a parsed response with zero images."""
         mock_response = create_mock_response(json_data={"data": []})
         parsed = endpoint.parse_response(mock_response)
         assert parsed is not None
         assert parsed.data.images == []
 
-    def test_parse_response_perf_ns_preserved(self, endpoint):
+    def test_parse_response_perf_ns_preserved(self, endpoint) -> None:
         """perf_ns from the raw response is preserved on the ParsedResponse."""
         mock_response = create_mock_response(
             perf_ns=999_888_777, json_data={"data": [{"b64_json": "x"}]}
@@ -374,8 +386,6 @@ class TestSniffMimeFromMagicBytes:
             pytest.param(b"\x00\x00\x00\x00", None, id="unknown"),
         ],
     )  # fmt: skip
-    def test_magic_bytes_dispatch(self, magic, expected):
+    def test_magic_bytes_dispatch(self, magic: bytes, expected: str | None) -> None:
         """Each supported image format dispatches to the matching MIME, unknown returns None."""
-        from aiperf.endpoints.openai_image_edit import _sniff_mime_from_magic_bytes
-
         assert _sniff_mime_from_magic_bytes(magic) == expected

--- a/tests/unit/endpoints/test_image_edit_endpoint.py
+++ b/tests/unit/endpoints/test_image_edit_endpoint.py
@@ -12,7 +12,7 @@ from aiperf.common.models import Image, Text, Turn
 from aiperf.common.models.model_endpoint_info import ModelEndpointInfo
 from aiperf.endpoints.openai_image_edit import (
     ImageEditEndpoint,
-    _sniff_mime_from_magic_bytes,
+    _sniff_mime_from_b64_prefix,
 )
 from aiperf.plugin.enums import EndpointType
 from tests.unit.endpoints.conftest import (
@@ -133,6 +133,29 @@ class TestImageEditEndpoint:
         assert payload["url"] == "https://example.com/source.png"
         assert "image" not in payload
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "HTTPS://example.com/img.png",
+            "HTTP://example.com/img.png",
+            "Https://Example.COM/img.png",
+        ],
+    )
+    def test_format_payload_url_scheme_is_case_insensitive(
+        self, endpoint, model_endpoint, url: str
+    ) -> None:
+        """RFC-legal uppercase/mixed-case schemes still route to the `url` field."""
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[url])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["url"] == url
+        assert "image" not in payload
+
     def test_format_payload_jpeg_data_url_uses_jpg_filename(
         self, endpoint, model_endpoint
     ) -> None:
@@ -237,6 +260,23 @@ class TestImageEditEndpoint:
         assert payload["image"]["content_type"] == "image/png"
         assert payload["image"]["b64_data"] == b64
 
+    def test_format_payload_svg_xml_data_url_strips_subtype_suffix(
+        self, endpoint, model_endpoint
+    ) -> None:
+        """`image/svg+xml` -> filename `image.svg` (not `image.svg+xml`)."""
+        b64 = base64.b64encode(b"<svg/>").decode("ascii")
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[f"data:image/svg+xml;base64,{b64}"])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["image"]["filename"] == "image.svg"
+        # Content-Type retains the full `image/svg+xml` MIME — only the filename strips.
+        assert payload["image"]["content_type"] == "image/svg+xml"
+
     def test_format_payload_no_turns_raises(self, endpoint, model_endpoint) -> None:
         """Missing turns raises a clear ValueError instead of indexing into an empty list."""
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
@@ -272,13 +312,13 @@ class TestImageEditEndpoint:
     def test_format_payload_invalid_base64_raises(
         self, endpoint, model_endpoint
     ) -> None:
-        """Non-base64 image content surfaces a clear decode error."""
+        """Image content not matching any known b64 prefix raises a clear error."""
         turn = Turn(
             texts=[Text(contents=["edit"])],
             images=[Image(contents=["not!base64!data"])],
         )
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
-        with pytest.raises(ValueError, match="not valid base64"):
+        with pytest.raises(ValueError, match="not a recognized image format"):
             endpoint.format_payload(request_info)
 
     def test_format_payload_malformed_data_url_raises(
@@ -371,21 +411,28 @@ class TestImageEditEndpoint:
         assert parsed.perf_ns == 999_888_777
 
 
-class TestSniffMimeFromMagicBytes:
-    """Covers each branch of _sniff_mime_from_magic_bytes."""
+class TestSniffMimeFromB64Prefix:
+    """Covers each branch of _sniff_mime_from_b64_prefix."""
 
     @pytest.mark.parametrize(
-        "magic,expected",
+        "magic_bytes,expected",
         [
             pytest.param(b"\x89PNG\r\n\x1a\n", "image/png", id="png"),
             pytest.param(b"\xff\xd8\xff\xe0", "image/jpeg", id="jpeg"),
-            pytest.param(b"RIFF\x00\x00\x00\x00WEBP", "image/webp", id="webp"),
+            pytest.param(b"RIFF\x00\x00\x00\x00WEBPVP8 ", "image/webp", id="webp"),
             pytest.param(b"GIF87a", "image/gif", id="gif87a"),
             pytest.param(b"GIF89a", "image/gif", id="gif89a"),
             pytest.param(b"BM\x00\x00", "image/bmp", id="bmp"),
-            pytest.param(b"\x00\x00\x00\x00", None, id="unknown"),
         ],
     )  # fmt: skip
-    def test_magic_bytes_dispatch(self, magic: bytes, expected: str | None) -> None:
-        """Each supported image format dispatches to the matching MIME, unknown returns None."""
-        assert _sniff_mime_from_magic_bytes(magic) == expected
+    def test_b64_prefix_dispatch(self, magic_bytes: bytes, expected: str) -> None:
+        """Each supported image format dispatches via its base64 prefix."""
+        b64 = base64.b64encode(magic_bytes).decode("ascii")
+        assert _sniff_mime_from_b64_prefix(b64) == expected
+
+    def test_unknown_prefix_returns_none(self) -> None:
+        """Non-image b64 content (or non-b64 garbage) returns None."""
+        # "garbage" b64-encoded -> "Z2FyYmFnZQ==" — doesn't match any prefix.
+        assert _sniff_mime_from_b64_prefix("Z2FyYmFnZQ==") is None
+        # Pure non-base64 garbage also returns None (no decode is attempted).
+        assert _sniff_mime_from_b64_prefix("not!base64!data") is None

--- a/tests/unit/endpoints/test_image_edit_endpoint.py
+++ b/tests/unit/endpoints/test_image_edit_endpoint.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ImageEditEndpoint."""
+
+import base64
+
+import pytest
+
+from aiperf.common.models import Image, Text, Turn
+from aiperf.endpoints.openai_image_edit import ImageEditEndpoint
+from aiperf.plugin.enums import EndpointType
+from tests.unit.endpoints.conftest import (
+    create_endpoint_with_mock_transport,
+    create_mock_response,
+    create_model_endpoint,
+    create_request_info,
+)
+
+# Tiny 1x1 PNG used as a stand-in for a real reference image.
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08"
+    b"\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xfc\xcf\xc0\x00"
+    b"\x00\x00\x03\x00\x01\x9a\xa3\x9eS\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+_PNG_B64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+_PNG_DATA_URL = f"data:image/png;base64,{_PNG_B64}"
+
+
+class TestImageEditEndpoint:
+    """Tests for ImageEditEndpoint format_payload + parse_response."""
+
+    @pytest.fixture
+    def model_endpoint(self):
+        return create_model_endpoint(
+            EndpointType.IMAGE_EDIT, model_name="black-forest-labs/FLUX.2-klein-4B"
+        )
+
+    @pytest.fixture
+    def endpoint(self, model_endpoint):
+        return create_endpoint_with_mock_transport(ImageEditEndpoint, model_endpoint)
+
+    # ===== format_payload =====
+
+    def test_format_payload_with_data_url_image(self, endpoint, model_endpoint):
+        """Data URL image content keeps the base64 string in the payload."""
+        turn = Turn(
+            texts=[Text(contents=["Make the cat blue"])],
+            images=[Image(contents=[_PNG_DATA_URL])],
+            model="black-forest-labs/FLUX.2-klein-4B",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["prompt"] == "Make the cat blue"
+        assert payload["model"] == "black-forest-labs/FLUX.2-klein-4B"
+        assert payload["response_format"] == "b64_json"
+        assert payload["n"] == 1
+        image_field = payload["image"]
+        assert image_field["b64_data"] == _PNG_B64
+        assert image_field["filename"].endswith(".png")
+        assert image_field["content_type"] == "image/png"
+        assert "url" not in payload
+
+    def test_format_payload_payload_is_json_serialisable(
+        self, endpoint, model_endpoint
+    ):
+        """Regression: payload must remain JSON-serialisable.
+
+        Raw bytes here break DatasetManager._generate_inputs_json_file
+        (pydantic model_dump(mode='json') + orjson.dumps).
+        """
+        import orjson
+        from pydantic import TypeAdapter
+
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[_PNG_DATA_URL])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+        TypeAdapter(dict).dump_python(payload, mode="json")
+        orjson.dumps(payload)
+
+    def test_format_payload_with_raw_base64_image(self, endpoint, model_endpoint):
+        """A raw base64 string (no data URL prefix) sniffs MIME from magic bytes."""
+        turn = Turn(
+            texts=[Text(contents=["Edit prompt"])],
+            images=[Image(contents=[_PNG_B64])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["image"]["b64_data"] == _PNG_B64
+        assert payload["image"]["content_type"] == "image/png"
+
+    def test_format_payload_raw_base64_jpeg_sniffed_from_magic_bytes(
+        self, endpoint, model_endpoint
+    ):
+        """JPEG content without data URL prefix is detected via FFD8FF magic bytes."""
+        jpeg_bytes = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9"
+        b64 = base64.b64encode(jpeg_bytes).decode("ascii")
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[b64])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["image"]["content_type"] == "image/jpeg"
+        assert payload["image"]["filename"].endswith(".jpg")
+
+    def test_format_payload_with_http_url_image(self, endpoint, model_endpoint):
+        """An http(s) URL is passed through as the multipart `url` field, no decode."""
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=["https://example.com/source.png"])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["url"] == "https://example.com/source.png"
+        assert "image" not in payload
+
+    def test_format_payload_jpeg_data_url_uses_jpg_filename(
+        self, endpoint, model_endpoint
+    ):
+        """JPEG data URLs round-trip with a `.jpg` filename and image/jpeg type."""
+        b64 = base64.b64encode(b"\xff\xd8\xff\xd9").decode("ascii")
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[f"data:image/jpeg;base64,{b64}"])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["image"]["filename"].endswith(".jpg")
+        assert payload["image"]["content_type"] == "image/jpeg"
+        assert payload["image"]["b64_data"] == b64
+
+    def test_format_payload_extra_inputs_merged_after_image(self, endpoint):
+        """Extra inputs (size, num_inference_steps, guidance_scale, ...) are merged in."""
+        model_endpoint = create_model_endpoint(
+            EndpointType.IMAGE_EDIT,
+            model_name="black-forest-labs/FLUX.2-klein-4B",
+            extra=[
+                ("size", "1024x1024"),
+                ("num_inference_steps", 28),
+                ("guidance_scale", 4.0),
+                ("seed", 42),
+            ],
+        )
+        ep = create_endpoint_with_mock_transport(ImageEditEndpoint, model_endpoint)
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[_PNG_DATA_URL])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = ep.format_payload(request_info)
+
+        assert payload["size"] == "1024x1024"
+        assert payload["num_inference_steps"] == 28
+        assert payload["guidance_scale"] == 4.0
+        assert payload["seed"] == 42
+
+    def test_format_payload_extra_inputs_cannot_overwrite_reserved(self):
+        """Reserved keys (prompt, image, url) are protected from --extra-inputs."""
+        model_endpoint = create_model_endpoint(
+            EndpointType.IMAGE_EDIT,
+            model_name="black-forest-labs/FLUX.2-klein-4B",
+            extra=[
+                ("prompt", "HIJACKED"),
+                ("image", "not-a-file"),
+                ("url", "https://malicious.example"),
+                ("size", "512x512"),
+            ],
+        )
+        ep = create_endpoint_with_mock_transport(ImageEditEndpoint, model_endpoint)
+        turn = Turn(
+            texts=[Text(contents=["legitimate prompt"])],
+            images=[Image(contents=[_PNG_DATA_URL])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = ep.format_payload(request_info)
+
+        assert payload["prompt"] == "legitimate prompt"
+        assert payload["image"]["b64_data"] == _PNG_B64
+        assert "url" not in payload
+        assert payload["size"] == "512x512"
+
+    def test_format_payload_no_turns_raises(self, endpoint, model_endpoint):
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
+        with pytest.raises(ValueError, match="requires at least one turn"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_no_text_raises(self, endpoint, model_endpoint):
+        turn = Turn(texts=[], images=[Image(contents=[_PNG_DATA_URL])])
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        with pytest.raises(ValueError, match="requires text prompt"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_no_image_raises(self, endpoint, model_endpoint):
+        turn = Turn(texts=[Text(contents=["edit"])], images=[])
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        with pytest.raises(ValueError, match="requires a reference image"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_invalid_base64_raises(self, endpoint, model_endpoint):
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=["not!base64!data"])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        with pytest.raises(ValueError, match="not valid base64"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_malformed_data_url_raises(self, endpoint, model_endpoint):
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=["data:image/png;base64"])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        with pytest.raises(ValueError, match="Malformed data URL"):
+            endpoint.format_payload(request_info)
+
+    # ===== parse_response =====
+
+    @pytest.mark.parametrize(
+        "json_data,expected_b64,expected_url",
+        [
+            pytest.param(
+                {"data": [{"b64_json": "aGVsbG8="}]},
+                "aGVsbG8=",
+                None,
+                id="b64_only",
+            ),
+            pytest.param(
+                {"data": [{"url": "https://cdn/edit.png"}]},
+                None,
+                "https://cdn/edit.png",
+                id="url_only",
+            ),
+            pytest.param(
+                {"data": [{"b64_json": "aGVsbG8=", "revised_prompt": "X"}]},
+                "aGVsbG8=",
+                None,
+                id="with_revised_prompt",
+            ),
+        ],
+    )  # fmt: skip
+    def test_parse_response_image_formats(
+        self, endpoint, json_data, expected_b64, expected_url
+    ):
+        mock_response = create_mock_response(json_data=json_data)
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert len(parsed.data.images) == 1
+        assert parsed.data.images[0].b64_json == expected_b64
+        assert parsed.data.images[0].url == expected_url
+
+    def test_parse_response_metadata_fields(self, endpoint):
+        json_data = {
+            "data": [{"b64_json": "img"}],
+            "size": "1024x1024",
+            "quality": "hd",
+            "output_format": "png",
+            "background": "transparent",
+        }
+        mock_response = create_mock_response(json_data=json_data)
+        parsed = endpoint.parse_response(mock_response)
+
+        assert parsed is not None
+        assert parsed.data.size == "1024x1024"
+        assert parsed.data.quality == "hd"
+        assert parsed.data.output_format == "png"
+        assert parsed.data.background == "transparent"
+
+    def test_parse_response_no_json_returns_none(self, endpoint):
+        mock_response = create_mock_response(json_data=None)
+        mock_response.get_raw.return_value = ""
+        assert endpoint.parse_response(mock_response) is None
+
+    def test_parse_response_empty_data_returns_no_images(self, endpoint):
+        mock_response = create_mock_response(json_data={"data": []})
+        parsed = endpoint.parse_response(mock_response)
+        assert parsed is not None
+        assert parsed.data.images == []
+
+    def test_parse_response_perf_ns_preserved(self, endpoint):
+        mock_response = create_mock_response(
+            perf_ns=999_888_777, json_data={"data": [{"b64_json": "x"}]}
+        )
+        parsed = endpoint.parse_response(mock_response)
+        assert parsed is not None
+        assert parsed.perf_ns == 999_888_777

--- a/tests/unit/endpoints/test_image_edit_endpoint.py
+++ b/tests/unit/endpoints/test_image_edit_endpoint.py
@@ -215,6 +215,22 @@ class TestImageEditEndpoint:
         assert payload["image"]["content_type"] == "image/png"
         assert payload["image"]["filename"].endswith(".png")
 
+    def test_format_payload_data_url_without_mime_metadata_sniffs(
+        self, endpoint, model_endpoint
+    ):
+        """A bare ``data:,<b64>`` URL (no MIME / no semicolon) falls back to magic-byte sniff."""
+        b64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[f"data:,{b64}"])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["image"]["content_type"] == "image/png"
+        assert payload["image"]["b64_data"] == b64
+
     def test_format_payload_no_turns_raises(self, endpoint, model_endpoint):
         """Missing turns raises a clear ValueError instead of indexing into an empty list."""
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[])

--- a/tests/unit/endpoints/test_image_edit_endpoint.py
+++ b/tests/unit/endpoints/test_image_edit_endpoint.py
@@ -4,7 +4,9 @@
 
 import base64
 
+import orjson
 import pytest
+from pydantic import TypeAdapter
 
 from aiperf.common.models import Image, Text, Turn
 from aiperf.endpoints.openai_image_edit import ImageEditEndpoint
@@ -70,9 +72,6 @@ class TestImageEditEndpoint:
         Raw bytes here break DatasetManager._generate_inputs_json_file
         (pydantic model_dump(mode='json') + orjson.dumps).
         """
-        import orjson
-        from pydantic import TypeAdapter
-
         turn = Turn(
             texts=[Text(contents=["edit"])],
             images=[Image(contents=[_PNG_DATA_URL])],
@@ -170,7 +169,7 @@ class TestImageEditEndpoint:
         assert payload["seed"] == 42
 
     def test_format_payload_extra_inputs_cannot_overwrite_reserved(self):
-        """Reserved keys (prompt, image, url) are protected from --extra-inputs."""
+        """Reserved keys (prompt, image, url, mask) are protected from --extra-inputs."""
         model_endpoint = create_model_endpoint(
             EndpointType.IMAGE_EDIT,
             model_name="black-forest-labs/FLUX.2-klein-4B",
@@ -178,6 +177,7 @@ class TestImageEditEndpoint:
                 ("prompt", "HIJACKED"),
                 ("image", "not-a-file"),
                 ("url", "https://malicious.example"),
+                ("mask", "/tmp/mask.png"),
                 ("size", "512x512"),
             ],
         )
@@ -193,7 +193,25 @@ class TestImageEditEndpoint:
         assert payload["prompt"] == "legitimate prompt"
         assert payload["image"]["b64_data"] == _PNG_B64
         assert "url" not in payload
+        assert "mask" not in payload
         assert payload["size"] == "512x512"
+
+    def test_format_payload_non_image_data_url_mime_ignored(
+        self, endpoint, model_endpoint
+    ):
+        """Data URLs that claim a non-image MIME type fall back to magic-byte sniff."""
+        b64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[f"data:text/html;base64,{b64}"])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        # Magic bytes (PNG signature) should win over the bogus header.
+        assert payload["image"]["content_type"] == "image/png"
+        assert payload["image"]["filename"].endswith(".png")
 
     def test_format_payload_no_turns_raises(self, endpoint, model_endpoint):
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
@@ -210,6 +228,16 @@ class TestImageEditEndpoint:
         turn = Turn(texts=[Text(contents=["edit"])], images=[])
         request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
         with pytest.raises(ValueError, match="requires a reference image"):
+            endpoint.format_payload(request_info)
+
+    def test_format_payload_empty_image_content_raises(self, endpoint, model_endpoint):
+        """Empty string in turn.images[0].contents[0] raises a clear error."""
+        turn = Turn(
+            texts=[Text(contents=["edit"])],
+            images=[Image(contents=[""])],
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        with pytest.raises(ValueError, match="content is empty"):
             endpoint.format_payload(request_info)
 
     def test_format_payload_invalid_base64_raises(self, endpoint, model_endpoint):
@@ -301,3 +329,24 @@ class TestImageEditEndpoint:
         parsed = endpoint.parse_response(mock_response)
         assert parsed is not None
         assert parsed.perf_ns == 999_888_777
+
+
+class TestSniffMimeFromMagicBytes:
+    """Covers each branch of _sniff_mime_from_magic_bytes."""
+
+    @pytest.mark.parametrize(
+        "magic,expected",
+        [
+            pytest.param(b"\x89PNG\r\n\x1a\n", "image/png", id="png"),
+            pytest.param(b"\xff\xd8\xff\xe0", "image/jpeg", id="jpeg"),
+            pytest.param(b"RIFF\x00\x00\x00\x00WEBP", "image/webp", id="webp"),
+            pytest.param(b"GIF87a", "image/gif", id="gif87a"),
+            pytest.param(b"GIF89a", "image/gif", id="gif89a"),
+            pytest.param(b"BM\x00\x00", "image/bmp", id="bmp"),
+            pytest.param(b"\x00\x00\x00\x00", None, id="unknown"),
+        ],
+    )  # fmt: skip
+    def test_magic_bytes_dispatch(self, magic, expected):
+        from aiperf.endpoints.openai_image_edit import _sniff_mime_from_magic_bytes
+
+        assert _sniff_mime_from_magic_bytes(magic) == expected

--- a/tests/unit/transports/test_aiohttp_client.py
+++ b/tests/unit/transports/test_aiohttp_client.py
@@ -584,3 +584,52 @@ class TestFirstTokenCallback:
         # All messages should be collected
         assert len(record.responses) == 2
         assert record.error is None
+
+
+class TestExpectedRequestBodySize:
+    """Tests for _expected_request_body_size."""
+
+    def test_bytes_returns_len(self) -> None:
+        from aiperf.transports.aiohttp_client import _expected_request_body_size
+
+        assert _expected_request_body_size(b"hello") == 5
+
+    def test_form_data_returns_serialized_size(self) -> None:
+        """FormData with text + binary fields reports a deterministic byte size.
+
+        Without this, on_request_sent never fires for multipart bodies and
+        cancel_after_ns waits until the send-timeout safety net.
+        """
+        from aiperf.transports.aiohttp_client import _expected_request_body_size
+
+        form = aiohttp.FormData()
+        form.add_field("prompt", "edit this")
+        form.add_field(
+            "image",
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\x10",
+            filename="ref.png",
+            content_type="image/png",
+        )
+
+        size = _expected_request_body_size(form)
+        assert isinstance(size, int)
+        assert size > 0
+
+    def test_unsupported_payload_returns_none(self) -> None:
+        from aiperf.transports.aiohttp_client import _expected_request_body_size
+
+        assert _expected_request_body_size("a json string") is None
+        assert _expected_request_body_size(None) is None
+        assert _expected_request_body_size({"k": "v"}) is None
+
+    def test_form_data_serialization_failure_returns_none(self) -> None:
+        """A FormData that aiohttp cannot serialize falls back to None instead
+        of raising, so one misshapen payload never blocks the cancel path.
+        """
+        from aiperf.transports.aiohttp_client import _expected_request_body_size
+
+        class _BrokenFormData(aiohttp.FormData):
+            def __call__(self) -> object:  # type: ignore[override]
+                raise ValueError("simulated aiohttp serialization failure")
+
+        assert _expected_request_body_size(_BrokenFormData()) is None

--- a/tests/unit/transports/test_aiohttp_client.py
+++ b/tests/unit/transports/test_aiohttp_client.py
@@ -590,6 +590,7 @@ class TestExpectedRequestBodySize:
     """Tests for _expected_request_body_size."""
 
     def test_bytes_returns_len(self) -> None:
+        """Bytes payloads use len() directly as the body size."""
         from aiperf.transports.aiohttp_client import _expected_request_body_size
 
         assert _expected_request_body_size(b"hello") == 5
@@ -616,6 +617,7 @@ class TestExpectedRequestBodySize:
         assert size > 0
 
     def test_unsupported_payload_returns_none(self) -> None:
+        """Strings, None, and dicts return None — only bytes/FormData are sized."""
         from aiperf.transports.aiohttp_client import _expected_request_body_size
 
         assert _expected_request_body_size("a json string") is None

--- a/tests/unit/transports/test_aiohttp_transport.py
+++ b/tests/unit/transports/test_aiohttp_transport.py
@@ -678,6 +678,61 @@ class TestAioHttpTransportCancellation:
         await transport.stop()
 
     @pytest.mark.asyncio
+    async def test_cancellation_works_with_multipart_form_data_body(
+        self, model_endpoint_non_streaming
+    ):
+        """Regression: cancel_after_ns must honor multipart bodies.
+
+        Before the fix, FormData bodies left expected_request_body_size=None,
+        so on_request_sent never fired and cancellation surfaced as
+        RequestSendTimeout instead of RequestCancellationError.
+        """
+        from aiperf.common.enums import RequestContentType
+
+        # Reuse the standard non-streaming endpoint, just flip its content-type.
+        model_endpoint_non_streaming.endpoint.request_content_type = (
+            RequestContentType.MULTIPART_FORM_DATA
+        )
+
+        transport = AioHttpTransport(model_endpoint=model_endpoint_non_streaming)
+        await transport.initialize()
+
+        capture_session, holder = self._create_mock_session_factory(
+            complete_immediately=False
+        )
+
+        with patch("aiohttp.ClientSession") as mock_session_class:
+            mock_session_class.side_effect = capture_session
+
+            cancel_after_ns = 100_000_000  # 100ms
+            request_info = create_request_info(
+                model_endpoint_non_streaming, cancel_after_ns=cancel_after_ns
+            )
+            # image_edit-shaped payload: text + base64 file field.
+            payload = {
+                "prompt": "edit",
+                "image": {
+                    "b64_data": "iVBORw0KGgoAAAANSUhEUg==",
+                    "filename": "ref.png",
+                    "content_type": "image/png",
+                },
+            }
+
+            task = asyncio.create_task(transport.send_request(request_info, payload))
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            await self._fire_request_sent_event(holder["trace_config"], body_size=4096)
+
+            record = await task
+
+        assert record.error is not None, f"Expected cancellation error, got: {record}"
+        assert record.error.type == "RequestCancellationError", (
+            f"Multipart cancellation regressed to {record.error.type!r}"
+        )
+        await transport.stop()
+
+    @pytest.mark.asyncio
     async def test_send_request_cancellation_record_has_timing(
         self, model_endpoint_non_streaming
     ):

--- a/tests/unit/transports/test_form_data.py
+++ b/tests/unit/transports/test_form_data.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for AioHttpTransport._build_form_data multipart serialization."""
+
+import base64
+
+import aiohttp
+import pytest
+
+from aiperf.transports.aiohttp_transport import AioHttpTransport
+
+
+class TestBuildFormData:
+    """Tests for the static _build_form_data helper."""
+
+    def test_text_fields_preserved(self):
+        """Plain text fields are added as string-valued form parts."""
+        form = AioHttpTransport._build_form_data(
+            {"prompt": "edit", "size": "1024x1024", "n": 2}
+        )
+        assert isinstance(form, aiohttp.FormData)
+
+        fields = list(form._fields)
+        assert {f[0]["name"] for f in fields} == {"prompt", "size", "n"}
+        for opts, _headers, value in fields:
+            assert "filename" not in opts
+            assert isinstance(value, str)
+
+    def test_bool_fields_lowercased(self):
+        """Booleans are stringified as `true`/`false` so backends accept them."""
+        form = AioHttpTransport._build_form_data(
+            {"enable_teacache": True, "stream": False}
+        )
+        values = {f[0]["name"]: f[2] for f in form._fields}
+        assert values == {"enable_teacache": "true", "stream": "false"}
+
+    def test_none_values_skipped(self):
+        """Fields with None are dropped (mirrors the JSON path's omission)."""
+        form = AioHttpTransport._build_form_data({"prompt": "p", "seed": None})
+        names = [f[0]["name"] for f in form._fields]
+        assert names == ["prompt"]
+
+    def test_b64_data_dict_decoded_to_file_upload(self):
+        """Dict with `b64_data` key is base64-decoded and emitted as a file part."""
+        png = b"\x89PNG\r\n\x1a\n\x00"
+        b64 = base64.b64encode(png).decode("ascii")
+        form = AioHttpTransport._build_form_data(
+            {
+                "prompt": "edit",
+                "image": {
+                    "b64_data": b64,
+                    "filename": "ref.png",
+                    "content_type": "image/png",
+                },
+            }
+        )
+        by_name = {f[0]["name"]: (f[0], f[1], f[2]) for f in form._fields}
+        assert by_name["prompt"][2] == "edit"
+        image_opts, image_headers, image_value = by_name["image"]
+        assert image_value == png
+        assert image_opts["filename"] == "ref.png"
+        assert image_headers["Content-Type"] == "image/png"
+
+    def test_b64_data_dict_defaults_filename_and_content_type(self):
+        """Missing filename/content_type fall back to safe defaults."""
+        b64 = base64.b64encode(b"\x00\x01\x02").decode("ascii")
+        form = AioHttpTransport._build_form_data({"image": {"b64_data": b64}})
+        opts, headers, value = form._fields[0]
+        assert opts["name"] == "image"
+        assert opts["filename"] == "image"
+        assert headers["Content-Type"] == "application/octet-stream"
+        assert value == b"\x00\x01\x02"
+
+    def test_b64_data_invalid_raises(self):
+        """Malformed base64 surfaces as a clear ValueError."""
+        with pytest.raises(ValueError, match="not valid base64"):
+            AioHttpTransport._build_form_data({"image": {"b64_data": "!!notb64!!"}})
+
+    def test_dict_without_b64_data_falls_back_to_string(self):
+        """A non-file-shaped dict is stringified, not treated as a file upload.
+
+        Guards against accidentally turning JSON-shaped extras into file fields.
+        """
+        form = AioHttpTransport._build_form_data({"meta": {"foo": "bar"}})
+        opts, _headers, value = form._fields[0]
+        assert opts["name"] == "meta"
+        assert "filename" not in opts
+        assert isinstance(value, str)

--- a/tests/unit/transports/test_form_data.py
+++ b/tests/unit/transports/test_form_data.py
@@ -86,3 +86,20 @@ class TestBuildFormData:
         assert opts["name"] == "meta"
         assert "filename" not in opts
         assert isinstance(value, str)
+
+    def test_text_only_payload_still_encodes_as_multipart(self):
+        """Text-only FormData must encode as multipart/form-data, not urlencoded.
+
+        Without ``default_to_multipart=True``, aiohttp treats text-only forms as
+        ``application/x-www-form-urlencoded``, which breaks the contract for
+        endpoints that declare ``requires_form_data: true`` (e.g., image_edit
+        with a ``url`` field instead of an inline image).
+        """
+        form = AioHttpTransport._build_form_data(
+            {"prompt": "edit", "url": "https://example.com/source.png"}
+        )
+        payload = form()
+        content_type = payload.headers.get("Content-Type", "")
+        assert content_type.startswith("multipart/form-data"), (
+            f"text-only FormData must be multipart, got {content_type!r}"
+        )


### PR DESCRIPTION
Adds a new `image_edit` endpoint type that POSTs a prompt + reference image to `/v1/images/edits` as multipart/form-data, compatible with SGLang's FLUX.2 unified diffusion serving and OpenAI's image-edit API shape.

- New `ImageEditEndpoint` (`format_payload` + `parse_response`) under `aiperf.endpoints.openai_image_edit`.
- Extends `AioHttpTransport._build_form_data` to recognize a JSON-serializable `{"b64_data": ..., "filename": ..., "content_type": ...}` shape so the same payload can flow into both `inputs.json` (as base64) and the multipart body (decoded to bytes at send time).
- Auto-defaults `request_content_type` to `multipart/form-data` for any endpoint with `requires_form_data: true` (also covers `video_generation`), removing a footgun where forgetting `--request-content-type` produced a confusing serialization error.
- Mock server `/v1/images/edits` route exercises full multipart parsing end-to-end.
- Tests: 57 new unit tests + 2 component integration tests, including a regression test for the JSON-serializability of the payload.
- Docs: `docs/plugins/plugin-system.md` and (auto-generated) `docs/cli-options.md` updated.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible image edit endpoint with multipart/form-data image upload support.

* **Documentation**
  * CLI and plugin docs updated to list the new image_edit endpoint and clarify form-data endpoint guidance.

* **Bug Fixes**
  * Improved content-type validation for form-data endpoints and fixed request-size/tracing and cancellation behavior for multipart/FormData requests.

* **Tests**
  * Added unit and integration tests covering image edits, form-data handling, and multipart request behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/906)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->