### PR TITLE
fix(tests): clean up process groups on timeout

### DIFF
--- a/tests/ci/test_docs_end_to_end/test_runner.py
+++ b/tests/ci/test_docs_end_to_end/test_runner.py
@@ -6,11 +6,17 @@ Test runner for executing server setup, health checks, and AIPerf tests.
 
 import logging
 import os
+import signal
 import subprocess
 import threading
 import time
+from collections.abc import Callable
+from contextlib import suppress
+from types import SimpleNamespace
+from typing import Any
 
 from constants import (
+    AIPERF_COMMAND_TIMEOUT,
     AIPERF_UI_TYPE,
     SETUP_MONITOR_TIMEOUT,
 )
@@ -18,6 +24,62 @@ from data_types import Server
 from utils import get_repo_root
 
 logger = logging.getLogger(__name__)
+
+
+class _ProcessGroupKillGuard:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._finished = False
+
+    def mark_finished(self) -> None:
+        with self._lock:
+            self._finished = True
+
+    def mark_killing_if_running(self, proc: Any) -> bool:
+        with self._lock:
+            if self._finished or proc.poll() is not None:
+                return False
+            self._finished = True
+            return True
+
+
+def _make_process_group_timeout_killer(
+    *,
+    proc: Any,
+    test_num: int,
+    server_name: str,
+    guard: _ProcessGroupKillGuard,
+) -> Callable[[], None]:
+    def _kill_on_timeout() -> None:
+        if not guard.mark_killing_if_running(proc):
+            return
+        logger.error(
+            f"AIPerf test {test_num} exceeded "
+            f"{AIPERF_COMMAND_TIMEOUT}s timeout for {server_name}; "
+            f"sending SIGKILL to process group"
+        )
+        with suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+
+    return _kill_on_timeout
+
+
+def test_timeout_killer_skips_process_marked_finished(monkeypatch):
+    killed = []
+    guard = _ProcessGroupKillGuard()
+    guard.mark_finished()
+    proc = SimpleNamespace(pid=12345, poll=lambda: None)
+    monkeypatch.setattr(os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+
+    killer = _make_process_group_timeout_killer(
+        proc=proc,
+        test_num=1,
+        server_name="test-server",
+        guard=guard,
+    )
+    killer()
+
+    assert killed == []
 
 
 class EndToEndTestRunner:
@@ -336,19 +398,37 @@ class EndToEndTestRunner:
                 text=True,
                 bufsize=1,
                 universal_newlines=True,
+                start_new_session=True,
             )
 
-            # Show real-time output
-            aiperf_output_lines = []
-            while True:
-                line = aiperf_process.stdout.readline()
-                if not line and aiperf_process.poll() is not None:
-                    break
-                if line:
-                    print(f"AIPERF[{server.name}]: {line.rstrip()}")
-                    aiperf_output_lines.append(line)
+            kill_guard = _ProcessGroupKillGuard()
+            watchdog = threading.Timer(
+                AIPERF_COMMAND_TIMEOUT,
+                _make_process_group_timeout_killer(
+                    proc=aiperf_process,
+                    test_num=i + 1,
+                    server_name=server.name,
+                    guard=kill_guard,
+                ),
+            )
+            watchdog.daemon = True
+            watchdog.start()
 
-            aiperf_process.wait()
+            try:
+                # Show real-time output
+                aiperf_output_lines = []
+                while True:
+                    line = aiperf_process.stdout.readline()
+                    if not line and aiperf_process.poll() is not None:
+                        break
+                    if line:
+                        print(f"AIPERF[{server.name}]: {line.rstrip()}")
+                        aiperf_output_lines.append(line)
+
+                aiperf_process.wait()
+            finally:
+                kill_guard.mark_finished()
+                watchdog.cancel()
 
             if aiperf_process.returncode != 0:
                 logger.error("=" * 60)

--- a/tests/component_integration/conftest.py
+++ b/tests/component_integration/conftest.py
@@ -17,6 +17,7 @@ import os
 import platform
 import signal
 import sys
+import threading
 from collections.abc import Generator
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
@@ -42,6 +43,27 @@ from tests.harness import (
 from tests.harness.fake_communication import CapturedPayload
 from tests.harness.fake_tokenizer import TOKEN, TOKEN_LEN
 from tests.harness.utils import AIPerfCLI, AIPerfRunnerFn, AIPerfRunnerResult
+
+COMPONENT_INTEGRATION_PROCESS_TITLE = "aiperf component_integration_test"
+
+
+def _set_component_integration_process_title() -> None:
+    try:
+        import setproctitle
+
+        setproctitle.setproctitle(COMPONENT_INTEGRATION_PROCESS_TITLE)
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True, scope="package")
+def component_integration_process_title() -> Generator[None, None, None]:
+    _set_component_integration_process_title()
+    with patch(
+        "aiperf.common.base_service.BaseService._set_process_title",
+        lambda self: None,
+    ):
+        yield
 
 
 class TeeStream:
@@ -82,13 +104,14 @@ class ComponentIntegrationTestDefaults:
     ui: str = "simple"
 
 
+def _raise_system_exit(code: int) -> None:
+    raise SystemExit(code)
+
+
 @pytest.fixture(autouse=True, scope="package")
 def mock_os_exit():
-    """Patch os._exit to raise an exception instead of exiting the process."""
-    with patch(
-        "os._exit",
-        side_effect=lambda code: SystemExit(code),
-    ):
+    """Patch os._exit to raise SystemExit instead of exiting the process."""
+    with patch("os._exit", side_effect=_raise_system_exit):
         yield
 
 
@@ -304,11 +327,18 @@ class AIPerfRunnerResultWithSharedBus(AIPerfRunnerResult):
 def aiperf_runner(
     temp_output_dir: Path,
 ) -> AIPerfRunnerFn:
-    """AIPerf subprocess runner."""
+    """AIPerf in-process runner.
+
+    Runs the CLI synchronously in the pytest process (the harness wires
+    FakeServiceManager + FakeCommunication at max plugin priority, so no
+    subprocesses are spawned). Enforces ``timeout`` via a watchdog thread that
+    sends SIGINT to the current process if ``app(...)`` does not return in
+    time; SIGINT raises KeyboardInterrupt, which is converted to TimeoutError.
+    """
 
     def runner(
         args: list[str], timeout: float = 200.0
-    ) -> AIPerfRunnerResultWithSharedBus:  # noqa: ARG001
+    ) -> AIPerfRunnerResultWithSharedBus:
         full_args = args
         # Only add --artifact-dir for profile command (not for plot)
         if args and args[0] == "profile":
@@ -326,12 +356,34 @@ def aiperf_runner(
         stdout_tee = TeeStream(sys.stdout)
         stderr_tee = TeeStream(sys.stderr)
 
-        # CLI calls os._exit(0) on success, so we expect SystemExit
+        finished = threading.Event()
+        timed_out = False
+
+        def _watchdog() -> None:
+            nonlocal timed_out
+            if not finished.wait(timeout):
+                timed_out = True
+                os.kill(os.getpid(), signal.SIGINT)
+
+        watchdog = threading.Thread(target=_watchdog, daemon=True)
+        watchdog.start()
+
         try:
-            with redirect_stdout(stdout_tee), redirect_stderr(stderr_tee):
-                app(full_args)
-        except SystemExit as e:
-            exit_code = e.code
+            # CLI calls os._exit(0) on success, so we expect SystemExit
+            try:
+                with redirect_stdout(stdout_tee), redirect_stderr(stderr_tee):
+                    app(full_args)
+            except SystemExit as e:
+                exit_code = e.code
+            except KeyboardInterrupt:
+                if timed_out:
+                    raise TimeoutError(
+                        f"aiperf_runner: app() exceeded {timeout}s timeout"
+                    ) from None
+                raise
+        finally:
+            finished.set()
+            watchdog.join(timeout=1.0)
 
         return AIPerfRunnerResultWithSharedBus(
             exit_code=exit_code,

--- a/tests/component_integration/test_process_title.py
+++ b/tests/component_integration/test_process_title.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import setproctitle
+
+from aiperf.common.base_service import BaseService
+from tests.component_integration.conftest import (
+    COMPONENT_INTEGRATION_PROCESS_TITLE,
+    _set_component_integration_process_title,
+)
+from tests.integration.conftest import _new_process_group_kwargs
+
+
+def test_component_integration_process_title_uses_suite_name(monkeypatch):
+    titles = []
+    monkeypatch.setattr(setproctitle, "setproctitle", titles.append)
+
+    _set_component_integration_process_title()
+
+    assert COMPONENT_INTEGRATION_PROCESS_TITLE == "aiperf component_integration_test"
+    assert titles == ["aiperf component_integration_test"]
+
+
+def test_base_service_process_title_is_disabled_for_component_integration(monkeypatch):
+    titles = []
+    monkeypatch.setattr(setproctitle, "setproctitle", titles.append)
+
+    service = SimpleNamespace(service_id="worker_123", debug=lambda message: None)
+    BaseService._set_process_title(service)
+
+    assert titles == []
+
+
+def test_subprocess_process_group_kwargs_use_process_group_when_supported():
+    assert _new_process_group_kwargs(supports_process_group=True) == {
+        "process_group": 0
+    }
+
+
+def test_subprocess_process_group_kwargs_use_session_on_python_310():
+    assert _new_process_group_kwargs(supports_process_group=False) == {
+        "start_new_session": True
+    }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,15 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
+import inspect
 import logging
 import multiprocessing
 import os
 import platform
 import signal
 import socket
+import subprocess
 import sys
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from multiprocessing.context import SpawnProcess
 from pathlib import Path
@@ -144,6 +146,31 @@ def get_venv_python() -> str:
             return str(python_path)
     # Fall back to sys.executable if not in a venv
     return sys.executable
+
+
+def _new_process_group_kwargs(
+    *, supports_process_group: bool | None = None
+) -> dict[str, int | bool]:
+    if supports_process_group is None:
+        supports_process_group = (
+            "process_group" in inspect.signature(subprocess.Popen).parameters
+        )
+    if supports_process_group:
+        return {"process_group": 0}
+    return {"start_new_session": True}
+
+
+def _killpg(process: asyncio.subprocess.Process, sig: int) -> None:
+    """Send `sig` to the entire process group of `process`.
+
+    aiperf spawns its system_controller + managers + workers as multiprocessing
+    children. Signalling only the leader (process.kill/terminate) on SIGKILL
+    skips multiprocessing's atexit cleanup and orphans the whole tree, which
+    then lingers indefinitely holding swap. The subprocess must be started in a
+    new process group for this to reach the descendants.
+    """
+    with suppress(ProcessLookupError):
+        os.killpg(process.pid, sig)
 
 
 @asynccontextmanager
@@ -308,15 +335,12 @@ async def aiperf_runner(
             "PYTHONUNBUFFERED": "1",
         }
 
-        # Capture stdout/stderr for validation error tests
-        # Use PIPE to capture output while still allowing it to be displayed
-        import subprocess
-
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,
+            **_new_process_group_kwargs(),
         )
 
         try:
@@ -336,9 +360,9 @@ async def aiperf_runner(
                 stderr = stderr_bytes.decode("utf-8", errors="replace")
             except asyncio.TimeoutError:
                 _logger.warning(
-                    "Process did not exit after SIGINT(), forcing termination"
+                    "Process did not exit after SIGINT, sending SIGTERM to process group"
                 )
-                process.terminate()
+                _killpg(process, signal.SIGTERM)
                 try:
                     stdout_bytes, stderr_bytes = await asyncio.wait_for(
                         process.communicate(), timeout=5
@@ -347,9 +371,9 @@ async def aiperf_runner(
                     stderr = stderr_bytes.decode("utf-8", errors="replace")
                 except asyncio.TimeoutError:
                     _logger.warning(
-                        "Process did not exit after kill(), forcing termination"
+                        "Process did not exit after SIGTERM, sending SIGKILL to process group"
                     )
-                    process.kill()
+                    _killpg(process, signal.SIGKILL)
                     stdout = ""
                     stderr = ""
             raise RuntimeError(f"AIPerf timed out after {timeout}s") from e
@@ -428,6 +452,7 @@ class AIPerfSignalCLI:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            **_new_process_group_kwargs(),
         )
 
         try:
@@ -478,12 +503,14 @@ class AIPerfSignalCLI:
                 try:
                     await asyncio.wait_for(process.wait(), timeout=30.0)
                 except asyncio.TimeoutError:
-                    _logger.warning("Process did not exit after SIGINT, forcing kill")
-                    process.kill()
+                    _logger.warning(
+                        "Process did not exit after SIGINT, sending SIGKILL to process group"
+                    )
+                    _killpg(process, signal.SIGKILL)
                     await process.wait()
 
         except asyncio.CancelledError:
-            process.kill()
+            _killpg(process, signal.SIGKILL)
             await process.wait()
             raise
 


### PR DESCRIPTION
## Summary
- Clean up AIPerf child process groups when component and integration test timeouts fire.
- Add process-title coverage for group cleanup behavior.
- Route docs end-to-end runner cleanup through the same timeout-safe process handling.

## Test plan
- [x] `uv run pytest -n auto tests/component_integration/test_process_title.py`
- [x] `uv run pytest -n auto tests/ci/test_docs_end_to_end/test_runner.py` (no tests collected; helper module)
- [x] `uv run pytest -n auto tests/ci/test_docs_end_to_end` (no tests collected; helper-only directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented timeout enforcement for test execution to prevent indefinite hangs and improve reliability.
  * Enhanced process management with improved signal handling for subprocess cleanup.
  * Added process title configuration for integration tests to improve debugging visibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/910)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->