### PR TITLE
fix(tokenizer): subprocess pre-warm; clean parent env; stub config

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -185,6 +185,14 @@ Timing manager configuration. Controls timing-related settings for credit phase 
 | `AIPERF_TIMING_CANCEL_DRAIN_TIMEOUT` | `10.0` | ≥ 1.0, ≤ 300.0 | Timeout in seconds for waiting for cancelled credits to drain after phase timeout |
 | `AIPERF_TIMING_RATE_RAMP_UPDATE_INTERVAL` | `0.1` | ≥ 0.01, ≤ 10.0 | Update interval in seconds for continuous rate ramping (default 0.1s = 100ms) |
 
+## TOKENIZER
+
+Tokenizer pre-warm and loading configuration. Controls how the CLI parent pre-warms tokenizer caches before spawning AIPerf services. Pre-warming runs in subprocesses so the parent never imports the heavy native libraries (``transformers``, Rust-backed ``tokenizers``, ``tiktoken``).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_TOKENIZER_PRELOAD_TIMEOUT` | `120.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for the parent's tokenizer pre-warm phase. Bounds the total wall-clock time for all parallel subprocess pre-warms. On timeout, subprocesses are killed and AIPerf continues; child services may then download tokenizers themselves on first use. |
+
 ## UI
 
 User interface and dashboard configuration. Controls refresh rates, update thresholds, and notification behavior for the various UI modes (dashboard, tqdm, etc.).

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -20,6 +20,7 @@ Structure:
     Environment.SERVER_METRICS.* - Server metrics collection
     Environment.SERVICE.*        - Service lifecycle and communication
     Environment.TIMING.*         - Timing manager settings
+    Environment.TOKENIZER.*      - Tokenizer pre-warm and loading
     Environment.UI.*             - User interface settings
     Environment.WORKER.*         - Worker management and scaling
     Environment.ZMQ.*            - ZMQ communication settings
@@ -730,6 +731,33 @@ class _ServiceSettings(BaseSettings):
         return self
 
 
+class _TokenizerSettings(BaseSettings):
+    """Tokenizer pre-warm and loading configuration.
+
+    Controls how the CLI parent pre-warms tokenizer caches before
+    spawning AIPerf services. Pre-warming runs in subprocesses so the
+    parent never imports the heavy native libraries (``transformers``,
+    Rust-backed ``tokenizers``, ``tiktoken``).
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="AIPERF_TOKENIZER_",
+    )
+
+    PRELOAD_TIMEOUT: float = Field(
+        ge=1.0,
+        le=100000.0,
+        default=120.0,
+        description=(
+            "Timeout in seconds for the parent's tokenizer pre-warm phase. "
+            "Bounds the total wall-clock time for all parallel subprocess "
+            "pre-warms. On timeout, subprocesses are killed and AIPerf "
+            "continues; child services may then download tokenizers "
+            "themselves on first use."
+        ),
+    )
+
+
 class _UISettings(BaseSettings):
     """User interface and dashboard configuration.
 
@@ -1031,6 +1059,10 @@ class _Environment(BaseSettings):
     TIMING: _TimingSettings = Field(
         default_factory=_TimingSettings,
         description="Timing manager settings",
+    )
+    TOKENIZER: _TokenizerSettings = Field(
+        default_factory=_TokenizerSettings,
+        description="Tokenizer pre-warm and loading settings",
     )
     UI: _UISettings = Field(
         default_factory=_UISettings,

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -185,6 +185,82 @@ def _is_hf_cached(name: str, revision: str | None = None) -> bool:
     return _is_revision_snapshot_cached(model_dir, revision)
 
 
+def _get_revision_snapshot_dir(name: str, revision: str) -> Path | None:
+    """Return the cached HF snapshot dir for ``(name, revision)``, or None.
+
+    Resolves alias-style short names the same way ``_is_hf_cached`` does.
+    Used by ``_ensure_offline_config_stub`` to locate where a tokenizer-only
+    repo's stub ``config.json`` should land.
+    """
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    cache_dir = Path(HF_HUB_CACHE)
+    if not cache_dir.is_dir():
+        return None
+
+    exact = cache_dir / f"models--{name.replace('/', '--')}"
+    if exact.is_dir():
+        model_dir = exact
+    else:
+        aliases = _find_hf_cache_aliases(name)
+        if len(aliases) != 1:
+            return None
+        model_dir = aliases[0]
+
+    snapshots_dir = model_dir / "snapshots"
+    if not snapshots_dir.is_dir():
+        return None
+    refs_file = model_dir / "refs" / revision
+    if refs_file.is_file():
+        snap = snapshots_dir / refs_file.read_text().strip()
+    else:
+        snap = snapshots_dir / revision
+    return snap if snap.is_dir() else None
+
+
+# tiktoken BPE-file URLs per encoding (sha1(url) keys the disk cache).
+# Derived encodings (p50k_edit, o200k_harmony) reuse a base encoding's BPE.
+_TIKTOKEN_ENCODING_URLS = {
+    "cl100k_base": "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken",
+    "o200k_base": "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken",
+    "o200k_harmony": "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken",
+    "p50k_base": "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken",
+    "p50k_edit": "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken",
+    "r50k_base": "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken",
+}
+
+
+def _is_tiktoken_cached(name: str) -> bool:
+    """Check if tiktoken's BPE file is on disk without importing tiktoken.
+
+    Mirrors ``tiktoken.load.read_file_cached`` lookup: ``sha1(url)`` under
+    ``TIKTOKEN_CACHE_DIR`` / ``DATA_GYM_CACHE_DIR`` / ``<tempdir>/data-gym-cache``.
+    Returns False for unknown encodings or when caching is disabled (empty
+    ``TIKTOKEN_CACHE_DIR``) so the caller falls through to a real load —
+    must not under-spawn (would leave child processes hitting the no-timeout
+    CDN call) but may over-spawn (just wastes a subprocess).
+    """
+    import hashlib
+    import tempfile
+
+    encoding = _BUILTIN_ENCODING if name == BUILTIN_TOKENIZER_NAME else name
+    url = _TIKTOKEN_ENCODING_URLS.get(encoding)
+    if url is None:
+        return False
+
+    cache_dir = os.environ.get("TIKTOKEN_CACHE_DIR")
+    if cache_dir is None:
+        cache_dir = os.environ.get("DATA_GYM_CACHE_DIR")
+    if cache_dir is None:
+        cache_dir = os.path.join(tempfile.gettempdir(), "data-gym-cache")
+    if cache_dir == "":
+        # tiktoken treats empty TIKTOKEN_CACHE_DIR as "disable caching"
+        return False
+
+    cache_key = hashlib.sha1(url.encode(), usedforsecurity=False).hexdigest()
+    return Path(cache_dir, cache_key).is_file()
+
+
 def resolve_alias(name: str) -> AliasResolutionResult:
     """Resolve a tokenizer name alias to its canonical repository ID.
 

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -6,9 +6,10 @@
 from __future__ import annotations
 
 import asyncio
-import os
+import multiprocessing as mp
 import sys
 import time
+from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -153,104 +154,290 @@ def _partition_fake_models(
     return fake_to_builtin, real_models
 
 
-async def preload_tokenizers(
-    resolved_names: dict[str, str] | None,
-    trust_remote_code: bool = False,
-    revision: str = "main",
-    logger: AIPerfLogger | None = None,
-) -> None:
-    """Preload tokenizer files into HF disk cache before spawning child processes.
+def _prefetch_one(
+    name: str,
+    trust_remote_code: bool,
+    revision: str,
+) -> tuple[str, str | None]:
+    """Subprocess target: warm one tokenizer's disk cache.
 
-    Child processes call _is_hf_cached() inside Tokenizer.from_pretrained().
-    When True, they use local_files_only=True and make zero HF network calls.
+    All heavy imports (``transformers``, ``tokenizers`` Rust ext,
+    ``tiktoken``) happen here, inside the subprocess — the CLI parent
+    never imports them. Returns ``(name, error_message_or_None)`` so the
+    parent can log per-name and continue.
+    """
+    try:
+        from aiperf.common.tokenizer import Tokenizer
 
-    Args:
-        resolved_names: Mapping of model names to resolved tokenizer names.
-                        If None or empty (validation was skipped), this is a no-op.
-        trust_remote_code: Whether to trust remote code when loading.
-        revision: The specific model version to use.
-        logger: Optional logger for progress output.
+        Tokenizer.from_pretrained(
+            name,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            resolve_alias=False,
+        )
+        return (name, None)
+    except Exception as e:  # noqa: BLE001 - HF/tiktoken/network surface arbitrary errors; serialize and let the parent log per-name
+        return (name, f"{type(e).__name__}: {e}")
+
+
+def _partition_preload_names(
+    resolved_names: dict[str, str],
+    revision: str,
+    logger: AIPerfLogger | None,
+) -> tuple[set[str], set[str], set[str]]:
+    """Split resolved tokenizer names into:
+
+      (tiktoken_to_warm, hf_to_warm, hf_already_cached)
+
+    Local paths and tiktoken encodings already in the disk cache are
+    dropped entirely. ``hf_already_cached`` is reported separately so
+    the caller can write an offline-config stub for tokenizer-only HF
+    repos that are already present but lack a ``config.json``.
     """
     from pathlib import Path
 
     from aiperf.common.tokenizer import (
         BUILTIN_TOKENIZER_NAME,
         TIKTOKEN_ENCODING_NAMES,
-        Tokenizer,
         _is_hf_cached,
+        _is_tiktoken_cached,
     )
+
+    tiktoken_names: set[str] = set()
+    hf_names: set[str] = set()
+    hf_already_cached: set[str] = set()
+    for name in set(resolved_names.values()):
+        if name == BUILTIN_TOKENIZER_NAME or name in TIKTOKEN_ENCODING_NAMES:
+            if _is_tiktoken_cached(name):
+                if logger:
+                    logger.debug(
+                        f"Tokenizer preload skipped for '{name}': already in tiktoken cache"
+                    )
+                continue
+            tiktoken_names.add(name)
+            continue
+        p = Path(name)
+        if p.is_absolute() or name.startswith(("./", "../")) or p.is_dir():
+            if logger:
+                logger.debug(f"Tokenizer preload skipped for '{name}': local path")
+            continue
+        if _is_hf_cached(name, revision):
+            if logger:
+                logger.debug(
+                    f"Tokenizer preload skipped for '{name}': already in HF cache"
+                )
+            hf_already_cached.add(name)
+            continue
+        hf_names.add(name)
+    return tiktoken_names, hf_names, hf_already_cached
+
+
+def _ensure_offline_config_stub(
+    name: str, revision: str, logger: AIPerfLogger | None = None
+) -> None:
+    """Write a stub ``config.json`` for tokenizer-only HF repos.
+
+    Tokenizer-only repos (e.g. ``hf-internal-testing/llama-tokenizer``)
+    ship no ``config.json``. ``AutoTokenizer.from_pretrained`` with
+    ``local_files_only=True`` then raises a misleading "Couldn't connect"
+    ``OSError`` because its config lookup can't fall through to
+    ``tokenizer_config.json`` like the online path does. Writing an empty
+    ``{}`` config.json into the cached snapshot satisfies the offline
+    lookup. Idempotent; no-op when the file already exists or when the
+    snapshot has no tokenizer indicator file at all.
+
+    Atomic via ``NamedTemporaryFile`` + ``Path.replace`` so a child
+    reading the file mid-write can never see a partial / empty config.
+
+    Raises:
+        OSError: If the stub cannot be written. Aborting startup here is
+            preferable to a downstream worker hanging with a misleading
+            "Couldn't connect" error pointing at HF Hub.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from aiperf.common.tokenizer import _get_revision_snapshot_dir
+
+    snapshot = _get_revision_snapshot_dir(name, revision)
+    if snapshot is None:
+        return
+    config_path = snapshot / "config.json"
+    if config_path.exists():
+        return
+    # Need at least one tokenizer indicator file — otherwise the snapshot
+    # is broken or unrelated, and fabricating a config won't help. Covers
+    # both legacy (tokenizer_config.json) and fast-only (tokenizer.json)
+    # repos.
+    if not any(
+        (snapshot / f).exists() for f in ("tokenizer_config.json", "tokenizer.json")
+    ):
+        return
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".json",
+            prefix="config.aiperf-",
+            dir=str(snapshot),
+            delete=False,
+        ) as tmp:
+            tmp.write("{}")
+            tmp_path = Path(tmp.name)
+        tmp_path.replace(config_path)
+    except OSError as e:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+        if logger:
+            logger.error(
+                f"Could not write stub config.json for tokenizer '{name}' "
+                f"at {config_path}: {e!r}. Offline tokenizer load would fail "
+                "in child services; aborting initialization."
+            )
+        raise
+    if logger:
+        logger.debug(f"Wrote stub config.json for tokenizer-only repo '{name}'")
+
+
+async def _run_prefetch_pool(
+    all_names: list[str],
+    *,
+    trust_remote_code: bool,
+    revision: str,
+    timeout: float,
+    logger: AIPerfLogger | None,
+) -> list[tuple[str, str | None]]:
+    """Run ``_prefetch_one`` for each name in a spawn ProcessPoolExecutor.
+
+    Bounds total wall-clock by ``timeout``. On timeout, kills running
+    subprocesses and returns ``TimeoutError`` results for every name.
+    """
+    ctx = mp.get_context("spawn")
+    loop = asyncio.get_running_loop()
+    pool = ProcessPoolExecutor(max_workers=len(all_names), mp_context=ctx)
+    try:
+        futures = [
+            loop.run_in_executor(pool, _prefetch_one, name, trust_remote_code, revision)
+            for name in all_names
+        ]
+        try:
+            return await asyncio.wait_for(asyncio.gather(*futures), timeout=timeout)
+        except asyncio.TimeoutError:
+            if logger:
+                logger.warning(
+                    f"Tokenizer preload exceeded "
+                    f"AIPERF_TOKENIZER_PRELOAD_TIMEOUT={timeout}s; "
+                    "killing prefetch subprocesses and continuing."
+                )
+            # ProcessPoolExecutor's cancel_futures only cancels queued work,
+            # not running subprocesses. Kill them explicitly to prevent
+            # zombies after pool.shutdown returns.
+            for proc in list(pool._processes.values()):  # noqa: SLF001
+                if proc.is_alive():
+                    proc.kill()
+            return [(name, "TimeoutError") for name in all_names]
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+
+async def preload_tokenizers(
+    resolved_names: dict[str, str] | None,
+    trust_remote_code: bool = False,
+    revision: str = "main",
+    logger: AIPerfLogger | None = None,
+) -> None:
+    """Preload tokenizer files into disk cache before spawning child services.
+
+    All prefetch work runs in short-lived ``ProcessPoolExecutor`` workers
+    using the ``spawn`` mp context. The CLI parent never imports
+    ``transformers``, the Rust-backed ``tokenizers`` extension, or
+    ``tiktoken`` — important because:
+
+    * macOS spawn re-imports everything per child; a bloated parent
+      wastes memory and startup time.
+    * Linux fork inherits parent state. ``tokenizers`` spins up Rayon
+      thread pools at import; forking after Rayon init is the textbook
+      "process forked after parallelism" trap (deadlock-prone).
+
+    Total wall-clock time across all parallel subprocess pre-warms is
+    bounded by ``Environment.TOKENIZER.PRELOAD_TIMEOUT``. On timeout,
+    subprocesses are killed and AIPerf continues — child services will
+    download tokenizers themselves on first use.
+
+    The CLI parent never mutates ``HF_HUB_OFFLINE`` / ``TRANSFORMERS_OFFLINE``
+    in its own ``os.environ``: child services inherit env at spawn, so a
+    parent-side mutation poisons legitimate online consumers (e.g.
+    ``dataset_manager`` loading a public HF dataset). Workers that
+    genuinely need offline mode set it locally in their own
+    ``_init_worker`` (see ``aiperf.dataset.generator.parallel_decode``).
+
+    Args:
+        resolved_names: Mapping of model names to resolved tokenizer names.
+                        If None or empty (validation was skipped), this is a no-op.
+        trust_remote_code: Whether to trust remote code when loading.
+        revision: The HF revision to fetch.
+        logger: Optional logger for progress output.
+    """
+    from aiperf.common.environment import Environment
 
     if not resolved_names:
         if logger:
             logger.debug("Tokenizer preload skipped: validation was not run")
         return
 
-    names_to_load: list[str] = []
-    for name in set(resolved_names.values()):
-        # tiktoken/builtin: no HF download needed
-        if name == BUILTIN_TOKENIZER_NAME or name in TIKTOKEN_ENCODING_NAMES:
-            if logger:
-                logger.debug(
-                    f"Tokenizer preload skipped for '{name}': tiktoken backend"
-                )
-            continue
-        # Local path: files already on disk
-        p = Path(name)
-        if p.is_absolute() or name.startswith(("./", "../")) or p.is_dir():
-            if logger:
-                logger.debug(f"Tokenizer preload skipped for '{name}': local path")
-            continue
-        # Already in HF disk cache
-        if _is_hf_cached(name, revision):
-            if logger:
-                logger.debug(
-                    f"Tokenizer preload skipped for '{name}': already in HF cache"
-                )
-            continue
-        names_to_load.append(name)
+    tiktoken_names, hf_names, hf_already_cached = _partition_preload_names(
+        resolved_names, revision, logger
+    )
 
-    if not names_to_load:
+    all_names = sorted(tiktoken_names | hf_names)
+    if not all_names and not hf_already_cached:
         if logger:
             logger.debug(
-                "Tokenizer preload: all tokenizers already cached, no download needed"
+                "Tokenizer preload: nothing to warm (all builtin/local/cached)"
             )
-        _enable_hf_offline_mode(logger)
         return
 
-    if logger:
-        logger.info(f"Preloading {len(names_to_load)} tokenizer(s) into local cache...")
-
-    failed: list[str] = []
-    for name in names_to_load:
+    results: list[tuple[str, str | None]] = []
+    if all_names:
         if logger:
-            logger.info(f"  Caching tokenizer: {name}")
-        try:
-            # Discard result — side effect is populating the HF disk cache so
-            # child processes find it cached and skip all network calls.
-            await asyncio.to_thread(
-                Tokenizer.from_pretrained,
-                name,
-                trust_remote_code=trust_remote_code,
-                revision=revision,
-                resolve_alias=False,  # already resolved by validate_tokenizer_early
+            parts: list[str] = []
+            if hf_names:
+                parts.append(f"{len(hf_names)} HF tokenizer(s)")
+            if tiktoken_names:
+                parts.append(f"{len(tiktoken_names)} tiktoken encoding(s)")
+            logger.info(
+                f"Preloading {' + '.join(parts)} in {len(all_names)} subprocess(es)..."
             )
-        except Exception:  # noqa: BLE001
-            failed.append(name)
 
-    if failed:
+        timeout = Environment.TOKENIZER.PRELOAD_TIMEOUT
+        start = time.perf_counter()
+        results = await _run_prefetch_pool(
+            all_names,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            timeout=timeout,
+            logger=logger,
+        )
+        elapsed = time.perf_counter() - start
+
+        for name, err in results:
+            if err is None:
+                if logger:
+                    logger.debug(f"Preloaded tokenizer: {name}")
+            elif logger:
+                kind = "tiktoken cache" if name in tiktoken_names else "tokenizer"
+                logger.warning(
+                    f"Failed to pre-warm {kind} for '{name}' ({err}). "
+                    "Child processes will load it themselves on first use."
+                )
+
         if logger:
-            names_str = ", ".join(f"'{n}'" for n in failed)
-            logger.warning(
-                f"Failed to preload {len(failed)} tokenizer(s): {names_str}. "
-                "Child processes will attempt to load them themselves."
-            )
-    else:
-        _enable_hf_offline_mode(logger)
+            logger.debug(f"Tokenizer preload completed in {elapsed:.2f}s")
 
-
-def _enable_hf_offline_mode(logger: AIPerfLogger | None = None) -> None:
-    """Set HF environment variables so spawned processes never make network calls."""
-    os.environ["HF_HUB_OFFLINE"] = "1"
-    os.environ["TRANSFORMERS_OFFLINE"] = "1"
-    if logger:
-        logger.debug("Enabled HF offline mode for child processes")
+    # Write offline-config stub for tokenizer-only HF repos. Covers both
+    # repos we warmed this run and repos that were already cached from a
+    # prior run. Idempotent and a no-op for repos that have a real
+    # config.json or aren't tokenizer-only.
+    warmed_hf = {name for name, err in results if err is None and name in hf_names}
+    for name in warmed_hf | hf_already_cached:
+        _ensure_offline_config_stub(name, revision, logger)

--- a/tests/unit/common/test_tokenizer.py
+++ b/tests/unit/common/test_tokenizer.py
@@ -163,3 +163,125 @@ class TestIsFakeModelName:
         from aiperf.common.tokenizer_fake_names import is_fake_model_name
 
         assert is_fake_model_name(name) is False
+
+
+class TestIsTiktokenCached:
+    """Tests for _is_tiktoken_cached — disk-cache hit check that skips subprocess pre-warm."""
+
+    def _cache_dir_and_key(self, name: str, base_dir) -> tuple[str, str]:
+        import hashlib
+
+        from aiperf.common.tokenizer import _BUILTIN_ENCODING, _TIKTOKEN_ENCODING_URLS
+
+        encoding = _BUILTIN_ENCODING if name == BUILTIN_TOKENIZER_NAME else name
+        url = _TIKTOKEN_ENCODING_URLS[encoding]
+        key = hashlib.sha1(url.encode(), usedforsecurity=False).hexdigest()
+        return str(base_dir), key
+
+    def test_returns_true_when_cache_file_exists(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from aiperf.common.tokenizer import _is_tiktoken_cached
+
+        cache_dir, key = self._cache_dir_and_key("o200k_base", tmp_path)
+        (tmp_path / key).write_bytes(b"fake bpe")
+        monkeypatch.setenv("TIKTOKEN_CACHE_DIR", cache_dir)
+
+        assert _is_tiktoken_cached("o200k_base") is True
+
+    def test_returns_false_when_cache_file_missing(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from aiperf.common.tokenizer import _is_tiktoken_cached
+
+        monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
+        assert _is_tiktoken_cached("o200k_base") is False
+
+    def test_builtin_maps_to_o200k_base(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Writing the o200k_base file should satisfy a 'builtin' cache check.
+        from aiperf.common.tokenizer import _is_tiktoken_cached
+
+        cache_dir, key = self._cache_dir_and_key("o200k_base", tmp_path)
+        (tmp_path / key).write_bytes(b"fake bpe")
+        monkeypatch.setenv("TIKTOKEN_CACHE_DIR", cache_dir)
+
+        assert _is_tiktoken_cached(BUILTIN_TOKENIZER_NAME) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            pytest.param("p50k_edit", id="p50k_edit-shares-p50k_base"),
+            pytest.param("o200k_harmony", id="o200k_harmony-shares-o200k_base"),
+        ],
+    )  # fmt: skip
+    def test_derived_encodings_check_base_url(
+        self, name: str, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # p50k_edit and o200k_harmony reuse another encoding's BPE; their URL
+        # mapping must point to the shared file.
+        from aiperf.common.tokenizer import _is_tiktoken_cached
+
+        cache_dir, key = self._cache_dir_and_key(name, tmp_path)
+        (tmp_path / key).write_bytes(b"fake bpe")
+        monkeypatch.setenv("TIKTOKEN_CACHE_DIR", cache_dir)
+
+        assert _is_tiktoken_cached(name) is True
+
+    def test_unknown_encoding_returns_false(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from aiperf.common.tokenizer import _is_tiktoken_cached
+
+        monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
+        # Even with the dir set, an encoding we have no URL for falls through
+        # to "not cached" so the caller runs the real pre-warm.
+        assert _is_tiktoken_cached("not_a_real_encoding") is False
+
+    def test_empty_cache_dir_disables_caching(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # tiktoken treats TIKTOKEN_CACHE_DIR="" as "disable caching" — we must
+        # mirror that and report not-cached so the caller re-downloads.
+        from aiperf.common.tokenizer import _is_tiktoken_cached
+
+        monkeypatch.setenv("TIKTOKEN_CACHE_DIR", "")
+        assert _is_tiktoken_cached("o200k_base") is False
+
+    def test_falls_back_to_data_gym_cache_dir(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from aiperf.common.tokenizer import _is_tiktoken_cached
+
+        monkeypatch.delenv("TIKTOKEN_CACHE_DIR", raising=False)
+        cache_dir, key = self._cache_dir_and_key("o200k_base", tmp_path)
+        (tmp_path / key).write_bytes(b"fake bpe")
+        monkeypatch.setenv("DATA_GYM_CACHE_DIR", cache_dir)
+
+        assert _is_tiktoken_cached("o200k_base") is True
+
+
+class TestTiktokenUrlsMatchTiktokenSource:
+    """Drift detector: our hardcoded URLs must match what tiktoken would download."""
+
+    def test_each_encoding_url_appears_in_tiktoken_source(self) -> None:
+        import inspect
+
+        from tiktoken_ext import openai_public
+
+        from aiperf.common.tokenizer import _TIKTOKEN_ENCODING_URLS
+
+        for name, url in _TIKTOKEN_ENCODING_URLS.items():
+            # o200k_harmony reuses o200k_base's BPE; the URL must appear in
+            # o200k_base's source (which o200k_harmony invokes).
+            target = "o200k_base" if name == "o200k_harmony" else name
+            # p50k_edit reuses p50k_base
+            target = "p50k_base" if name == "p50k_edit" else target
+            ctor = getattr(openai_public, target, None)
+            assert ctor is not None, f"tiktoken_ext.openai_public missing {target}"
+            assert url in inspect.getsource(ctor), (
+                f"hardcoded URL for {name!r} ({url!r}) is no longer in "
+                f"tiktoken_ext.openai_public.{target} — tiktoken changed the URL; "
+                f"update _TIKTOKEN_ENCODING_URLS in src/aiperf/common/tokenizer.py"
+            )

--- a/tests/unit/common/test_tokenizer_validator.py
+++ b/tests/unit/common/test_tokenizer_validator.py
@@ -3,8 +3,11 @@
 
 """Tests for early tokenizer validation and preloading."""
 
+import asyncio
+import concurrent.futures
 import os
 from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -55,10 +58,53 @@ def _mock_endpoint_meta() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def _clean_hf_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Remove HF offline env vars before each test so assertions are reliable."""
+def _clean_hf_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Remove HF offline env vars and point tiktoken cache at an empty dir.
+
+    Pointing ``TIKTOKEN_CACHE_DIR`` at a per-test tmp dir makes the
+    ``_is_tiktoken_cached`` short-circuit in ``_partition_preload_names``
+    return False so tests deterministically exercise the prefetch path
+    regardless of whether the host has tiktoken's BPE file cached.
+    """
     monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
     monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path / "tiktoken-empty"))
+
+
+class _SyncExecutor:
+    """Synchronous in-process drop-in for ProcessPoolExecutor used in tests."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def __enter__(self) -> "_SyncExecutor":
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+    def submit(self, fn, /, *args, **kwargs) -> concurrent.futures.Future:
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except BaseException as e:  # noqa: BLE001 - mirror real executor behavior
+            future.set_exception(e)
+        return future
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        pass
+
+    # Expose an empty _processes dict so the timeout-cleanup branch is benign.
+    _processes: dict = {}
+
+
+@pytest.fixture(autouse=True)
+def _sync_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace ProcessPoolExecutor with an in-process synchronous fake."""
+    monkeypatch.setattr(
+        "aiperf.common.tokenizer_validator.ProcessPoolExecutor",
+        _SyncExecutor,
+    )
 
 
 class TestPreloadTokenizers:
@@ -77,17 +123,42 @@ class TestPreloadTokenizers:
         mock_load.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_skips_builtin_name(self) -> None:
+    async def test_prewarms_builtin_tiktoken(self) -> None:
+        # Pre-warming ensures macOS child processes (spawned fresh) find the
+        # tiktoken encoding file on disk and make zero network calls.
         with patch.object(Tokenizer, "from_pretrained") as mock_load:
             await preload_tokenizers({"model": BUILTIN_TOKENIZER_NAME})
-        mock_load.assert_not_called()
+        mock_load.assert_called_once_with(
+            BUILTIN_TOKENIZER_NAME,
+            trust_remote_code=False,
+            revision="main",
+            resolve_alias=False,
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("encoding_name", sorted(TIKTOKEN_ENCODING_NAMES))
-    async def test_skips_tiktoken_encoding_names(self, encoding_name: str) -> None:
+    async def test_prewarms_tiktoken_encoding_names(self, encoding_name: str) -> None:
         with patch.object(Tokenizer, "from_pretrained") as mock_load:
             await preload_tokenizers({"model": encoding_name})
-        mock_load.assert_not_called()
+        mock_load.assert_called_once_with(
+            encoding_name,
+            trust_remote_code=False,
+            revision="main",
+            resolve_alias=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_tiktoken_prewarm_failure_logs_warning_continues(
+        self, mock_logger: MagicMock
+    ) -> None:
+        with patch.object(
+            Tokenizer, "from_pretrained", side_effect=RuntimeError("CDN blocked")
+        ):
+            await preload_tokenizers(
+                {"model": BUILTIN_TOKENIZER_NAME}, logger=mock_logger
+            )
+        mock_logger.warning.assert_called_once()
+        assert BUILTIN_TOKENIZER_NAME in mock_logger.warning.call_args[0][0]
 
     @pytest.mark.asyncio
     async def test_skips_already_cached(self) -> None:
@@ -172,18 +243,21 @@ class TestPreloadTokenizers:
         assert mock_load.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_enables_offline_mode_after_successful_preload(self) -> None:
+    async def test_does_not_mutate_parent_env_after_successful_preload(self) -> None:
+        # Children inherit os.environ at spawn time. Mutating it in the parent
+        # poisons every subsequently spawned service (DatasetManager included),
+        # breaking public HF dataset loading (OfflineModeIsEnabled).
         resolved = {"model": "meta-llama/Llama-2-7b-hf"}
         with (
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
             patch.object(Tokenizer, "from_pretrained"),
         ):
             await preload_tokenizers(resolved)
-        assert os.environ.get("HF_HUB_OFFLINE") == "1"
-        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+        assert "HF_HUB_OFFLINE" not in os.environ
+        assert "TRANSFORMERS_OFFLINE" not in os.environ
 
     @pytest.mark.asyncio
-    async def test_enables_offline_mode_when_all_already_cached(self) -> None:
+    async def test_does_not_mutate_parent_env_when_all_already_cached(self) -> None:
         resolved = {"model": "meta-llama/Llama-2-7b-hf"}
         with (
             patch("aiperf.common.tokenizer._is_hf_cached", return_value=True),
@@ -191,27 +265,86 @@ class TestPreloadTokenizers:
         ):
             await preload_tokenizers(resolved)
         mock_load.assert_not_called()
-        assert os.environ.get("HF_HUB_OFFLINE") == "1"
-        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+        assert "HF_HUB_OFFLINE" not in os.environ
+        assert "TRANSFORMERS_OFFLINE" not in os.environ
 
     @pytest.mark.asyncio
-    async def test_does_not_enable_offline_mode_on_failure(self) -> None:
-        resolved = {"model": "meta-llama/Llama-2-7b-hf"}
-        with (
-            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
-            patch.object(
-                Tokenizer, "from_pretrained", side_effect=RuntimeError("network error")
-            ),
+    async def test_does_not_mutate_parent_env_when_tiktoken_prewarm_fails(self) -> None:
+        with patch.object(
+            Tokenizer, "from_pretrained", side_effect=RuntimeError("CDN blocked")
         ):
-            await preload_tokenizers(resolved)
-        assert os.environ.get("HF_HUB_OFFLINE") is None
-        assert os.environ.get("TRANSFORMERS_OFFLINE") is None
+            await preload_tokenizers({"model": BUILTIN_TOKENIZER_NAME})
+        assert "HF_HUB_OFFLINE" not in os.environ
+        assert "TRANSFORMERS_OFFLINE" not in os.environ
 
     @pytest.mark.asyncio
     async def test_does_not_enable_offline_mode_when_skipped(self) -> None:
         await preload_tokenizers(None)
         assert os.environ.get("HF_HUB_OFFLINE") is None
         assert os.environ.get("TRANSFORMERS_OFFLINE") is None
+
+    @pytest.mark.asyncio
+    async def test_uses_spawn_context_with_correct_max_workers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Verify the executor is constructed with mp_context=spawn (so the
+        # parent never inherits-into-fork the heavy native libs) and
+        # max_workers matches the deduplicated name count.
+        captured: dict[str, object] = {}
+
+        def _capturing_executor(*args, **kwargs):  # type: ignore[no-untyped-def]
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _SyncExecutor(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "aiperf.common.tokenizer_validator.ProcessPoolExecutor",
+            _capturing_executor,
+        )
+
+        resolved = {
+            "m1": "meta-llama/Llama-2-7b-hf",
+            "m2": "meta-llama/Llama-2-7b-hf",  # duplicate
+            "m3": "mistralai/Mistral-7B-v0.1",
+        }
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
+            patch.object(Tokenizer, "from_pretrained"),
+        ):
+            await preload_tokenizers(resolved)
+
+        kwargs = captured.get("kwargs", {})
+        mp_context = kwargs.get("mp_context")
+        assert mp_context is not None
+        assert type(mp_context).__name__ == "SpawnContext"
+        assert kwargs.get("max_workers") == 2  # deduplicated
+
+    @pytest.mark.asyncio
+    async def test_timeout_logs_warning_and_continues(
+        self, mock_logger: MagicMock
+    ) -> None:
+        # When asyncio.wait_for times out, preload_tokenizers must log a
+        # warning, kill subprocesses, and return without raising.
+        with (
+            patch("aiperf.common.tokenizer._is_hf_cached", return_value=False),
+            patch.object(Tokenizer, "from_pretrained"),
+            patch(
+                "aiperf.common.tokenizer_validator.asyncio.wait_for",
+                side_effect=asyncio.TimeoutError,
+            ),
+        ):
+            await preload_tokenizers(
+                {"m1": "meta-llama/Llama-2-7b-hf"}, logger=mock_logger
+            )
+
+        # Two warnings: one for the timeout itself, one per failed name.
+        assert mock_logger.warning.call_count >= 1
+        timeout_messages = [
+            call.args[0]
+            for call in mock_logger.warning.call_args_list
+            if "AIPERF_TOKENIZER_PRELOAD_TIMEOUT" in call.args[0]
+        ]
+        assert timeout_messages, "expected a timeout warning message"
 
 
 @pytest.mark.usefixtures("_mock_endpoint_meta")
@@ -311,3 +444,214 @@ class TestValidatorFakeModelFallback:
         # No placeholder warning emitted.
         mock_logger.warning.assert_not_called()
         assert result == {"mock-llama": "Qwen/Qwen3-0.6B"}
+
+
+class TestOfflineConfigStub:
+    """Stub config.json for tokenizer-only HF repos so offline child loads succeed.
+
+    Some HF repos (e.g. hf-internal-testing/llama-tokenizer) ship only
+    tokenizer files, no config.json. AutoTokenizer's offline path raises
+    OSError('Couldn't connect') in that case even though the tokenizer
+    files are fully cached. preload_tokenizers writes a stub config.json
+    in the parent so child services find it during their offline load.
+    """
+
+    def _setup_snapshot(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+        name: str,
+        *,
+        with_config: bool,
+        with_tokenizer_config: bool = True,
+        with_tokenizer_json: bool = False,
+    ) -> Path:
+        import json
+        from pathlib import Path
+
+        from huggingface_hub import constants as hf_const
+
+        monkeypatch.setattr(hf_const, "HF_HUB_CACHE", str(tmp_path))
+        model_dir = tmp_path / f"models--{name.replace('/', '--')}"
+        snapshot = model_dir / "snapshots" / "abc123"
+        refs = model_dir / "refs"
+        snapshot.mkdir(parents=True)
+        refs.mkdir(parents=True)
+        (refs / "main").write_text("abc123")
+        if with_tokenizer_config:
+            (snapshot / "tokenizer_config.json").write_text(
+                json.dumps({"tokenizer_class": "LlamaTokenizer"})
+            )
+        if with_tokenizer_json:
+            (snapshot / "tokenizer.json").write_text("{}")
+        if with_config:
+            (snapshot / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        return Path(snapshot)
+
+    @pytest.mark.asyncio
+    async def test_writes_stub_for_already_cached_tokenizer_only_repo(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Already cached → no subprocess fires, but stub still gets written.
+        name = "hf-internal-testing/llama-tokenizer"
+        snapshot = self._setup_snapshot(tmp_path, monkeypatch, name, with_config=False)
+        config_path = snapshot / "config.json"
+        assert not config_path.exists()
+
+        with patch.object(Tokenizer, "from_pretrained") as mock_load:
+            await preload_tokenizers({"model": name})
+
+        mock_load.assert_not_called()  # cache hit; no prefetch needed
+        assert config_path.is_file()
+        assert config_path.read_text() == "{}"
+
+    @pytest.mark.asyncio
+    async def test_writes_stub_after_fresh_prefetch(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No cache initially; subprocess "downloads" (mocked) and creates
+        # the snapshot dir with tokenizer_config.json but no config.json.
+        # Parent then writes the stub.
+        import json
+        from pathlib import Path
+
+        from huggingface_hub import constants as hf_const
+
+        monkeypatch.setattr(hf_const, "HF_HUB_CACHE", str(tmp_path))
+        name = "hf-internal-testing/llama-tokenizer"
+        model_dir = tmp_path / f"models--{name.replace('/', '--')}"
+        snapshot = model_dir / "snapshots" / "abc123"
+
+        def fake_from_pretrained(*args, **kwargs):
+            (model_dir / "refs").mkdir(parents=True, exist_ok=True)
+            (model_dir / "refs" / "main").write_text("abc123")
+            snapshot.mkdir(parents=True, exist_ok=True)
+            (snapshot / "tokenizer_config.json").write_text(
+                json.dumps({"tokenizer_class": "LlamaTokenizer"})
+            )
+            return None
+
+        with patch.object(
+            Tokenizer, "from_pretrained", side_effect=fake_from_pretrained
+        ):
+            await preload_tokenizers({"model": name})
+
+        config_path = Path(snapshot / "config.json")
+        assert config_path.is_file()
+        assert config_path.read_text() == "{}"
+
+    @pytest.mark.asyncio
+    async def test_does_not_overwrite_existing_config(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Repo already has a real config.json; we must NOT overwrite it.
+        name = "meta-llama/Llama-2-7b-hf"
+        snapshot = self._setup_snapshot(tmp_path, monkeypatch, name, with_config=True)
+        config_path = snapshot / "config.json"
+        original_text = config_path.read_text()
+
+        with patch.object(Tokenizer, "from_pretrained"):
+            await preload_tokenizers({"model": name})
+
+        assert config_path.read_text() == original_text
+
+    @pytest.mark.asyncio
+    async def test_writes_stub_for_fast_tokenizer_only_repo(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fast-tokenizer-only repos ship just tokenizer.json — no
+        # tokenizer_config.json. Stub should still be written.
+        name = "fast-tokenizer-only-repo"
+        snapshot = self._setup_snapshot(
+            tmp_path,
+            monkeypatch,
+            name,
+            with_config=False,
+            with_tokenizer_config=False,
+            with_tokenizer_json=True,
+        )
+        config_path = snapshot / "config.json"
+        assert not config_path.exists()
+
+        with patch.object(Tokenizer, "from_pretrained"):
+            await preload_tokenizers({"model": name})
+
+        assert config_path.is_file()
+        assert config_path.read_text() == "{}"
+
+    @pytest.mark.asyncio
+    async def test_does_not_write_stub_when_no_tokenizer_files_present(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Snapshot exists but has no tokenizer indicator file at all —
+        # not a tokenizer repo, just broken/unrelated cache state. Don't
+        # fabricate a config that transformers might pick up.
+        name = "weird-incomplete-repo"
+        snapshot = self._setup_snapshot(
+            tmp_path,
+            monkeypatch,
+            name,
+            with_config=False,
+            with_tokenizer_config=False,
+            with_tokenizer_json=False,
+        )
+        config_path = snapshot / "config.json"
+
+        with patch.object(Tokenizer, "from_pretrained"):
+            await preload_tokenizers({"model": name})
+
+        assert not config_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_does_not_write_stub_when_prefetch_failed(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If the subprocess prefetch failed, the snapshot may not exist —
+        # don't try to write a stub into a missing directory.
+        from huggingface_hub import constants as hf_const
+
+        monkeypatch.setattr(hf_const, "HF_HUB_CACHE", str(tmp_path))
+        name = "meta-llama/Llama-2-7b-hf"
+
+        with patch.object(
+            Tokenizer, "from_pretrained", side_effect=RuntimeError("download blew up")
+        ):
+            await preload_tokenizers({"model": name})
+
+        # No cache dir was created; nothing to stub.
+        assert not (tmp_path / f"models--{name.replace('/', '--')}").exists()
+
+    @pytest.mark.asyncio
+    async def test_oserror_on_stub_write_aborts_initialization(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If we can't write the stub (read-only filesystem, etc.), abort
+        # startup rather than letting child services hang with a misleading
+        # "Couldn't connect" error.
+        import tempfile
+
+        name = "hf-internal-testing/llama-tokenizer"
+        snapshot = self._setup_snapshot(tmp_path, monkeypatch, name, with_config=False)
+        original = tempfile.NamedTemporaryFile
+
+        def selective_raise(*args, **kwargs):
+            # Only raise for tmp files our stub-writer tries to create
+            # inside the snapshot dir; leave other NamedTemporaryFile users
+            # in the test machinery alone.
+            if str(kwargs.get("dir", "")) == str(snapshot):
+                raise OSError("read-only filesystem")
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(tempfile, "NamedTemporaryFile", selective_raise)
+
+        logger = MagicMock()
+        with (
+            patch.object(Tokenizer, "from_pretrained"),
+            pytest.raises(OSError, match="read-only filesystem"),
+        ):
+            await preload_tokenizers({"model": name}, logger=logger)
+
+        logger.error.assert_called_once()
+        assert "config.json" in logger.error.call_args[0][0]
+        # Atomic: no partial / leftover tmp file in the snapshot dir.
+        assert list(snapshot.glob("config.aiperf-*.json")) == []


### PR DESCRIPTION
## Summary

Fixes three coupled tokenizer-preload bugs on `release/0.8.0` / `main`:

- **HF datasets fail with `OfflineModeIsEnabled`** — `preload_tokenizers` was mutating the CLI process's `os.environ` (`HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1`), which every spawned child service inherited at `Process.start()` time, blocking `DatasetManager.load_dataset()` for `--public-dataset`. Mutation removed entirely; workers that need offline mode still self-set it locally in `_init_worker` (`parallel_decode.py`); tokenizer loads in children skip the network via the existing `_is_hf_cached` → `local_files_only=True` gate.
- **macOS hang at worker startup with placeholder model** — tiktoken's `requests.get(url)` has no timeout → urllib3 → `sock.settimeout(None)` blocks forever. Parent now pre-warms tiktoken caches in a `ProcessPoolExecutor(mp_context="spawn")` bounded by `AIPERF_TOKENIZER_PRELOAD_TIMEOUT` (default 120s, `Environment.TOKENIZER.PRELOAD_TIMEOUT`); children find the cache on disk and skip the network. CLI parent never imports `transformers`, the Rust-backed `tokenizers` extension, or `tiktoken`. Subprocess is also skipped entirely when tiktoken's BPE file is already on disk.
- **Tokenizer-only HF repos fail offline** — repos like `hf-internal-testing/llama-tokenizer` ship no `config.json`; `AutoTokenizer.from_pretrained(local_files_only=True)` raises misleading `OSError('Couldn't connect')`. After pre-warm, parent walks every HF repo it has in cache (freshly warmed + already cached) and writes a stub `{}` `config.json`. Atomic via `tempfile.NamedTemporaryFile` + `Path.replace`; covers both legacy (`tokenizer_config.json`) and fast-tokenizer-only (`tokenizer.json`) repos; OSError aborts startup loudly instead of letting children hang.

Co-authored with @FrankD412 (offline-config-stub origin, preload infrastructure) and @dbermudez (tiktoken CDN timeout fix origin).

## Test plan

- [x] Full unit suite green (9361 passed / 8 skipped)
- [x] End-to-end repro against `aiperf-mock-server` on Linux: `aiperf profile --model test --endpoint-type chat --url localhost:8000 --request-count 5 --ui-type none` completes successfully (5/5 requests, no errors); confirmed tiktoken pre-warm subprocess fires on cold cache, skipped on warm cache.
- [ ] macOS verification of original hang repro (cannot run here; requires reviewer with M-series macOS)
- [ ] Verification with `--public-dataset` against a real HF public dataset to confirm `OfflineModeIsEnabled` no longer fires (requires HF_TOKEN access)
- [ ] Verification with a tokenizer-only repo (e.g. `--tokenizer hf-internal-testing/llama-tokenizer`) to confirm offline-config-stub works end-to-end

## Notes

- Supersedes #899 (HF env mutation — band-aid no-op that left dead callsites + broken tests) with a proper fix.
- Supersedes the tiktoken half of #907 (`tiktoken.load.read_file` monkey-patch); subprocess-with-timeout obviates the patch. The "await all services" race-fix half of #907 is independent and not bundled here.
- Approach diverges from #907 / @FrankD412's `port-offline-context-manager` branch on tokenizer-only repos: this PR writes a stub `{}` config.json into the snapshot dir (simple, ~30 lines, no transformers internals touched) rather than monkey-patching `cached_file` across every transformers submodule that imports it (~100 lines, fragile across transformers versions). Tradeoff: one 2-byte file per affected repo in the user's HF cache.
- New env var documented in `docs/environment-variables.md`: `AIPERF_TOKENIZER_PRELOAD_TIMEOUT` (1.0-100000.0s, default 120.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AIPERF_TOKENIZER_PRELOAD_TIMEOUT env var to control tokenizer preload timeout.
  * Improved tokenizer offline loading and on-disk caching behavior for tokenizer-only repositories.
  * Tokenizer preloading now runs in isolated subprocesses with global timeout and robust failure handling.

* **Documentation**
  * Added TOKENIZER section documenting the new timeout setting and behavior.

* **Tests**
  * Expanded unit tests covering cache behavior, offline fallbacks, preload orchestration, and timeout scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/918)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->