### PR TITLE
chore(tests): Speed up uncertainty plot unit tests

### DIFF
--- a/tests/unit/plot/conftest.py
+++ b/tests/unit/plot/conftest.py
@@ -9,15 +9,23 @@ and made available to test functions in the same directory and subdirectories.
 """
 
 import logging
+import warnings
 from pathlib import Path
 from typing import Any
 
+import matplotlib.figure
 import pytest
 
 from aiperf.plot.core.mode_detector import ModeDetector
 
 logging.getLogger("choreographer").setLevel(logging.WARNING)
 logging.getLogger("kaleido").setLevel(logging.WARNING)
+warnings.filterwarnings(
+    "ignore",
+    message="There is no current event loop",
+    category=DeprecationWarning,
+    module="looptime\\._internal\\.plugin",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -165,32 +173,36 @@ def sample_aggregated_data() -> dict[str, Any]:
 
 
 @pytest.fixture(autouse=True)
-def mock_kaleido_write_image(request, monkeypatch):
-    """Mock Plotly's write_image to avoid slow Kaleido rendering in unit tests only.
+def mock_plot_image_writers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock expensive plot image finalization in unit tests."""
 
-    This fixture automatically patches fig.write_image() and fig.to_image()
-    to avoid the expensive Kaleido/Chrome rendering process during unit tests.
-    Integration tests are skipped to allow real PNG generation.
-    """
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
 
-    def mock_write_image(self, *args, **kwargs):
-        """Mock write_image that creates an empty file."""
-        # Extract the file path from args or kwargs
-        if args:
-            path = Path(args[0])
-        else:
-            path = Path(kwargs.get("file", kwargs.get("path", "/tmp/mock.png")))
-
-        # Create parent directory if needed
+    def write_png(path_like: object) -> None:
+        path = Path(path_like)
         path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(png_bytes)
 
-        # Write a minimal PNG header to make it a valid file
-        path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+    def mock_write_image(self: object, *args: object, **kwargs: object) -> None:
+        if args:
+            write_png(args[0])
+        else:
+            write_png(kwargs.get("file", kwargs.get("path", "/tmp/mock.png")))
 
-    def mock_to_image(self, *args, **kwargs):
-        """Mock to_image that returns minimal PNG bytes."""
-        return b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    def mock_to_image(self: object, *args: object, **kwargs: object) -> bytes:
+        return png_bytes
 
-    # Patch the methods on the Figure class
+    def mock_savefig(
+        self: matplotlib.figure.Figure, fname: object, *args: object, **kwargs: object
+    ) -> None:
+        write_png(fname)
+
+    def mock_tight_layout(
+        self: matplotlib.figure.Figure, *args: object, **kwargs: object
+    ) -> None:
+        return None
+
     monkeypatch.setattr("plotly.graph_objects.Figure.write_image", mock_write_image)
     monkeypatch.setattr("plotly.graph_objects.Figure.to_image", mock_to_image)
+    monkeypatch.setattr(matplotlib.figure.Figure, "savefig", mock_savefig)
+    monkeypatch.setattr(matplotlib.figure.Figure, "tight_layout", mock_tight_layout)

--- a/tests/unit/plot/test_uncertainty_plot_confidence.py
+++ b/tests/unit/plot/test_uncertainty_plot_confidence.py
@@ -767,6 +767,9 @@ def valid_benchmark_point(draw: st.DrawFn) -> BenchmarkPoint:
     )
 
 
+RENDERER_MAX_EXAMPLES = 20
+
+
 @st.composite
 def valid_uncertainty_data(
     draw: st.DrawFn, min_points: int = 1
@@ -826,7 +829,7 @@ class TestPlotlyRendererSortedMeanTraceWithErrorBars:
     """
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_mean_trace_x_values_sorted_ascending(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -842,7 +845,7 @@ class TestPlotlyRendererSortedMeanTraceWithErrorBars:
         assert x_vals == sorted(x_vals), f"x-values not sorted: {x_vals}"
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_error_bars_match_asymmetric_ci_bounds(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -896,7 +899,7 @@ class TestPlotlyRendererOneEllipseTracePerPoint:
     """
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_ellipse_trace_count_equals_point_count(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -911,7 +914,7 @@ class TestPlotlyRendererOneEllipseTracePerPoint:
         )
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_ellipse_traces_have_showlegend_false(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -941,7 +944,7 @@ class TestPlotlyRendererExactlyOneEllipseLegendEntry:
     """
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_exactly_one_confidence_region_legend_entry(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -962,7 +965,7 @@ class TestPlotlyRendererExactlyOneEllipseLegendEntry:
         )
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_legend_entry_contains_confidence_level_percentage(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -999,7 +1002,7 @@ class TestPlotlyRendererTextAnnotationsForLabeledPoints:
     """
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_non_empty_text_count_equals_labeled_point_count(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1102,7 +1105,7 @@ class TestMatplotlibRendererSortedMeanLineWithErrorBars:
     """
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_mean_line_x_values_sorted_ascending(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1121,7 +1124,7 @@ class TestMatplotlibRendererSortedMeanLineWithErrorBars:
         plt.close(fig)
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_errorbar_asymmetric_values_match_ci_bounds(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1171,7 +1174,7 @@ class TestMatplotlibRendererSortedMeanLineWithErrorBars:
         plt.close(fig)
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_mean_line_y_values_match_sorted_points(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1208,7 +1211,7 @@ class TestMatplotlibRendererOneEllipsePatchPerPoint:
     """
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_ellipse_patch_count_equals_point_count(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1227,7 +1230,7 @@ class TestMatplotlibRendererOneEllipsePatchPerPoint:
         plt.close(fig)
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_ellipse_rotation_matches_cov_xy(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1255,7 +1258,7 @@ class TestMatplotlibRendererOneEllipsePatchPerPoint:
         plt.close(fig)
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_ellipse_centers_match_point_means(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1299,7 +1302,7 @@ class TestCrossBackendElementCountConsistency:
     """
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_same_number_of_mean_points(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1326,7 +1329,7 @@ class TestCrossBackendElementCountConsistency:
         plt.close(mpl_fig)
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_same_number_of_ellipses(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1352,7 +1355,7 @@ class TestCrossBackendElementCountConsistency:
         plt.close(mpl_fig)
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_same_number_of_error_bar_pairs(
         self,
         data: LatencyThroughputUncertaintyData,
@@ -1381,7 +1384,7 @@ class TestCrossBackendElementCountConsistency:
         plt.close(mpl_fig)
 
     @given(data=valid_uncertainty_data(min_points=1))
-    @settings(max_examples=100, deadline=None)
+    @settings(max_examples=RENDERER_MAX_EXAMPLES, deadline=None)
     def test_mixed_cov_xy_handled_identically(
         self,
         data: LatencyThroughputUncertaintyData,


### PR DESCRIPTION
## Summary
- Stub Matplotlib tight layout and savefig finalization in plot unit tests to avoid slow font/render work and glyph warnings.
- Reduce expensive renderer/cross-backend uncertainty plot property examples while keeping lower-level geometry/model properties at 100 examples.

## Test plan
- [x] `uv run ruff format tests/unit/plot/conftest.py tests/unit/plot/test_uncertainty_plot_confidence.py --check`
- [x] `uv run ruff check tests/unit/plot/conftest.py tests/unit/plot/test_uncertainty_plot_confidence.py`
- [x] `PYTHONUNBUFFERED=1 uv run pytest tests/unit/plot/test_uncertainty_plot_confidence.py -n auto --durations=20 --durations-min=0.05`
- [x] `PYTHONUNBUFFERED=1 uv run pytest tests/unit/ -n auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)