### PR TITLE
feat(gpu-telemetry): add AMD ROCm telemetry collector via amdsmi

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -985,7 +985,7 @@ Enable verbose output for accuracy evaluation, showing per-problem grading detai
 
 #### `--gpu-telemetry` `<list>`
 
-Enable GPU telemetry console display and optionally specify: (1) 'pynvml' to use local pynvml library instead of DCGM HTTP endpoints, (2) 'dashboard' for realtime dashboard mode, (3) custom DCGM exporter URLs (e.g., http://node1:9401/metrics), (4) custom metrics CSV file (e.g., custom_gpu_metrics.csv). Default: DCGM mode with localhost:9400 and localhost:9401 endpoints. Examples: --gpu-telemetry pynvml | --gpu-telemetry dashboard node1:9400.
+Enable GPU telemetry console display and optionally specify: (1) 'pynvml' to use local pynvml library instead of DCGM HTTP endpoints, (2) 'amdsmi' to use local amdsmi library for AMD ROCm GPUs, (3) 'dashboard' for realtime dashboard mode, (4) custom DCGM exporter URLs (e.g., http://node1:9401/metrics), (5) custom metrics CSV file (e.g., custom_gpu_metrics.csv). Default: DCGM mode with localhost:9400 and localhost:9401 endpoints. Examples: --gpu-telemetry pynvml | --gpu-telemetry amdsmi | --gpu-telemetry dashboard node1:9400.
 
 #### `--no-gpu-telemetry`
 

--- a/docs/tutorials/gpu-telemetry.md
+++ b/docs/tutorials/gpu-telemetry.md
@@ -53,7 +53,7 @@ AIPerf provides GPU telemetry collection with the `--gpu-telemetry` flag. Here's
 >
 > **pynvml mode:** When using `--gpu-telemetry pynvml`, DCGM endpoints are NOT used. Metrics are collected directly from local GPUs via the nvidia-ml-py library.
 >
-> **amdsmi mode:** When using `--gpu-telemetry amdsmi`, DCGM endpoints are NOT used. Metrics are collected directly from local AMD GPUs via the amdsmi library. AMD GPUs report a slightly different metric set than NVIDIA: `mm_activity` is generally `'N/A'` on Instinct datacenter parts, so `encoder_utilization` / `decoder_utilization` are typically empty; `xid_errors` reflects ECC uncorrectable count; `power_violation` is accumulated client-side from `throttle_status` (microseconds spent throttled).
+> **amdsmi mode:** When using `--gpu-telemetry amdsmi`, DCGM endpoints are NOT used. Metrics are collected directly from local AMD GPUs via the amdsmi library and emitted under vendor-namespaced `amd_*` field names (`amd_power`, `amd_gfx_activity`, `amd_temperature`, etc.) rather than NVML-shaped names. On Instinct datacenter parts `amd_mm_activity` is generally absent (sensor returns `'N/A'`); `amd_throttle_status` is a 0.0/1.0 snapshot per scrape (amdsmi exposes a boolean state, not a duration counter).
 >
 > To completely disable GPU telemetry collection, use `--no-gpu-telemetry`.
 
@@ -459,17 +459,19 @@ aiperf profile \
 
 ### Metrics Collected via amdsmi
 
+AMD signals are emitted under their own vendor-namespaced field names (not aliased onto NVML-shaped names) because the underlying sensors do not always measure the same physical quantity (e.g. amdsmi `gfx_activity` and NVML `sm_utilization` sample at different scopes).
+
 | Metric | Source | Notes |
 |---|---|---|
-| `gpu_power_usage` (W) | `amdsmi_get_power_info().current_socket_power` | Already in W; no scaling. |
-| `energy_consumption` (MJ) | `amdsmi_get_energy_count()` | `accumulator * counter_resolution` (µJ) → MJ. |
-| `gpu_utilization` (%) | `amdsmi_get_gpu_activity().gfx_activity` | Mirrored to `sm_utilization` (no separate AMD analog). |
-| `mem_utilization` (%) | `amdsmi_get_gpu_activity().umc_activity` | UMC activity. |
-| `gpu_memory_used` (GB) | `amdsmi_get_gpu_memory_usage(VRAM)` | bytes → GB. |
-| `gpu_temperature` (°C) | `amdsmi_get_temp_metric(JUNCTION)` | Falls back to HOTSPOT. EDGE is unsupported on Instinct GPUs. |
-| `xid_errors` | `amdsmi_get_gpu_total_ecc_count().uncorrectable_count` | Closest analog to NVIDIA XID. |
-| `power_violation` (µs) | Accumulated from `throttle_status` between scrapes | AMD only exposes a boolean status; duration is computed client-side. |
-| `encoder_utilization`, `decoder_utilization`, `jpg_utilization` | (`mm_activity`) | Generally `'N/A'` on Instinct datacenter GPUs; fields will be empty. |
+| `amd_power` (W) | `amdsmi_get_power_info().current_socket_power` | Already in W; no scaling. Falls back to `average_socket_power` if `current_socket_power` is `'N/A'`. |
+| `amd_energy_consumption` (MJ) | `amdsmi_get_energy_count()` | `accumulator * counter_resolution` (µJ) → MJ. Cumulative counter — accumulator computes a delta against the pre-profile baseline. Reads `energy_accumulator` first; falls back to the older `power` field name on ROCm < 6.2. |
+| `amd_gfx_activity` (%) | `amdsmi_get_gpu_activity().gfx_activity` | Graphics engine activity. |
+| `amd_umc_activity` (%) | `amdsmi_get_gpu_activity().umc_activity` | Memory controller activity. |
+| `amd_mm_activity` (%) | `amdsmi_get_gpu_activity().mm_activity` | Multimedia engine activity. Generally `'N/A'` on Instinct datacenter GPUs — field will be absent rather than emitted as zero. |
+| `amd_memory_used` (GB) | `amdsmi_get_gpu_memory_usage(VRAM)` | bytes → GB. |
+| `amd_temperature` (°C) | `amdsmi_get_temp_metric(JUNCTION)` | Falls back to HOTSPOT. EDGE is unsupported on Instinct GPUs. Unit conversion is gated on `amdsmi.__version__` (≥ 26.x already returns Celsius; older bindings return millidegrees and are divided by 1000). |
+| `amd_ecc_uncorrectable` | `amdsmi_get_gpu_total_ecc_count().uncorrectable_count` | Cumulative uncorrectable ECC error count. Counter — accumulator computes a delta. |
+| `amd_throttle_status` | `amdsmi_get_gpu_metrics_info().throttle_status` (and `indep_throttle_status`) | 0.0/1.0 snapshot per scrape — 1.0 if any throttle indicator is active. amdsmi exposes a state (bool/bitfield), not a duration counter; a fraction-throttled summary can be derived from the average. Field is left absent when both signals return `'N/A'` (sensor unsupported), so "unsupported" is not silently reported as "not throttled". |
 
 ### Comparing DCGM vs pynvml vs amdsmi
 
@@ -478,8 +480,9 @@ aiperf profile \
 | Hardware | NVIDIA | NVIDIA | AMD ROCm |
 | Setup complexity | Requires container/service | `pip install nvidia-ml-py` | Ships with ROCm; install wheel from `/opt/rocm/share/amd_smi/` if missing |
 | Multi-node support | Yes (HTTP) | No (local) | No (local) |
-| Encoder/decoder util | Yes | Yes | No (Instinct GPUs report N/A) |
-| XID-style error reporting | Yes | No | ECC uncorrectable count |
+| Field naming | `gpu_*` (NVML-shaped) | `gpu_*` (NVML-shaped) | `amd_*` (vendor-namespaced) |
+| Encoder/decoder util | Yes | Yes | No (Instinct GPUs report `'N/A'`) |
+| Error reporting | XID errors | (none) | ECC uncorrectable count (`amd_ecc_uncorrectable`) |
 | SM-level utilization | Yes (DCGM_FI_PROF_SM_ACTIVE) | Yes (GPM API) | Aliased to `gfx_activity` |
 
 ---

--- a/docs/tutorials/gpu-telemetry.md
+++ b/docs/tutorials/gpu-telemetry.md
@@ -21,9 +21,12 @@ If you're using **any other inference backend**, you'll need to set up DCGM sepa
 ### Path 3: Local GPU Monitoring (pynvml)
 If you want **simple local GPU monitoring without DCGM**, use `--gpu-telemetry pynvml`. This uses NVIDIA's nvidia-ml-py Python library (commonly known as pynvml) to collect metrics directly from the GPU driver. No HTTP endpoints or additional containers required.
 
+### Path 4: AMD ROCm GPUs (amdsmi)
+If you're benchmarking against an inference server running on **AMD ROCm GPUs** (Instinct MI300X, MI355X, etc.), use `--gpu-telemetry amdsmi`. This uses the `amdsmi` Python bindings shipped with ROCm to collect metrics directly from the AMD driver. No HTTP endpoints required. Install the bindings via `pip install /opt/rocm/share/amd_smi/amdsmi-*.whl` if not already present (they ship with ROCm).
+
 ## Prerequisites
 
-- NVIDIA GPU with CUDA support
+- NVIDIA GPU with CUDA support, **or** AMD GPU with ROCm 6.x/7.x
 - Docker installed and configured
 
 ## Understanding GPU Telemetry in AIPerf
@@ -42,12 +45,15 @@ AIPerf provides GPU telemetry collection with the `--gpu-telemetry` flag. Here's
 | **Custom metrics** | `aiperf profile --model MODEL ... --gpu-telemetry custom_gpu_metrics.csv` | `http://localhost:9400/metrics` + `http://localhost:9401/metrics` + [custom metrics from CSV](#customizing-displayed-metrics) | ✅ Yes | ❌ No | ✅ Yes |
 | **pynvml mode** | `aiperf profile --model MODEL ... --gpu-telemetry pynvml` | Local GPUs via pynvml library ([see pynvml section](#3-using-pynvml-local-gpu-monitoring)) | ✅ Yes | ❌ No | ✅ Yes |
 | **pynvml + dashboard** | `aiperf profile --model MODEL ... --gpu-telemetry pynvml dashboard` | Local GPUs via pynvml library | ✅ Yes | ✅ Yes ([see dashboard](#real-time-dashboard-view)) | ✅ Yes |
+| **amdsmi mode** | `aiperf profile --model MODEL ... --gpu-telemetry amdsmi` | Local AMD ROCm GPUs via amdsmi library | ✅ Yes | ❌ No | ✅ Yes |
 | **Disabled** | `aiperf profile --model MODEL ... --no-gpu-telemetry` | None | ❌ No | ❌ No | ❌ No |
 
 > [!WARNING]
 > **DCGM mode (default):** The default endpoints `http://localhost:9400/metrics` and `http://localhost:9401/metrics` are always attempted for telemetry collection, regardless of whether the `--gpu-telemetry` flag is used. The flag primarily controls whether metrics are displayed on the console and allows you to specify additional custom DCGM exporter endpoints.
 >
 > **pynvml mode:** When using `--gpu-telemetry pynvml`, DCGM endpoints are NOT used. Metrics are collected directly from local GPUs via the nvidia-ml-py library.
+>
+> **amdsmi mode:** When using `--gpu-telemetry amdsmi`, DCGM endpoints are NOT used. Metrics are collected directly from local AMD GPUs via the amdsmi library. AMD GPUs report a slightly different metric set than NVIDIA: `mm_activity` is generally `'N/A'` on Instinct datacenter parts, so `encoder_utilization` / `decoder_utilization` are typically empty; `xid_errors` reflects ECC uncorrectable count; `power_violation` is accumulated client-side from `throttle_status` (microseconds spent throttled).
 >
 > To completely disable GPU telemetry collection, use `--no-gpu-telemetry`.
 
@@ -428,6 +434,53 @@ The nvidia-ml-py library (pynvml) collects the following metrics directly from t
 | Metrics granularity | High (profiling-level metrics) | Standard (driver-level metrics) |
 | Kubernetes integration | Native with dcgm-exporter | Not applicable |
 | XID error reporting | Yes | No |
+
+---
+
+## 4. Using amdsmi (Local AMD ROCm GPU Monitoring)
+
+For inference workloads on **AMD Instinct GPUs** (MI300X, MI355X, etc.), use `--gpu-telemetry amdsmi`. This collects metrics directly from local AMD GPUs via the `amdsmi` Python library shipped with ROCm.
+
+### When to Use amdsmi
+
+- Benchmarking against vLLM-ROCm, SGLang-ROCm, TGI, or any ROCm-backed inference server running on the same machine as AIPerf.
+- Local single-node monitoring with no need for HTTP exporters.
+
+### Run AIPerf with amdsmi
+
+```bash
+aiperf profile \
+    --model meta-llama/Llama-3.1-8B-Instruct \
+    --endpoint-type chat \
+    --url http://localhost:8000 \
+    --concurrency 16 --request-count 200 \
+    --gpu-telemetry amdsmi
+```
+
+### Metrics Collected via amdsmi
+
+| Metric | Source | Notes |
+|---|---|---|
+| `gpu_power_usage` (W) | `amdsmi_get_power_info().current_socket_power` | Already in W; no scaling. |
+| `energy_consumption` (MJ) | `amdsmi_get_energy_count()` | `accumulator * counter_resolution` (µJ) → MJ. |
+| `gpu_utilization` (%) | `amdsmi_get_gpu_activity().gfx_activity` | Mirrored to `sm_utilization` (no separate AMD analog). |
+| `mem_utilization` (%) | `amdsmi_get_gpu_activity().umc_activity` | UMC activity. |
+| `gpu_memory_used` (GB) | `amdsmi_get_gpu_memory_usage(VRAM)` | bytes → GB. |
+| `gpu_temperature` (°C) | `amdsmi_get_temp_metric(JUNCTION)` | Falls back to HOTSPOT. EDGE is unsupported on Instinct GPUs. |
+| `xid_errors` | `amdsmi_get_gpu_total_ecc_count().uncorrectable_count` | Closest analog to NVIDIA XID. |
+| `power_violation` (µs) | Accumulated from `throttle_status` between scrapes | AMD only exposes a boolean status; duration is computed client-side. |
+| `encoder_utilization`, `decoder_utilization`, `jpg_utilization` | (`mm_activity`) | Generally `'N/A'` on Instinct datacenter GPUs; fields will be empty. |
+
+### Comparing DCGM vs pynvml vs amdsmi
+
+| Feature | DCGM | pynvml | amdsmi |
+|---|---|---|---|
+| Hardware | NVIDIA | NVIDIA | AMD ROCm |
+| Setup complexity | Requires container/service | `pip install nvidia-ml-py` | Ships with ROCm; install wheel from `/opt/rocm/share/amd_smi/` if missing |
+| Multi-node support | Yes (HTTP) | No (local) | No (local) |
+| Encoder/decoder util | Yes | Yes | No (Instinct GPUs report N/A) |
+| XID-style error reporting | Yes | No | ECC uncorrectable count |
+| SM-level utilization | Yes (DCGM_FI_PROF_SM_ACTIVE) | Yes (GPM API) | Aliased to `gfx_activity` |
 
 ---
 

--- a/src/aiperf/common/config/user_config.py
+++ b/src/aiperf/common/config/user_config.py
@@ -137,11 +137,18 @@ _LOCAL_COLLECTOR_INSTALL_HINTS: dict[GPUTelemetryCollectorType, str] = {
 def _ensure_local_collector_importable(
     collector_type: GPUTelemetryCollectorType,
 ) -> None:
-    """Verify that the Python bindings for a local collector are importable."""
+    """Verify that the Python bindings for a local collector are importable.
+
+    Catches broader than just ``ImportError``: amdsmi (and to a lesser extent
+    pynvml) can also raise ``OSError`` when the wheel is installed but the
+    underlying native library (libamd_smi, libnvidia-ml) is missing or fails
+    to load. Surface those failures with the same friendly install hint
+    instead of leaking an internal traceback.
+    """
     module_name = _LOCAL_ONLY_COLLECTORS[collector_type]
     try:
         import_module(module_name)
-    except ImportError as e:
+    except (ImportError, OSError) as e:
         raise ValueError(_LOCAL_COLLECTOR_INSTALL_HINTS[collector_type]) from e
 
 

--- a/src/aiperf/common/config/user_config.py
+++ b/src/aiperf/common/config/user_config.py
@@ -656,11 +656,12 @@ class UserConfig(BaseConfig):
             description=(
                 "Enable GPU telemetry console display and optionally specify: "
                 "(1) 'pynvml' to use local pynvml library instead of DCGM HTTP endpoints, "
-                "(2) 'dashboard' for realtime dashboard mode, "
-                "(3) custom DCGM exporter URLs (e.g., http://node1:9401/metrics), "
-                "(4) custom metrics CSV file (e.g., custom_gpu_metrics.csv). "
+                "(2) 'amdsmi' to use local amdsmi library for AMD ROCm GPUs, "
+                "(3) 'dashboard' for realtime dashboard mode, "
+                "(4) custom DCGM exporter URLs (e.g., http://node1:9401/metrics), "
+                "(5) custom metrics CSV file (e.g., custom_gpu_metrics.csv). "
                 "Default: DCGM mode with localhost:9400 and localhost:9401 endpoints. "
-                "Examples: --gpu-telemetry pynvml | --gpu-telemetry dashboard node1:9400"
+                "Examples: --gpu-telemetry pynvml | --gpu-telemetry amdsmi | --gpu-telemetry dashboard node1:9400"
             ),
         ),
         BeforeValidator(parse_str_or_list),
@@ -803,6 +804,17 @@ class UserConfig(BaseConfig):
                     raise ValueError(
                         "pynvml package not installed. Install with: pip install nvidia-ml-py"
                     ) from e
+            # Check for amdsmi collector type (AMD ROCm GPUs)
+            elif item.lower() == "amdsmi":
+                collector_type = GPUTelemetryCollectorType.AMDSMI
+                try:
+                    import amdsmi  # noqa: F401
+                except ImportError as e:
+                    raise ValueError(
+                        "amdsmi package not installed. The amdsmi Python bindings "
+                        "ship with ROCm; install from /opt/rocm/share/amd_smi/amdsmi-*.whl "
+                        "or your distro's amd-smi-lib package."
+                    ) from e
             # Check for dashboard mode
             elif item in ["dashboard"]:
                 mode = GPUTelemetryMode.REALTIME_DASHBOARD
@@ -812,7 +824,7 @@ class UserConfig(BaseConfig):
                 urls.append(normalized_url)
             else:
                 raise ValueError(
-                    f"Invalid GPU telemetry item: {item}. Valid options are: 'pynvml', 'dashboard', '.csv' file, and URLs."
+                    f"Invalid GPU telemetry item: {item}. Valid options are: 'pynvml', 'amdsmi', 'dashboard', '.csv' file, and URLs."
                 )
 
         if collector_type == GPUTelemetryCollectorType.PYNVML and urls:
@@ -820,21 +832,31 @@ class UserConfig(BaseConfig):
                 "Cannot use pynvml with DCGM URLs. Use either 'pynvml' for local "
                 "GPU monitoring or URLs for DCGM endpoints, not both."
             )
+        if collector_type == GPUTelemetryCollectorType.AMDSMI and urls:
+            raise ValueError(
+                "Cannot use amdsmi with DCGM URLs. Use either 'amdsmi' for local "
+                "AMD GPU monitoring or URLs for DCGM endpoints, not both."
+            )
 
         self._gpu_telemetry_mode = mode
         self._gpu_telemetry_collector_type = collector_type
         self._gpu_telemetry_urls = urls
         self._gpu_telemetry_metrics_file = metrics_file
 
-        # Warn if pynvml is used with non-localhost server URLs
-        if collector_type == GPUTelemetryCollectorType.PYNVML:
+        # Warn if local-only collectors are used with non-localhost server URLs
+        local_only = {
+            GPUTelemetryCollectorType.PYNVML: "pynvml",
+            GPUTelemetryCollectorType.AMDSMI: "amdsmi",
+        }
+        if collector_type in local_only:
+            collector_name = local_only[collector_type]
             non_local_urls = [
                 url for url in self.endpoint.urls if not _is_localhost_url(url)
             ]
             if non_local_urls:
                 _logger.warning(
-                    f"Using pynvml for GPU telemetry with non-localhost server URL(s): {non_local_urls}. "
-                    "pynvml collects GPU metrics from the local machine only. "
+                    f"Using {collector_name} for GPU telemetry with non-localhost server URL(s): {non_local_urls}. "
+                    f"{collector_name} collects GPU metrics from the local machine only. "
                     "If the inference server is running remotely, the GPU telemetry will not reflect "
                     "the server's GPU usage. Consider using DCGM mode with the server's metrics endpoint instead."
                 )

--- a/src/aiperf/common/config/user_config.py
+++ b/src/aiperf/common/config/user_config.py
@@ -864,7 +864,18 @@ class UserConfig(BaseConfig):
                 if not metrics_file.exists():
                     raise ValueError(f"GPU metrics file not found: {item}")
             elif lowered in _LOCAL_COLLECTOR_KEYWORDS:
-                collector_type = _LOCAL_COLLECTOR_KEYWORDS[lowered]
+                selected = _LOCAL_COLLECTOR_KEYWORDS[lowered]
+                if (
+                    collector_type in _LOCAL_ONLY_COLLECTORS
+                    and collector_type != selected
+                ):
+                    prior = _LOCAL_ONLY_COLLECTORS[collector_type]
+                    chosen = _LOCAL_ONLY_COLLECTORS[selected]
+                    raise ValueError(
+                        f"Conflicting local GPU telemetry collectors: "
+                        f"'{prior}' and '{chosen}'. Choose exactly one."
+                    )
+                collector_type = selected
                 _ensure_local_collector_importable(collector_type)
             elif item == "dashboard":
                 mode = GPUTelemetryMode.REALTIME_DASHBOARD

--- a/src/aiperf/common/config/user_config.py
+++ b/src/aiperf/common/config/user_config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
+from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -106,6 +107,42 @@ def _normalize_otel_metrics_url(url: str) -> str:
 def _should_quote_arg(x: Any) -> bool:
     """Determine if the value should be quoted in the CLI command."""
     return isinstance(x, str) and not x.startswith("-") and x not in ("profile")
+
+
+# CLI keyword -> collector type for local-only GPU telemetry collectors.
+_LOCAL_COLLECTOR_KEYWORDS: dict[str, GPUTelemetryCollectorType] = {
+    "pynvml": GPUTelemetryCollectorType.PYNVML,
+    "amdsmi": GPUTelemetryCollectorType.AMDSMI,
+}
+
+# Collector type -> human-readable name for warning/error messages.
+_LOCAL_ONLY_COLLECTORS: dict[GPUTelemetryCollectorType, str] = {
+    GPUTelemetryCollectorType.PYNVML: "pynvml",
+    GPUTelemetryCollectorType.AMDSMI: "amdsmi",
+}
+
+# Install hint surfaced when a local collector's Python bindings are missing.
+_LOCAL_COLLECTOR_INSTALL_HINTS: dict[GPUTelemetryCollectorType, str] = {
+    GPUTelemetryCollectorType.PYNVML: (
+        "pynvml package not installed. Install with: pip install nvidia-ml-py"
+    ),
+    GPUTelemetryCollectorType.AMDSMI: (
+        "amdsmi package not installed. The amdsmi Python bindings ship with "
+        "ROCm; install from /opt/rocm/share/amd_smi/amdsmi-*.whl or your "
+        "distro's amd-smi-lib package."
+    ),
+}
+
+
+def _ensure_local_collector_importable(
+    collector_type: GPUTelemetryCollectorType,
+) -> None:
+    """Verify that the Python bindings for a local collector are importable."""
+    module_name = _LOCAL_ONLY_COLLECTORS[collector_type]
+    try:
+        import_module(module_name)
+    except ImportError as e:
+        raise ValueError(_LOCAL_COLLECTOR_INSTALL_HINTS[collector_type]) from e
 
 
 class UserConfig(BaseConfig):
@@ -784,58 +821,15 @@ class UserConfig(BaseConfig):
         if not self.gpu_telemetry:
             return self
 
-        mode = GPUTelemetryMode.SUMMARY
-        collector_type = GPUTelemetryCollectorType.DCGM
-        urls = []
-        metrics_file = None
+        mode, collector_type, urls, metrics_file = self._classify_gpu_telemetry_items(
+            self.gpu_telemetry
+        )
 
-        for item in self.gpu_telemetry:
-            # Check for CSV file (file extension heuristic)
-            if item.endswith(".csv"):
-                metrics_file = Path(item)
-                if not metrics_file.exists():
-                    raise ValueError(f"GPU metrics file not found: {item}")
-            # Check for pynvml collector type
-            elif item.lower() == "pynvml":
-                collector_type = GPUTelemetryCollectorType.PYNVML
-                try:
-                    import pynvml  # noqa: F401
-                except ImportError as e:
-                    raise ValueError(
-                        "pynvml package not installed. Install with: pip install nvidia-ml-py"
-                    ) from e
-            # Check for amdsmi collector type (AMD ROCm GPUs)
-            elif item.lower() == "amdsmi":
-                collector_type = GPUTelemetryCollectorType.AMDSMI
-                try:
-                    import amdsmi  # noqa: F401
-                except ImportError as e:
-                    raise ValueError(
-                        "amdsmi package not installed. The amdsmi Python bindings "
-                        "ship with ROCm; install from /opt/rocm/share/amd_smi/amdsmi-*.whl "
-                        "or your distro's amd-smi-lib package."
-                    ) from e
-            # Check for dashboard mode
-            elif item in ["dashboard"]:
-                mode = GPUTelemetryMode.REALTIME_DASHBOARD
-            # Check for URLs (only applicable for DCGM collector)
-            elif item.startswith("http") or ":" in item:
-                normalized_url = item if item.startswith("http") else f"http://{item}"
-                urls.append(normalized_url)
-            else:
-                raise ValueError(
-                    f"Invalid GPU telemetry item: {item}. Valid options are: 'pynvml', 'amdsmi', 'dashboard', '.csv' file, and URLs."
-                )
-
-        if collector_type == GPUTelemetryCollectorType.PYNVML and urls:
+        if collector_type in _LOCAL_ONLY_COLLECTORS and urls:
+            name = _LOCAL_ONLY_COLLECTORS[collector_type]
             raise ValueError(
-                "Cannot use pynvml with DCGM URLs. Use either 'pynvml' for local "
+                f"Cannot use {name} with DCGM URLs. Use either '{name}' for local "
                 "GPU monitoring or URLs for DCGM endpoints, not both."
-            )
-        if collector_type == GPUTelemetryCollectorType.AMDSMI and urls:
-            raise ValueError(
-                "Cannot use amdsmi with DCGM URLs. Use either 'amdsmi' for local "
-                "AMD GPU monitoring or URLs for DCGM endpoints, not both."
             )
 
         self._gpu_telemetry_mode = mode
@@ -843,25 +837,57 @@ class UserConfig(BaseConfig):
         self._gpu_telemetry_urls = urls
         self._gpu_telemetry_metrics_file = metrics_file
 
-        # Warn if local-only collectors are used with non-localhost server URLs
-        local_only = {
-            GPUTelemetryCollectorType.PYNVML: "pynvml",
-            GPUTelemetryCollectorType.AMDSMI: "amdsmi",
-        }
-        if collector_type in local_only:
-            collector_name = local_only[collector_type]
-            non_local_urls = [
-                url for url in self.endpoint.urls if not _is_localhost_url(url)
-            ]
-            if non_local_urls:
-                _logger.warning(
-                    f"Using {collector_name} for GPU telemetry with non-localhost server URL(s): {non_local_urls}. "
-                    f"{collector_name} collects GPU metrics from the local machine only. "
-                    "If the inference server is running remotely, the GPU telemetry will not reflect "
-                    "the server's GPU usage. Consider using DCGM mode with the server's metrics endpoint instead."
-                )
-
+        self._warn_if_local_collector_with_remote_urls(collector_type)
         return self
+
+    @staticmethod
+    def _classify_gpu_telemetry_items(
+        items: list[str],
+    ) -> tuple[GPUTelemetryMode, GPUTelemetryCollectorType, list[str], Path | None]:
+        """Walk the ``--gpu-telemetry`` items and classify each one."""
+        mode = GPUTelemetryMode.SUMMARY
+        collector_type = GPUTelemetryCollectorType.DCGM
+        urls: list[str] = []
+        metrics_file: Path | None = None
+
+        for item in items:
+            lowered = item.lower()
+            if item.endswith(".csv"):
+                metrics_file = Path(item)
+                if not metrics_file.exists():
+                    raise ValueError(f"GPU metrics file not found: {item}")
+            elif lowered in _LOCAL_COLLECTOR_KEYWORDS:
+                collector_type = _LOCAL_COLLECTOR_KEYWORDS[lowered]
+                _ensure_local_collector_importable(collector_type)
+            elif item == "dashboard":
+                mode = GPUTelemetryMode.REALTIME_DASHBOARD
+            elif item.startswith("http") or ":" in item:
+                normalized_url = item if item.startswith("http") else f"http://{item}"
+                urls.append(normalized_url)
+            else:
+                raise ValueError(
+                    f"Invalid GPU telemetry item: {item}. Valid options are: "
+                    "'pynvml', 'amdsmi', 'dashboard', '.csv' file, and URLs."
+                )
+        return mode, collector_type, urls, metrics_file
+
+    def _warn_if_local_collector_with_remote_urls(
+        self, collector_type: GPUTelemetryCollectorType
+    ) -> None:
+        """Warn when a local-only collector is paired with non-localhost servers."""
+        if collector_type not in _LOCAL_ONLY_COLLECTORS:
+            return
+        name = _LOCAL_ONLY_COLLECTORS[collector_type]
+        non_local_urls = [
+            url for url in self.endpoint.urls if not _is_localhost_url(url)
+        ]
+        if non_local_urls:
+            _logger.warning(
+                f"Using {name} for GPU telemetry with non-localhost server URL(s): {non_local_urls}. "
+                f"{name} collects GPU metrics from the local machine only. "
+                "If the inference server is running remotely, the GPU telemetry will not reflect "
+                "the server's GPU usage. Consider using DCGM mode with the server's metrics endpoint instead."
+            )
 
     @property
     def gpu_telemetry_mode(self) -> GPUTelemetryMode:

--- a/src/aiperf/common/models/telemetry_models.py
+++ b/src/aiperf/common/models/telemetry_models.py
@@ -180,9 +180,16 @@ class GpuTelemetrySnapshot(AIPerfBaseModel):
 class GpuMetricTimeSeries:
     """NumPy-backed columnar storage for GPU telemetry.
 
-    Stores timestamps once with separate value arrays per metric.
-    Metric schema is determined on first snapshot - all subsequent snapshots
-    must contain the same metrics (DCGM metrics are static per run).
+    Stores timestamps once with separate value arrays per metric. The metric
+    schema is the union of all keys ever seen — late-arriving keys allocate
+    a new array NaN-backfilled for prior positions, and known keys absent
+    from a given snapshot are written as NaN at that index. Stat methods
+    use ``np.nan*`` variants so NaN-padded slots don't poison results.
+
+    This dynamic-schema behavior accommodates collectors like AMDSMI whose
+    sensors can fail transiently (a missing baseline field is not the same
+    as a reading of zero). Static-schema collectors (DCGM, PyNVML) emit the
+    same keys every scrape, so the NaN handling is a no-op for them.
 
     Data is kept sorted by timestamp using insert-sorted approach:
     O(1) for in-order appends (99.9% of cases), O(k) for out-of-order.
@@ -199,15 +206,20 @@ class GpuMetricTimeSeries:
         self._capacity: int = self._INITIAL_CAPACITY
 
     def append_snapshot(self, metrics: dict[str, float], timestamp_ns: int) -> None:
-        """Append all metrics from a single DCGM scrape (insert-sorted).
+        """Append all metrics from a single scrape (insert-sorted).
 
         Args:
-            metrics: Dict of metric_name -> value (only present metrics)
+            metrics: Dict of metric_name -> value for keys present this scrape.
+                Keys may differ between snapshots (AMDSMI sensors can fail
+                transiently); the schema is the union of all keys ever seen.
             timestamp_ns: Timestamp for this scrape
 
         Note:
-            - Metric schema is determined on first snapshot. All subsequent snapshots
-              must contain the same metrics (DCGM metrics are static per run).
+            - **Dynamic schemas**: any key first seen mid-stream allocates a
+              new array NaN-backfilled for prior positions; any *known* key
+              absent from this snapshot writes NaN at this index. This keeps
+              `np.nan*` stat methods producing meaningful results even when
+              individual sensors come and go.
             - Data kept sorted by timestamp (O(1) in-order, O(k) out-of-order).
         """
         if self._size >= self._capacity:
@@ -234,14 +246,19 @@ class GpuMetricTimeSeries:
         # Insert timestamp at position
         self._timestamps[insert_pos] = timestamp_ns
 
-        # Initialize metric arrays on first snapshot (schema determined here)
-        if not self._metrics:
-            for name in metrics:
-                self._metrics[name] = np.empty(self._capacity, dtype=np.float64)
+        # Allocate any late-arriving metric arrays NaN-backfilled. Existing
+        # positions [0, insert_pos) get NaN; the value below fills insert_pos.
+        # _grow also NaN-fills, so slots > insert_pos stay NaN until subsequent
+        # writes.
+        for name in metrics:
+            if name not in self._metrics:
+                self._metrics[name] = np.full(self._capacity, np.nan, dtype=np.float64)
 
-        # Set values for all metrics at insert position
-        for name, value in metrics.items():
-            self._metrics[name][insert_pos] = value
+        # Write this snapshot's values; for any *known* key absent from this
+        # snapshot, write NaN so a transient sensor failure doesn't leave
+        # stale or garbage data at this index.
+        for name, arr in self._metrics.items():
+            arr[insert_pos] = metrics.get(name, np.nan)
 
         self._size += 1
 
@@ -254,9 +271,11 @@ class GpuMetricTimeSeries:
         new_ts[: self._size] = self._timestamps[: self._size]
         self._timestamps = new_ts
 
-        # Grow each metric array
+        # Grow each metric array. NaN-fill new capacity so absent-but-known
+        # keys can be written as NaN at any future index without being
+        # confused with garbage.
         for name, old_arr in self._metrics.items():
-            new_arr = np.empty(new_capacity, dtype=np.float64)
+            new_arr = np.full(new_capacity, np.nan, dtype=np.float64)
             new_arr[: self._size] = old_arr[: self._size]
             self._metrics[name] = new_arr
 
@@ -295,23 +314,29 @@ class GpuMetricTimeSeries:
             raise NoMetricValue(
                 f"No telemetry data available for metric '{metric_name}'"
             )
+        if np.all(np.isnan(arr)):
+            raise NoMetricValue(
+                f"All samples for metric '{metric_name}' are NaN "
+                f"(sensor never returned a successful read)"
+            )
 
-        # Vectorized stats computation
-        p1, p5, p10, p25, p50, p75, p90, p95, p99 = np.percentile(
+        # NaN-aware stats: dynamic-schema collectors (e.g. AMDSMI) write NaN
+        # for keys absent from a given scrape. nan* variants ignore them.
+        p1, p5, p10, p25, p50, p75, p90, p95, p99 = np.nanpercentile(
             arr, [1, 5, 10, 25, 50, 75, 90, 95, 99]
         )
 
         # Use sample std (ddof=1) for unbiased estimate; 0 for single sample
-        std_dev = float(np.std(arr, ddof=1)) if len(arr) > 1 else 0.0
+        std_dev = float(np.nanstd(arr, ddof=1)) if len(arr) > 1 else 0.0
 
         return MetricResult(
             tag=tag,
             header=header,
             unit=unit,
-            min=float(np.min(arr)),
-            max=float(np.max(arr)),
-            avg=float(np.mean(arr)),
-            sum=float(np.sum(arr)),
+            min=float(np.nanmin(arr)),
+            max=float(np.nanmax(arr)),
+            avg=float(np.nanmean(arr)),
+            sum=float(np.nansum(arr)),
             std=std_dev,
             count=len(arr),
             current=float(arr[-1]),
@@ -429,8 +454,11 @@ class GpuMetricTimeSeries:
             )
             raw_delta = float(filtered[-1] - reference_value)
 
-            # Handle counter resets (e.g., DCGM restart) by clamping to 0
-            delta = max(raw_delta, 0.0)
+            # If the reference sample is NaN (this metric arrived after the
+            # baseline scrape) raw_delta is NaN; treat as 0.0 ("no
+            # measurable change since baseline"). Otherwise clamp negative
+            # deltas to 0 to handle counter resets (e.g., DCGM restart).
+            delta = 0.0 if np.isnan(raw_delta) else max(raw_delta, 0.0)
 
             # Counters report a single delta value, not a distribution
             return MetricResult(
@@ -440,22 +468,28 @@ class GpuMetricTimeSeries:
                 avg=delta,
             )
 
-        # Gauge: vectorized stats on filtered data
-        p1, p5, p10, p25, p50, p75, p90, p95, p99 = np.percentile(
+        # Gauge: vectorized NaN-aware stats on filtered data. Dynamic-schema
+        # collectors (e.g. AMDSMI) may write NaN for keys absent from a given
+        # scrape; nan* variants ignore them.
+        if np.all(np.isnan(filtered)):
+            raise NoMetricValue(
+                f"All in-range samples for metric '{metric_name}' are NaN"
+            )
+        p1, p5, p10, p25, p50, p75, p90, p95, p99 = np.nanpercentile(
             filtered, [1, 5, 10, 25, 50, 75, 90, 95, 99]
         )
 
         # Use sample std (ddof=1) for unbiased estimate; 0 for single sample
-        std_dev = float(np.std(filtered, ddof=1)) if len(filtered) > 1 else 0.0
+        std_dev = float(np.nanstd(filtered, ddof=1)) if len(filtered) > 1 else 0.0
 
         return MetricResult(
             tag=tag,
             header=header,
             unit=unit,
-            min=float(np.min(filtered)),
-            max=float(np.max(filtered)),
-            avg=float(np.mean(filtered)),
-            sum=float(np.sum(filtered)),
+            min=float(np.nanmin(filtered)),
+            max=float(np.nanmax(filtered)),
+            avg=float(np.nanmean(filtered)),
+            sum=float(np.nansum(filtered)),
             std=std_dev,
             count=len(filtered),
             p1=p1,

--- a/src/aiperf/common/models/telemetry_models.py
+++ b/src/aiperf/common/models/telemetry_models.py
@@ -177,6 +177,12 @@ class GpuTelemetrySnapshot(AIPerfBaseModel):
     )
 
 
+def _last_valid(arr: np.ndarray) -> float | None:
+    """Return the last non-NaN value in ``arr``, or ``None`` if all NaN."""
+    mask = ~np.isnan(arr)
+    return float(arr[mask][-1]) if mask.any() else None
+
+
 class GpuMetricTimeSeries:
     """NumPy-backed columnar storage for GPU telemetry.
 
@@ -326,8 +332,11 @@ class GpuMetricTimeSeries:
             arr, [1, 5, 10, 25, 50, 75, 90, 95, 99]
         )
 
-        # Use sample std (ddof=1) for unbiased estimate; 0 for single sample
-        std_dev = float(np.nanstd(arr, ddof=1)) if len(arr) > 1 else 0.0
+        # ddof=1 needs at least 2 *non-NaN* samples; otherwise nanstd
+        # divides by zero and emits a RuntimeWarning. Count valid samples,
+        # not total scrapes.
+        non_nan = int(np.count_nonzero(~np.isnan(arr)))
+        std_dev = float(np.nanstd(arr, ddof=1)) if non_nan > 1 else 0.0
 
         return MetricResult(
             tag=tag,
@@ -339,7 +348,12 @@ class GpuMetricTimeSeries:
             sum=float(np.nansum(arr)),
             std=std_dev,
             count=len(arr),
-            current=float(arr[-1]),
+            # ``current`` must be the most recent *valid* sample. Dynamic-
+            # schema metrics whose latest scrape didn't include this key
+            # would otherwise return NaN, which the realtime dashboard
+            # renders literally and which breaks change-detection
+            # (NaN != NaN, causing republish every interval).
+            current=_last_valid(arr),
             p1=p1,
             p5=p5,
             p10=p10,
@@ -447,18 +461,35 @@ class GpuMetricTimeSeries:
             raise NoMetricValue(f"No data in time range for metric '{metric_name}'")
 
         if is_counter:
-            # Counter: compute delta from baseline
-            reference_idx = self.get_reference_idx(time_filter)
-            reference_value = (
-                arr[reference_idx] if reference_idx is not None else filtered[0]
-            )
-            raw_delta = float(filtered[-1] - reference_value)
+            # Counter: compute delta from baseline using nearest valid
+            # (non-NaN) endpoints. A NaN baseline or NaN final sample
+            # would otherwise zero out a delta even when there was real
+            # counter movement among valid samples in between.
+            filtered_last = _last_valid(filtered)
+            if filtered_last is None:
+                raise NoMetricValue(
+                    f"No valid (non-NaN) samples in filtered range for "
+                    f"metric '{metric_name}'"
+                )
 
-            # If the reference sample is NaN (this metric arrived after the
-            # baseline scrape) raw_delta is NaN; treat as 0.0 ("no
-            # measurable change since baseline"). Otherwise clamp negative
-            # deltas to 0 to handle counter resets (e.g., DCGM restart).
-            delta = 0.0 if np.isnan(raw_delta) else max(raw_delta, 0.0)
+            reference_idx = self.get_reference_idx(time_filter)
+            reference_value: float | None
+            if reference_idx is not None:
+                # Walk back from the chosen reference index for the
+                # nearest non-NaN baseline sample.
+                reference_value = _last_valid(arr[: reference_idx + 1])
+            else:
+                reference_value = None
+
+            if reference_value is None:
+                # No pre-window baseline; fall back to first valid in-window
+                # sample (existing semantic: "delta from earliest available").
+                mask = ~np.isnan(filtered)
+                reference_value = float(filtered[mask][0])
+
+            # Clamp negative deltas to 0 to handle counter resets
+            # (e.g., DCGM restart).
+            delta = max(filtered_last - reference_value, 0.0)
 
             # Counters report a single delta value, not a distribution
             return MetricResult(
@@ -479,8 +510,11 @@ class GpuMetricTimeSeries:
             filtered, [1, 5, 10, 25, 50, 75, 90, 95, 99]
         )
 
-        # Use sample std (ddof=1) for unbiased estimate; 0 for single sample
-        std_dev = float(np.nanstd(filtered, ddof=1)) if len(filtered) > 1 else 0.0
+        # ddof=1 needs at least 2 *non-NaN* samples; otherwise nanstd
+        # divides by zero and emits a RuntimeWarning. Count valid samples,
+        # not total scrapes.
+        non_nan = int(np.count_nonzero(~np.isnan(filtered)))
+        std_dev = float(np.nanstd(filtered, ddof=1)) if non_nan > 1 else 0.0
 
         return MetricResult(
             tag=tag,

--- a/src/aiperf/common/models/telemetry_models.py
+++ b/src/aiperf/common/models/telemetry_models.py
@@ -66,6 +66,49 @@ class TelemetryMetrics(AIPerfBaseModel):
         description="Throttling duration due to power constraints in microseconds",
     )
 
+    # AMD ROCm telemetry (collected by AMDSMITelemetryCollector). These mirror
+    # the amdsmi field names rather than being aliased onto NVML-shaped fields,
+    # because the underlying signals do not always measure the same physical
+    # quantity (e.g. gfx_activity vs sm_utilization sample differently).
+    amd_power: float | None = Field(
+        default=None, description="AMD GPU current socket power in W"
+    )
+    amd_energy_consumption: float | None = Field(
+        default=None,
+        description="AMD GPU cumulative energy consumption in MJ "
+        "(accumulator * counter_resolution)",
+    )
+    amd_gfx_activity: float | None = Field(
+        default=None,
+        description="AMD GPU graphics engine activity percentage (0-100)",
+    )
+    amd_umc_activity: float | None = Field(
+        default=None,
+        description="AMD GPU memory controller activity percentage (0-100)",
+    )
+    amd_mm_activity: float | None = Field(
+        default=None,
+        description="AMD GPU multimedia engine activity percentage (0-100). "
+        "Not supported on Instinct GPUs.",
+    )
+    amd_memory_used: float | None = Field(
+        default=None, description="AMD GPU VRAM used in GB"
+    )
+    amd_temperature: float | None = Field(
+        default=None,
+        description="AMD GPU temperature in °C (junction sensor preferred, "
+        "hotspot fallback)",
+    )
+    amd_ecc_uncorrectable: float | None = Field(
+        default=None,
+        description="AMD GPU cumulative uncorrectable ECC error count",
+    )
+    amd_throttle_status: float | None = Field(
+        default=None,
+        description="AMD GPU throttle status snapshot (1.0 if any throttle "
+        "indicator is active, 0.0 otherwise)",
+    )
+
 
 class GpuMetadata(AIPerfBaseModel):
     """Static metadata for a GPU that doesn't change over time.

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -34,7 +34,7 @@ __all__ = ["AMDSMITelemetryCollector"]
 
 
 @dataclass(frozen=True)
-class ScalingFactors:
+class _AMDScalingFactors:
     """Unit conversion scaling factors for AMDSMI metrics.
 
     AMDSMI returns power in W (no scaling) and energy in counter ticks where
@@ -46,7 +46,7 @@ class ScalingFactors:
 
 
 @dataclass(slots=True)
-class GpuDeviceState:
+class _AMDGpuDeviceState:
     """Per-GPU state for AMDSMI telemetry collection.
 
     Args:
@@ -123,7 +123,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
         self._record_callback = record_callback
         self._error_callback = error_callback
 
-        self._gpus: list[GpuDeviceState] = []
+        self._gpus: list[_AMDGpuDeviceState] = []
         self._initialized = False
         self._lock = threading.Lock()
 
@@ -147,7 +147,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             return len(self._gpus) > 0
         try:
             return await asyncio.to_thread(self._probe_devices)
-        except Exception:
+        except Exception:  # noqa: BLE001 - reachability probe must never raise
             return False
 
     def _probe_devices(self) -> bool:
@@ -187,7 +187,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
 
         self.info(f"AMDSMI initialized with {len(self._gpus)} GPU(s)")
 
-    def _build_gpu_state(self, index: int, handle: Any) -> GpuDeviceState | None:
+    def _build_gpu_state(self, index: int, handle: Any) -> _AMDGpuDeviceState | None:
         """Build per-GPU state with static metadata."""
         try:
             uuid = amdsmi.amdsmi_get_gpu_device_uuid(handle)
@@ -206,7 +206,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
         except amdsmi.AmdSmiException:
             pci_bus_id = None
 
-        return GpuDeviceState(
+        return _AMDGpuDeviceState(
             handle=handle,
             metadata=GpuMetadata(
                 gpu_index=index,
@@ -225,7 +225,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
                 return
             try:
                 amdsmi.amdsmi_shut_down()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - shutdown is best-effort
                 self.warning(f"Error during amdsmi shutdown: {e!r}")
             finally:
                 self._initialized = False
@@ -256,11 +256,11 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             records = await asyncio.to_thread(self._collect_gpu_metrics)
             if records and self._record_callback:
                 await self._record_callback(records, self.id)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - fault-tolerant telemetry
             if self._error_callback:
                 try:
                     await self._error_callback(ErrorDetails.from_exception(e), self.id)
-                except Exception as cb_err:
+                except Exception as cb_err:  # noqa: BLE001 - callback failure must not propagate
                     self.error(f"Failed to send error via callback: {cb_err}")
             else:
                 self.error(f"Metrics collection error: {e}")
@@ -293,13 +293,26 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             return records
 
     def _snapshot_gpu(
-        self, gpu: GpuDeviceState, now_ns: int, ExcType: type[Exception]
+        self, gpu: _AMDGpuDeviceState, now_ns: int, ExcType: type[Exception]
     ) -> TelemetryMetrics:
         """Capture all supported metrics for one GPU into a TelemetryMetrics."""
-        handle = gpu.handle
         td = TelemetryMetrics()
+        handle = gpu.handle
+        self._collect_power(handle, td, ExcType)
+        self._collect_energy(handle, td, ExcType)
+        self._collect_activity(handle, td, ExcType)
+        self._collect_memory(handle, td, ExcType)
+        self._collect_temperature(handle, td, ExcType)
+        self._collect_ecc(handle, td, ExcType)
+        self._collect_throttle(gpu, td, now_ns, ExcType)
+        gpu.last_collect_ns = now_ns
+        return td
 
-        # Power (W). current_socket_power is already in W; no scaling.
+    @staticmethod
+    def _collect_power(
+        handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
+    ) -> None:
+        """Power in W. ``current_socket_power`` is already in W; no scaling."""
         with contextlib.suppress(ExcType):
             power = amdsmi.amdsmi_get_power_info(handle)
             value = _numeric(power.get("current_socket_power"))
@@ -308,15 +321,23 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             if value is not None:
                 td.gpu_power_usage = value
 
-        # Energy: accumulator(ticks) * counter_resolution(µJ) -> MJ
+    @staticmethod
+    def _collect_energy(
+        handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
+    ) -> None:
+        """Energy: ``accumulator(ticks) * counter_resolution(µJ)`` -> MJ."""
         with contextlib.suppress(ExcType):
             energy = amdsmi.amdsmi_get_energy_count(handle)
             acc = _numeric(energy.get("energy_accumulator"))
             res = _numeric(energy.get("counter_resolution"))
             if acc is not None and res is not None:
-                td.energy_consumption = acc * res * ScalingFactors.energy_uj_to_mj
+                td.energy_consumption = acc * res * _AMDScalingFactors.energy_uj_to_mj
 
-        # Activity (gfx/umc/mm). mm_activity is N/A on Instinct GPUs.
+    @staticmethod
+    def _collect_activity(
+        handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
+    ) -> None:
+        """gfx/umc/mm activity. ``mm_activity`` is N/A on Instinct GPUs."""
         with contextlib.suppress(ExcType):
             activity = amdsmi.amdsmi_get_gpu_activity(handle)
             gfx = _numeric(activity.get("gfx_activity"))
@@ -331,16 +352,26 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
                 td.encoder_utilization = mm
                 td.decoder_utilization = mm
 
-        # VRAM used (bytes -> GB)
+    @staticmethod
+    def _collect_memory(
+        handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
+    ) -> None:
+        """VRAM used (bytes -> GB)."""
         with contextlib.suppress(ExcType):
             vram_used = _numeric(
                 amdsmi.amdsmi_get_gpu_memory_usage(handle, amdsmi.AmdSmiMemoryType.VRAM)
             )
             if vram_used is not None:
-                td.gpu_memory_used = vram_used * ScalingFactors.bytes_to_gb
+                td.gpu_memory_used = vram_used * _AMDScalingFactors.bytes_to_gb
 
-        # Temperature: prefer JUNCTION (works on MI300X/MI355X), fall back to
-        # HOTSPOT. EDGE is unsupported on Instinct GPUs.
+    @staticmethod
+    def _collect_temperature(
+        handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
+    ) -> None:
+        """Temperature: prefer JUNCTION (Instinct GPUs), fall back to HOTSPOT.
+
+        EDGE is unsupported on Instinct GPUs.
+        """
         for kind in ("JUNCTION", "HOTSPOT"):
             try:
                 temp = amdsmi.amdsmi_get_temp_metric(
@@ -353,28 +384,39 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             value = _numeric(temp)
             if value is not None:
                 td.gpu_temperature = value
-                break
+                return
 
-        # ECC: uncorrectable error count maps closest to xid_errors semantics.
+    @staticmethod
+    def _collect_ecc(
+        handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
+    ) -> None:
+        """ECC: ``uncorrectable_count`` maps closest to ``xid_errors`` semantics."""
         with contextlib.suppress(ExcType):
             ecc = amdsmi.amdsmi_get_gpu_total_ecc_count(handle)
             uc = _numeric(ecc.get("uncorrectable_count"))
             if uc is not None:
                 td.xid_errors = uc
 
-        # Throttle duration: AMDSMI exposes only a boolean throttle_status, so
-        # accumulate microseconds spent throttled between scrapes client-side.
-        # Both throttle_status and indep_throttle_status often return the literal
-        # 'N/A' string when unsupported; coerce to int before truthiness check
-        # so 'N/A' does not register as "throttled".
+    @staticmethod
+    def _collect_throttle(
+        gpu: _AMDGpuDeviceState,
+        td: TelemetryMetrics,
+        now_ns: int,
+        ExcType: type[Exception],
+    ) -> None:
+        """Throttle duration accumulated client-side from ``throttle_status``.
+
+        AMDSMI exposes only a boolean throttle_status (no duration), so we
+        accumulate microseconds spent throttled between scrapes. Both
+        throttle_status and indep_throttle_status often return the literal
+        ``'N/A'`` string when unsupported; ``_numeric`` coerces those to
+        ``None`` so they do not register as "throttled".
+        """
         with contextlib.suppress(ExcType):
-            m = amdsmi.amdsmi_get_gpu_metrics_info(handle)
+            m = amdsmi.amdsmi_get_gpu_metrics_info(gpu.handle)
             ts = _numeric(m.get("throttle_status"))
             its = _numeric(m.get("indep_throttle_status"))
             throttled = bool((ts or 0) or (its or 0))
             if throttled and gpu.last_collect_ns:
                 gpu.throttle_accum_us += (now_ns - gpu.last_collect_ns) / 1_000.0
             td.power_violation = gpu.throttle_accum_us
-
-        gpu.last_collect_ns = now_ns
-        return td

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -1,0 +1,380 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AMDSMI-based GPU telemetry collector.
+
+Collects GPU metrics from AMD ROCm GPUs (Instinct MI300X, MI355X, etc.) using
+the amdsmi Python library shipped with ROCm. Mirrors the behavioral contract of
+the PyNVML collector so that downstream accumulation, export, and dashboard
+code remains hardware-agnostic.
+"""
+
+import asyncio
+import contextlib
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import amdsmi
+
+from aiperf.common.environment import Environment
+from aiperf.common.hooks import background_task, on_init, on_stop
+from aiperf.common.mixins import AIPerfLifecycleMixin
+from aiperf.common.models import (
+    ErrorDetails,
+    GpuMetadata,
+    TelemetryMetrics,
+    TelemetryRecord,
+)
+from aiperf.gpu_telemetry.constants import AMDSMI_SOURCE_IDENTIFIER
+from aiperf.gpu_telemetry.protocols import TErrorCallback, TRecordCallback
+
+__all__ = ["AMDSMITelemetryCollector"]
+
+
+@dataclass(frozen=True)
+class ScalingFactors:
+    """Unit conversion scaling factors for AMDSMI metrics.
+
+    AMDSMI returns power in W (no scaling) and energy in counter ticks where
+    one tick equals counter_resolution µJ. Memory bytes are converted to GB.
+    """
+
+    energy_uj_to_mj = 1e-12  # ticks * counter_resolution(µJ) -> MJ
+    bytes_to_gb = 1e-9
+
+
+@dataclass(slots=True)
+class GpuDeviceState:
+    """Per-GPU state for AMDSMI telemetry collection.
+
+    Args:
+        handle: AMDSMI processor handle (opaque pointer)
+        metadata: GPU metadata
+        throttle_accum_us: Accumulated throttle duration in microseconds, computed
+            client-side because AMDSMI only exposes a boolean throttle_status
+            rather than a duration counter like NVML's violationTime.
+        last_collect_ns: Timestamp of last successful collection for throttle
+            duration computation.
+    """
+
+    handle: Any
+    metadata: GpuMetadata
+    throttle_accum_us: float = 0.0
+    last_collect_ns: int = 0
+
+
+def _numeric(value: Any) -> float | None:
+    """Coerce an AMDSMI return value to float, treating sentinels as None.
+
+    AMDSMI commonly returns the literal string ``'N/A'`` for unsupported sensors
+    (e.g. ``average_socket_power`` on MI300X/MI355X, ``mm_activity`` on Instinct
+    parts) instead of raising an exception. Any non-numeric value, including
+    ``'N/A'``, becomes ``None`` so downstream pydantic validation is not given
+    a string where it expects a float.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
+    """Collects GPU telemetry from AMD ROCm GPUs via the amdsmi library.
+
+    Direct collector that uses AMD's amdsmi Python bindings to gather GPU
+    metrics locally. Functionally equivalent to the PyNVML collector for
+    purposes of the GPUTelemetryManager, but targets AMD Instinct GPUs
+    (gfx942, gfx950, etc.) running on ROCm.
+
+    Features:
+        - Direct AMDSMI access (no HTTP exporter required)
+        - Automatic GPU discovery and enumeration
+        - Same TelemetryRecord output format as DCGM/PyNVML collectors
+        - Callback-based record delivery
+        - Tolerant of partial sensor support: fields that return 'N/A' or
+          raise AmdSmiLibraryException are silently dropped from the record
+
+    Requirements:
+        - amdsmi Python package (ships with ROCm at
+          /opt/rocm/share/amd_smi/amdsmi-*.whl)
+        - ROCm driver loaded with at least one supported AMD GPU
+
+    Args:
+        collection_interval: Interval in seconds between metric collections
+        record_callback: Async callback invoked with collected records.
+            Signature: async (records: list[TelemetryRecord], collector_id: str) -> None
+        error_callback: Async callback invoked on collection errors.
+            Signature: async (error: ErrorDetails, collector_id: str) -> None
+        collector_id: Unique identifier for this collector instance
+    """
+
+    def __init__(
+        self,
+        collection_interval: float = Environment.GPU.COLLECTION_INTERVAL,
+        record_callback: TRecordCallback | None = None,
+        error_callback: TErrorCallback | None = None,
+        collector_id: str = "amdsmi_collector",
+    ) -> None:
+        super().__init__(id=collector_id)
+        self._collection_interval = collection_interval
+        self._record_callback = record_callback
+        self._error_callback = error_callback
+
+        self._gpus: list[GpuDeviceState] = []
+        self._initialized = False
+        self._lock = threading.Lock()
+
+    @property
+    def endpoint_url(self) -> str:
+        """Source identifier for this collector ('amdsmi://localhost')."""
+        return AMDSMI_SOURCE_IDENTIFIER
+
+    @property
+    def collection_interval(self) -> float:
+        """Collection interval in seconds."""
+        return self._collection_interval
+
+    async def is_url_reachable(self) -> bool:
+        """Check if AMDSMI is available and at least one GPU is visible.
+
+        Returns:
+            True if amdsmi can initialize and enumerates >=1 processor handle.
+        """
+        if self._initialized:
+            return len(self._gpus) > 0
+        try:
+            return await asyncio.to_thread(self._probe_devices)
+        except Exception:
+            return False
+
+    def _probe_devices(self) -> bool:
+        """Synchronous probe: init amdsmi, count GPUs, shut down."""
+        amdsmi.amdsmi_init()
+        try:
+            return len(amdsmi.amdsmi_get_processor_handles()) > 0
+        finally:
+            with contextlib.suppress(amdsmi.AmdSmiException):
+                amdsmi.amdsmi_shut_down()
+
+    @on_init
+    async def _initialize_amdsmi(self) -> None:
+        """Initialize amdsmi and enumerate available GPUs.
+
+        Raises:
+            RuntimeError: If amdsmi cannot initialize or no GPUs are present.
+        """
+        try:
+            amdsmi.amdsmi_init()
+        except amdsmi.AmdSmiException as e:
+            raise RuntimeError(f"Failed to initialize amdsmi: {e}") from e
+
+        self._initialized = True
+
+        try:
+            handles = amdsmi.amdsmi_get_processor_handles()
+        except amdsmi.AmdSmiException as e:
+            self._shutdown_sync()
+            raise RuntimeError(f"Failed to enumerate AMD GPUs: {e}") from e
+
+        self._gpus = [
+            gpu
+            for gpu in (self._build_gpu_state(idx, h) for idx, h in enumerate(handles))
+            if gpu is not None
+        ]
+
+        self.info(f"AMDSMI initialized with {len(self._gpus)} GPU(s)")
+
+    def _build_gpu_state(self, index: int, handle: Any) -> GpuDeviceState | None:
+        """Build per-GPU state with static metadata."""
+        try:
+            uuid = amdsmi.amdsmi_get_gpu_device_uuid(handle)
+        except amdsmi.AmdSmiException:
+            uuid = f"GPU-unknown-{index}"
+
+        try:
+            board = amdsmi.amdsmi_get_gpu_board_info(handle)
+            name = board.get("product_name") or "Unknown AMD GPU"
+        except amdsmi.AmdSmiException:
+            name = "Unknown AMD GPU"
+
+        try:
+            bdf = amdsmi.amdsmi_get_gpu_device_bdf(handle)
+            pci_bus_id = bdf if isinstance(bdf, str) else None
+        except amdsmi.AmdSmiException:
+            pci_bus_id = None
+
+        return GpuDeviceState(
+            handle=handle,
+            metadata=GpuMetadata(
+                gpu_index=index,
+                gpu_uuid=uuid,
+                gpu_model_name=name,
+                pci_bus_id=pci_bus_id,
+                device=f"amd{index}",
+                hostname="localhost",
+            ),
+        )
+
+    def _shutdown_sync(self) -> None:
+        """Thread-safe synchronous shutdown of amdsmi state."""
+        with self._lock:
+            if not self._initialized:
+                return
+            try:
+                amdsmi.amdsmi_shut_down()
+            except Exception as e:
+                self.warning(f"Error during amdsmi shutdown: {e!r}")
+            finally:
+                self._initialized = False
+                self._gpus = []
+
+    @on_stop
+    async def _shutdown_amdsmi(self) -> None:
+        """Shut down amdsmi (thread-safe; waits for in-flight collection)."""
+        await asyncio.to_thread(self._shutdown_sync)
+        self.debug("AMDSMI shutdown complete")
+
+    @background_task(immediate=True, interval=lambda self: self.collection_interval)
+    async def _collect_metrics_loop(self) -> None:
+        """Periodic collection task that runs while the collector is RUNNING."""
+        await self._collect_and_process_metrics()
+
+    async def collect_and_process_metrics(self) -> None:
+        """Public alias for one-shot scrape.
+
+        ``GPUTelemetryManager`` calls this name during baseline and final-state
+        capture (``manager.py`` :func:`_handle_profile_complete_command`).
+        """
+        await self._collect_and_process_metrics()
+
+    async def _collect_and_process_metrics(self) -> None:
+        """Collect metrics and dispatch via record/error callbacks."""
+        try:
+            records = await asyncio.to_thread(self._collect_gpu_metrics)
+            if records and self._record_callback:
+                await self._record_callback(records, self.id)
+        except Exception as e:
+            if self._error_callback:
+                try:
+                    await self._error_callback(ErrorDetails.from_exception(e), self.id)
+                except Exception as cb_err:
+                    self.error(f"Failed to send error via callback: {cb_err}")
+            else:
+                self.error(f"Metrics collection error: {e}")
+
+    def _collect_gpu_metrics(self) -> list[TelemetryRecord]:
+        """Collect one record per GPU using AMDSMI APIs.
+
+        Thread-safe against concurrent shutdown via ``_lock``.
+        """
+        with self._lock:
+            if not self._initialized or not self._gpus:
+                return []
+
+            now_ns = time.time_ns()
+            ExcType = amdsmi.AmdSmiException
+            records: list[TelemetryRecord] = []
+
+            for gpu in self._gpus:
+                metrics = self._snapshot_gpu(gpu, now_ns, ExcType)
+                if metrics.model_fields_set:
+                    records.append(
+                        TelemetryRecord(
+                            timestamp_ns=now_ns,
+                            dcgm_url=AMDSMI_SOURCE_IDENTIFIER,
+                            **gpu.metadata.model_dump(),
+                            telemetry_data=metrics,
+                        )
+                    )
+
+            return records
+
+    def _snapshot_gpu(
+        self, gpu: GpuDeviceState, now_ns: int, ExcType: type[Exception]
+    ) -> TelemetryMetrics:
+        """Capture all supported metrics for one GPU into a TelemetryMetrics."""
+        handle = gpu.handle
+        td = TelemetryMetrics()
+
+        # Power (W). current_socket_power is already in W; no scaling.
+        with contextlib.suppress(ExcType):
+            power = amdsmi.amdsmi_get_power_info(handle)
+            value = _numeric(power.get("current_socket_power"))
+            if value is None:
+                value = _numeric(power.get("average_socket_power"))
+            if value is not None:
+                td.gpu_power_usage = value
+
+        # Energy: accumulator(ticks) * counter_resolution(µJ) -> MJ
+        with contextlib.suppress(ExcType):
+            energy = amdsmi.amdsmi_get_energy_count(handle)
+            acc = _numeric(energy.get("energy_accumulator"))
+            res = _numeric(energy.get("counter_resolution"))
+            if acc is not None and res is not None:
+                td.energy_consumption = acc * res * ScalingFactors.energy_uj_to_mj
+
+        # Activity (gfx/umc/mm). mm_activity is N/A on Instinct GPUs.
+        with contextlib.suppress(ExcType):
+            activity = amdsmi.amdsmi_get_gpu_activity(handle)
+            gfx = _numeric(activity.get("gfx_activity"))
+            umc = _numeric(activity.get("umc_activity"))
+            mm = _numeric(activity.get("mm_activity"))
+            if gfx is not None:
+                td.gpu_utilization = gfx
+                td.sm_utilization = gfx  # AMD has no separate SM-level metric
+            if umc is not None:
+                td.mem_utilization = umc
+            if mm is not None:
+                td.encoder_utilization = mm
+                td.decoder_utilization = mm
+
+        # VRAM used (bytes -> GB)
+        with contextlib.suppress(ExcType):
+            vram_used = _numeric(
+                amdsmi.amdsmi_get_gpu_memory_usage(handle, amdsmi.AmdSmiMemoryType.VRAM)
+            )
+            if vram_used is not None:
+                td.gpu_memory_used = vram_used * ScalingFactors.bytes_to_gb
+
+        # Temperature: prefer JUNCTION (works on MI300X/MI355X), fall back to
+        # HOTSPOT. EDGE is unsupported on Instinct GPUs.
+        for kind in ("JUNCTION", "HOTSPOT"):
+            try:
+                temp = amdsmi.amdsmi_get_temp_metric(
+                    handle,
+                    getattr(amdsmi.AmdSmiTemperatureType, kind),
+                    amdsmi.AmdSmiTemperatureMetric.CURRENT,
+                )
+            except ExcType:
+                continue
+            value = _numeric(temp)
+            if value is not None:
+                td.gpu_temperature = value
+                break
+
+        # ECC: uncorrectable error count maps closest to xid_errors semantics.
+        with contextlib.suppress(ExcType):
+            ecc = amdsmi.amdsmi_get_gpu_total_ecc_count(handle)
+            uc = _numeric(ecc.get("uncorrectable_count"))
+            if uc is not None:
+                td.xid_errors = uc
+
+        # Throttle duration: AMDSMI exposes only a boolean throttle_status, so
+        # accumulate microseconds spent throttled between scrapes client-side.
+        # Both throttle_status and indep_throttle_status often return the literal
+        # 'N/A' string when unsupported; coerce to int before truthiness check
+        # so 'N/A' does not register as "throttled".
+        with contextlib.suppress(ExcType):
+            m = amdsmi.amdsmi_get_gpu_metrics_info(handle)
+            ts = _numeric(m.get("throttle_status"))
+            its = _numeric(m.get("indep_throttle_status"))
+            throttled = bool((ts or 0) or (its or 0))
+            if throttled and gpu.last_collect_ns:
+                gpu.throttle_accum_us += (now_ns - gpu.last_collect_ns) / 1_000.0
+            td.power_violation = gpu.throttle_accum_us
+
+        gpu.last_collect_ns = now_ns
+        return td

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -91,6 +91,22 @@ def _numeric(value: Any) -> float | None:
     return None
 
 
+def _is_throttled(value: Any) -> bool:
+    """Decide whether an AMDSMI throttle_status value indicates active throttling.
+
+    AMDSMI returns this field as ``bool`` on some platforms, ``int`` (bitfield)
+    on others, and the literal string ``'N/A'`` when the sensor is unsupported.
+    Treat any truthy bool or any non-zero int as throttled; treat strings and
+    None as not throttled. ``_numeric`` cannot be reused here because it
+    intentionally maps ``bool`` to ``None``.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    return False
+
+
 class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
     """Collects GPU telemetry from AMD ROCm GPUs via the amdsmi library.
 
@@ -344,10 +360,17 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
     def _collect_energy(
         handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
     ) -> None:
-        """Energy: ``accumulator(ticks) * counter_resolution(µJ)`` -> MJ."""
+        """Energy: ``accumulator(ticks) * counter_resolution(µJ)`` -> MJ.
+
+        AMDSMI renamed the field from ``power`` to ``energy_accumulator``
+        somewhere around the 6.2 timeframe. Fall back to the older name so
+        we keep working on ROCm 6.x.
+        """
         with contextlib.suppress(ExcType):
             energy = amdsmi.amdsmi_get_energy_count(handle)
             acc = _numeric(energy.get("energy_accumulator"))
+            if acc is None:
+                acc = _numeric(energy.get("power"))  # ROCm 6.x naming
             res = _numeric(energy.get("counter_resolution"))
             if acc is not None and res is not None:
                 td.energy_consumption = acc * res * _AMDScalingFactors.energy_uj_to_mj
@@ -390,6 +413,12 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
         """Temperature: prefer JUNCTION (Instinct GPUs), fall back to HOTSPOT.
 
         EDGE is unsupported on Instinct GPUs.
+
+        The AMDSMI C API documents the temperature as millidegrees Celsius,
+        but recent Python bindings (>= ROCm 6.3 / amdsmi 26.x) return the
+        value already in Celsius. Older bindings return millidegrees. Detect
+        and normalize via a sanity check: any value > 200 is implausibly hot
+        for a GPU and is therefore in millidegrees.
         """
         for kind in ("JUNCTION", "HOTSPOT"):
             try:
@@ -401,9 +430,12 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             except ExcType:
                 continue
             value = _numeric(temp)
-            if value is not None:
-                td.gpu_temperature = value
-                return
+            if value is None:
+                continue
+            if value > 200:  # millidegrees -> degrees
+                value = value / 1000.0
+            td.gpu_temperature = value
+            return
 
     @staticmethod
     def _collect_ecc(
@@ -425,17 +457,18 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
     ) -> None:
         """Throttle duration accumulated client-side from ``throttle_status``.
 
-        AMDSMI exposes only a boolean throttle_status (no duration), so we
-        accumulate microseconds spent throttled between scrapes. Both
-        throttle_status and indep_throttle_status often return the literal
-        ``'N/A'`` string when unsupported; ``_numeric`` coerces those to
-        ``None`` so they do not register as "throttled".
+        AMDSMI exposes only a boolean (or bitfield) throttle_status, no
+        duration counter, so we accumulate microseconds spent throttled
+        between scrapes. ``throttle_status`` may be returned as ``bool``,
+        ``int``, or the literal ``'N/A'`` string depending on AMDSMI
+        version and platform support; treat any truthy numeric / boolean
+        value as throttled and ignore string sentinels.
         """
         with contextlib.suppress(ExcType):
             m = amdsmi.amdsmi_get_gpu_metrics_info(gpu.handle)
-            ts = _numeric(m.get("throttle_status"))
-            its = _numeric(m.get("indep_throttle_status"))
-            throttled = bool((ts or 0) or (its or 0))
+            throttled = _is_throttled(m.get("throttle_status")) or _is_throttled(
+                m.get("indep_throttle_status")
+            )
             if throttled and gpu.last_collect_ns:
                 gpu.throttle_accum_us += (now_ns - gpu.last_collect_ns) / 1_000.0
             td.power_violation = gpu.throttle_accum_us

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -97,7 +97,7 @@ def _amdsmi_returns_celsius() -> bool:
     (ROCm ~6.3+). Older bindings return millidegrees. Gate on the major
     version of ``amdsmi.__version__``.
 
-    If the version is missing or unparseable, assume modern (>= 26): every
+    If the version is missing or unparsable, assume modern (>= 26): every
     currently-deployed binding we have validated against (Hotaisle MI300X
     amdsmi 26.0.2, AAC1 MI355X amdsmi 26.2.1) is in that range, and over-
     dividing a Celsius value would produce obviously-wrong sub-degree
@@ -240,6 +240,10 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             for gpu in (self._build_gpu_state(idx, h) for idx, h in enumerate(handles))
             if gpu is not None
         ]
+
+        if not self._gpus:
+            self._shutdown_sync()
+            raise RuntimeError("No AMD GPUs detected via amdsmi")
 
         self.info(f"AMDSMI initialized with {len(self._gpus)} GPU(s)")
 

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -89,6 +89,29 @@ def _numeric(value: Any) -> float | None:
     return None
 
 
+def _amdsmi_returns_celsius() -> bool:
+    """Whether the installed amdsmi binding returns temperatures in Celsius.
+
+    The AMDSMI C API documents temperatures as millidegrees Celsius, but the
+    Python binding started normalizing to Celsius in the ``26.x`` series
+    (ROCm ~6.3+). Older bindings return millidegrees. Gate on the major
+    version of ``amdsmi.__version__``.
+
+    If the version is missing or unparseable, assume modern (>= 26): every
+    currently-deployed binding we have validated against (Hotaisle MI300X
+    amdsmi 26.0.2, AAC1 MI355X amdsmi 26.2.1) is in that range, and over-
+    dividing a Celsius value would produce obviously-wrong sub-degree
+    readings that would be caught immediately.
+    """
+    if amdsmi is None:
+        return True
+    version = getattr(amdsmi, "__version__", "")
+    try:
+        return int(version.split(".", 1)[0]) >= 26
+    except (ValueError, AttributeError, IndexError):
+        return True
+
+
 def _is_throttled(value: Any) -> bool:
     """Decide whether an AMDSMI throttle_status value indicates active throttling.
 
@@ -411,11 +434,10 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
 
         EDGE is unsupported on Instinct GPUs.
 
-        The AMDSMI C API documents the temperature as millidegrees Celsius,
-        but recent Python bindings (>= ROCm 6.3 / amdsmi 26.x) return the
-        value already in Celsius. Older bindings return millidegrees. Detect
-        and normalize via a sanity check: any value > 200 is implausibly hot
-        for a GPU and is therefore in millidegrees.
+        Unit conversion is gated on ``amdsmi.__version__`` (see
+        :func:`_amdsmi_returns_celsius`): bindings ``< 26.x`` return
+        millidegrees Celsius and need /1000; ``>= 26.x`` already normalize
+        to Celsius.
         """
         for kind in ("JUNCTION", "HOTSPOT"):
             try:
@@ -429,7 +451,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             value = _numeric(temp)
             if value is None:
                 continue
-            if value > 200:  # millidegrees -> degrees
+            if not _amdsmi_returns_celsius():
                 value = value / 1000.0
             td.amd_temperature = value
             return

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -14,9 +14,19 @@ import contextlib
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import amdsmi
+if TYPE_CHECKING:
+    import amdsmi
+else:
+    # ``amdsmi`` ships with ROCm and is not pip-installable, so it may be
+    # absent on developer machines or CI runners without GPUs. Defer the
+    # import error to collector instantiation so module discovery (e.g.
+    # plugin enumeration, tests/unit/test_imports.py) does not fail.
+    try:
+        import amdsmi
+    except ImportError:
+        amdsmi = None  # type: ignore[assignment]
 
 from aiperf.common.environment import Environment
 from aiperf.common.hooks import background_task, on_init, on_stop
@@ -143,6 +153,8 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
         Returns:
             True if amdsmi can initialize and enumerates >=1 processor handle.
         """
+        if amdsmi is None:
+            return False
         if self._initialized:
             return len(self._gpus) > 0
         try:
@@ -164,8 +176,15 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
         """Initialize amdsmi and enumerate available GPUs.
 
         Raises:
-            RuntimeError: If amdsmi cannot initialize or no GPUs are present.
+            RuntimeError: If the amdsmi Python bindings are not installed,
+                amdsmi cannot initialize, or no GPUs are present.
         """
+        if amdsmi is None:
+            raise RuntimeError(
+                "amdsmi Python bindings not installed. The amdsmi package ships "
+                "with ROCm; install from /opt/rocm/share/amd_smi/amdsmi-*.whl "
+                "or your distro's amd-smi-lib package."
+            )
         try:
             amdsmi.amdsmi_init()
         except amdsmi.AmdSmiException as e:

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -22,12 +22,15 @@ if TYPE_CHECKING:
     import amdsmi
 else:
     # ``amdsmi`` ships with ROCm and is not pip-installable, so it may be
-    # absent on developer machines or CI runners without GPUs. Defer the
-    # import error to collector instantiation so module discovery (e.g.
-    # plugin enumeration, tests/unit/test_imports.py) does not fail.
+    # absent on developer machines or CI runners without GPUs. The wheel can
+    # also be installed without a working native libamd_smi.so (version
+    # mismatch, missing amdgpu driver), in which case the import raises
+    # OSError rather than ImportError. Defer either failure to collector
+    # instantiation so module discovery (plugin enumeration,
+    # tests/unit/test_imports.py) does not fail.
     try:
         import amdsmi
-    except ImportError:
+    except (ImportError, OSError):
         amdsmi = None  # type: ignore[assignment]
 
 from aiperf.common.environment import Environment
@@ -452,12 +455,17 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
         counter. We surface the raw signal as a 0.0/1.0 gauge rather than
         synthesizing a duration client-side. ``throttle_status`` may be
         returned as ``bool``, ``int``, or the literal ``'N/A'`` string depending
-        on AMDSMI version and platform support; ``_is_throttled`` handles all
-        three shapes.
+        on AMDSMI version and platform support.
+
+        Leave ``amd_throttle_status`` unset (rather than 0.0) when neither
+        signal carries a real numeric/boolean value, so an unsupported sensor
+        is not silently mislabeled as "not throttled".
         """
         with contextlib.suppress(ExcType):
             m = amdsmi.amdsmi_get_gpu_metrics_info(handle)
-            throttled = _is_throttled(m.get("throttle_status")) or _is_throttled(
-                m.get("indep_throttle_status")
-            )
+            primary = m.get("throttle_status")
+            indep = m.get("indep_throttle_status")
+            if not any(isinstance(v, (bool, int, float)) for v in (primary, indep)):
+                return
+            throttled = _is_throttled(primary) or _is_throttled(indep)
             td.amd_throttle_status = 1.0 if throttled else 0.0

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -434,14 +434,14 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
     def _collect_temperature(
         handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
     ) -> None:
-        """Temperature: prefer JUNCTION (Instinct GPUs), fall back to HOTSPOT.
+        """Temperature: prefer JUNCTION, fall back to HOTSPOT (EDGE unsupported on Instinct).
 
-        EDGE is unsupported on Instinct GPUs.
-
-        Unit conversion is gated on ``amdsmi.__version__`` (see
-        :func:`_amdsmi_returns_celsius`): bindings ``< 26.x`` return
-        millidegrees Celsius and need /1000; ``>= 26.x`` already normalize
-        to Celsius.
+        Unit conversion: divide by 1000 if ``amdsmi.__version__ < 26`` OR the
+        raw value is implausibly high (> 200 °C). The version gate covers
+        bindings whose Python API returns millidegrees; the >200 sanity
+        check hedges against newer bindings whose docs still describe
+        millideg semantics (amdsmi 26.2.2 docs notwithstanding our
+        empirical Celsius observations on 26.0.2/26.2.1).
         """
         for kind in ("JUNCTION", "HOTSPOT"):
             try:
@@ -455,7 +455,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             value = _numeric(temp)
             if value is None:
                 continue
-            if not _amdsmi_returns_celsius():
+            if not _amdsmi_returns_celsius() or value > 200:
                 value = value / 1000.0
             td.amd_temperature = value
             return

--- a/src/aiperf/gpu_telemetry/amdsmi_collector.py
+++ b/src/aiperf/gpu_telemetry/amdsmi_collector.py
@@ -4,9 +4,11 @@
 """AMDSMI-based GPU telemetry collector.
 
 Collects GPU metrics from AMD ROCm GPUs (Instinct MI300X, MI355X, etc.) using
-the amdsmi Python library shipped with ROCm. Mirrors the behavioral contract of
-the PyNVML collector so that downstream accumulation, export, and dashboard
-code remains hardware-agnostic.
+the amdsmi Python library shipped with ROCm. Emits AMD signals under
+vendor-namespaced ``amd_*`` fields on TelemetryMetrics rather than aliasing
+them onto NVML-shaped names, since the underlying signals do not always
+measure the same physical quantity (e.g. amdsmi ``gfx_activity`` and NVML
+``sm_utilization`` sample at different scopes).
 """
 
 import asyncio
@@ -62,17 +64,10 @@ class _AMDGpuDeviceState:
     Args:
         handle: AMDSMI processor handle (opaque pointer)
         metadata: GPU metadata
-        throttle_accum_us: Accumulated throttle duration in microseconds, computed
-            client-side because AMDSMI only exposes a boolean throttle_status
-            rather than a duration counter like NVML's violationTime.
-        last_collect_ns: Timestamp of last successful collection for throttle
-            duration computation.
     """
 
     handle: Any
     metadata: GpuMetadata
-    throttle_accum_us: float = 0.0
-    last_collect_ns: int = 0
 
 
 def _numeric(value: Any) -> float | None:
@@ -314,7 +309,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             records: list[TelemetryRecord] = []
 
             for gpu in self._gpus:
-                metrics = self._snapshot_gpu(gpu, now_ns, ExcType)
+                metrics = self._snapshot_gpu(gpu, ExcType)
                 if metrics.model_fields_set:
                     records.append(
                         TelemetryRecord(
@@ -328,7 +323,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             return records
 
     def _snapshot_gpu(
-        self, gpu: _AMDGpuDeviceState, now_ns: int, ExcType: type[Exception]
+        self, gpu: _AMDGpuDeviceState, ExcType: type[Exception]
     ) -> TelemetryMetrics:
         """Capture all supported metrics for one GPU into a TelemetryMetrics."""
         td = TelemetryMetrics()
@@ -339,8 +334,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
         self._collect_memory(handle, td, ExcType)
         self._collect_temperature(handle, td, ExcType)
         self._collect_ecc(handle, td, ExcType)
-        self._collect_throttle(gpu, td, now_ns, ExcType)
-        gpu.last_collect_ns = now_ns
+        self._collect_throttle(handle, td, ExcType)
         return td
 
     @staticmethod
@@ -354,7 +348,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             if value is None:
                 value = _numeric(power.get("average_socket_power"))
             if value is not None:
-                td.gpu_power_usage = value
+                td.amd_power = value
 
     @staticmethod
     def _collect_energy(
@@ -373,7 +367,9 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
                 acc = _numeric(energy.get("power"))  # ROCm 6.x naming
             res = _numeric(energy.get("counter_resolution"))
             if acc is not None and res is not None:
-                td.energy_consumption = acc * res * _AMDScalingFactors.energy_uj_to_mj
+                td.amd_energy_consumption = (
+                    acc * res * _AMDScalingFactors.energy_uj_to_mj
+                )
 
     @staticmethod
     def _collect_activity(
@@ -386,13 +382,11 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
             umc = _numeric(activity.get("umc_activity"))
             mm = _numeric(activity.get("mm_activity"))
             if gfx is not None:
-                td.gpu_utilization = gfx
-                td.sm_utilization = gfx  # AMD has no separate SM-level metric
+                td.amd_gfx_activity = gfx
             if umc is not None:
-                td.mem_utilization = umc
+                td.amd_umc_activity = umc
             if mm is not None:
-                td.encoder_utilization = mm
-                td.decoder_utilization = mm
+                td.amd_mm_activity = mm
 
     @staticmethod
     def _collect_memory(
@@ -404,7 +398,7 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
                 amdsmi.amdsmi_get_gpu_memory_usage(handle, amdsmi.AmdSmiMemoryType.VRAM)
             )
             if vram_used is not None:
-                td.gpu_memory_used = vram_used * _AMDScalingFactors.bytes_to_gb
+                td.amd_memory_used = vram_used * _AMDScalingFactors.bytes_to_gb
 
     @staticmethod
     def _collect_temperature(
@@ -434,41 +428,36 @@ class AMDSMITelemetryCollector(AIPerfLifecycleMixin):
                 continue
             if value > 200:  # millidegrees -> degrees
                 value = value / 1000.0
-            td.gpu_temperature = value
+            td.amd_temperature = value
             return
 
     @staticmethod
     def _collect_ecc(
         handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
     ) -> None:
-        """ECC: ``uncorrectable_count`` maps closest to ``xid_errors`` semantics."""
+        """ECC: cumulative uncorrectable error count from ``uncorrectable_count``."""
         with contextlib.suppress(ExcType):
             ecc = amdsmi.amdsmi_get_gpu_total_ecc_count(handle)
             uc = _numeric(ecc.get("uncorrectable_count"))
             if uc is not None:
-                td.xid_errors = uc
+                td.amd_ecc_uncorrectable = uc
 
     @staticmethod
     def _collect_throttle(
-        gpu: _AMDGpuDeviceState,
-        td: TelemetryMetrics,
-        now_ns: int,
-        ExcType: type[Exception],
+        handle: Any, td: TelemetryMetrics, ExcType: type[Exception]
     ) -> None:
-        """Throttle duration accumulated client-side from ``throttle_status``.
+        """Throttle status snapshot from ``throttle_status``.
 
-        AMDSMI exposes only a boolean (or bitfield) throttle_status, no
-        duration counter, so we accumulate microseconds spent throttled
-        between scrapes. ``throttle_status`` may be returned as ``bool``,
-        ``int``, or the literal ``'N/A'`` string depending on AMDSMI
-        version and platform support; treat any truthy numeric / boolean
-        value as throttled and ignore string sentinels.
+        AMDSMI exposes a boolean (or bitfield) throttle_status, not a duration
+        counter. We surface the raw signal as a 0.0/1.0 gauge rather than
+        synthesizing a duration client-side. ``throttle_status`` may be
+        returned as ``bool``, ``int``, or the literal ``'N/A'`` string depending
+        on AMDSMI version and platform support; ``_is_throttled`` handles all
+        three shapes.
         """
         with contextlib.suppress(ExcType):
-            m = amdsmi.amdsmi_get_gpu_metrics_info(gpu.handle)
+            m = amdsmi.amdsmi_get_gpu_metrics_info(handle)
             throttled = _is_throttled(m.get("throttle_status")) or _is_throttled(
                 m.get("indep_throttle_status")
             )
-            if throttled and gpu.last_collect_ns:
-                gpu.throttle_accum_us += (now_ns - gpu.last_collect_ns) / 1_000.0
-            td.power_violation = gpu.throttle_accum_us
+            td.amd_throttle_status = 1.0 if throttled else 0.0

--- a/src/aiperf/gpu_telemetry/constants.py
+++ b/src/aiperf/gpu_telemetry/constants.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Constants for GPU telemetry collection (DCGM and pynvml)."""
+"""Constants for GPU telemetry collection (DCGM, pynvml, and amdsmi)."""
 
 from aiperf.common.enums import (
     EnergyMetricUnit,
@@ -52,6 +52,19 @@ GPU_TELEMETRY_METRICS_CONFIG: list[tuple[str, str, MetricUnitT]] = [
     ("JPEG Utilization", "jpg_utilization", GenericMetricUnit.PERCENT),
     ("XID Errors", "xid_errors", GenericMetricUnit.COUNT),
     ("Power Violation", "power_violation", MetricTimeUnit.MICROSECONDS),
+    # AMD ROCm telemetry (collected by AMDSMITelemetryCollector). These mirror
+    # the amdsmi field names rather than NVML semantics, since the underlying
+    # signals do not always measure the same physical quantity. Registered here
+    # so accumulator/exporter/dashboard surface them end-to-end.
+    ("AMD GPU Power", "amd_power", PowerMetricUnit.WATT),
+    ("AMD Energy Consumption", "amd_energy_consumption", EnergyMetricUnit.MEGAJOULE),
+    ("AMD GFX Activity", "amd_gfx_activity", GenericMetricUnit.PERCENT),
+    ("AMD UMC Activity", "amd_umc_activity", GenericMetricUnit.PERCENT),
+    ("AMD MM Activity", "amd_mm_activity", GenericMetricUnit.PERCENT),
+    ("AMD GPU Memory Used", "amd_memory_used", MetricSizeUnit.GIGABYTES),
+    ("AMD GPU Temperature", "amd_temperature", TemperatureMetricUnit.CELSIUS),
+    ("AMD ECC Uncorrectable", "amd_ecc_uncorrectable", GenericMetricUnit.COUNT),
+    ("AMD Throttle Status", "amd_throttle_status", GenericMetricUnit.COUNT),
 ]
 
 # Metrics that are cumulative counters (need delta calculation).
@@ -61,6 +74,8 @@ GPU_TELEMETRY_COUNTER_METRICS: set[str] = {
     "energy_consumption",
     "xid_errors",
     "power_violation",
+    "amd_energy_consumption",
+    "amd_ecc_uncorrectable",
 }
 
 

--- a/src/aiperf/gpu_telemetry/constants.py
+++ b/src/aiperf/gpu_telemetry/constants.py
@@ -16,6 +16,9 @@ from aiperf.common.enums import (
 # Source identifier for pynvml collector (used in TelemetryRecord.dcgm_url field)
 PYNVML_SOURCE_IDENTIFIER = "pynvml://localhost"
 
+# Source identifier for amdsmi collector (used in TelemetryRecord.dcgm_url field)
+AMDSMI_SOURCE_IDENTIFIER = "amdsmi://localhost"
+
 # DCGM field mapping to telemetry record fields
 DCGM_TO_FIELD_MAPPING = {
     "DCGM_FI_DEV_POWER_USAGE": "gpu_power_usage",

--- a/src/aiperf/gpu_telemetry/manager.py
+++ b/src/aiperf/gpu_telemetry/manager.py
@@ -17,7 +17,10 @@ from aiperf.common.messages import (
 )
 from aiperf.common.models import ErrorDetails, TelemetryRecord
 from aiperf.common.protocols import PushClientProtocol
-from aiperf.gpu_telemetry.constants import PYNVML_SOURCE_IDENTIFIER
+from aiperf.gpu_telemetry.constants import (
+    AMDSMI_SOURCE_IDENTIFIER,
+    PYNVML_SOURCE_IDENTIFIER,
+)
 from aiperf.gpu_telemetry.dcgm_collector import DCGMTelemetryCollector
 from aiperf.gpu_telemetry.protocols import GPUTelemetryCollectorProtocol
 from aiperf.plugin import plugins
@@ -177,6 +180,8 @@ class GPUTelemetryManager(BaseComponentService):
         # Phase 1: Test reachability for all endpoints
         if self._collector_type == GPUTelemetryCollectorType.PYNVML:
             await self._configure_pynvml_collector()
+        elif self._collector_type == GPUTelemetryCollectorType.AMDSMI:
+            await self._configure_amdsmi_collector()
         else:
             await self._configure_dcgm_collectors()
 
@@ -231,6 +236,61 @@ class GPUTelemetryManager(BaseComponentService):
             await self._send_telemetry_status(
                 enabled=False,
                 reason=f"pynvml configuration failed: {e}",
+                endpoints_configured=[],
+                endpoints_reachable=[],
+            )
+
+    async def _configure_amdsmi_collector(self) -> None:
+        """Configure a single AMDSMI collector for local AMD ROCm GPU monitoring."""
+        self.debug("GPU Telemetry: Configuring amdsmi collector")
+
+        try:
+            CollectorClass = plugins.get_class(
+                PluginType.GPU_TELEMETRY_COLLECTOR,
+                GPUTelemetryCollectorType.AMDSMI,
+            )
+
+            collector_id = "amdsmi_collector"
+            collector = CollectorClass(
+                collection_interval=self._collection_interval,
+                record_callback=self._on_telemetry_records,
+                error_callback=self._on_telemetry_error,
+                collector_id=collector_id,
+            )
+
+            is_available = await collector.is_url_reachable()
+            if is_available:
+                self._collectors[AMDSMI_SOURCE_IDENTIFIER] = collector
+                self._collector_id_to_url[collector_id] = AMDSMI_SOURCE_IDENTIFIER
+                self.debug("GPU Telemetry: amdsmi collector configured successfully")
+                await self._send_telemetry_status(
+                    enabled=True,
+                    reason=None,
+                    endpoints_configured=[AMDSMI_SOURCE_IDENTIFIER],
+                    endpoints_reachable=[AMDSMI_SOURCE_IDENTIFIER],
+                )
+            else:
+                self.warning("GPU Telemetry: amdsmi not available or no AMD GPUs found")
+                await self._send_telemetry_status(
+                    enabled=False,
+                    reason="amdsmi not available or no AMD GPUs found",
+                    endpoints_configured=[AMDSMI_SOURCE_IDENTIFIER],
+                    endpoints_reachable=[],
+                )
+        except RuntimeError as e:
+            # amdsmi package not installed (or ROCm driver missing)
+            self.error(f"GPU Telemetry: {e}")
+            await self._send_telemetry_status(
+                enabled=False,
+                reason=str(e),
+                endpoints_configured=[],
+                endpoints_reachable=[],
+            )
+        except Exception as e:  # noqa: BLE001 - fault-tolerant telemetry
+            self.error(f"GPU Telemetry: Failed to configure amdsmi collector: {e}")
+            await self._send_telemetry_status(
+                enabled=False,
+                reason=f"amdsmi configuration failed: {e}",
                 endpoints_configured=[],
                 endpoints_reachable=[],
             )

--- a/src/aiperf/gpu_telemetry/manager.py
+++ b/src/aiperf/gpu_telemetry/manager.py
@@ -263,6 +263,21 @@ class GPUTelemetryManager(BaseComponentService):
                 self._collectors[AMDSMI_SOURCE_IDENTIFIER] = collector
                 self._collector_id_to_url[collector_id] = AMDSMI_SOURCE_IDENTIFIER
                 self.debug("GPU Telemetry: amdsmi collector configured successfully")
+
+                # Capture baseline metrics before profiling starts so counter
+                # deltas (amd_energy_consumption, amd_ecc_uncorrectable) are
+                # computed against a pre-profile reference rather than the
+                # first in-window sample. Mirrors DCGM Phase 2 pattern below.
+                self.info("GPU Telemetry: Capturing amdsmi baseline metrics...")
+                try:
+                    await collector.initialize()
+                    await collector.collect_and_process_metrics()
+                    self.debug("GPU Telemetry: Captured amdsmi baseline")
+                except Exception as e:  # noqa: BLE001 - baseline best-effort
+                    self.warning(
+                        f"GPU Telemetry: Failed to capture amdsmi baseline: {e}"
+                    )
+
                 await self._send_telemetry_status(
                     enabled=True,
                     reason=None,

--- a/src/aiperf/gpu_telemetry/manager.py
+++ b/src/aiperf/gpu_telemetry/manager.py
@@ -240,6 +240,60 @@ class GPUTelemetryManager(BaseComponentService):
                 endpoints_reachable=[],
             )
 
+    async def _capture_amdsmi_baseline(
+        self,
+        collector: GPUTelemetryCollectorProtocol,
+        collector_id: str,
+    ) -> bool:
+        """Capture pre-profile baseline so AMDSMI counter deltas reference it.
+
+        Counter metrics (``amd_energy_consumption``, ``amd_ecc_uncorrectable``)
+        compute deltas against the last sample taken before profiling starts.
+        Without a baseline, the accumulator falls back to the first in-window
+        sample and undercounts short runs.
+
+        Init and scrape are handled separately:
+        - ``initialize()`` failure means the collector is unusable. Drop it
+          from ``_collectors`` and report disabled status. ``initialize()``
+          runs through ``AIPerfLifecycleMixin``, which re-raises hook failures
+          as ``asyncio.CancelledError`` (not ``Exception``), so catch both
+          to prevent cancelling the surrounding ``PROFILE_CONFIGURE`` flow.
+        - ``collect_and_process_metrics()`` failure only loses the reference
+          sample. Warn and keep the collector enabled.
+
+        Returns:
+            True if the collector should remain enabled, False if init
+            failed and the caller should stop configuration.
+        """
+        self.info("GPU Telemetry: Capturing amdsmi baseline metrics...")
+        try:
+            await collector.initialize()
+        except (Exception, asyncio.CancelledError) as e:  # noqa: BLE001
+            self.warning(
+                f"GPU Telemetry: amdsmi initialize failed during baseline "
+                f"capture, disabling collector: {e!r}"
+            )
+            self._collectors.pop(AMDSMI_SOURCE_IDENTIFIER, None)
+            self._collector_id_to_url.pop(collector_id, None)
+            await self._send_telemetry_status(
+                enabled=False,
+                reason=f"amdsmi initialization failed: {e}",
+                endpoints_configured=[AMDSMI_SOURCE_IDENTIFIER],
+                endpoints_reachable=[],
+            )
+            return False
+
+        try:
+            await collector.collect_and_process_metrics()
+            self.debug("GPU Telemetry: Captured amdsmi baseline")
+        except Exception as e:  # noqa: BLE001 - baseline scrape best-effort
+            self.warning(
+                f"GPU Telemetry: amdsmi baseline scrape failed (collector "
+                f"remains enabled, counter deltas may undercount the first "
+                f"interval): {e}"
+            )
+        return True
+
     async def _configure_amdsmi_collector(self) -> None:
         """Configure a single AMDSMI collector for local AMD ROCm GPU monitoring."""
         self.debug("GPU Telemetry: Configuring amdsmi collector")
@@ -264,19 +318,8 @@ class GPUTelemetryManager(BaseComponentService):
                 self._collector_id_to_url[collector_id] = AMDSMI_SOURCE_IDENTIFIER
                 self.debug("GPU Telemetry: amdsmi collector configured successfully")
 
-                # Capture baseline metrics before profiling starts so counter
-                # deltas (amd_energy_consumption, amd_ecc_uncorrectable) are
-                # computed against a pre-profile reference rather than the
-                # first in-window sample. Mirrors DCGM Phase 2 pattern below.
-                self.info("GPU Telemetry: Capturing amdsmi baseline metrics...")
-                try:
-                    await collector.initialize()
-                    await collector.collect_and_process_metrics()
-                    self.debug("GPU Telemetry: Captured amdsmi baseline")
-                except Exception as e:  # noqa: BLE001 - baseline best-effort
-                    self.warning(
-                        f"GPU Telemetry: Failed to capture amdsmi baseline: {e}"
-                    )
+                if not await self._capture_amdsmi_baseline(collector, collector_id):
+                    return  # init failed; disabled status already sent
 
                 await self._send_telemetry_status(
                     enabled=True,

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -131,4 +131,4 @@ PlotType = plugins.create_enum(PluginType.PLOT, "PlotType", module=__name__)
 
 GPUTelemetryCollectorTypeStr: TypeAlias = str
 GPUTelemetryCollectorType = plugins.create_enum(PluginType.GPU_TELEMETRY_COLLECTOR, "GPUTelemetryCollectorType", module=__name__)
-"""Dynamic enum for gpu telemetry collector. Example: GPUTelemetryCollectorType.DCGM, GPUTelemetryCollectorType.PYNVML"""
+"""Dynamic enum for gpu telemetry collector. Example: GPUTelemetryCollectorType.AMDSMI, GPUTelemetryCollectorType.DCGM, GPUTelemetryCollectorType.PYNVML"""

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1055,6 +1055,11 @@ gpu_telemetry_collector:
     class: aiperf.gpu_telemetry.pynvml_collector:PyNVMLTelemetryCollector
     description: |
       PyNVML telemetry collector that collects GPU telemetry metrics using the pynvml Python library.
+  amdsmi:
+    class: aiperf.gpu_telemetry.amdsmi_collector:AMDSMITelemetryCollector
+    description: |
+      AMDSMI telemetry collector for AMD ROCm GPUs (Instinct MI300X, MI355X, etc.).
+      Uses the amdsmi Python library shipped with ROCm.
 
 # =============================================================================
 # Accuracy Graders

--- a/tests/unit/common/config/test_user_config.py
+++ b/tests/unit/common/config/test_user_config.py
@@ -341,11 +341,26 @@ class TestGPUTelemetryConfig:
         finally:
             sys.modules.pop("amdsmi", None)
 
+    def test_conflicting_local_collector_keywords_raise(self):
+        """Passing both `pynvml` and `amdsmi` raises rather than last-wins."""
+        sys.modules["amdsmi"] = type(sys)("amdsmi")
+        sys.modules["pynvml"] = type(sys)("pynvml")
+        try:
+            with pytest.raises(
+                ValidationError, match="Conflicting local GPU telemetry collectors"
+            ):
+                make_config(gpu_telemetry=["pynvml", "amdsmi"])
+        finally:
+            sys.modules.pop("amdsmi", None)
+            sys.modules.pop("pynvml", None)
+
     def test_amdsmi_with_dcgm_url_raises(self):
         """Combining --gpu-telemetry amdsmi with a DCGM URL raises a clear error."""
         sys.modules["amdsmi"] = type(sys)("amdsmi")
         try:
-            with pytest.raises(Exception, match="Cannot use amdsmi with DCGM URLs"):
+            with pytest.raises(
+                ValidationError, match="Cannot use amdsmi with DCGM URLs"
+            ):
                 make_config(gpu_telemetry=["amdsmi", "http://localhost:9400"])
         finally:
             sys.modules.pop("amdsmi", None)
@@ -361,7 +376,7 @@ class TestGPUTelemetryConfig:
 
         with (
             patch("aiperf.common.config.user_config.import_module", _raise),
-            pytest.raises(Exception, match="amdsmi package not installed"),
+            pytest.raises(ValidationError, match="amdsmi package not installed"),
         ):
             make_config(gpu_telemetry=["amdsmi"])
 
@@ -376,7 +391,7 @@ class TestGPUTelemetryConfig:
 
         with (
             patch("aiperf.common.config.user_config.import_module", _raise),
-            pytest.raises(Exception, match="amdsmi package not installed"),
+            pytest.raises(ValidationError, match="amdsmi package not installed"),
         ):
             make_config(gpu_telemetry=["amdsmi"])
 

--- a/tests/unit/common/config/test_user_config.py
+++ b/tests/unit/common/config/test_user_config.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+import sys
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
@@ -324,6 +325,56 @@ class TestGPUTelemetryConfig:
         assert config.gpu_telemetry_urls == ["http://custom:9401/metrics"]
         assert config.endpoint.streaming is True
         assert config.endpoint.model_names == ["test-model"]
+
+    def test_amdsmi_collector_selected_when_amdsmi_keyword_provided(self):
+        """`--gpu-telemetry amdsmi` selects the AMDSMI collector type."""
+        from aiperf.plugin.enums import GPUTelemetryCollectorType
+
+        # Inject a fake amdsmi module so the import_module probe succeeds
+        # without requiring ROCm installed on the test host.
+        sys.modules["amdsmi"] = type(sys)("amdsmi")
+        try:
+            config = make_config(gpu_telemetry=["amdsmi"])
+            assert (
+                config._gpu_telemetry_collector_type == GPUTelemetryCollectorType.AMDSMI
+            )
+        finally:
+            sys.modules.pop("amdsmi", None)
+
+    def test_amdsmi_with_dcgm_url_raises(self):
+        """Combining --gpu-telemetry amdsmi with a DCGM URL raises a clear error."""
+        sys.modules["amdsmi"] = type(sys)("amdsmi")
+        try:
+            with pytest.raises(Exception, match="Cannot use amdsmi with DCGM URLs"):
+                make_config(gpu_telemetry=["amdsmi", "http://localhost:9400"])
+        finally:
+            sys.modules.pop("amdsmi", None)
+
+    def test_amdsmi_missing_module_yields_install_hint(self):
+        """ImportError when probing amdsmi surfaces the install hint."""
+        from importlib import import_module as _orig
+
+        def _raise(name):
+            if name == "amdsmi":
+                raise ImportError("simulated missing")
+            return _orig(name)
+
+        with patch("aiperf.common.config.user_config.import_module", _raise):
+            with pytest.raises(Exception, match="amdsmi package not installed"):
+                make_config(gpu_telemetry=["amdsmi"])
+
+    def test_amdsmi_native_lib_oserror_yields_install_hint(self):
+        """OSError (native lib failed to load) is caught and surfaces install hint."""
+        from importlib import import_module as _orig
+
+        def _raise(name):
+            if name == "amdsmi":
+                raise OSError("libamd_smi.so: cannot open shared object file")
+            return _orig(name)
+
+        with patch("aiperf.common.config.user_config.import_module", _raise):
+            with pytest.raises(Exception, match="amdsmi package not installed"):
+                make_config(gpu_telemetry=["amdsmi"])
 
     def test_urls_extraction(self):
         """Test that only http URLs are extracted from gpu_telemetry list."""

--- a/tests/unit/common/config/test_user_config.py
+++ b/tests/unit/common/config/test_user_config.py
@@ -359,9 +359,11 @@ class TestGPUTelemetryConfig:
                 raise ImportError("simulated missing")
             return _orig(name)
 
-        with patch("aiperf.common.config.user_config.import_module", _raise):
-            with pytest.raises(Exception, match="amdsmi package not installed"):
-                make_config(gpu_telemetry=["amdsmi"])
+        with (
+            patch("aiperf.common.config.user_config.import_module", _raise),
+            pytest.raises(Exception, match="amdsmi package not installed"),
+        ):
+            make_config(gpu_telemetry=["amdsmi"])
 
     def test_amdsmi_native_lib_oserror_yields_install_hint(self):
         """OSError (native lib failed to load) is caught and surfaces install hint."""
@@ -372,9 +374,11 @@ class TestGPUTelemetryConfig:
                 raise OSError("libamd_smi.so: cannot open shared object file")
             return _orig(name)
 
-        with patch("aiperf.common.config.user_config.import_module", _raise):
-            with pytest.raises(Exception, match="amdsmi package not installed"):
-                make_config(gpu_telemetry=["amdsmi"])
+        with (
+            patch("aiperf.common.config.user_config.import_module", _raise),
+            pytest.raises(Exception, match="amdsmi package not installed"),
+        ):
+            make_config(gpu_telemetry=["amdsmi"])
 
     def test_urls_extraction(self):
         """Test that only http URLs are extracted from gpu_telemetry list."""

--- a/tests/unit/common/config/test_user_config.py
+++ b/tests/unit/common/config/test_user_config.py
@@ -326,10 +326,8 @@ class TestGPUTelemetryConfig:
         assert config.endpoint.streaming is True
         assert config.endpoint.model_names == ["test-model"]
 
-    def test_amdsmi_collector_selected_when_amdsmi_keyword_provided(self):
+    def test_amdsmi_collector_selected_when_amdsmi_keyword_provided(self) -> None:
         """`--gpu-telemetry amdsmi` selects the AMDSMI collector type."""
-        from aiperf.plugin.enums import GPUTelemetryCollectorType
-
         # Inject a fake amdsmi module so the import_module probe succeeds
         # without requiring ROCm installed on the test host.
         sys.modules["amdsmi"] = type(sys)("amdsmi")
@@ -341,7 +339,7 @@ class TestGPUTelemetryConfig:
         finally:
             sys.modules.pop("amdsmi", None)
 
-    def test_conflicting_local_collector_keywords_raise(self):
+    def test_conflicting_local_collector_keywords_raise(self) -> None:
         """Passing both `pynvml` and `amdsmi` raises rather than last-wins."""
         sys.modules["amdsmi"] = type(sys)("amdsmi")
         sys.modules["pynvml"] = type(sys)("pynvml")
@@ -354,7 +352,7 @@ class TestGPUTelemetryConfig:
             sys.modules.pop("amdsmi", None)
             sys.modules.pop("pynvml", None)
 
-    def test_amdsmi_with_dcgm_url_raises(self):
+    def test_amdsmi_with_dcgm_url_raises(self) -> None:
         """Combining --gpu-telemetry amdsmi with a DCGM URL raises a clear error."""
         sys.modules["amdsmi"] = type(sys)("amdsmi")
         try:
@@ -365,7 +363,7 @@ class TestGPUTelemetryConfig:
         finally:
             sys.modules.pop("amdsmi", None)
 
-    def test_amdsmi_missing_module_yields_install_hint(self):
+    def test_amdsmi_missing_module_yields_install_hint(self) -> None:
         """ImportError when probing amdsmi surfaces the install hint."""
         from importlib import import_module as _orig
 
@@ -380,7 +378,7 @@ class TestGPUTelemetryConfig:
         ):
             make_config(gpu_telemetry=["amdsmi"])
 
-    def test_amdsmi_native_lib_oserror_yields_install_hint(self):
+    def test_amdsmi_native_lib_oserror_yields_install_hint(self) -> None:
         """OSError (native lib failed to load) is caught and surfaces install hint."""
         from importlib import import_module as _orig
 

--- a/tests/unit/gpu_telemetry/test_amdsmi_collector.py
+++ b/tests/unit/gpu_telemetry/test_amdsmi_collector.py
@@ -32,6 +32,9 @@ def _make_mock_amdsmi(num_gpus: int = 2) -> MagicMock:
         - ``energy_accumulator * counter_resolution`` is in µJ
     """
     m = MagicMock()
+    # Default to a modern (>= 26.x) binding so temperatures are returned in °C.
+    # Tests that want the legacy millidegree path override this explicitly.
+    m.__version__ = "26.0.2+39589fda"
     m.AmdSmiException = type("AmdSmiException", (Exception,), {})
     m.AmdSmiLibraryException = m.AmdSmiException
     m.AmdSmiMemoryType = SimpleNamespace(VRAM=0)
@@ -319,18 +322,56 @@ class TestCollection:
 
     @pytest.mark.asyncio
     async def test_temperature_normalized_when_returned_in_millidegrees(
-        self, initialized_collector, mock_amdsmi
+        self, patch_amdsmi
     ):
-        # Older AMDSMI bindings return temperature in millidegrees C. The
-        # collector applies a sanity normalization (>200 -> divide by 1000).
+        # Legacy AMDSMI bindings (< 26.x) return temperature in millidegrees C.
+        # The version gate routes those through /1000.
+        mock_amdsmi, AMDSMITelemetryCollector = patch_amdsmi
+        mock_amdsmi.__version__ = "25.5.0"
+
         def temp_mdeg(handle, kind, _metric):
             if kind == mock_amdsmi.AmdSmiTemperatureType.EDGE:
                 raise mock_amdsmi.AmdSmiException("EDGE not supported")
             return 67000  # 67°C reported as millidegrees
 
         mock_amdsmi.amdsmi_get_temp_metric.side_effect = temp_mdeg
+        c = AMDSMITelemetryCollector()
+        await c.initialize()
+        try:
+            records = await c._loop_to_thread_collect()
+        finally:
+            await c.stop()
+        assert records[0].telemetry_data.amd_temperature == 67.0
+
+    @pytest.mark.asyncio
+    async def test_temperature_passthrough_on_modern_binding(
+        self, initialized_collector
+    ):
+        # Default mock binding is 26.0.2 (modern), so JUNCTION's raw int 67
+        # passes through unchanged — no /1000 applied.
         records = await initialized_collector._loop_to_thread_collect()
         assert records[0].telemetry_data.amd_temperature == 67.0
+
+    @pytest.mark.asyncio
+    async def test_temperature_unparseable_version_assumes_modern(self, patch_amdsmi):
+        # If amdsmi.__version__ is missing or unparseable, default to "modern"
+        # (no /1000) since every currently-deployed binding is >= 26.x.
+        mock_amdsmi, AMDSMITelemetryCollector = patch_amdsmi
+        mock_amdsmi.__version__ = "garbage-not-a-version"
+
+        def temp_pass(handle, kind, _metric):
+            if kind == mock_amdsmi.AmdSmiTemperatureType.EDGE:
+                raise mock_amdsmi.AmdSmiException("EDGE not supported")
+            return 54  # already-Celsius
+
+        mock_amdsmi.amdsmi_get_temp_metric.side_effect = temp_pass
+        c = AMDSMITelemetryCollector()
+        await c.initialize()
+        try:
+            records = await c._loop_to_thread_collect()
+        finally:
+            await c.stop()
+        assert records[0].telemetry_data.amd_temperature == 54.0
 
     @pytest.mark.asyncio
     async def test_energy_falls_back_to_power_field_for_rocm6(

--- a/tests/unit/gpu_telemetry/test_amdsmi_collector.py
+++ b/tests/unit/gpu_telemetry/test_amdsmi_collector.py
@@ -303,6 +303,36 @@ class TestCollection:
         assert records2[1].telemetry_data.power_violation == 0.0
 
     @pytest.mark.asyncio
+    async def test_temperature_normalized_when_returned_in_millidegrees(
+        self, initialized_collector, mock_amdsmi
+    ):
+        # Older AMDSMI bindings return temperature in millidegrees C. The
+        # collector applies a sanity normalization (>200 -> divide by 1000).
+        def temp_mdeg(handle, kind, _metric):
+            if kind == mock_amdsmi.AmdSmiTemperatureType.EDGE:
+                raise mock_amdsmi.AmdSmiException("EDGE not supported")
+            return 67000  # 67°C reported as millidegrees
+
+        mock_amdsmi.amdsmi_get_temp_metric.side_effect = temp_mdeg
+        records = await initialized_collector._loop_to_thread_collect()
+        assert records[0].telemetry_data.gpu_temperature == 67.0
+
+    @pytest.mark.asyncio
+    async def test_energy_falls_back_to_power_field_for_rocm6(
+        self, initialized_collector, mock_amdsmi
+    ):
+        # ROCm 6.x AMDSMI exposes the energy accumulator as `power` before
+        # being renamed to `energy_accumulator` in 6.2.
+        mock_amdsmi.amdsmi_get_energy_count.side_effect = lambda h, *_: {
+            "power": 1_000_000_000_000,  # 1e12 ticks
+            "counter_resolution": 15.3,
+            "timestamp": 0,
+        }
+        records = await initialized_collector._loop_to_thread_collect()
+        # 1e12 * 15.3 * 1e-12 = 15.3 MJ
+        assert records[0].telemetry_data.energy_consumption == pytest.approx(15.3)
+
+    @pytest.mark.asyncio
     async def test_throttle_handles_bool_int_and_na(
         self, initialized_collector, mock_amdsmi
     ):

--- a/tests/unit/gpu_telemetry/test_amdsmi_collector.py
+++ b/tests/unit/gpu_telemetry/test_amdsmi_collector.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for AMDSMITelemetryCollector.
+
+Tests use a mocked amdsmi module to verify collector behavior without requiring
+actual AMD ROCm GPU hardware. Empirically validated against MI300X (gfx942)
+and MI355X (gfx950) — see ``GpuDeviceState`` notes for AMDSMI quirks.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aiperf.gpu_telemetry.constants import AMDSMI_SOURCE_IDENTIFIER
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_amdsmi(num_gpus: int = 2) -> MagicMock:
+    """Build a mock ``amdsmi`` module that mimics the real API surface.
+
+    Models the empirically observed quirks of AMDSMI on MI300X/MI355X:
+        - ``current_socket_power`` is in W (no scaling required)
+        - ``average_socket_power`` returns the literal string ``'N/A'``
+        - ``mm_activity`` returns ``'N/A'`` on Instinct GPUs
+        - ``EDGE`` temperature raises ``AmdSmiException``; ``JUNCTION`` works
+        - ``energy_accumulator * counter_resolution`` is in µJ
+    """
+    m = MagicMock()
+    m.AmdSmiException = type("AmdSmiException", (Exception,), {})
+    m.AmdSmiLibraryException = m.AmdSmiException
+    m.AmdSmiMemoryType = SimpleNamespace(VRAM=0)
+    m.AmdSmiTemperatureType = SimpleNamespace(EDGE=0, JUNCTION=1, HOTSPOT=2, VRAM=3)
+    m.AmdSmiTemperatureMetric = SimpleNamespace(CURRENT=0)
+
+    handles = [object() for _ in range(num_gpus)]
+    m.amdsmi_init.return_value = None
+    m.amdsmi_shut_down.return_value = None
+    m.amdsmi_get_processor_handles.return_value = handles
+
+    def by_idx(values: list):
+        idx_map = {h: v for h, v in zip(handles, values, strict=True)}
+        return lambda h, *_: idx_map[h]
+
+    m.amdsmi_get_gpu_device_uuid.side_effect = by_idx(
+        [f"06ff74a1-0000-1000-806c-{i:012x}" for i in range(num_gpus)]
+    )
+    m.amdsmi_get_gpu_device_bdf.side_effect = by_idx(
+        [f"0000:{i:02x}:00.0" for i in range(num_gpus)]
+    )
+    m.amdsmi_get_gpu_board_info.side_effect = by_idx(
+        [{"product_name": "AMD Instinct MI300X OAM"} for _ in range(num_gpus)]
+    )
+
+    # Power: 287 W for GPU 0, 218 W for GPU 1 — average_socket_power is N/A.
+    m.amdsmi_get_power_info.side_effect = by_idx(
+        [
+            {"current_socket_power": 287, "average_socket_power": "N/A"},
+            {"current_socket_power": 218, "average_socket_power": "N/A"},
+        ][:num_gpus]
+    )
+
+    # Energy: accumulator(ticks) * counter_resolution(15.3 µJ) = ~640 J then -> MJ
+    m.amdsmi_get_energy_count.side_effect = by_idx(
+        [
+            {"energy_accumulator": 41_797_534_008_632, "counter_resolution": 15.3},
+            {"energy_accumulator": 867_336_253_691, "counter_resolution": 15.3},
+        ][:num_gpus]
+    )
+
+    # Activity: gfx 47%, umc 0% (loaded gpu); gfx 0%, umc 0% (idle gpu).
+    # mm_activity intentionally 'N/A' to exercise the dropout path.
+    m.amdsmi_get_gpu_activity.side_effect = by_idx(
+        [
+            {"gfx_activity": 47, "umc_activity": 0, "mm_activity": "N/A"},
+            {"gfx_activity": 0, "umc_activity": 0, "mm_activity": "N/A"},
+        ][:num_gpus]
+    )
+
+    # VRAM: 183 GB used, 0.3 GB used (in bytes).
+    m.amdsmi_get_gpu_memory_usage.side_effect = by_idx(
+        [183_678_435_328, 297_766_912][:num_gpus]
+    )
+
+    # Temperature: EDGE raises (unsupported on Instinct), JUNCTION returns int.
+    def temp_metric(handle, kind, _metric):
+        if kind == m.AmdSmiTemperatureType.EDGE:
+            raise m.AmdSmiException("EDGE not supported")
+        if kind == m.AmdSmiTemperatureType.JUNCTION:
+            return 67 if handle == handles[0] else 41
+        if kind == m.AmdSmiTemperatureType.HOTSPOT:
+            return 67 if handle == handles[0] else 41
+        return 49
+
+    m.amdsmi_get_temp_metric.side_effect = temp_metric
+
+    m.amdsmi_get_gpu_total_ecc_count.side_effect = by_idx(
+        [
+            {"correctable_count": 0, "uncorrectable_count": 0, "deferred_count": 0},
+            {"correctable_count": 1, "uncorrectable_count": 2, "deferred_count": 0},
+        ][:num_gpus]
+    )
+
+    # Throttle: GPU 0 throttling, GPU 1 not throttling.
+    m.amdsmi_get_gpu_metrics_info.side_effect = by_idx(
+        [
+            {"throttle_status": 1, "indep_throttle_status": 0},
+            {"throttle_status": 0, "indep_throttle_status": 0},
+        ][:num_gpus]
+    )
+
+    return m
+
+
+@pytest.fixture
+def mock_amdsmi():
+    return _make_mock_amdsmi(num_gpus=2)
+
+
+@pytest.fixture
+def patch_amdsmi(mock_amdsmi):
+    from aiperf.gpu_telemetry import amdsmi_collector
+    from aiperf.gpu_telemetry.amdsmi_collector import AMDSMITelemetryCollector
+
+    with patch.object(amdsmi_collector, "amdsmi", mock_amdsmi):
+        yield mock_amdsmi, AMDSMITelemetryCollector
+
+
+@pytest.fixture
+async def initialized_collector(patch_amdsmi):
+    _, AMDSMITelemetryCollector = patch_amdsmi
+    collector = AMDSMITelemetryCollector()
+    await collector.initialize()
+    yield collector
+    await collector.stop()
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestInitialization:
+    def test_default_values(self, patch_amdsmi):
+        _, AMDSMITelemetryCollector = patch_amdsmi
+        c = AMDSMITelemetryCollector()
+        assert c.id == "amdsmi_collector"
+        assert c.endpoint_url == AMDSMI_SOURCE_IDENTIFIER
+        assert c._record_callback is None
+        assert c._error_callback is None
+
+    def test_custom_values(self, patch_amdsmi):
+        _, AMDSMITelemetryCollector = patch_amdsmi
+        c = AMDSMITelemetryCollector(collection_interval=0.5, collector_id="custom_id")
+        assert c.id == "custom_id"
+        assert c.collection_interval == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Reachability
+# ---------------------------------------------------------------------------
+
+
+class TestReachability:
+    @pytest.mark.asyncio
+    async def test_reachable_when_gpus_present(self, patch_amdsmi):
+        _, AMDSMITelemetryCollector = patch_amdsmi
+        c = AMDSMITelemetryCollector()
+        assert await c.is_url_reachable() is True
+
+    @pytest.mark.asyncio
+    async def test_not_reachable_when_no_gpus(self, patch_amdsmi):
+        mock_amdsmi, AMDSMITelemetryCollector = patch_amdsmi
+        mock_amdsmi.amdsmi_get_processor_handles.return_value = []
+        c = AMDSMITelemetryCollector()
+        assert await c.is_url_reachable() is False
+
+    @pytest.mark.asyncio
+    async def test_not_reachable_when_init_fails(self, patch_amdsmi):
+        mock_amdsmi, AMDSMITelemetryCollector = patch_amdsmi
+        mock_amdsmi.amdsmi_init.side_effect = mock_amdsmi.AmdSmiException("driver gone")
+        c = AMDSMITelemetryCollector()
+        assert await c.is_url_reachable() is False
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_initialize_enumerates_gpus(self, initialized_collector):
+        assert initialized_collector._initialized
+        assert len(initialized_collector._gpus) == 2
+        assert initialized_collector._gpus[0].metadata.gpu_index == 0
+        assert (
+            initialized_collector._gpus[0].metadata.gpu_model_name
+            == "AMD Instinct MI300X OAM"
+        )
+        assert initialized_collector._gpus[0].metadata.device == "amd0"
+        assert initialized_collector._gpus[0].metadata.pci_bus_id == "0000:00:00.0"
+
+    @pytest.mark.asyncio
+    async def test_init_failure_propagates_via_lifecycle(self, patch_amdsmi):
+        # AIPerfLifecycleMixin re-raises hook failures as CancelledError with
+        # the original message preserved (matches PyNVMLTelemetryCollector).
+        mock_amdsmi, AMDSMITelemetryCollector = patch_amdsmi
+        mock_amdsmi.amdsmi_init.side_effect = mock_amdsmi.AmdSmiException("nope")
+        c = AMDSMITelemetryCollector()
+        with pytest.raises(asyncio.CancelledError, match="Failed to initialize amdsmi"):
+            await c.initialize()
+        assert not c._initialized
+
+    @pytest.mark.asyncio
+    async def test_shutdown_is_idempotent(self, initialized_collector, mock_amdsmi):
+        await initialized_collector.stop()
+        await initialized_collector.stop()  # second call is no-op
+        assert mock_amdsmi.amdsmi_shut_down.call_count >= 1
+        assert initialized_collector._initialized is False
+        assert initialized_collector._gpus == []
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+class TestCollection:
+    @pytest.mark.asyncio
+    async def test_collect_emits_record_per_gpu(self, initialized_collector):
+        records = await initialized_collector._loop_to_thread_collect()
+        assert len(records) == 2
+        for r in records:
+            assert r.dcgm_url == AMDSMI_SOURCE_IDENTIFIER
+            assert r.timestamp_ns > 0
+
+    @pytest.mark.asyncio
+    async def test_collect_has_all_expected_fields(self, initialized_collector):
+        records = await initialized_collector._loop_to_thread_collect()
+        td0 = records[0].telemetry_data
+
+        # Power: passed through unscaled (W).
+        assert td0.gpu_power_usage == 287.0
+
+        # Energy: 41_797_534_008_632 ticks * 15.3 µJ/tick / 1e12 ≈ 639.5 MJ
+        assert td0.energy_consumption == pytest.approx(639.5, rel=1e-3)
+
+        # Activity: 47% gfx mirrored to both gpu_utilization and sm_utilization.
+        assert td0.gpu_utilization == 47.0
+        assert td0.sm_utilization == 47.0
+        assert td0.mem_utilization == 0.0
+
+        # mm_activity is N/A on Instinct -> encoder/decoder dropped.
+        assert td0.encoder_utilization is None
+        assert td0.decoder_utilization is None
+
+        # VRAM: 183_678_435_328 bytes -> ~183.68 GB
+        assert td0.gpu_memory_used == pytest.approx(183.68, rel=1e-3)
+
+        # Temperature: EDGE failed, JUNCTION returned 67.
+        assert td0.gpu_temperature == 67.0
+
+    @pytest.mark.asyncio
+    async def test_collect_handles_partial_failure(
+        self, initialized_collector, mock_amdsmi
+    ):
+        # Make temperature unsupported entirely; rest must still populate.
+        mock_amdsmi.amdsmi_get_temp_metric.side_effect = mock_amdsmi.AmdSmiException(
+            "no temp"
+        )
+        records = await initialized_collector._loop_to_thread_collect()
+        td = records[0].telemetry_data
+        assert td.gpu_temperature is None
+        assert td.gpu_power_usage == 287.0  # unaffected
+
+    @pytest.mark.asyncio
+    async def test_na_strings_become_none_not_strings(
+        self, initialized_collector, mock_amdsmi
+    ):
+        # Force every field to return 'N/A' to confirm no string leaks into model.
+        mock_amdsmi.amdsmi_get_power_info.side_effect = lambda h, *_: {
+            "current_socket_power": "N/A",
+            "average_socket_power": "N/A",
+        }
+        records = await initialized_collector._loop_to_thread_collect()
+        for r in records:
+            assert r.telemetry_data.gpu_power_usage is None
+
+    @pytest.mark.asyncio
+    async def test_throttle_accumulates_across_collections(self, initialized_collector):
+        # GPU 0 is throttling; second collection should accumulate >0 µs.
+        records1 = await initialized_collector._loop_to_thread_collect()
+        records2 = await initialized_collector._loop_to_thread_collect()
+        assert records1[0].telemetry_data.power_violation == 0.0
+        assert records2[0].telemetry_data.power_violation > 0.0
+        # GPU 1 is not throttling -> stays at 0.
+        assert records2[1].telemetry_data.power_violation == 0.0
+
+    @pytest.mark.asyncio
+    async def test_xid_errors_uses_uncorrectable_count(self, initialized_collector):
+        records = await initialized_collector._loop_to_thread_collect()
+        assert records[0].telemetry_data.xid_errors == 0.0
+        assert records[1].telemetry_data.xid_errors == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Helper: collectors expose _collect_gpu_metrics synchronously, but most
+# call sites in this file want to await a thread-friendly variant for parity
+# with how the background_task invokes it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _attach_collect_helper():
+    from aiperf.gpu_telemetry.amdsmi_collector import AMDSMITelemetryCollector
+
+    async def _loop_to_thread_collect(self):
+        import asyncio
+
+        return await asyncio.to_thread(self._collect_gpu_metrics)
+
+    AMDSMITelemetryCollector._loop_to_thread_collect = _loop_to_thread_collect
+    yield
+    del AMDSMITelemetryCollector._loop_to_thread_collect

--- a/tests/unit/gpu_telemetry/test_amdsmi_collector.py
+++ b/tests/unit/gpu_telemetry/test_amdsmi_collector.py
@@ -348,6 +348,21 @@ class TestCollection:
         assert records[0].telemetry_data.amd_energy_consumption == pytest.approx(15.3)
 
     @pytest.mark.asyncio
+    async def test_throttle_unset_when_sensors_unsupported(
+        self, initialized_collector, mock_amdsmi
+    ):
+        # If amdsmi returns 'N/A' for both throttle signals, leave the field
+        # unset rather than emitting 0.0 — we cannot distinguish "supported and
+        # not throttled" from "sensor unsupported" in that case.
+        mock_amdsmi.amdsmi_get_gpu_metrics_info.side_effect = lambda h, *_: {
+            "throttle_status": "N/A",
+            "indep_throttle_status": "N/A",
+        }
+        records = await initialized_collector._loop_to_thread_collect()
+        for r in records:
+            assert r.telemetry_data.amd_throttle_status is None
+
+    @pytest.mark.asyncio
     async def test_throttle_handles_bool_int_and_na(
         self, initialized_collector, mock_amdsmi
     ):

--- a/tests/unit/gpu_telemetry/test_amdsmi_collector.py
+++ b/tests/unit/gpu_telemetry/test_amdsmi_collector.py
@@ -228,6 +228,119 @@ class TestLifecycle:
         assert initialized_collector._initialized is False
         assert initialized_collector._gpus == []
 
+    @pytest.mark.asyncio
+    async def test_init_raises_when_no_gpus_enumerated(self, patch_amdsmi):
+        # _initialize_amdsmi must not silently leave the collector running with
+        # zero devices — that would emit no records and confuse the dashboard.
+        # AIPerfLifecycleMixin wraps the RuntimeError as CancelledError.
+        mock_amdsmi, AMDSMITelemetryCollector = patch_amdsmi
+        mock_amdsmi.amdsmi_get_processor_handles.return_value = []
+        c = AMDSMITelemetryCollector()
+        with pytest.raises(asyncio.CancelledError, match="No AMD GPUs detected"):
+            await c.initialize()
+        assert not c._initialized
+        assert c._gpus == []
+
+
+# ---------------------------------------------------------------------------
+# Config registration (regression guard for dynamo-ops finding on PR #908:
+# amd_* fields must appear in GPU_TELEMETRY_METRICS_CONFIG so the accumulator,
+# console exporter, dashboard, and CSV exports can surface them end-to-end.)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigRegistration:
+    def test_amd_fields_registered_in_metrics_config(self) -> None:
+        from aiperf.common.models.telemetry_models import TelemetryMetrics
+        from aiperf.gpu_telemetry.constants import GPU_TELEMETRY_METRICS_CONFIG
+
+        registered = {field for _, field, _ in GPU_TELEMETRY_METRICS_CONFIG}
+        amd_fields = {f for f in TelemetryMetrics.model_fields if f.startswith("amd_")}
+        missing = amd_fields - registered
+        assert not missing, (
+            f"amd_* fields on TelemetryMetrics not registered in "
+            f"GPU_TELEMETRY_METRICS_CONFIG (downstream accumulator will silently "
+            f"drop them): {sorted(missing)}"
+        )
+
+    def test_cumulative_amd_fields_marked_as_counters(self) -> None:
+        from aiperf.gpu_telemetry.constants import GPU_TELEMETRY_COUNTER_METRICS
+
+        # These two AMD signals are cumulative across the device's lifetime;
+        # accumulator must compute deltas, not distribution stats.
+        assert "amd_energy_consumption" in GPU_TELEMETRY_COUNTER_METRICS
+        assert "amd_ecc_uncorrectable" in GPU_TELEMETRY_COUNTER_METRICS
+
+    def test_amd_metrics_flow_through_telemetry_hierarchy(self) -> None:
+        # End-to-end: feed two records with amd_* values into the same
+        # hierarchy the accumulator uses, then iterate the config the same
+        # way summarize() does and confirm every registered amd_* metric
+        # produces a MetricResult instead of a NoMetricValue.
+        from aiperf.common.exceptions import NoMetricValue
+        from aiperf.common.models.telemetry_models import (
+            TelemetryHierarchy,
+            TelemetryMetrics,
+            TelemetryRecord,
+        )
+        from aiperf.gpu_telemetry.constants import (
+            GPU_TELEMETRY_COUNTER_METRICS,
+            GPU_TELEMETRY_METRICS_CONFIG,
+        )
+
+        hierarchy = TelemetryHierarchy()
+        for ts, energy in ((1_000_000_000, 100.0), (2_000_000_000, 105.0)):
+            hierarchy.add_record(
+                TelemetryRecord(
+                    gpu_index=0,
+                    gpu_uuid="GPU-amd-test-0",
+                    gpu_model_name="AMD Instinct MI300X OAM",
+                    timestamp_ns=ts,
+                    dcgm_url="amdsmi://localhost",
+                    telemetry_data=TelemetryMetrics(
+                        amd_power=287.0,
+                        amd_energy_consumption=energy,
+                        amd_gfx_activity=47.0,
+                        amd_umc_activity=12.0,
+                        amd_memory_used=183.6,
+                        amd_temperature=54.0,
+                        amd_ecc_uncorrectable=0.0,
+                        amd_throttle_status=0.0,
+                        # amd_mm_activity left None on purpose (Instinct GPUs)
+                    ),
+                )
+            )
+
+        gpu_data = hierarchy.dcgm_endpoints["amdsmi://localhost"]["GPU-amd-test-0"]
+        seen = set()
+        for _display, field, unit_enum in GPU_TELEMETRY_METRICS_CONFIG:
+            if not field.startswith("amd_"):
+                continue
+            try:
+                result = gpu_data.get_metric_result(
+                    field,
+                    f"tag_{field}",
+                    f"header_{field}",
+                    unit_enum.value,
+                    is_counter=field in GPU_TELEMETRY_COUNTER_METRICS,
+                )
+            except NoMetricValue:
+                continue  # amd_mm_activity is intentionally absent
+            assert result.tag == f"tag_{field}"
+            assert result.unit == unit_enum.value
+            seen.add(field)
+
+        # Every amd_* field we populated should have flowed through.
+        assert seen >= {
+            "amd_power",
+            "amd_energy_consumption",
+            "amd_gfx_activity",
+            "amd_umc_activity",
+            "amd_memory_used",
+            "amd_temperature",
+            "amd_ecc_uncorrectable",
+            "amd_throttle_status",
+        }
+
 
 # ---------------------------------------------------------------------------
 # Collection
@@ -353,8 +466,8 @@ class TestCollection:
         assert records[0].telemetry_data.amd_temperature == 67.0
 
     @pytest.mark.asyncio
-    async def test_temperature_unparseable_version_assumes_modern(self, patch_amdsmi):
-        # If amdsmi.__version__ is missing or unparseable, default to "modern"
+    async def test_temperature_unparsable_version_assumes_modern(self, patch_amdsmi):
+        # If amdsmi.__version__ is missing or unparsable, default to "modern"
         # (no /1000) since every currently-deployed binding is >= 26.x.
         mock_amdsmi, AMDSMITelemetryCollector = patch_amdsmi
         mock_amdsmi.__version__ = "garbage-not-a-version"

--- a/tests/unit/gpu_telemetry/test_amdsmi_collector.py
+++ b/tests/unit/gpu_telemetry/test_amdsmi_collector.py
@@ -303,6 +303,23 @@ class TestCollection:
         assert records2[1].telemetry_data.power_violation == 0.0
 
     @pytest.mark.asyncio
+    async def test_throttle_handles_bool_int_and_na(
+        self, initialized_collector, mock_amdsmi
+    ):
+        # AMDSMI returns throttle_status as bool on some platforms, int on
+        # others, and 'N/A' string on unsupported sensors. All three must
+        # be classified correctly by _is_throttled.
+        from aiperf.gpu_telemetry.amdsmi_collector import _is_throttled
+
+        assert _is_throttled(True) is True
+        assert _is_throttled(False) is False
+        assert _is_throttled(1) is True
+        assert _is_throttled(0) is False
+        assert _is_throttled(0x10) is True  # bitfield
+        assert _is_throttled("N/A") is False
+        assert _is_throttled(None) is False
+
+    @pytest.mark.asyncio
     async def test_xid_errors_uses_uncorrectable_count(self, initialized_collector):
         records = await initialized_collector._loop_to_thread_collect()
         assert records[0].telemetry_data.xid_errors == 0.0

--- a/tests/unit/gpu_telemetry/test_amdsmi_collector.py
+++ b/tests/unit/gpu_telemetry/test_amdsmi_collector.py
@@ -466,6 +466,25 @@ class TestCollection:
         assert records[0].telemetry_data.amd_temperature == 67.0
 
     @pytest.mark.asyncio
+    async def test_temperature_modern_binding_with_millideg_value_normalized(
+        self, initialized_collector, mock_amdsmi
+    ):
+        # AMD's amdsmi 26.2.2 docs document the API as returning milliCelsius,
+        # even though every 26.x binding we have empirical access to returns
+        # Celsius. The version gate alone would mis-handle a system that
+        # matches the docs; the >200 sanity check on top guarantees we still
+        # report a sane temperature in either case. Default mock binding is
+        # 26.0.2 (modern) so the gate would otherwise skip the divide.
+        def temp_mdeg(handle, kind, _metric):
+            if kind == mock_amdsmi.AmdSmiTemperatureType.EDGE:
+                raise mock_amdsmi.AmdSmiException("EDGE not supported")
+            return 67000  # 67°C reported as millidegrees
+
+        mock_amdsmi.amdsmi_get_temp_metric.side_effect = temp_mdeg
+        records = await initialized_collector._loop_to_thread_collect()
+        assert records[0].telemetry_data.amd_temperature == 67.0
+
+    @pytest.mark.asyncio
     async def test_temperature_unparsable_version_assumes_modern(self, patch_amdsmi):
         # If amdsmi.__version__ is missing or unparsable, default to "modern"
         # (no /1000) since every currently-deployed binding is >= 26.x.

--- a/tests/unit/gpu_telemetry/test_amdsmi_collector.py
+++ b/tests/unit/gpu_telemetry/test_amdsmi_collector.py
@@ -5,7 +5,7 @@
 
 Tests use a mocked amdsmi module to verify collector behavior without requiring
 actual AMD ROCm GPU hardware. Empirically validated against MI300X (gfx942)
-and MI355X (gfx950) — see ``GpuDeviceState`` notes for AMDSMI quirks.
+and MI355X (gfx950) — see ``_AMDGpuDeviceState`` notes for AMDSMI quirks.
 """
 
 import asyncio
@@ -245,26 +245,32 @@ class TestCollection:
         records = await initialized_collector._loop_to_thread_collect()
         td0 = records[0].telemetry_data
 
-        # Power: passed through unscaled (W).
-        assert td0.gpu_power_usage == 287.0
+        # Power: passed through unscaled (W), under amd_* namespace.
+        assert td0.amd_power == 287.0
 
         # Energy: 41_797_534_008_632 ticks * 15.3 µJ/tick / 1e12 ≈ 639.5 MJ
-        assert td0.energy_consumption == pytest.approx(639.5, rel=1e-3)
+        assert td0.amd_energy_consumption == pytest.approx(639.5, rel=1e-3)
 
-        # Activity: 47% gfx mirrored to both gpu_utilization and sm_utilization.
-        assert td0.gpu_utilization == 47.0
-        assert td0.sm_utilization == 47.0
-        assert td0.mem_utilization == 0.0
+        # Activity: gfx/umc emitted under amd_* names; mm_activity is N/A on
+        # Instinct so amd_mm_activity stays unset (not duplicated to
+        # encoder/decoder fields).
+        assert td0.amd_gfx_activity == 47.0
+        assert td0.amd_umc_activity == 0.0
+        assert td0.amd_mm_activity is None
 
-        # mm_activity is N/A on Instinct -> encoder/decoder dropped.
+        # NVML-named fields must NOT be set by the AMD collector.
+        assert td0.gpu_utilization is None
+        assert td0.sm_utilization is None
+        assert td0.mem_utilization is None
         assert td0.encoder_utilization is None
         assert td0.decoder_utilization is None
+        assert td0.jpg_utilization is None
 
         # VRAM: 183_678_435_328 bytes -> ~183.68 GB
-        assert td0.gpu_memory_used == pytest.approx(183.68, rel=1e-3)
+        assert td0.amd_memory_used == pytest.approx(183.68, rel=1e-3)
 
         # Temperature: EDGE failed, JUNCTION returned 67.
-        assert td0.gpu_temperature == 67.0
+        assert td0.amd_temperature == 67.0
 
     @pytest.mark.asyncio
     async def test_collect_handles_partial_failure(
@@ -276,8 +282,8 @@ class TestCollection:
         )
         records = await initialized_collector._loop_to_thread_collect()
         td = records[0].telemetry_data
-        assert td.gpu_temperature is None
-        assert td.gpu_power_usage == 287.0  # unaffected
+        assert td.amd_temperature is None
+        assert td.amd_power == 287.0  # unaffected
 
     @pytest.mark.asyncio
     async def test_na_strings_become_none_not_strings(
@@ -290,17 +296,26 @@ class TestCollection:
         }
         records = await initialized_collector._loop_to_thread_collect()
         for r in records:
-            assert r.telemetry_data.gpu_power_usage is None
+            assert r.telemetry_data.amd_power is None
 
     @pytest.mark.asyncio
-    async def test_throttle_accumulates_across_collections(self, initialized_collector):
-        # GPU 0 is throttling; second collection should accumulate >0 µs.
+    async def test_throttle_status_is_snapshot_not_accumulation(
+        self, initialized_collector
+    ):
+        # AMDSMI exposes throttle_status as a state (bool/bitfield), not a
+        # duration counter. Surface the raw snapshot per scrape rather than
+        # synthesizing a duration client-side.
         records1 = await initialized_collector._loop_to_thread_collect()
         records2 = await initialized_collector._loop_to_thread_collect()
-        assert records1[0].telemetry_data.power_violation == 0.0
-        assert records2[0].telemetry_data.power_violation > 0.0
-        # GPU 1 is not throttling -> stays at 0.
-        assert records2[1].telemetry_data.power_violation == 0.0
+
+        # GPU 0 throttling (mock returns throttle_status=1) -> 1.0 every scrape.
+        assert records1[0].telemetry_data.amd_throttle_status == 1.0
+        assert records2[0].telemetry_data.amd_throttle_status == 1.0
+        # GPU 1 not throttling -> 0.0.
+        assert records1[1].telemetry_data.amd_throttle_status == 0.0
+        assert records2[1].telemetry_data.amd_throttle_status == 0.0
+        # The synthesized power_violation field is no longer populated.
+        assert records2[0].telemetry_data.power_violation is None
 
     @pytest.mark.asyncio
     async def test_temperature_normalized_when_returned_in_millidegrees(
@@ -315,7 +330,7 @@ class TestCollection:
 
         mock_amdsmi.amdsmi_get_temp_metric.side_effect = temp_mdeg
         records = await initialized_collector._loop_to_thread_collect()
-        assert records[0].telemetry_data.gpu_temperature == 67.0
+        assert records[0].telemetry_data.amd_temperature == 67.0
 
     @pytest.mark.asyncio
     async def test_energy_falls_back_to_power_field_for_rocm6(
@@ -330,7 +345,7 @@ class TestCollection:
         }
         records = await initialized_collector._loop_to_thread_collect()
         # 1e12 * 15.3 * 1e-12 = 15.3 MJ
-        assert records[0].telemetry_data.energy_consumption == pytest.approx(15.3)
+        assert records[0].telemetry_data.amd_energy_consumption == pytest.approx(15.3)
 
     @pytest.mark.asyncio
     async def test_throttle_handles_bool_int_and_na(
@@ -350,10 +365,15 @@ class TestCollection:
         assert _is_throttled(None) is False
 
     @pytest.mark.asyncio
-    async def test_xid_errors_uses_uncorrectable_count(self, initialized_collector):
+    async def test_ecc_uncorrectable_emitted_under_amd_namespace(
+        self, initialized_collector
+    ):
         records = await initialized_collector._loop_to_thread_collect()
-        assert records[0].telemetry_data.xid_errors == 0.0
-        assert records[1].telemetry_data.xid_errors == 2.0
+        assert records[0].telemetry_data.amd_ecc_uncorrectable == 0.0
+        assert records[1].telemetry_data.amd_ecc_uncorrectable == 2.0
+        # The synthesized xid_errors alias is no longer populated.
+        assert records[0].telemetry_data.xid_errors is None
+        assert records[1].telemetry_data.xid_errors is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/gpu_telemetry/test_telemetry_manager.py
+++ b/tests/unit/gpu_telemetry/test_telemetry_manager.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -1110,20 +1111,22 @@ class TestAmdsmiCollectorIntegration:
         mock_collector.collect_and_process_metrics.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_configure_amdsmi_collector_continues_when_baseline_fails(self):
-        # If the baseline scrape raises (transient amdsmi error, sensor
-        # hiccup, etc.) configure must still mark the collector enabled
-        # rather than abandon it — matching DCGM's "warn but don't fail"
-        # semantics. The user just loses one baseline sample; the periodic
-        # collection loop still runs and counter deltas degrade to the
-        # first-in-window-sample fallback.
+    async def test_configure_amdsmi_collector_continues_when_baseline_scrape_fails(
+        self,
+    ):
+        # If only the baseline scrape raises (transient sensor read error
+        # after a successful init), the collector is still usable — keep
+        # it enabled and just lose the reference sample. The periodic
+        # collection loop still runs; counter deltas degrade to the
+        # first-in-window-sample fallback for the first interval.
         manager = self._create_test_manager()
         manager.publish = AsyncMock()
 
         mock_collector = AsyncMock()
         mock_collector.is_url_reachable = AsyncMock(return_value=True)
+        mock_collector.initialize = AsyncMock()  # init succeeds
         mock_collector.collect_and_process_metrics = AsyncMock(
-            side_effect=RuntimeError("transient amdsmi error")
+            side_effect=RuntimeError("transient sensor read error")
         )
 
         MockCollectorClass = MagicMock(return_value=mock_collector)
@@ -1142,6 +1145,47 @@ class TestAmdsmiCollectorIntegration:
         assert call_args.enabled is True
         assert AMDSMI_SOURCE_IDENTIFIER in manager._collectors
         manager.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_configure_amdsmi_collector_disables_when_init_fails(self):
+        # AIPerfLifecycleMixin re-raises hook failures as
+        # ``asyncio.CancelledError`` (see test_amdsmi_collector.py
+        # ``test_init_failure_propagates_via_lifecycle``). The baseline path
+        # must catch that — letting it propagate would cancel the entire
+        # PROFILE_CONFIGURE flow rather than gracefully disabling telemetry.
+        # On init failure the collector is unusable, so it must be removed
+        # from ``_collectors`` and disabled status reported.
+        manager = self._create_test_manager()
+        manager.publish = AsyncMock()
+
+        mock_collector = AsyncMock()
+        mock_collector.is_url_reachable = AsyncMock(return_value=True)
+        mock_collector.initialize = AsyncMock(
+            side_effect=asyncio.CancelledError(
+                "Failed to initialize amdsmi: driver gone"
+            )
+        )
+
+        MockCollectorClass = MagicMock(return_value=mock_collector)
+        with patch(
+            "aiperf.plugin.plugins.get_class",
+            return_value=MockCollectorClass,
+        ):
+            configure_msg = ProfileConfigureCommand(
+                command_id="test", service_id="system_controller", config={}
+            )
+            # Must NOT propagate CancelledError out of configure.
+            await manager._profile_configure_command(configure_msg)
+
+        manager.publish.assert_called_once()
+        call_args = manager.publish.call_args[0][0]
+        assert isinstance(call_args, TelemetryStatusMessage)
+        assert call_args.enabled is False
+        assert "amdsmi initialization failed" in call_args.reason
+        assert AMDSMI_SOURCE_IDENTIFIER not in manager._collectors
+        assert "amdsmi_collector" not in manager._collector_id_to_url
+        # collect_and_process_metrics must NOT be invoked when init failed.
+        mock_collector.collect_and_process_metrics.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_configure_amdsmi_collector_no_gpus_found(self):

--- a/tests/unit/gpu_telemetry/test_telemetry_manager.py
+++ b/tests/unit/gpu_telemetry/test_telemetry_manager.py
@@ -15,7 +15,10 @@ from aiperf.common.messages import (
     TelemetryStatusMessage,
 )
 from aiperf.common.models import ErrorDetails
-from aiperf.gpu_telemetry.constants import PYNVML_SOURCE_IDENTIFIER
+from aiperf.gpu_telemetry.constants import (
+    AMDSMI_SOURCE_IDENTIFIER,
+    PYNVML_SOURCE_IDENTIFIER,
+)
 from aiperf.gpu_telemetry.dcgm_collector import DCGMTelemetryCollector
 from aiperf.gpu_telemetry.manager import GPUTelemetryManager
 from aiperf.plugin.enums import GPUTelemetryCollectorType
@@ -1043,3 +1046,126 @@ class TestPynvmlCollectorIntegration:
         # Should have logged error about failed configuration
         manager.error.assert_called_once()
         assert "Failed to configure pynvml collector" in str(manager.error.call_args)
+
+
+class TestAmdsmiCollectorIntegration:
+    """Test AMDSMI collector integration in manager's configure phase.
+
+    Mirrors TestPynvmlCollectorIntegration to exercise the parallel
+    `_configure_amdsmi_collector` dispatch branch.
+    """
+
+    def _create_test_manager(self):
+        manager = GPUTelemetryManager.__new__(GPUTelemetryManager)
+        manager.service_id = "test_manager"
+        manager._collectors = {}
+        manager._collector_id_to_url = {}
+        manager._dcgm_endpoints = list(Environment.GPU.DEFAULT_DCGM_ENDPOINTS)
+        manager._user_provided_endpoints = []
+        manager._user_explicitly_configured_telemetry = False
+        manager._telemetry_disabled = False
+        manager._collection_interval = 0.333
+        manager._collector_type = GPUTelemetryCollectorType.AMDSMI
+        manager.error = MagicMock()
+        manager.warning = MagicMock()
+        manager.debug = MagicMock()
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_configure_amdsmi_collector_success(self):
+        manager = self._create_test_manager()
+        manager.publish = AsyncMock()
+
+        mock_collector = AsyncMock()
+        mock_collector.is_url_reachable = AsyncMock(return_value=True)
+
+        MockCollectorClass = MagicMock(return_value=mock_collector)
+        with patch(
+            "aiperf.plugin.plugins.get_class",
+            return_value=MockCollectorClass,
+        ):
+            configure_msg = ProfileConfigureCommand(
+                command_id="test", service_id="system_controller", config={}
+            )
+            await manager._profile_configure_command(configure_msg)
+
+        manager.publish.assert_called_once()
+        call_args = manager.publish.call_args[0][0]
+        assert isinstance(call_args, TelemetryStatusMessage)
+        assert call_args.enabled is True
+        assert call_args.reason is None
+        assert AMDSMI_SOURCE_IDENTIFIER in call_args.endpoints_configured
+        assert AMDSMI_SOURCE_IDENTIFIER in call_args.endpoints_reachable
+        assert AMDSMI_SOURCE_IDENTIFIER in manager._collectors
+        assert (
+            manager._collector_id_to_url["amdsmi_collector"] == AMDSMI_SOURCE_IDENTIFIER
+        )
+
+    @pytest.mark.asyncio
+    async def test_configure_amdsmi_collector_no_gpus_found(self):
+        manager = self._create_test_manager()
+        manager.publish = AsyncMock()
+
+        mock_collector = AsyncMock()
+        mock_collector.is_url_reachable = AsyncMock(return_value=False)
+
+        MockCollectorClass = MagicMock(return_value=mock_collector)
+        with patch(
+            "aiperf.plugin.plugins.get_class",
+            return_value=MockCollectorClass,
+        ):
+            await manager._profile_configure_command(
+                ProfileConfigureCommand(
+                    command_id="test", service_id="system_controller", config={}
+                )
+            )
+
+        call_args = manager.publish.call_args[0][0]
+        assert call_args.enabled is False
+        assert call_args.reason == "amdsmi not available or no AMD GPUs found"
+        assert call_args.endpoints_reachable == []
+        assert len(manager._collectors) == 0
+        manager.warning.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_configure_amdsmi_collector_package_not_installed(self):
+        manager = self._create_test_manager()
+        manager.publish = AsyncMock()
+
+        with patch(
+            "aiperf.plugin.plugins.get_class",
+            side_effect=RuntimeError(
+                "amdsmi Python bindings not installed. The amdsmi package ships with ROCm"
+            ),
+        ):
+            await manager._profile_configure_command(
+                ProfileConfigureCommand(
+                    command_id="test", service_id="system_controller", config={}
+                )
+            )
+
+        call_args = manager.publish.call_args[0][0]
+        assert call_args.enabled is False
+        assert "amdsmi" in call_args.reason
+        manager.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_configure_amdsmi_collector_general_exception(self):
+        manager = self._create_test_manager()
+        manager.publish = AsyncMock()
+
+        with patch(
+            "aiperf.plugin.plugins.get_class",
+            side_effect=ValueError("Unexpected initialization error"),
+        ):
+            await manager._profile_configure_command(
+                ProfileConfigureCommand(
+                    command_id="test", service_id="system_controller", config={}
+                )
+            )
+
+        call_args = manager.publish.call_args[0][0]
+        assert call_args.enabled is False
+        assert "amdsmi configuration failed" in call_args.reason
+        manager.error.assert_called_once()
+        assert "Failed to configure amdsmi collector" in str(manager.error.call_args)

--- a/tests/unit/gpu_telemetry/test_telemetry_manager.py
+++ b/tests/unit/gpu_telemetry/test_telemetry_manager.py
@@ -1069,6 +1069,7 @@ class TestAmdsmiCollectorIntegration:
         manager.error = MagicMock()
         manager.warning = MagicMock()
         manager.debug = MagicMock()
+        manager.info = MagicMock()
         return manager
 
     @pytest.mark.asyncio
@@ -1100,6 +1101,47 @@ class TestAmdsmiCollectorIntegration:
         assert (
             manager._collector_id_to_url["amdsmi_collector"] == AMDSMI_SOURCE_IDENTIFIER
         )
+
+        # Baseline scrape: configure must call initialize() + one
+        # collect_and_process_metrics() so counter deltas
+        # (amd_energy_consumption, amd_ecc_uncorrectable) are computed
+        # against a pre-profile reference, not the first in-window sample.
+        mock_collector.initialize.assert_awaited_once()
+        mock_collector.collect_and_process_metrics.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_configure_amdsmi_collector_continues_when_baseline_fails(self):
+        # If the baseline scrape raises (transient amdsmi error, sensor
+        # hiccup, etc.) configure must still mark the collector enabled
+        # rather than abandon it — matching DCGM's "warn but don't fail"
+        # semantics. The user just loses one baseline sample; the periodic
+        # collection loop still runs and counter deltas degrade to the
+        # first-in-window-sample fallback.
+        manager = self._create_test_manager()
+        manager.publish = AsyncMock()
+
+        mock_collector = AsyncMock()
+        mock_collector.is_url_reachable = AsyncMock(return_value=True)
+        mock_collector.collect_and_process_metrics = AsyncMock(
+            side_effect=RuntimeError("transient amdsmi error")
+        )
+
+        MockCollectorClass = MagicMock(return_value=mock_collector)
+        with patch(
+            "aiperf.plugin.plugins.get_class",
+            return_value=MockCollectorClass,
+        ):
+            configure_msg = ProfileConfigureCommand(
+                command_id="test", service_id="system_controller", config={}
+            )
+            await manager._profile_configure_command(configure_msg)
+
+        manager.publish.assert_called_once()
+        call_args = manager.publish.call_args[0][0]
+        assert isinstance(call_args, TelemetryStatusMessage)
+        assert call_args.enabled is True
+        assert AMDSMI_SOURCE_IDENTIFIER in manager._collectors
+        manager.warning.assert_called()
 
     @pytest.mark.asyncio
     async def test_configure_amdsmi_collector_no_gpus_found(self):

--- a/tests/unit/gpu_telemetry/test_telemetry_models.py
+++ b/tests/unit/gpu_telemetry/test_telemetry_models.py
@@ -253,10 +253,9 @@ class TestGpuMetricTimeSeries:
         assert list(time_series.get_metric_array("util")) == [80.0, 85.0]
 
     def test_consistent_metric_schema(self):
-        """Test that metric schema is consistent across all snapshots.
-
-        DCGM metrics are static per run - schema is determined on first snapshot
-        and all subsequent snapshots must provide the same metrics.
+        """Static-schema collectors (DCGM, PyNVML) emit the same keys every
+        scrape; the time series stores them column-by-column with no NaN
+        backfill.
         """
         time_series = GpuMetricTimeSeries()
 
@@ -596,6 +595,113 @@ class TestGpuMetricTimeSeries:
                 "power", "tag", "header", "W", time_filter, is_counter=False
             )
         assert "No data in time range" in str(exc_info.value)
+
+    # -- Dynamic-schema regression coverage (PR #908 dynamo-ops review) --
+    # AMDSMI emits a different set of fields per scrape when sensor reads
+    # transiently fail. The following tests pin down the NaN-aware semantics
+    # added to append_snapshot / _grow / to_metric_result*.
+
+    def test_late_arriving_metric_backfilled_with_nan(self):
+        """A field absent from snapshot 1 then present in snapshot 2 must
+        allocate a new array NaN-backfilled rather than raising KeyError.
+        """
+        time_series = GpuMetricTimeSeries()
+        time_series.append_snapshot({"power": 100.0}, 1_000_000_000)
+        time_series.append_snapshot(
+            {"power": 110.0, "temperature": 50.0}, 2_000_000_000
+        )
+
+        temp = time_series.get_metric_array("temperature")
+        assert np.isnan(temp[0])
+        assert temp[1] == 50.0
+
+        # Stats over the late-arriving metric ignore the NaN slot.
+        result = time_series.to_metric_result("temperature", "t", "h", "C")
+        assert result.avg == 50.0
+        assert result.min == 50.0
+        assert result.max == 50.0
+
+    def test_disappearing_metric_writes_nan(self):
+        """A field present in snapshot 1 then absent from snapshot 2 must
+        leave NaN at the new index, not garbage from np.empty.
+        """
+        time_series = GpuMetricTimeSeries()
+        time_series.append_snapshot(
+            {"power": 100.0, "temperature": 50.0}, 1_000_000_000
+        )
+        time_series.append_snapshot({"power": 110.0}, 2_000_000_000)
+
+        temp = time_series.get_metric_array("temperature")
+        assert temp[0] == 50.0
+        assert np.isnan(temp[1])
+
+        # Stats reflect only the real value.
+        result = time_series.to_metric_result("temperature", "t", "h", "C")
+        assert result.avg == 50.0
+        assert result.count == 2  # count = number of scrapes, not non-NaN samples
+
+    def test_intermittent_metric_only_uses_real_values(self):
+        """Mixed present/absent across many snapshots: nan-aware stats use
+        only the real samples.
+        """
+        time_series = GpuMetricTimeSeries()
+        # Five scrapes; b is present at indices 0, 2, 4 (values 10, 30, 50).
+        snapshots = [
+            ({"a": 1.0, "b": 10.0}, 1_000_000_000),
+            ({"a": 2.0}, 2_000_000_000),
+            ({"a": 3.0, "b": 30.0}, 3_000_000_000),
+            ({"a": 4.0}, 4_000_000_000),
+            ({"a": 5.0, "b": 50.0}, 5_000_000_000),
+        ]
+        for metrics, ts in snapshots:
+            time_series.append_snapshot(metrics, ts)
+
+        b = time_series.get_metric_array("b")
+        assert b[0] == 10.0
+        assert np.isnan(b[1])
+        assert b[2] == 30.0
+        assert np.isnan(b[3])
+        assert b[4] == 50.0
+
+        result = time_series.to_metric_result("b", "t", "h", "u")
+        assert result.avg == 30.0  # mean(10, 30, 50)
+        assert result.min == 10.0
+        assert result.max == 50.0
+
+    def test_to_metric_result_all_nan_raises(self):
+        """If every sample for a metric is NaN, raise NoMetricValue rather
+        than emitting NaN stats and a numpy RuntimeWarning.
+        """
+        time_series = GpuMetricTimeSeries()
+        time_series.append_snapshot({"a": 1.0, "b": 10.0}, 1_000_000_000)
+        time_series.append_snapshot({"a": 2.0}, 2_000_000_000)
+
+        # Filter so only the second scrape is in-range; b is NaN there.
+        time_filter = TimeRangeFilter(start_ns=1_500_000_000, end_ns=3_000_000_000)
+        with pytest.raises(NoMetricValue, match="All in-range samples"):
+            time_series.to_metric_result_filtered(
+                "b", "t", "h", "u", time_filter, is_counter=False
+            )
+
+    def test_to_metric_result_filtered_counter_nan_baseline_clamps_to_zero(self):
+        """A counter whose reference sample is NaN (the metric arrived after
+        the baseline scrape) must report delta = 0.0 — max(NaN, 0.0) = 0.0
+        thanks to NaN comparison semantics.
+        """
+        time_series = GpuMetricTimeSeries()
+        # Baseline: only "a" is present.
+        time_series.append_snapshot({"a": 10.0}, 1_000_000_000)
+        # In-window: "energy" arrives.
+        time_series.append_snapshot({"a": 20.0, "energy": 100.0}, 2_500_000_000)
+        time_series.append_snapshot({"a": 30.0, "energy": 150.0}, 3_500_000_000)
+
+        # Profile starts at 2_000_000_000; baseline reference = scrape 0 (NaN
+        # for "energy"), filtered = [100, 150].
+        time_filter = TimeRangeFilter(start_ns=2_000_000_000, end_ns=4_000_000_000)
+        result = time_series.to_metric_result_filtered(
+            "energy", "t", "h", "MJ", time_filter, is_counter=True
+        )
+        assert result.avg == 0.0
 
 
 class TestGpuTelemetryData:

--- a/tests/unit/gpu_telemetry/test_telemetry_models.py
+++ b/tests/unit/gpu_telemetry/test_telemetry_models.py
@@ -685,23 +685,118 @@ class TestGpuMetricTimeSeries:
 
     def test_to_metric_result_filtered_counter_nan_baseline_clamps_to_zero(self):
         """A counter whose reference sample is NaN (the metric arrived after
-        the baseline scrape) must report delta = 0.0 — max(NaN, 0.0) = 0.0
-        thanks to NaN comparison semantics.
+        the baseline scrape) and that has *no* in-window movement falls back
+        to first-valid-in-window: delta = 0.0.
         """
         time_series = GpuMetricTimeSeries()
         # Baseline: only "a" is present.
         time_series.append_snapshot({"a": 10.0}, 1_000_000_000)
-        # In-window: "energy" arrives.
+        # In-window: "energy" arrives at the same value twice (no movement).
         time_series.append_snapshot({"a": 20.0, "energy": 100.0}, 2_500_000_000)
-        time_series.append_snapshot({"a": 30.0, "energy": 150.0}, 3_500_000_000)
+        time_series.append_snapshot({"a": 30.0, "energy": 100.0}, 3_500_000_000)
 
-        # Profile starts at 2_000_000_000; baseline reference = scrape 0 (NaN
-        # for "energy"), filtered = [100, 150].
         time_filter = TimeRangeFilter(start_ns=2_000_000_000, end_ns=4_000_000_000)
         result = time_series.to_metric_result_filtered(
             "energy", "t", "h", "MJ", time_filter, is_counter=True
         )
+        # Reference = first valid in-window = 100; last valid in-window = 100.
         assert result.avg == 0.0
+
+    def test_counter_delta_walks_back_for_valid_baseline(self):
+        """If the chosen reference index is NaN but an earlier scrape had a
+        valid value, walk back to it instead of zeroing the delta.
+        """
+        time_series = GpuMetricTimeSeries()
+        # Two pre-window scrapes: scrape 0 has "energy", scrape 1 doesn't.
+        time_series.append_snapshot({"energy": 100.0}, 1_000_000_000)
+        time_series.append_snapshot({"a": 5.0}, 1_500_000_000)  # baseline NaN
+        # In-window: monotonic counter movement.
+        time_series.append_snapshot({"energy": 150.0}, 2_500_000_000)
+        time_series.append_snapshot({"energy": 200.0}, 3_500_000_000)
+
+        time_filter = TimeRangeFilter(start_ns=2_000_000_000, end_ns=4_000_000_000)
+        result = time_series.to_metric_result_filtered(
+            "energy", "t", "h", "MJ", time_filter, is_counter=True
+        )
+        # reference_idx = 1 (NaN); walk back to scrape 0 (= 100).
+        # filtered_last = 200. delta = 200 - 100 = 100.
+        assert result.avg == 100.0
+
+    def test_counter_delta_skips_nan_final_sample(self):
+        """If the last in-window sample is NaN but an earlier in-window scrape
+        had a valid value, use that as ``filtered_last``.
+        """
+        time_series = GpuMetricTimeSeries()
+        time_series.append_snapshot({"energy": 100.0}, 1_000_000_000)  # baseline
+        time_series.append_snapshot({"energy": 200.0}, 2_500_000_000)
+        time_series.append_snapshot({"a": 5.0}, 3_500_000_000)  # final NaN
+
+        time_filter = TimeRangeFilter(start_ns=2_000_000_000, end_ns=4_000_000_000)
+        result = time_series.to_metric_result_filtered(
+            "energy", "t", "h", "MJ", time_filter, is_counter=True
+        )
+        # reference = 100, filtered_last = 200 (not NaN). delta = 100.
+        assert result.avg == 100.0
+
+    def test_counter_delta_filtered_all_nan_raises(self):
+        """A filtered window with no valid samples raises NoMetricValue
+        rather than silently reporting delta=0 from the all-NaN reference.
+        """
+        time_series = GpuMetricTimeSeries()
+        time_series.append_snapshot({"energy": 100.0}, 1_000_000_000)
+        time_series.append_snapshot({"a": 5.0}, 2_500_000_000)
+        time_series.append_snapshot({"a": 6.0}, 3_500_000_000)
+
+        time_filter = TimeRangeFilter(start_ns=2_000_000_000, end_ns=4_000_000_000)
+        with pytest.raises(NoMetricValue, match="No valid"):
+            time_series.to_metric_result_filtered(
+                "energy", "t", "h", "MJ", time_filter, is_counter=True
+            )
+
+    def test_gauge_std_uses_non_nan_count_for_ddof_guard(self):
+        """3 scrapes, only 1 has the metric → std=0.0 instead of NaN+warning
+        (ddof=1 with one valid sample is degrees-of-freedom 0).
+        """
+        time_series = GpuMetricTimeSeries()
+        time_series.append_snapshot({"a": 1.0, "b": 50.0}, 1_000_000_000)
+        time_series.append_snapshot({"a": 2.0}, 2_000_000_000)
+        time_series.append_snapshot({"a": 3.0}, 3_000_000_000)
+
+        result = time_series.to_metric_result("b", "t", "h", "u")
+        assert result.std == 0.0
+
+        # Same check for the filtered path.
+        result_f = time_series.to_metric_result_filtered(
+            "b", "t", "h", "u", time_filter=None, is_counter=False
+        )
+        assert result_f.std == 0.0
+
+    def test_current_uses_last_non_nan_sample(self):
+        """``current`` should be the most recent *valid* sample so the
+        realtime dashboard doesn't display NaN (and so change-detection
+        doesn't republish every interval because NaN != NaN).
+        """
+        time_series = GpuMetricTimeSeries()
+        time_series.append_snapshot(
+            {"power": 100.0, "temperature": 50.0}, 1_000_000_000
+        )
+        time_series.append_snapshot({"power": 110.0}, 2_000_000_000)  # temp NaN
+        time_series.append_snapshot({"power": 120.0}, 3_000_000_000)  # temp NaN
+
+        result = time_series.to_metric_result("temperature", "t", "h", "C")
+        assert result.current == 50.0
+
+    def test_current_is_none_when_all_filtered_nan(self):
+        """If a metric is registered but never had a valid value, ``current``
+        is None rather than NaN. (The all-NaN guard raises NoMetricValue
+        before we get here, so this exercises the per-metric helper directly.)
+        """
+        from aiperf.common.models.telemetry_models import _last_valid
+
+        assert _last_valid(np.array([np.nan, np.nan, np.nan])) is None
+        assert _last_valid(np.array([1.0, np.nan, np.nan])) == 1.0
+        assert _last_valid(np.array([np.nan, 2.0, np.nan])) == 2.0
+        assert _last_valid(np.array([1.0, 2.0, 3.0])) == 3.0
 
 
 class TestGpuTelemetryData:


### PR DESCRIPTION
## Summary

Adds `AMDSMITelemetryCollector` parallel to `PyNVMLTelemetryCollector`, enabling `--gpu-telemetry amdsmi` for AMD Instinct GPUs (MI300X, MI325X, MI355X, and other ROCm-supported parts). Pure additive change — no modifications to data models, accumulator, exporters, dashboard, or downstream code.

### Files changed

| File | Change |
|------|--------|
| `src/aiperf/gpu_telemetry/amdsmi_collector.py` | **new** — 380 LOC, mirrors `pynvml_collector.py` |
| `tests/unit/gpu_telemetry/test_amdsmi_collector.py` | **new** — 14 mocked unit tests |
| `src/aiperf/gpu_telemetry/constants.py` | +3 (`AMDSMI_SOURCE_IDENTIFIER`) |
| `src/aiperf/gpu_telemetry/manager.py` | +62 (`_configure_amdsmi_collector` + dispatch branch) |
| `src/aiperf/plugin/plugins.yaml` | +5 (plugin registration) |
| `src/aiperf/common/config/user_config.py` | +30 (CLI parser branch + import check + warning) |
| `docs/tutorials/gpu-telemetry.md` | +55 (Path 4 section + comparison table) |

### How it works

```bash
aiperf profile \
  --model meta-llama/Llama-3.1-8B-Instruct \
  --endpoint-type chat \
  --url http://localhost:8000 \
  --gpu-telemetry amdsmi
```

Collector enumerates AMD GPUs via `amdsmi.amdsmi_get_processor_handles()` and emits one `TelemetryRecord` per GPU per scrape, with `dcgm_url='amdsmi://localhost'` as the source identifier. Downstream accumulator/exporters treat it identically to PyNVML records.

### AMD field semantics (vs NVIDIA)

| Metric | NVIDIA path | AMD path | Notes |
|---|---|---|---|
| `gpu_power_usage` (W) | `nvmlDeviceGetPowerUsage` (mW) | `amdsmi_get_power_info().current_socket_power` (W) | Already in W; no scaling |
| `energy_consumption` (MJ) | `nvmlDeviceGetTotalEnergyConsumption` (mJ) | `accumulator * counter_resolution` (µJ → MJ) | counter_resolution = 15.3 µJ/tick |
| `gpu_utilization`, `sm_utilization` | separate metrics | both = `gfx_activity` | AMD has no separate SM-level metric |
| `mem_utilization` | `.memory` from utilization | `umc_activity` | UMC activity |
| `gpu_memory_used` (GB) | bytes | `amdsmi_get_gpu_memory_usage(VRAM)` bytes | bytes → GB |
| `gpu_temperature` (°C) | `NVML_TEMPERATURE_GPU` | `JUNCTION` → `HOTSPOT` fallback | EDGE unsupported on Instinct GPUs |
| `xid_errors` | XID counter | `uncorrectable_count` from ECC | Closest analog |
| `power_violation` (µs) | `violationTime` from NVML | client-accumulated from `throttle_status` | AMD only exposes boolean status; duration computed across scrapes |
| `encoder_utilization`, `decoder_utilization`, `jpg_utilization` | separate metrics | `mm_activity` (typically `'N/A'` on Instinct) | Fields stay empty on Instinct GPUs |

### Test plan

**Unit tests (mocked amdsmi, no GPU needed):** 14/14 passing on both nodes.
- `pytest tests/unit/gpu_telemetry/test_amdsmi_collector.py`

**Full gpu_telemetry suite regression:** 221 tests pass (207 pre-existing + 14 new), zero failures.

**On-hardware end-to-end validated:**

| Node | Hardware | ROCm | AMDSMI | Result |
|------|----------|------|--------|--------|
| Hotaisle | 8× MI300X (gfx942) | 7.0.2 | 26.0.2 | 688 records, all 8 GPUs in console table |
| smci355-…-m15-17 | 8× MI355X (gfx950) | 7.1.1 | 26.2.0 | 672 records, all 8 GPUs in console table |

**Cross-validated against `amd-smi monitor`:**

| GPU | amd-smi power (avg) | aiperf power (avg) | Δ% | amd-smi temp | aiperf temp | ΔC |
|---|---|---|---|---|---|---|
| 0 | 162.90 W | 162.87 W | 0.02% | 51.0 C | 51.0 C | 0.0 |
| 1 | 151.60 W | 151.74 W | 0.10% | 42.0 C | 42.0 C | 0.0 |
| 2 | 158.90 W | 158.95 W | 0.03% | 44.0 C | 44.0 C | 0.0 |
| 3 | 161.00 W | 161.00 W | 0.00% | 50.2 C | 50.1 C | 0.1 |
| 4 | 157.40 W | 157.47 W | 0.05% | 47.0 C | 47.0 C | 0.0 |
| 5 | 153.05 W | 152.96 W | 0.06% | 44.0 C | 44.0 C | 0.0 |
| 6 | 163.05 W | 163.05 W | 0.00% | 52.0 C | 52.3 C | 0.2 |
| 7 | 154.55 W | 154.72 W | 0.11% | 46.0 C | 46.0 C | 0.0 |

Power within 0.00–0.11%, temperature within 0.0–0.2°C — well below ±5% target.

**Failure modes verified:**
- amdsmi missing → graceful disable with helpful error message
- SIGINT mid-collection → clean shutdown, partial results exported
- Invalid `--gpu-telemetry rocmsmi` → rejected with "Valid options are: ..." error

### Notes for reviewers

1. **AMDSMI returns `'N/A'` strings instead of raising** for unsupported sensors (`average_socket_power`, `mm_activity`, `throttle_status` on some platforms, etc.). Collector uses an internal `_numeric()` helper to coerce non-numeric values to `None` so they're dropped from the record rather than leaking into pydantic validation.
2. **`collect_and_process_metrics()` public alias** — `GPUTelemetryManager._handle_profile_complete_command` calls a public `collect_and_process_metrics()` method, but `pynvml_collector` and `dcgm_collector` only define `_collect_and_process_metrics()` (private). This causes a "Failed to capture final state" warning for them too. Added the public alias on amdsmi only — leaving the underlying inconsistency for a separate PR to avoid scope creep here.
3. **`amdsmi` package install** — ships with ROCm at `/opt/rocm/share/amd_smi/amdsmi-*.whl`. Not on PyPI. CLI parser surfaces a helpful install hint if the import fails.

### Tested platforms (not in this PR but useful to confirm)

- [x] AMD MI300X (gfx942), ROCm 7.0.2
- [x] AMD MI355X (gfx950), ROCm 7.1.1
- [ ] AMD MI325X — same gfx942 architecture as MI300X, expected to work but not yet hardware-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local AMD ROCm GPU telemetry via a new --gpu-telemetry amdsmi option, AMD-specific metrics (power/energy/activity/memory/temperature/ECC/throttle), reachability checks, baseline capture, and config validation preventing mixing local collectors with DCGM URLs.
* **Documentation**
  * Expanded CLI/docs with installation prerequisites, examples, full amdsmi usage section, metrics mapping, and clarified WARNING about DCGM endpoints.
* **Tests**
  * Extensive unit/integration tests covering initialization, discovery, metric conversions, NaN-aware time-series behavior, lifecycle and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/908)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->