### PR TITLE
fix(tokenizer): patch PreTrainedConfig offline for tokenizer-only HF repos

### DIFF
--- a/src/aiperf/cli_runner.py
+++ b/src/aiperf/cli_runner.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import contextlib
 import sys
 
@@ -94,10 +93,7 @@ def _run_single_benchmark(
 
     from aiperf.common.aiperf_logger import AIPerfLogger
     from aiperf.common.bootstrap import bootstrap_and_run_service
-    from aiperf.common.tokenizer_validator import (
-        preload_tokenizers,
-        validate_tokenizer_early,
-    )
+    from aiperf.common.tokenizer_validator import validate_tokenizer_early
 
     logger = AIPerfLogger(__name__)
 
@@ -136,17 +132,6 @@ def _run_single_benchmark(
 
     # Validate tokenizer early (before spawning services) to fail fast.
     user_config.tokenizer.resolved_names = validate_tokenizer_early(user_config, logger)
-
-    # Preload tokenizer files into HF disk cache so child processes use
-    # local_files_only=True and make zero HF network calls.
-    asyncio.run(
-        preload_tokenizers(
-            user_config.tokenizer.resolved_names,
-            trust_remote_code=user_config.tokenizer.trust_remote_code,
-            revision=user_config.tokenizer.revision,
-            logger=logger,
-        )
-    )
 
     # Validate custom GPU metrics CSV file
     if user_config.gpu_telemetry_metrics_file:
@@ -210,24 +195,6 @@ def _run_multi_benchmark(
     setup_rich_logging(user_config, service_config)
 
     logger = AIPerfLogger(__name__)
-
-    # Resolve tokenizer aliases and preload files into HF disk cache once,
-    # before any subprocesses spawn. Each subprocess then finds the tokenizer
-    # cached on disk and makes zero HF network calls.
-    from aiperf.common.tokenizer_validator import (
-        preload_tokenizers,
-        validate_tokenizer_early,
-    )
-
-    user_config.tokenizer.resolved_names = validate_tokenizer_early(user_config, logger)
-    asyncio.run(
-        preload_tokenizers(
-            user_config.tokenizer.resolved_names,
-            trust_remote_code=user_config.tokenizer.trust_remote_code,
-            revision=user_config.tokenizer.revision,
-            logger=logger,
-        )
-    )
 
     # Inform user about UI mode (now that logging is set up)
     if "ui_type" not in service_config.model_fields_set:

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -137,8 +137,26 @@ def _find_hf_cache_aliases(name: str) -> list[Path]:
     ]
 
 
+def _is_within(child: Path, parent: Path) -> bool:
+    """Return True iff *child* resolves to a path inside *parent*.
+
+    Resolution follows symlinks, so a symlinked sibling outside *parent* is
+    rejected. Used to reject path-traversal attempts from a user-controlled
+    revision string.
+    """
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
 def _get_revision_snapshot_dir(name: str, revision: str) -> Path | None:
-    """Return the cached HF snapshot dir for ``(name, revision)``, or None."""
+    """Return the cached HF snapshot dir for ``(name, revision)``, or None.
+
+    Rejects revisions that would resolve outside the model's snapshots/
+    directory (e.g. ``../sibling`` or absolute paths).
+    """
     from huggingface_hub.constants import HF_HUB_CACHE
 
     cache_dir = Path(HF_HUB_CACHE)
@@ -158,11 +176,14 @@ def _get_revision_snapshot_dir(name: str, revision: str) -> Path | None:
     if not snapshots_dir.is_dir():
         return None
 
-    refs_file = model_dir / "refs" / revision
-    if refs_file.is_file():
+    refs_dir = model_dir / "refs"
+    refs_file = refs_dir / revision
+    if _is_within(refs_file, refs_dir) and refs_file.is_file():
         snap = snapshots_dir / refs_file.read_text().strip()
     else:
         snap = snapshots_dir / revision
+    if not _is_within(snap, snapshots_dir):
+        return None
     return snap if snap.is_dir() else None
 
 

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -135,6 +135,50 @@ def _offline_model_info_patch():
         huggingface_hub.model_info = original
 
 
+def _rebind_cached_file(from_obj: object, to_obj: object) -> None:
+    """Replace ``cached_file`` with *to_obj* in every transformers module
+    whose local binding currently points at *from_obj*.
+
+    Transformers modules typically do ``from .utils import cached_file`` at
+    import time, creating per-module local bindings. Patching only the
+    canonical location (``transformers.utils.hub``) leaves those bindings
+    untouched, so the wrapper never gets called.
+    """
+    import sys
+
+    for mod_name, mod in list(sys.modules.items()):
+        if mod is None or not mod_name.startswith("transformers"):
+            continue
+        if mod.__dict__.get("cached_file") is from_obj:
+            mod.cached_file = to_obj
+
+
+def _make_offline_config_wrapper(
+    original: Callable, snapshot: Path, name: str, stub_path: Path
+) -> Callable:
+    """Wrap *original* so config.json lookups that raise OSError fall through
+    to a stub path, but only when on-disk evidence still matches a
+    tokenizer-only repo. Other filenames pass through unchanged.
+    """
+
+    def wrapper(path_or_repo_id, filename, *args, **kwargs):
+        if filename != "config.json":
+            return original(path_or_repo_id, filename, *args, **kwargs)
+        try:
+            return original(path_or_repo_id, filename, *args, **kwargs)
+        except OSError:
+            if (snapshot / "tokenizer_config.json").exists() and not (
+                snapshot / "config.json"
+            ).exists():
+                _logger.debug(
+                    f"Returning stub config.json for tokenizer-only repo '{name}'"
+                )
+                return str(stub_path)
+            raise
+
+    return wrapper
+
+
 @contextlib.contextmanager
 def _offline_config_fallback(name: str, revision: str):
     """Provide a stub config.json for tokenizer-only HF repos during offline load.
@@ -145,11 +189,11 @@ def _offline_config_fallback(name: str, revision: str):
     "couldn't connect" OSError that AutoTokenizer can't recover from.
 
     Patches transformers' ``cached_file`` resolver to hand back a synthetic
-    empty config.json path for the one lookup that needs it. The resolver's
-    contract — "return a local path or raise" — has been stable across
-    transformers versions, so this survives refactors that move
-    ``PreTrainedConfig.from_pretrained`` or change which exception it raises
-    on a missing entry.
+    empty config.json path for the one lookup that needs it. Rebinds every
+    transformers module that imported ``cached_file`` by name so the wrapper
+    is reached regardless of which call site (configuration_utils,
+    tokenization_auto, ...) triggers the lookup; on exit we re-scan to also
+    unpatch any module imported lazily during the ``with`` block.
     """
     import shutil
     import tempfile
@@ -178,26 +222,12 @@ def _offline_config_fallback(name: str, revision: str):
     stub_path = stub_dir / "config.json"
     stub_path.write_text("{}")
 
-    def patched(path_or_repo_id, filename, *args, **kwargs):
-        if filename != "config.json":
-            return original(path_or_repo_id, filename, *args, **kwargs)
-        try:
-            return original(path_or_repo_id, filename, *args, **kwargs)
-        except OSError:
-            if (snapshot / "tokenizer_config.json").exists() and not (
-                snapshot / "config.json"
-            ).exists():
-                _logger.debug(
-                    f"Returning stub config.json for tokenizer-only repo '{name}'"
-                )
-                return str(stub_path)
-            raise
-
-    hub_module.cached_file = patched
+    patched = _make_offline_config_wrapper(original, snapshot, name, stub_path)
+    _rebind_cached_file(original, patched)
     try:
         yield
     finally:
-        hub_module.cached_file = original
+        _rebind_cached_file(patched, original)
         shutil.rmtree(stub_dir, ignore_errors=True)
 
 

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -137,32 +137,12 @@ def _find_hf_cache_aliases(name: str) -> list[Path]:
     ]
 
 
-def _is_revision_snapshot_cached(model_dir: Path, revision: str) -> bool:
-    """Check if a specific revision snapshot exists in an HF model cache directory.
-
-    Supports both named refs (``main``, ``v1.2``) and direct commit hashes.
-    """
-    snapshots_dir = model_dir / "snapshots"
-    if not snapshots_dir.is_dir():
-        return False
-    # Named ref: refs/<revision> contains the commit hash
-    refs_file = model_dir / "refs" / revision
-    if refs_file.is_file():
-        commit_hash = refs_file.read_text().strip()
-        return (snapshots_dir / commit_hash).is_dir()
-    # Direct commit hash
-    return (snapshots_dir / revision).is_dir()
-
-
-def _is_hf_cached(name: str, revision: str | None = None) -> bool:
+def _is_hf_cached(name: str) -> bool:
     """Check if a HuggingFace model is available in the local cache.
 
     Looks for ``models--<name>/`` (with ``/`` replaced by ``--``) inside the
     HF hub cache directory.  Also handles alias-style short names, returning
     True only when a single unambiguous match exists.
-
-    When *revision* is given, also verifies that the specific revision snapshot
-    is present — a model directory from a different revision is not sufficient.
     """
     from huggingface_hub.constants import HF_HUB_CACHE
 
@@ -173,16 +153,9 @@ def _is_hf_cached(name: str, revision: str | None = None) -> bool:
     # Exact match: "meta-llama/Llama-2-7b-hf" -> "models--meta-llama--Llama-2-7b-hf"
     exact = cache_dir / f"models--{name.replace('/', '--')}"
     if exact.is_dir():
-        model_dir = exact
-    else:
-        aliases = _find_hf_cache_aliases(name)
-        if len(aliases) != 1:
-            return False
-        model_dir = aliases[0]
-
-    if revision is None:
         return True
-    return _is_revision_snapshot_cached(model_dir, revision)
+
+    return len(_find_hf_cache_aliases(name)) == 1
 
 
 def resolve_alias(name: str) -> AliasResolutionResult:
@@ -341,7 +314,7 @@ class Tokenizer:
                 from transformers import AutoTokenizer
 
                 # Offline mode or cached: skip network, load from local cache
-                if _is_offline_mode() or _is_hf_cached(name, revision=revision):
+                if _is_offline_mode() or _is_hf_cached(name):
                     tokenizer_instance = cls._from_pretrained_local(
                         AutoTokenizer.from_pretrained,
                         name,

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -137,6 +137,35 @@ def _find_hf_cache_aliases(name: str) -> list[Path]:
     ]
 
 
+def _get_revision_snapshot_dir(name: str, revision: str) -> Path | None:
+    """Return the cached HF snapshot dir for ``(name, revision)``, or None."""
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    cache_dir = Path(HF_HUB_CACHE)
+    if not cache_dir.is_dir():
+        return None
+
+    exact = cache_dir / f"models--{name.replace('/', '--')}"
+    if exact.is_dir():
+        model_dir = exact
+    else:
+        aliases = _find_hf_cache_aliases(name)
+        if len(aliases) != 1:
+            return None
+        model_dir = aliases[0]
+
+    snapshots_dir = model_dir / "snapshots"
+    if not snapshots_dir.is_dir():
+        return None
+
+    refs_file = model_dir / "refs" / revision
+    if refs_file.is_file():
+        snap = snapshots_dir / refs_file.read_text().strip()
+    else:
+        snap = snapshots_dir / revision
+    return snap if snap.is_dir() else None
+
+
 def _is_hf_cached(name: str) -> bool:
     """Check if a HuggingFace model is available in the local cache.
 

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -112,6 +112,69 @@ def _is_offline_mode() -> bool:
     )
 
 
+@contextlib.contextmanager
+def _offline_model_info_patch():
+    """Stub huggingface_hub.model_info so transformers 4.57+ tokenizer loading
+    works offline.
+
+    transformers 4.57+ runs _patch_mistral_regex during tokenizer instantiation,
+    which calls huggingface_hub.model_info() to inspect repo tags — even when
+    the caller passed local_files_only=True. Replacing it with a stub returning
+    tags=None lets the regex shim run without a network call.
+    """
+    import huggingface_hub
+
+    class _OfflineModelInfo:
+        tags = None
+
+    original = huggingface_hub.model_info
+    huggingface_hub.model_info = lambda *a, **kw: _OfflineModelInfo()
+    try:
+        yield
+    finally:
+        huggingface_hub.model_info = original
+
+
+@contextlib.contextmanager
+def _offline_config_fallback(name: str, revision: str):
+    """Make PreTrainedConfig.from_pretrained return an empty config for
+    tokenizer-only repos cached without a config.json.
+
+    Mirrors the online 404-fallthrough: when the snapshot has tokenizer_config.json
+    but no config.json, AutoTokenizer's offline fallback path raises a misleading
+    "couldn't connect" OSError. The patch swallows the OSError only when the
+    on-disk evidence matches a tokenizer-only repo, returning an empty
+    PreTrainedConfig so dispatch falls through to tokenizer_config.json.
+    """
+    from transformers import PreTrainedConfig
+
+    descriptor = PreTrainedConfig.__dict__["from_pretrained"]
+    original_func = descriptor.__func__
+
+    def patched(cls, *args, **kwargs):
+        try:
+            return original_func(cls, *args, **kwargs)
+        except OSError:
+            snapshot = _get_revision_snapshot_dir(name, revision)
+            if (
+                snapshot is not None
+                and not (snapshot / "config.json").exists()
+                and (snapshot / "tokenizer_config.json").exists()
+            ):
+                _logger.debug(
+                    f"No config.json for tokenizer-only repo '{name}'; "
+                    "returning empty PreTrainedConfig for offline dispatch"
+                )
+                return cls()
+            raise
+
+    PreTrainedConfig.from_pretrained = classmethod(patched)
+    try:
+        yield
+    finally:
+        PreTrainedConfig.from_pretrained = descriptor
+
+
 def _find_hf_cache_aliases(name: str) -> list[Path]:
     """Find HF cache directories matching a model name alias.
 
@@ -424,16 +487,7 @@ class Tokenizer:
         revision: str = "main",
     ) -> "Tokenizer":
         """Load a tokenizer from local cache (offline mode)."""
-        # Workaround for transformers 4.57+ bug: _patch_mistral_regex
-        # calls model_info() even with local_files_only=True
-        import huggingface_hub
-
-        class _OfflineModelInfo:
-            tags = None
-
-        _original_model_info = huggingface_hub.model_info
-        huggingface_hub.model_info = lambda *a, **kw: _OfflineModelInfo()
-        try:
+        with _offline_model_info_patch(), _offline_config_fallback(name, revision):
             tokenizer_cls = cls()
             try:
                 tokenizer_cls._tokenizer = from_pretrained_func(
@@ -449,16 +503,15 @@ class Tokenizer:
                 if cached_id is None:
                     raise
                 _logger.debug(f"Retrying offline load with cached alias: {cached_id}")
-                tokenizer_cls._tokenizer = from_pretrained_func(
-                    cached_id,
-                    trust_remote_code=trust_remote_code,
-                    revision=revision,
-                    local_files_only=True,
-                )
+                with _offline_config_fallback(cached_id, revision):
+                    tokenizer_cls._tokenizer = from_pretrained_func(
+                        cached_id,
+                        trust_remote_code=trust_remote_code,
+                        revision=revision,
+                        local_files_only=True,
+                    )
             tokenizer_cls._apply_kwarg_overrides()
             return tokenizer_cls
-        finally:
-            huggingface_hub.model_info = _original_model_info
 
     @classmethod
     def _from_tiktoken(cls, encoding_name: str = _BUILTIN_ENCODING) -> "Tokenizer":

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -137,42 +137,68 @@ def _offline_model_info_patch():
 
 @contextlib.contextmanager
 def _offline_config_fallback(name: str, revision: str):
-    """Make PreTrainedConfig.from_pretrained return an empty config for
-    tokenizer-only repos cached without a config.json.
+    """Provide a stub config.json for tokenizer-only HF repos during offline load.
 
-    Mirrors the online 404-fallthrough: when the snapshot has tokenizer_config.json
-    but no config.json, AutoTokenizer's offline fallback path raises a misleading
-    "couldn't connect" OSError. The patch swallows the OSError only when the
-    on-disk evidence matches a tokenizer-only repo, returning an empty
-    PreTrainedConfig so dispatch falls through to tokenizer_config.json.
+    Tokenizer-only repos (e.g. ``hf-internal-testing/llama-tokenizer``) ship no
+    config.json. Online, AutoTokenizer treats the 404 as a signal to fall
+    through to tokenizer_config.json. Offline, the missing file surfaces as a
+    "couldn't connect" OSError that AutoTokenizer can't recover from.
+
+    Patches transformers' ``cached_file`` resolver to hand back a synthetic
+    empty config.json path for the one lookup that needs it. The resolver's
+    contract — "return a local path or raise" — has been stable across
+    transformers versions, so this survives refactors that move
+    ``PreTrainedConfig.from_pretrained`` or change which exception it raises
+    on a missing entry.
     """
-    from transformers import PreTrainedConfig
+    import shutil
+    import tempfile
 
-    descriptor = PreTrainedConfig.__dict__["from_pretrained"]
-    original_func = descriptor.__func__
+    snapshot = _get_revision_snapshot_dir(name, revision)
+    if (
+        snapshot is None
+        or (snapshot / "config.json").exists()
+        or not (snapshot / "tokenizer_config.json").exists()
+    ):
+        yield
+        return
 
-    def patched(cls, *args, **kwargs):
+    try:
+        from transformers.utils import hub as hub_module
+    except ImportError:
+        yield
+        return
+
+    original = getattr(hub_module, "cached_file", None)
+    if original is None:
+        yield
+        return
+
+    stub_dir = Path(tempfile.mkdtemp(prefix="aiperf-offline-config-"))
+    stub_path = stub_dir / "config.json"
+    stub_path.write_text("{}")
+
+    def patched(path_or_repo_id, filename, *args, **kwargs):
+        if filename != "config.json":
+            return original(path_or_repo_id, filename, *args, **kwargs)
         try:
-            return original_func(cls, *args, **kwargs)
+            return original(path_or_repo_id, filename, *args, **kwargs)
         except OSError:
-            snapshot = _get_revision_snapshot_dir(name, revision)
-            if (
-                snapshot is not None
-                and not (snapshot / "config.json").exists()
-                and (snapshot / "tokenizer_config.json").exists()
-            ):
+            if (snapshot / "tokenizer_config.json").exists() and not (
+                snapshot / "config.json"
+            ).exists():
                 _logger.debug(
-                    f"No config.json for tokenizer-only repo '{name}'; "
-                    "returning empty PreTrainedConfig for offline dispatch"
+                    f"Returning stub config.json for tokenizer-only repo '{name}'"
                 )
-                return cls()
+                return str(stub_path)
             raise
 
-    PreTrainedConfig.from_pretrained = classmethod(patched)
+    hub_module.cached_file = patched
     try:
         yield
     finally:
-        PreTrainedConfig.from_pretrained = descriptor
+        hub_module.cached_file = original
+        shutil.rmtree(stub_dir, ignore_errors=True)
 
 
 def _find_hf_cache_aliases(name: str) -> list[Path]:

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -1,12 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Early tokenizer validation and preloading before spawning services."""
+"""Early tokenizer validation before spawning services."""
 
 from __future__ import annotations
 
-import asyncio
-import os
 import sys
 import time
 from typing import TYPE_CHECKING
@@ -151,106 +149,3 @@ def _partition_fake_models(
         else:
             real_models.append(model)
     return fake_to_builtin, real_models
-
-
-async def preload_tokenizers(
-    resolved_names: dict[str, str] | None,
-    trust_remote_code: bool = False,
-    revision: str = "main",
-    logger: AIPerfLogger | None = None,
-) -> None:
-    """Preload tokenizer files into HF disk cache before spawning child processes.
-
-    Child processes call _is_hf_cached() inside Tokenizer.from_pretrained().
-    When True, they use local_files_only=True and make zero HF network calls.
-
-    Args:
-        resolved_names: Mapping of model names to resolved tokenizer names.
-                        If None or empty (validation was skipped), this is a no-op.
-        trust_remote_code: Whether to trust remote code when loading.
-        revision: The specific model version to use.
-        logger: Optional logger for progress output.
-    """
-    from pathlib import Path
-
-    from aiperf.common.tokenizer import (
-        BUILTIN_TOKENIZER_NAME,
-        TIKTOKEN_ENCODING_NAMES,
-        Tokenizer,
-        _is_hf_cached,
-    )
-
-    if not resolved_names:
-        if logger:
-            logger.debug("Tokenizer preload skipped: validation was not run")
-        return
-
-    names_to_load: list[str] = []
-    for name in set(resolved_names.values()):
-        # tiktoken/builtin: no HF download needed
-        if name == BUILTIN_TOKENIZER_NAME or name in TIKTOKEN_ENCODING_NAMES:
-            if logger:
-                logger.debug(
-                    f"Tokenizer preload skipped for '{name}': tiktoken backend"
-                )
-            continue
-        # Local path: files already on disk
-        p = Path(name)
-        if p.is_absolute() or name.startswith(("./", "../")) or p.is_dir():
-            if logger:
-                logger.debug(f"Tokenizer preload skipped for '{name}': local path")
-            continue
-        # Already in HF disk cache
-        if _is_hf_cached(name, revision):
-            if logger:
-                logger.debug(
-                    f"Tokenizer preload skipped for '{name}': already in HF cache"
-                )
-            continue
-        names_to_load.append(name)
-
-    if not names_to_load:
-        if logger:
-            logger.debug(
-                "Tokenizer preload: all tokenizers already cached, no download needed"
-            )
-        _enable_hf_offline_mode(logger)
-        return
-
-    if logger:
-        logger.info(f"Preloading {len(names_to_load)} tokenizer(s) into local cache...")
-
-    failed: list[str] = []
-    for name in names_to_load:
-        if logger:
-            logger.info(f"  Caching tokenizer: {name}")
-        try:
-            # Discard result — side effect is populating the HF disk cache so
-            # child processes find it cached and skip all network calls.
-            await asyncio.to_thread(
-                Tokenizer.from_pretrained,
-                name,
-                trust_remote_code=trust_remote_code,
-                revision=revision,
-                resolve_alias=False,  # already resolved by validate_tokenizer_early
-            )
-        except Exception:  # noqa: BLE001
-            failed.append(name)
-
-    if failed:
-        if logger:
-            names_str = ", ".join(f"'{n}'" for n in failed)
-            logger.warning(
-                f"Failed to preload {len(failed)} tokenizer(s): {names_str}. "
-                "Child processes will attempt to load them themselves."
-            )
-    else:
-        _enable_hf_offline_mode(logger)
-
-
-def _enable_hf_offline_mode(logger: AIPerfLogger | None = None) -> None:
-    """Set HF environment variables so spawned processes never make network calls."""
-    os.environ["HF_HUB_OFFLINE"] = "1"
-    os.environ["TRANSFORMERS_OFFLINE"] = "1"
-    if logger:
-        logger.debug("Enabled HF offline mode for child processes")

--- a/src/aiperf/dataset/generator/parallel_decode.py
+++ b/src/aiperf/dataset/generator/parallel_decode.py
@@ -36,10 +36,7 @@ def _init_worker(
     starts. It loads the tokenizer so subsequent decode calls don't need to reload it.
 
     Args:
-        tokenizer_name: Pre-resolved model name or local path. Must not be an
-            unresolved alias — callers (e.g. BaseTraceLoader) are expected to
-            resolve aliases before passing this value, because
-            ``resolve_alias=False`` is used to avoid network calls in workers.
+        tokenizer_name: Name or path of the pretrained tokenizer to load.
         trust_remote_code: Whether to trust remote code when loading.
         revision: The specific model version to use.
     """
@@ -96,8 +93,7 @@ def parallel_decode(
 
     Args:
         token_sequences: List of token ID lists to decode.
-        tokenizer_name: Pre-resolved model name or local path (alias resolution
-            is skipped; callers must resolve aliases beforehand).
+        tokenizer_name: Name or path of the pretrained tokenizer to use in workers.
         max_workers: Number of worker processes. Defaults to min(cpu_count, 8).
         chunksize: Number of items per worker batch for map().
         trust_remote_code: Whether to trust remote code when loading.
@@ -117,7 +113,6 @@ def parallel_decode(
             tokenizer_name,
             trust_remote_code=trust_remote_code,
             revision=revision,
-            resolve_alias=False,
         )
         return [tokenizer.decode(tokens) for tokens in token_sequences]
 

--- a/src/aiperf/records/inference_result_parser.py
+++ b/src/aiperf/records/inference_result_parser.py
@@ -74,11 +74,10 @@ class InferenceResultParser(CommunicationMixin):
             )
             return
 
-        tokenizer_config = self.user_config.tokenizer
-        self.info(
-            f"Configuring tokenizers for inference result parser (resolve_alias: {tokenizer_config.should_resolve_alias})"
-        )
+        self.info("Configuring tokenizers for inference result parser")
         begin = time.perf_counter()
+        tokenizer_config = self.user_config.tokenizer
+
         async with self.tokenizer_lock:
             self.tokenizers = {}
             for model in self.model_endpoint.models.models:

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -11,6 +11,7 @@ from aiperf.common.tokenizer import (
     Tokenizer,
     _get_revision_snapshot_dir,
     _is_hf_cached,
+    _offline_config_fallback,
 )
 
 
@@ -176,3 +177,171 @@ class TestGetRevisionSnapshotDir:
         assert (
             _get_revision_snapshot_dir("meta-llama/Llama-2-7b-hf", str(outside)) is None
         )
+
+
+class TestOfflineConfigFallback:
+    """Patch transformers.PreTrainedConfig.from_pretrained so AutoTokenizer's
+    offline fallback returns an empty config for tokenizer-only repos.
+
+    Why: tokenizer-only HF repos (e.g. hf-internal-testing/llama-tokenizer)
+    ship no config.json. Online, the hub returns 404 and AutoTokenizer falls
+    through to tokenizer_config.json. Offline, the missing file raises a
+    misleading "couldn't connect" OSError that AutoTokenizer doesn't recover
+    from. The patch swallows the OSError only when the on-disk evidence
+    matches a tokenizer-only repo (config.json absent, tokenizer_config.json
+    present), returning an empty PreTrainedConfig so dispatch falls through.
+    """
+
+    def _make_snapshot(
+        self,
+        hf_cache: Path,
+        name: str,
+        *,
+        with_config: bool,
+        with_tokenizer_config: bool,
+    ) -> Path:
+        """Build a minimal cached snapshot and return its directory."""
+        model_dir = hf_cache / f"models--{name.replace('/', '--')}"
+        snap = model_dir / "snapshots" / "abc123"
+        snap.mkdir(parents=True)
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "refs" / "main").write_text("abc123")
+        if with_config:
+            (snap / "config.json").write_text('{"model_type": "llama"}')
+        if with_tokenizer_config:
+            (snap / "tokenizer_config.json").write_text(
+                '{"tokenizer_class": "LlamaTokenizer"}'
+            )
+        return snap
+
+    def test_returns_empty_config_when_only_tokenizer_config_present(
+        self, hf_cache
+    ) -> None:
+        from transformers import PreTrainedConfig
+
+        name = "hf-internal-testing/llama-tokenizer"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+
+        def raising(*args, **kwargs):
+            raise OSError("Couldn't connect")
+
+        # Replace the underlying loader so we exercise the patched wrapper
+        # without touching the network.
+        with (
+            _offline_config_fallback(name, "main"),
+            pytest.MonkeyPatch.context() as mp,
+        ):
+            mp.setattr(
+                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
+                raising,
+            )
+            result = PreTrainedConfig.from_pretrained(name, local_files_only=True)
+
+        assert isinstance(result, PreTrainedConfig)
+
+    def test_reraises_when_config_present(self, hf_cache) -> None:
+        from transformers import PreTrainedConfig
+
+        name = "meta-llama/Llama-2-7b-hf"
+        self._make_snapshot(
+            hf_cache, name, with_config=True, with_tokenizer_config=True
+        )
+
+        def raising(*args, **kwargs):
+            raise OSError("Couldn't connect")
+
+        with (
+            _offline_config_fallback(name, "main"),
+            pytest.MonkeyPatch.context() as mp,
+            pytest.raises(OSError, match="Couldn't connect"),
+        ):
+            mp.setattr(
+                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
+                raising,
+            )
+            PreTrainedConfig.from_pretrained(name, local_files_only=True)
+
+    def test_reraises_when_tokenizer_config_absent(self, hf_cache) -> None:
+        from transformers import PreTrainedConfig
+
+        name = "some-broken/repo"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=False
+        )
+
+        def raising(*args, **kwargs):
+            raise OSError("Couldn't connect")
+
+        with (
+            _offline_config_fallback(name, "main"),
+            pytest.MonkeyPatch.context() as mp,
+            pytest.raises(OSError, match="Couldn't connect"),
+        ):
+            mp.setattr(
+                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
+                raising,
+            )
+            PreTrainedConfig.from_pretrained(name, local_files_only=True)
+
+    def test_reraises_for_non_oserror(self, hf_cache) -> None:
+        from transformers import PreTrainedConfig
+
+        name = "hf-internal-testing/llama-tokenizer"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+
+        def raising(*args, **kwargs):
+            raise ValueError("schema mismatch")
+
+        with (
+            _offline_config_fallback(name, "main"),
+            pytest.MonkeyPatch.context() as mp,
+            pytest.raises(ValueError, match="schema mismatch"),
+        ):
+            mp.setattr(
+                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
+                raising,
+            )
+            PreTrainedConfig.from_pretrained(name, local_files_only=True)
+
+    def test_reraises_when_snapshot_dir_none(self, hf_cache) -> None:
+        from transformers import PreTrainedConfig
+
+        # No snapshot is created — _get_revision_snapshot_dir returns None.
+        name = "not-cached/anywhere"
+
+        def raising(*args, **kwargs):
+            raise OSError("Couldn't connect")
+
+        with (
+            _offline_config_fallback(name, "main"),
+            pytest.MonkeyPatch.context() as mp,
+            pytest.raises(OSError, match="Couldn't connect"),
+        ):
+            mp.setattr(
+                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
+                raising,
+            )
+            PreTrainedConfig.from_pretrained(name, local_files_only=True)
+
+    def test_restores_original_on_normal_exit(self, hf_cache) -> None:
+        from transformers import PreTrainedConfig
+
+        original = PreTrainedConfig.__dict__["from_pretrained"]
+        with _offline_config_fallback("anything", "main"):
+            assert PreTrainedConfig.__dict__["from_pretrained"] is not original
+        assert PreTrainedConfig.__dict__["from_pretrained"] is original
+
+    def test_restores_original_on_exception(self, hf_cache) -> None:
+        from transformers import PreTrainedConfig
+
+        original = PreTrainedConfig.__dict__["from_pretrained"]
+        with (
+            pytest.raises(RuntimeError, match="boom"),
+            _offline_config_fallback("anything", "main"),
+        ):
+            raise RuntimeError("boom")
+        assert PreTrainedConfig.__dict__["from_pretrained"] is original

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -17,13 +17,6 @@ def hf_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-def _make_revision_snapshot(model_dir: Path, ref: str, commit_hash: str) -> None:
-    """Create a refs/<ref> file and the corresponding snapshots/<hash>/ directory."""
-    (model_dir / "refs").mkdir(parents=True, exist_ok=True)
-    (model_dir / "refs" / ref).write_text(commit_hash)
-    (model_dir / "snapshots" / commit_hash).mkdir(parents=True, exist_ok=True)
-
-
 class TestIsHfCached:
     def test_returns_false_when_cache_dir_missing(self, tmp_path, monkeypatch) -> None:
         nonexistent = tmp_path / "does_not_exist"
@@ -54,47 +47,6 @@ class TestIsHfCached:
         (hf_cache / "models--org-a--gpt2").mkdir()
         (hf_cache / "models--org-b--gpt2").mkdir()
         assert _is_hf_cached("gpt2") is False
-
-    # --- revision-aware tests ---
-
-    def test_revision_returns_true_when_named_ref_and_snapshot_exist(
-        self, hf_cache
-    ) -> None:
-        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
-        _make_revision_snapshot(model_dir, "main", "abc123")
-        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="main") is True
-
-    def test_revision_returns_false_when_refs_file_missing(self, hf_cache) -> None:
-        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
-        (model_dir / "snapshots" / "abc123").mkdir(parents=True)
-        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="v1.2") is False
-
-    def test_revision_returns_false_when_snapshot_dir_missing(self, hf_cache) -> None:
-        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
-        (model_dir / "refs").mkdir(parents=True)
-        (model_dir / "refs" / "v1.2").write_text("def456")
-        # snapshots/def456/ intentionally not created
-        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="v1.2") is False
-
-    def test_revision_returns_false_when_different_revision_cached(
-        self, hf_cache
-    ) -> None:
-        # "main" is cached; "v1.2" is not
-        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
-        _make_revision_snapshot(model_dir, "main", "abc123")
-        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="v1.2") is False
-
-    def test_revision_as_direct_commit_hash_returns_true(self, hf_cache) -> None:
-        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
-        (model_dir / "snapshots" / "abc123").mkdir(parents=True)
-        assert _is_hf_cached("meta-llama/Llama-2-7b-hf", revision="abc123") is True
-
-    def test_no_revision_returns_true_when_only_directory_exists(
-        self, hf_cache
-    ) -> None:
-        # Backward-compat: no revision arg → directory-only check
-        (hf_cache / "models--meta-llama--Llama-2-7b-hf").mkdir()
-        assert _is_hf_cached("meta-llama/Llama-2-7b-hf") is True
 
 
 class TestFindCachedModelForAlias:

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -4,6 +4,7 @@
 """Tests for HuggingFace cache detection in the tokenizer module."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -12,6 +13,7 @@ from aiperf.common.tokenizer import (
     _get_revision_snapshot_dir,
     _is_hf_cached,
     _offline_config_fallback,
+    _offline_model_info_patch,
 )
 
 
@@ -411,3 +413,155 @@ class TestOfflineConfigFallback:
 
         # Temp dir is removed once the context manager exits.
         assert not stub_dir.exists()
+
+    def test_reraises_when_evidence_disappears_mid_load(
+        self, hf_cache, monkeypatch
+    ) -> None:
+        """If tokenizer_config.json disappears (or config.json appears) between
+        context entry and the cached_file call, the wrapper must re-raise the
+        OSError rather than silently return the stub path."""
+        from transformers.utils import hub as hub_module
+
+        name = "hf-internal-testing/llama-tokenizer"
+        snap = self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+
+        def raising(*args, **kwargs):
+            raise OSError("Couldn't connect")
+
+        monkeypatch.setattr(hub_module, "cached_file", raising)
+
+        with _offline_config_fallback(name, "main"):
+            # Simulate concurrent cache mutation: evidence no longer matches
+            # a tokenizer-only repo.
+            (snap / "tokenizer_config.json").unlink()
+            with pytest.raises(OSError, match="Couldn't connect"):
+                hub_module.cached_file(name, "config.json")
+
+    def test_noop_when_cached_file_attr_missing(self, hf_cache, monkeypatch) -> None:
+        """If transformers.utils.hub has no cached_file attribute (unsupported
+        version), the context manager is a no-op rather than blowing up."""
+        from transformers.utils import hub as hub_module
+
+        name = "hf-internal-testing/llama-tokenizer"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+        monkeypatch.delattr(hub_module, "cached_file", raising=False)
+
+        with _offline_config_fallback(name, "main"):
+            assert not hasattr(hub_module, "cached_file")
+
+
+class TestOfflineModelInfoPatch:
+    """Stub huggingface_hub.model_info so transformers 4.57+'s tokenizer
+    instantiation doesn't make a network call to inspect repo tags.
+    """
+
+    def test_stubs_model_info_with_tags_none(self) -> None:
+        import huggingface_hub
+
+        with _offline_model_info_patch():
+            info = huggingface_hub.model_info("any-repo")
+            assert info.tags is None
+
+    def test_restores_original_on_normal_exit(self) -> None:
+        import huggingface_hub
+
+        original = huggingface_hub.model_info
+        with _offline_model_info_patch():
+            assert huggingface_hub.model_info is not original
+        assert huggingface_hub.model_info is original
+
+    def test_restores_original_on_exception(self) -> None:
+        import huggingface_hub
+
+        original = huggingface_hub.model_info
+        with (
+            pytest.raises(RuntimeError, match="boom"),
+            _offline_model_info_patch(),
+        ):
+            raise RuntimeError("boom")
+        assert huggingface_hub.model_info is original
+
+
+class TestFromPretrainedOfflineDispatch:
+    """Exercise Tokenizer.from_pretrained's offline branch end-to-end so the
+    context manager stack in _from_pretrained_local (model_info patch +
+    config fallback) is actually entered.
+    """
+
+    def test_cached_model_routes_to_local_loader(self, hf_cache, monkeypatch) -> None:
+        """When the model dir is present in HF cache, from_pretrained must
+        take the offline branch and dispatch to _from_pretrained_local."""
+        name = "meta-llama/Llama-2-7b-hf"
+        (hf_cache / f"models--{name.replace('/', '--')}").mkdir()
+
+        stub_tokenizer = MagicMock(name="tokenizer")
+        captured: dict = {}
+
+        def fake_from_pretrained(_name, **kwargs):
+            captured["name"] = _name
+            captured["local_files_only"] = kwargs.get("local_files_only")
+            return stub_tokenizer
+
+        from transformers import AutoTokenizer
+
+        monkeypatch.setattr(AutoTokenizer, "from_pretrained", fake_from_pretrained)
+
+        result = Tokenizer.from_pretrained(name, resolve_alias=False)
+
+        assert result._tokenizer is stub_tokenizer
+        assert captured["name"] == name
+        assert captured["local_files_only"] is True
+
+    def test_offline_loader_retries_with_cached_alias(
+        self, hf_cache, monkeypatch
+    ) -> None:
+        """When the first load attempt fails but a cached alias exists, the
+        offline loader retries with the resolved alias under a fresh
+        _offline_config_fallback context (line 562-568)."""
+        # User asks for the short alias; cache holds the full canonical name.
+        user_name = "gpt2"
+        cached_name = "openai-community/gpt2"
+        (hf_cache / "models--openai-community--gpt2").mkdir()
+
+        attempts: list[str] = []
+        stub_tokenizer = MagicMock(name="tokenizer")
+
+        def fake_from_pretrained(_name, **kwargs):
+            attempts.append(_name)
+            if _name == user_name:
+                raise OSError("not found")
+            return stub_tokenizer
+
+        from transformers import AutoTokenizer
+
+        monkeypatch.setattr(AutoTokenizer, "from_pretrained", fake_from_pretrained)
+
+        result = Tokenizer.from_pretrained(user_name, resolve_alias=False)
+
+        assert attempts == [user_name, cached_name]
+        assert result._tokenizer is stub_tokenizer
+
+    def test_offline_loader_raises_when_no_alias_match(
+        self, hf_cache, monkeypatch
+    ) -> None:
+        """If the first attempt fails and no cached alias is found, the
+        original exception propagates."""
+        name = "meta-llama/Llama-2-7b-hf"
+        # Cache present so the offline branch is taken, but loader will raise.
+        (hf_cache / f"models--{name.replace('/', '--')}").mkdir()
+
+        def fake_from_pretrained(*args, **kwargs):
+            raise OSError("broken")
+
+        from transformers import AutoTokenizer
+
+        monkeypatch.setattr(AutoTokenizer, "from_pretrained", fake_from_pretrained)
+
+        from aiperf.common.exceptions import TokenizerError
+
+        with pytest.raises(TokenizerError):
+            Tokenizer.from_pretrained(name, resolve_alias=False)

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from aiperf.common.tokenizer import Tokenizer, _is_hf_cached
+from aiperf.common.tokenizer import (
+    Tokenizer,
+    _get_revision_snapshot_dir,
+    _is_hf_cached,
+)
 
 
 @pytest.fixture
@@ -15,6 +19,13 @@ def hf_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point HF_HUB_CACHE at a temporary directory."""
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(tmp_path))
     return tmp_path
+
+
+def _make_revision_snapshot(model_dir: Path, ref: str, commit_hash: str) -> None:
+    """Create a refs/<ref> file and the corresponding snapshots/<hash>/ directory."""
+    (model_dir / "refs").mkdir(parents=True, exist_ok=True)
+    (model_dir / "refs" / ref).write_text(commit_hash)
+    (model_dir / "snapshots" / commit_hash).mkdir(parents=True, exist_ok=True)
 
 
 class TestIsHfCached:
@@ -73,3 +84,95 @@ class TestFindCachedModelForAlias:
         (hf_cache / "models--org-a--gpt2").mkdir()
         (hf_cache / "models--org-b--gpt2").mkdir()
         assert Tokenizer._find_cached_model_for_alias("gpt2") is None
+
+
+class TestGetRevisionSnapshotDir:
+    """Branch coverage for the _get_revision_snapshot_dir helper."""
+
+    def test_returns_none_when_cache_dir_missing(self, tmp_path, monkeypatch) -> None:
+        nonexistent = tmp_path / "does_not_exist"
+        monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(nonexistent))
+        assert _get_revision_snapshot_dir("any-model", "main") is None
+
+    def test_returns_snapshot_for_exact_match_with_named_ref(self, hf_cache) -> None:
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        _make_revision_snapshot(model_dir, "main", "abc123")
+        result = _get_revision_snapshot_dir("meta-llama/Llama-2-7b-hf", "main")
+        assert result == model_dir / "snapshots" / "abc123"
+
+    def test_resolves_via_alias_when_exact_match_missing(self, hf_cache) -> None:
+        # Single alias match — exact `models--<name>` dir is not present.
+        model_dir = hf_cache / "models--openai-community--gpt2"
+        _make_revision_snapshot(model_dir, "main", "abc123")
+        result = _get_revision_snapshot_dir("gpt2", "main")
+        assert result == model_dir / "snapshots" / "abc123"
+
+    def test_returns_none_when_alias_ambiguous(self, hf_cache) -> None:
+        for org in ("org-a", "org-b"):
+            model_dir = hf_cache / f"models--{org}--gpt2"
+            _make_revision_snapshot(model_dir, "main", "abc123")
+        assert _get_revision_snapshot_dir("gpt2", "main") is None
+
+    def test_returns_none_when_no_alias_match(self, hf_cache) -> None:
+        # Empty cache — neither exact dir nor any alias matches.
+        assert _get_revision_snapshot_dir("nonexistent", "main") is None
+
+    def test_returns_none_when_snapshots_dir_missing(self, hf_cache) -> None:
+        # Model dir exists, but `snapshots/` subdir is absent.
+        (hf_cache / "models--meta-llama--Llama-2-7b-hf").mkdir()
+        assert _get_revision_snapshot_dir("meta-llama/Llama-2-7b-hf", "main") is None
+
+    def test_uses_revision_as_snapshot_name_when_no_refs_file(self, hf_cache) -> None:
+        # No refs/<rev> file: the revision is treated as a direct commit hash.
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        (model_dir / "snapshots" / "abc123").mkdir(parents=True)
+        result = _get_revision_snapshot_dir("meta-llama/Llama-2-7b-hf", "abc123")
+        assert result == model_dir / "snapshots" / "abc123"
+
+    def test_returns_none_when_resolved_snapshot_dir_missing(self, hf_cache) -> None:
+        # refs/main points to a hash whose snapshots/<hash>/ was never created.
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "refs" / "main").write_text("def456")
+        (model_dir / "snapshots").mkdir(parents=True)
+        assert _get_revision_snapshot_dir("meta-llama/Llama-2-7b-hf", "main") is None
+
+    def test_rejects_revision_traversing_out_of_snapshots(self, hf_cache) -> None:
+        """A revision like '../sibling' must not return a path outside snapshots/.
+
+        Even when a sibling directory under model_dir exists with the right
+        layout, the function must refuse to return it.
+        """
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        (model_dir / "snapshots").mkdir(parents=True)
+        # Plant a sibling directory that '../sibling' would resolve to.
+        (model_dir / "sibling").mkdir(parents=True)
+        assert (
+            _get_revision_snapshot_dir("meta-llama/Llama-2-7b-hf", "../sibling") is None
+        )
+
+    def test_rejects_revision_with_traversal_via_refs(self, hf_cache) -> None:
+        """A revision that traverses the refs lookup must not return a path.
+
+        Plants a file at model_dir/sibling that would be reached by
+        refs/../sibling. The function must reject this without reading it.
+        """
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "snapshots" / "abc123").mkdir(parents=True)
+        # Sibling file that refs/../sibling would land on; contents look like
+        # a valid commit hash so the snapshot lookup would otherwise succeed.
+        (model_dir / "sibling").write_text("abc123")
+        assert (
+            _get_revision_snapshot_dir("meta-llama/Llama-2-7b-hf", "../sibling") is None
+        )
+
+    def test_rejects_absolute_path_revision(self, hf_cache) -> None:
+        """An absolute path as revision must be refused even if the dir exists."""
+        model_dir = hf_cache / "models--meta-llama--Llama-2-7b-hf"
+        (model_dir / "snapshots").mkdir(parents=True)
+        outside = hf_cache / "outside"
+        outside.mkdir()
+        assert (
+            _get_revision_snapshot_dir("meta-llama/Llama-2-7b-hf", str(outside)) is None
+        )

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -180,16 +180,16 @@ class TestGetRevisionSnapshotDir:
 
 
 class TestOfflineConfigFallback:
-    """Patch transformers.PreTrainedConfig.from_pretrained so AutoTokenizer's
-    offline fallback returns an empty config for tokenizer-only repos.
+    """Patch transformers' cached_file resolver so AutoTokenizer's offline
+    config.json lookup falls through to tokenizer_config.json for
+    tokenizer-only HF repos (e.g. hf-internal-testing/llama-tokenizer)
+    cached without a config.json.
 
-    Why: tokenizer-only HF repos (e.g. hf-internal-testing/llama-tokenizer)
-    ship no config.json. Online, the hub returns 404 and AutoTokenizer falls
-    through to tokenizer_config.json. Offline, the missing file raises a
-    misleading "couldn't connect" OSError that AutoTokenizer doesn't recover
-    from. The patch swallows the OSError only when the on-disk evidence
-    matches a tokenizer-only repo (config.json absent, tokenizer_config.json
-    present), returning an empty PreTrainedConfig so dispatch falls through.
+    Online, the hub returns 404 for the missing config.json and AutoTokenizer
+    dispatches via tokenizer_config.json. Offline, the missing file raises a
+    misleading "couldn't connect" OSError. The context manager hands back a
+    synthetic empty config.json path only when the on-disk evidence matches
+    a tokenizer-only repo, leaving every other lookup untouched.
     """
 
     def _make_snapshot(
@@ -214,10 +214,10 @@ class TestOfflineConfigFallback:
             )
         return snap
 
-    def test_returns_empty_config_when_only_tokenizer_config_present(
-        self, hf_cache
+    def test_returns_stub_path_when_only_tokenizer_config_present(
+        self, hf_cache, monkeypatch
     ) -> None:
-        from transformers import PreTrainedConfig
+        from transformers.utils import hub as hub_module
 
         name = "hf-internal-testing/llama-tokenizer"
         self._make_snapshot(
@@ -227,66 +227,87 @@ class TestOfflineConfigFallback:
         def raising(*args, **kwargs):
             raise OSError("Couldn't connect")
 
-        # Replace the underlying loader so we exercise the patched wrapper
-        # without touching the network.
+        monkeypatch.setattr(hub_module, "cached_file", raising)
+
+        with _offline_config_fallback(name, "main"):
+            path = hub_module.cached_file(name, "config.json")
+            assert Path(path).is_file()
+            assert Path(path).read_text() == "{}"
+
+    def test_passes_through_non_config_filenames(self, hf_cache, monkeypatch) -> None:
+        from transformers.utils import hub as hub_module
+
+        name = "hf-internal-testing/llama-tokenizer"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+
+        def raising(*args, **kwargs):
+            raise OSError("Couldn't connect")
+
+        monkeypatch.setattr(hub_module, "cached_file", raising)
+
+        # tokenizer.json is not the file we stub — OSError must propagate.
         with (
             _offline_config_fallback(name, "main"),
-            pytest.MonkeyPatch.context() as mp,
+            pytest.raises(OSError, match="Couldn't connect"),
         ):
-            mp.setattr(
-                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
-                raising,
-            )
-            result = PreTrainedConfig.from_pretrained(name, local_files_only=True)
+            hub_module.cached_file(name, "tokenizer.json")
 
-        assert isinstance(result, PreTrainedConfig)
+    def test_passes_through_when_cached_file_succeeds(
+        self, hf_cache, monkeypatch
+    ) -> None:
+        from transformers.utils import hub as hub_module
 
-    def test_reraises_when_config_present(self, hf_cache) -> None:
-        from transformers import PreTrainedConfig
+        name = "hf-internal-testing/llama-tokenizer"
+        snap = self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+        # Resolver returns a real cached path — wrapper must not intercept.
+        cached = snap / "tokenizer_config.json"
+        monkeypatch.setattr(hub_module, "cached_file", lambda *a, **kw: str(cached))
+
+        with _offline_config_fallback(name, "main"):
+            result = hub_module.cached_file(name, "config.json")
+
+        assert result == str(cached)
+
+    def test_noop_when_config_already_cached(self, hf_cache, monkeypatch) -> None:
+        from transformers.utils import hub as hub_module
 
         name = "meta-llama/Llama-2-7b-hf"
         self._make_snapshot(
             hf_cache, name, with_config=True, with_tokenizer_config=True
         )
 
-        def raising(*args, **kwargs):
-            raise OSError("Couldn't connect")
+        original = hub_module.cached_file
+        with _offline_config_fallback(name, "main"):
+            # Snapshot already has config.json — context manager is a no-op.
+            assert hub_module.cached_file is original
 
-        with (
-            _offline_config_fallback(name, "main"),
-            pytest.MonkeyPatch.context() as mp,
-            pytest.raises(OSError, match="Couldn't connect"),
-        ):
-            mp.setattr(
-                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
-                raising,
-            )
-            PreTrainedConfig.from_pretrained(name, local_files_only=True)
-
-    def test_reraises_when_tokenizer_config_absent(self, hf_cache) -> None:
-        from transformers import PreTrainedConfig
+    def test_noop_when_tokenizer_config_absent(self, hf_cache) -> None:
+        from transformers.utils import hub as hub_module
 
         name = "some-broken/repo"
         self._make_snapshot(
             hf_cache, name, with_config=False, with_tokenizer_config=False
         )
 
-        def raising(*args, **kwargs):
-            raise OSError("Couldn't connect")
+        original = hub_module.cached_file
+        with _offline_config_fallback(name, "main"):
+            # Not a tokenizer-only repo — context manager is a no-op.
+            assert hub_module.cached_file is original
 
-        with (
-            _offline_config_fallback(name, "main"),
-            pytest.MonkeyPatch.context() as mp,
-            pytest.raises(OSError, match="Couldn't connect"),
-        ):
-            mp.setattr(
-                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
-                raising,
-            )
-            PreTrainedConfig.from_pretrained(name, local_files_only=True)
+    def test_noop_when_snapshot_dir_none(self) -> None:
+        from transformers.utils import hub as hub_module
 
-    def test_reraises_for_non_oserror(self, hf_cache) -> None:
-        from transformers import PreTrainedConfig
+        # No snapshot exists for this repo — _get_revision_snapshot_dir returns None.
+        original = hub_module.cached_file
+        with _offline_config_fallback("not-cached/anywhere", "main"):
+            assert hub_module.cached_file is original
+
+    def test_reraises_for_non_oserror(self, hf_cache, monkeypatch) -> None:
+        from transformers.utils import hub as hub_module
 
         name = "hf-internal-testing/llama-tokenizer"
         self._make_snapshot(
@@ -296,52 +317,63 @@ class TestOfflineConfigFallback:
         def raising(*args, **kwargs):
             raise ValueError("schema mismatch")
 
+        monkeypatch.setattr(hub_module, "cached_file", raising)
+
         with (
             _offline_config_fallback(name, "main"),
-            pytest.MonkeyPatch.context() as mp,
             pytest.raises(ValueError, match="schema mismatch"),
         ):
-            mp.setattr(
-                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
-                raising,
-            )
-            PreTrainedConfig.from_pretrained(name, local_files_only=True)
+            hub_module.cached_file(name, "config.json")
 
-    def test_reraises_when_snapshot_dir_none(self, hf_cache) -> None:
-        from transformers import PreTrainedConfig
+    def test_restores_original_on_normal_exit(self, hf_cache, monkeypatch) -> None:
+        from transformers.utils import hub as hub_module
 
-        # No snapshot is created — _get_revision_snapshot_dir returns None.
-        name = "not-cached/anywhere"
+        name = "hf-internal-testing/llama-tokenizer"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+        sentinel = lambda *a, **kw: "sentinel"  # noqa: E731
+        monkeypatch.setattr(hub_module, "cached_file", sentinel)
 
-        def raising(*args, **kwargs):
-            raise OSError("Couldn't connect")
+        with _offline_config_fallback(name, "main"):
+            assert hub_module.cached_file is not sentinel
+        assert hub_module.cached_file is sentinel
 
-        with (
-            _offline_config_fallback(name, "main"),
-            pytest.MonkeyPatch.context() as mp,
-            pytest.raises(OSError, match="Couldn't connect"),
-        ):
-            mp.setattr(
-                "transformers.configuration_utils.PreTrainedConfig.get_config_dict",
-                raising,
-            )
-            PreTrainedConfig.from_pretrained(name, local_files_only=True)
+    def test_restores_original_on_exception(self, hf_cache, monkeypatch) -> None:
+        from transformers.utils import hub as hub_module
 
-    def test_restores_original_on_normal_exit(self, hf_cache) -> None:
-        from transformers import PreTrainedConfig
+        name = "hf-internal-testing/llama-tokenizer"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+        sentinel = lambda *a, **kw: "sentinel"  # noqa: E731
+        monkeypatch.setattr(hub_module, "cached_file", sentinel)
 
-        original = PreTrainedConfig.__dict__["from_pretrained"]
-        with _offline_config_fallback("anything", "main"):
-            assert PreTrainedConfig.__dict__["from_pretrained"] is not original
-        assert PreTrainedConfig.__dict__["from_pretrained"] is original
-
-    def test_restores_original_on_exception(self, hf_cache) -> None:
-        from transformers import PreTrainedConfig
-
-        original = PreTrainedConfig.__dict__["from_pretrained"]
         with (
             pytest.raises(RuntimeError, match="boom"),
-            _offline_config_fallback("anything", "main"),
+            _offline_config_fallback(name, "main"),
         ):
             raise RuntimeError("boom")
-        assert PreTrainedConfig.__dict__["from_pretrained"] is original
+        assert hub_module.cached_file is sentinel
+
+    def test_cleans_up_stub_dir_on_exit(self, hf_cache, monkeypatch) -> None:
+        from transformers.utils import hub as hub_module
+
+        name = "hf-internal-testing/llama-tokenizer"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+        monkeypatch.setattr(
+            hub_module,
+            "cached_file",
+            lambda *a, **kw: (_ for _ in ()).throw(OSError("x")),
+        )
+
+        with _offline_config_fallback(name, "main"):
+            path = Path(hub_module.cached_file(name, "config.json"))
+            assert path.is_file()
+            stub_dir = path.parent
+            assert stub_dir.is_dir()
+
+        # Temp dir is removed once the context manager exits.
+        assert not stub_dir.exists()

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -356,6 +356,40 @@ class TestOfflineConfigFallback:
             raise RuntimeError("boom")
         assert hub_module.cached_file is sentinel
 
+    def test_patches_local_bindings_in_other_modules(
+        self, hf_cache, monkeypatch
+    ) -> None:
+        """transformers modules typically do ``from .utils import cached_file``
+        at import time, creating per-module local bindings. The actual
+        config.json lookup happens via configuration_utils' local binding
+        (configuration_utils.py:725), not via transformers.utils.hub directly.
+        Patching only hub_module.cached_file leaves those bindings untouched,
+        which silently bypasses the fallback. The context manager must reach
+        every module that imported cached_file by name.
+        """
+        from transformers import configuration_utils
+        from transformers.utils import hub as hub_module
+
+        name = "hf-internal-testing/llama-tokenizer"
+        self._make_snapshot(
+            hf_cache, name, with_config=False, with_tokenizer_config=True
+        )
+
+        def raising(*args, **kwargs):
+            raise OSError("Couldn't connect")
+
+        # Replace BOTH bindings with the raising stub, mirroring real usage
+        # where transformers internals call their local binding.
+        monkeypatch.setattr(hub_module, "cached_file", raising)
+        monkeypatch.setattr(configuration_utils, "cached_file", raising)
+
+        with _offline_config_fallback(name, "main"):
+            # The bug: callers using configuration_utils' local binding get
+            # the unpatched original. The fix must patch that too.
+            path = configuration_utils.cached_file(name, "config.json")
+            assert Path(path).is_file()
+            assert Path(path).read_text() == "{}"
+
     def test_cleans_up_stub_dir_on_exit(self, hf_cache, monkeypatch) -> None:
         from transformers.utils import hub as hub_module
 

--- a/tests/unit/common/test_tokenizer_validator.py
+++ b/tests/unit/common/test_tokenizer_validator.py
@@ -1,9 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for early tokenizer validation and preloading."""
+"""Tests for early tokenizer validation."""
 
-import os
 from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
@@ -14,10 +13,7 @@ from aiperf.common.tokenizer import (
     TIKTOKEN_ENCODING_NAMES,
     Tokenizer,
 )
-from aiperf.common.tokenizer_validator import (
-    preload_tokenizers,
-    validate_tokenizer_early,
-)
+from aiperf.common.tokenizer_validator import validate_tokenizer_early
 
 
 @pytest.fixture
@@ -52,166 +48,6 @@ def _mock_endpoint_meta() -> Iterator[None]:
         return_value=meta,
     ):
         yield
-
-
-@pytest.fixture(autouse=True)
-def _clean_hf_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Remove HF offline env vars before each test so assertions are reliable."""
-    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
-    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
-
-
-class TestPreloadTokenizers:
-    """Tests for preload_tokenizers() — cache-warming step before child processes spawn."""
-
-    @pytest.mark.asyncio
-    async def test_skips_when_resolved_names_none(self) -> None:
-        with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            await preload_tokenizers(None)
-        mock_load.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_skips_when_resolved_names_empty(self) -> None:
-        with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            await preload_tokenizers({})
-        mock_load.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_skips_builtin_name(self) -> None:
-        with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            await preload_tokenizers({"model": BUILTIN_TOKENIZER_NAME})
-        mock_load.assert_not_called()
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("encoding_name", sorted(TIKTOKEN_ENCODING_NAMES))
-    async def test_skips_tiktoken_encoding_names(self, encoding_name: str) -> None:
-        with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            await preload_tokenizers({"model": encoding_name})
-        mock_load.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_skips_already_cached(self) -> None:
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=True),
-            patch.object(Tokenizer, "from_pretrained") as mock_load,
-        ):
-            await preload_tokenizers({"model": "meta-llama/Llama-2-7b-hf"})
-        mock_load.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_skips_local_absolute_path(self, tmp_path) -> None:
-        local_path = str(tmp_path)
-        with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            await preload_tokenizers({"model": local_path})
-        mock_load.assert_not_called()
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("local_name", ["./my-tokenizer", "../my-tokenizer"])
-    async def test_skips_local_relative_path(self, local_name: str) -> None:
-        with patch.object(Tokenizer, "from_pretrained") as mock_load:
-            await preload_tokenizers({"model": local_name})
-        mock_load.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_deduplicates_same_tokenizer_across_models(self) -> None:
-        resolved = {
-            "model-a": "meta-llama/Llama-2-7b-hf",
-            "model-b": "meta-llama/Llama-2-7b-hf",
-        }
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
-            patch.object(Tokenizer, "from_pretrained") as mock_load,
-        ):
-            await preload_tokenizers(resolved)
-        mock_load.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_calls_from_pretrained_with_correct_params(self) -> None:
-        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
-            patch.object(Tokenizer, "from_pretrained") as mock_load,
-        ):
-            await preload_tokenizers(
-                resolved,
-                trust_remote_code=True,
-                revision="v1.0",
-            )
-        mock_load.assert_called_once_with(
-            "meta-llama/Llama-2-7b-hf",
-            trust_remote_code=True,
-            revision="v1.0",
-            resolve_alias=False,
-        )
-
-    @pytest.mark.asyncio
-    async def test_swallows_exception_and_warns(self, mock_logger: MagicMock) -> None:
-        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
-            patch.object(
-                Tokenizer, "from_pretrained", side_effect=RuntimeError("network error")
-            ),
-        ):
-            await preload_tokenizers(resolved, logger=mock_logger)  # must not raise
-
-        mock_logger.warning.assert_called_once()
-        assert "meta-llama/Llama-2-7b-hf" in mock_logger.warning.call_args[0][0]
-
-    @pytest.mark.asyncio
-    async def test_loads_multiple_distinct_tokenizers(self) -> None:
-        resolved = {
-            "model-a": "meta-llama/Llama-2-7b-hf",
-            "model-b": "mistralai/Mistral-7B-v0.1",
-        }
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
-            patch.object(Tokenizer, "from_pretrained") as mock_load,
-        ):
-            await preload_tokenizers(resolved)
-        assert mock_load.call_count == 2
-
-    @pytest.mark.asyncio
-    async def test_enables_offline_mode_after_successful_preload(self) -> None:
-        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
-            patch.object(Tokenizer, "from_pretrained"),
-        ):
-            await preload_tokenizers(resolved)
-        assert os.environ.get("HF_HUB_OFFLINE") == "1"
-        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
-
-    @pytest.mark.asyncio
-    async def test_enables_offline_mode_when_all_already_cached(self) -> None:
-        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=True),
-            patch.object(Tokenizer, "from_pretrained") as mock_load,
-        ):
-            await preload_tokenizers(resolved)
-        mock_load.assert_not_called()
-        assert os.environ.get("HF_HUB_OFFLINE") == "1"
-        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
-
-    @pytest.mark.asyncio
-    async def test_does_not_enable_offline_mode_on_failure(self) -> None:
-        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
-            patch.object(
-                Tokenizer, "from_pretrained", side_effect=RuntimeError("network error")
-            ),
-        ):
-            await preload_tokenizers(resolved)
-        assert os.environ.get("HF_HUB_OFFLINE") is None
-        assert os.environ.get("TRANSFORMERS_OFFLINE") is None
-
-    @pytest.mark.asyncio
-    async def test_does_not_enable_offline_mode_when_skipped(self) -> None:
-        await preload_tokenizers(None)
-        assert os.environ.get("HF_HUB_OFFLINE") is None
-        assert os.environ.get("TRANSFORMERS_OFFLINE") is None
 
 
 @pytest.mark.usefixtures("_mock_endpoint_meta")

--- a/tests/unit/dataset/generator/test_parallel_decode.py
+++ b/tests/unit/dataset/generator/test_parallel_decode.py
@@ -35,10 +35,7 @@ class TestParallelDecode:
 
         # Should use sequential decoding (Tokenizer.from_pretrained called once)
         mock_tokenizer_class.from_pretrained.assert_called_once_with(
-            "gpt2",
-            trust_remote_code=False,
-            revision="main",
-            resolve_alias=False,
+            "gpt2", trust_remote_code=False, revision="main"
         )
         assert mock_tokenizer.decode.call_count == 2
         assert result == ["decoded", "decoded"]
@@ -316,10 +313,7 @@ class TestParallelDecodeTokenizerArgs:
         )
 
         mock_tokenizer_class.from_pretrained.assert_called_once_with(
-            "kimi-vl",
-            trust_remote_code=True,
-            revision="v1.2",
-            resolve_alias=False,
+            "kimi-vl", trust_remote_code=True, revision="v1.2"
         )
 
     @patch.object(pd_module, "ProcessPoolExecutor")


### PR DESCRIPTION
## Summary

- Patches `PreTrainedConfig.from_pretrained` via a context manager during offline tokenizer load, so AutoTokenizer can fall through to `tokenizer_config.json` for tokenizer-only HF repos (e.g. `hf-internal-testing/llama-tokenizer`) instead of raising a misleading "couldn't connect" `OSError`.
- Extracts the existing `huggingface_hub.model_info` shim into a sibling context manager (`_offline_model_info_patch`) and wires both into `Tokenizer._from_pretrained_local`.
- Adds an `_is_within` containment check on the user-controlled `revision` string used for HF cache snapshot lookups, rejecting `../sibling`-style traversals and absolute paths.

## Background

This PR sits on top of the in-flight revert of #842 (preload-in-main-process). The offline patching mechanism originally shipped on `fdinatale/offline-fix` was layered on the preload feature; this PR ports just the `PreTrainedConfig` context-manager (and the path-traversal hardening it relies on) so the offline-load fix works without restoring the reverted preload path. Commit history:

1. `0cb7e8c9` Add `_get_revision_snapshot_dir` helper (chain-cherry-picked from `a75b9d61`; preload-bound additions dropped).
2. `cbaff8eb` Add `_is_within` and path-traversal guards (cherry-picked from `caa164a4`; `_is_revision_snapshot_cached` dropped as unused on this branch).
3. `6b3d5962` Add `_offline_model_info_patch` + `_offline_config_fallback` context managers, wire into `_from_pretrained_local` (cherry-picked from `d73ff89b`; `_ensure_offline_config_stub` removal hunks skipped since the disk-stub never existed here).

## Test plan

- [x] `pytest tests/unit/common/test_tokenizer_cache.py tests/unit/common/test_tokenizer_validator.py` — 40 passed locally (11 new `TestGetRevisionSnapshotDir`, 7 new `TestOfflineConfigFallback`).
- [ ] `pytest tests/unit/ -n auto` on CI.
- [ ] Smoke-test offline tokenizer load against a tokenizer-only repo (e.g. `hf-internal-testing/llama-tokenizer`) with `HF_HUB_OFFLINE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline tokenizer caching with enhanced path traversal protection and stub configuration fallback.
  * Refined tokenizer alias resolution to be more automatic and consistent across usage scenarios.

* **Refactor**
  * Simplified tokenizer initialization by removing asynchronous preloading step, streamlining the startup process.
  * Updated tokenizer configuration logging and timing for improved clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/917)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->