### PR TITLE
feat(dataset): per-row HTTP headers in mooncake_trace

### DIFF
--- a/docs/benchmark-modes/trace-replay.md
+++ b/docs/benchmark-modes/trace-replay.md
@@ -158,6 +158,8 @@ Headers are merged on top of the endpoint-level headers configured via `--header
 
 The merge is performed at the dict level, not at the value level: if `baggage` is set both in the endpoint configuration and in a trace row, the trace row's value replaces the endpoint value entirely -- entries are not concatenated. To combine them, place the full merged string in the trace row.
 
+> **Security note:** trace `headers` are merged *after* the `Authorization` header derived from `--api-key` / endpoint config, so a trace row carrying `{"Authorization": "Bearer ..."}` will override the configured credential. Only ingest trace files you trust.
+
 ## Profile using real Mooncake Trace
 
 For real-world benchmarking, use the FAST25 production trace data from the Mooncake research paper:

--- a/docs/benchmark-modes/trace-replay.md
+++ b/docs/benchmark-modes/trace-replay.md
@@ -52,6 +52,7 @@ Required fields for trace replay:
 - `hash_ids`: List of block hashes (optional)
 - `tools`: List of OpenAI-compatible tool definitions (optional, requires `messages`)
 - `extra`: Dict of vendor extras (optional). Shallow-merged into the top of the request body at dispatch; user-supplied keys win over `--extra-inputs`.
+- `headers`: Per-request HTTP headers as a `{name: value}` dict (optional). See [Per-Request HTTP Headers](#per-request-http-headers).
 
 Example entry:
 
@@ -143,6 +144,19 @@ Use the `extra` field to inject arbitrary key-value pairs into the HTTP payload 
 ```
 
 **Merge semantics:** Merging is shallow — a per-entry `{"nvext": {...}}` replaces the entire global `nvext` key. Deep merge is not performed.
+
+## Per-Request HTTP Headers
+
+Each trace row may carry an optional `headers` dict whose entries are injected as HTTP headers on the outgoing request for that turn. This is useful for inference platforms that route on a header value -- for example a session/affinity token or a W3C `baggage` header for distributed-tracing context propagation:
+
+```json
+{"timestamp": 0, "text_input": "hello", "output_length": 10, "headers": {"x-session-token": "tok-A"}}
+{"timestamp": 100, "text_input": "world", "output_length": 10, "headers": {"x-session-token": "tok-B", "baggage": "userId=alice,sessionId=tok-B"}}
+```
+
+Headers are merged on top of the endpoint-level headers configured via `--header`/`-H`, so on key conflict the trace value wins. Different turns in the same session may carry different headers.
+
+The merge is performed at the dict level, not at the value level: if `baggage` is set both in the endpoint configuration and in a trace row, the trace row's value replaces the endpoint value entirely -- entries are not concatenated. To combine them, place the full merged string in the trace row.
 
 ## Profile using real Mooncake Trace
 

--- a/src/aiperf/common/models/dataset_models.py
+++ b/src/aiperf/common/models/dataset_models.py
@@ -227,6 +227,13 @@ class Turn(AIPerfBaseModel):
         description="Duration of the audio content in seconds. Used by ASR-specific "
         "metrics like RTFx. Set by ASR dataset loaders.",
     )
+    headers: dict[str, str] | None = Field(
+        default=None,
+        description="Per-turn custom HTTP headers to inject into the outgoing request. "
+        "Merged after endpoint-config headers so per-turn values win on key conflict. "
+        "Set by trace dataset loaders (e.g., MooncakeTrace) when the source data "
+        "carries per-row headers.",
+    )
 
     def metadata(self) -> TurnMetadata:
         """Get the metadata of the turn."""
@@ -285,6 +292,7 @@ class Turn(AIPerfBaseModel):
             prerequisites=list(self.prerequisites),
             branch_ids=list(self.branch_ids),
             audio_duration_seconds=self.audio_duration_seconds,
+            headers=dict(self.headers) if self.headers is not None else None,
         )
 
 

--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -227,6 +227,7 @@ class MooncakeTrace(AIPerfBaseModel):
     - With messages: {"messages": [{"role": "user", "content": "Hello"}], "output_length": 4}
     - With payload: {"payload": {"prompt": "Hello", "max_tokens": 50}, "timestamp": 1000}
     - With timestamp and hash ID: {"timestamp": 1000, "input_length": 10, "hash_ids": [123]}
+    - With per-request headers: {"text_input": "Hello", "output_length": 4, "headers": {"x-session-token": "tok-A", "baggage": "userId=alice"}}
     """
 
     type: Literal[CustomDatasetType.MOONCAKE_TRACE] = CustomDatasetType.MOONCAKE_TRACE

--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -273,6 +273,13 @@ class MooncakeTrace(AIPerfBaseModel):
         default=None,
         description="Per-turn extra fields shallow-merged into the request body at dispatch time. Keys override formatter defaults on collision.",
     )
+    headers: dict[str, str] | None = Field(
+        None,
+        description="Per-request HTTP headers to inject for this turn (e.g., "
+        "{'x-session-token': 'abc'} for routing affinity, or {'baggage': "
+        "'k1=v1,k2=v2'} for W3C context propagation). Merged into the outgoing "
+        "request after endpoint-config headers, so trace values win on key conflict.",
+    )
 
     @model_validator(mode="after")
     def validate_input(self) -> "MooncakeTrace":

--- a/src/aiperf/dataset/loader/mooncake_trace.py
+++ b/src/aiperf/dataset/loader/mooncake_trace.py
@@ -119,7 +119,7 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
                 extra_body=trace.extra,
             )
         if trace.messages is not None:
-            return Turn(
+            turn = Turn(
                 timestamp=trace.timestamp,
                 delay=trace.delay,
                 max_tokens=trace.output_length,
@@ -127,9 +127,13 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
                 raw_tools=trace.tools,
                 extra_body=trace.extra,
             )
-        turn = super()._build_turn(trace, prompt)
-        if trace.extra is not None:
-            turn.extra_body = trace.extra
+        else:
+            turn = super()._build_turn(trace, prompt)
+            if trace.extra is not None:
+                turn.extra_body = trace.extra
+        # Copy to avoid aliasing the trace's dict on the Turn; matches the
+        # defensive copy pattern in Turn.copy_with_stripped_media.
+        turn.headers = dict(trace.headers) if trace.headers is not None else None
         return turn
 
     # ------------------------------------------------------------------
@@ -137,9 +141,16 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
     # ------------------------------------------------------------------
 
     def _synthesis_exclude_fields(self) -> frozenset[str]:
-        return frozenset({"type"})
+        return frozenset({"type", "headers"})
 
     def _reconstruct_traces(
         self, originals: list[MooncakeTrace], synth_dicts: list[dict[str, Any]]
     ) -> list[MooncakeTrace]:
-        return [MooncakeTrace.model_validate(t) for t in synth_dicts]
+        result: list[MooncakeTrace] = []
+        for i, synth_dict in enumerate(synth_dicts):
+            trace = MooncakeTrace.model_validate(synth_dict)
+            if originals:
+                original = originals[i] if i < len(originals) else originals[-1]
+                trace.headers = original.headers
+            result.append(trace)
+        return result

--- a/src/aiperf/dataset/loader/mooncake_trace.py
+++ b/src/aiperf/dataset/loader/mooncake_trace.py
@@ -150,6 +150,8 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
         for i, synth_dict in enumerate(synth_dicts):
             trace = MooncakeTrace.model_validate(synth_dict)
             if originals:
+                # Synthesis may emit more traces than originals (e.g., speedup
+                # expansion); reuse the last original's headers for the tail.
                 original = originals[i] if i < len(originals) else originals[-1]
                 trace.headers = original.headers
             result.append(trace)

--- a/src/aiperf/dataset/loader/mooncake_trace.py
+++ b/src/aiperf/dataset/loader/mooncake_trace.py
@@ -111,14 +111,14 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
 
     def _build_turn(self, trace: MooncakeTrace, prompt: str) -> Turn:
         if trace.payload is not None:
-            return Turn(
+            turn = Turn(
                 timestamp=trace.timestamp,
                 delay=trace.delay,
                 max_tokens=trace.output_length,
                 raw_payload=trace.payload,
                 extra_body=trace.extra,
             )
-        if trace.messages is not None:
+        elif trace.messages is not None:
             turn = Turn(
                 timestamp=trace.timestamp,
                 delay=trace.delay,

--- a/src/aiperf/endpoints/base_endpoint.py
+++ b/src/aiperf/endpoints/base_endpoint.py
@@ -45,6 +45,10 @@ class BaseEndpoint(AIPerfLoggerMixin, ABC):
         headers from the current turn. Per-turn headers come from trace dataset
         loaders (e.g., MooncakeTrace) and let traces drive request-affinity
         headers like `x-session-token` or W3C `baggage`.
+
+        Header names are matched case-insensitively per RFC 7230: a per-turn
+        `authorization` replaces an endpoint-config `Authorization` rather than
+        producing two duplicate wire headers.
         """
         cfg = self.model_endpoint.endpoint
         headers = dict(cfg.headers) if cfg.headers else {}
@@ -53,8 +57,13 @@ class BaseEndpoint(AIPerfLoggerMixin, ABC):
         # turns[-1] is the current turn; in DELTAS_WITHOUT_RESPONSES mode the
         # worker accumulates prior user/assistant turns in the list, so turns[0]
         # would always pick the first turn's headers.
-        if request_info.turns and request_info.turns[-1].headers:
-            headers.update(request_info.turns[-1].headers)
+        turn_headers = request_info.turns[-1].headers if request_info.turns else None
+        if turn_headers:
+            turn_keys_lower = {k.lower() for k in turn_headers}
+            headers = {
+                k: v for k, v in headers.items() if k.lower() not in turn_keys_lower
+            }
+            headers.update(turn_headers)
         return headers
 
     def get_endpoint_params(self, request_info: RequestInfo) -> dict[str, str]:

--- a/src/aiperf/endpoints/base_endpoint.py
+++ b/src/aiperf/endpoints/base_endpoint.py
@@ -39,11 +39,22 @@ class BaseEndpoint(AIPerfLoggerMixin, ABC):
         self.model_endpoint = model_endpoint
 
     def get_endpoint_headers(self, request_info: RequestInfo) -> dict[str, str]:
-        """Get endpoint headers (auth + user custom). Override to customize."""
+        """Get endpoint headers (auth + user custom + per-turn). Override to customize.
+
+        Merge order (later wins on conflict): endpoint config -> auth -> per-turn
+        headers from the current turn. Per-turn headers come from trace dataset
+        loaders (e.g., MooncakeTrace) and let traces drive request-affinity
+        headers like `x-session-token` or W3C `baggage`.
+        """
         cfg = self.model_endpoint.endpoint
         headers = dict(cfg.headers) if cfg.headers else {}
         if cfg.api_key:
             headers["Authorization"] = f"Bearer {cfg.api_key}"
+        # turns[-1] is the current turn; in DELTAS_WITHOUT_RESPONSES mode the
+        # worker accumulates prior user/assistant turns in the list, so turns[0]
+        # would always pick the first turn's headers.
+        if request_info.turns and request_info.turns[-1].headers:
+            headers.update(request_info.turns[-1].headers)
         return headers
 
     def get_endpoint_params(self, request_info: RequestInfo) -> dict[str, str]:

--- a/src/aiperf/workers/inference_client.py
+++ b/src/aiperf/workers/inference_client.py
@@ -221,6 +221,17 @@ class InferenceClient(AIPerfLifecycleMixin):
         # and reduce memory usage (placeholders instead of large image/audio/video data)
         record.turns = [turn.copy_with_stripped_media() for turn in request_info.turns]
 
+        # Redact per-turn headers on the stored copies; trace rows can carry
+        # sensitive values (e.g., `Authorization`) that otherwise bypass the
+        # `request_headers` redaction path and end up serialised in ZMQ
+        # records.  Also rebind `request_info.turns` to the redacted copies so
+        # downstream consumers of `record.request_info.turns` see the same
+        # scrubbed dicts; the original `session.turn_list` still points at the
+        # in-memory user turns and is untouched.
+        for turn in record.turns:
+            turn.headers = redact_headers(turn.headers)
+        request_info.turns = record.turns
+
         # If this is the first turn, calculate the credit drop latency
         if request_info.turn_index == 0 and request_info.drop_perf_ns is not None:
             record.credit_drop_latency = (

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -198,6 +198,40 @@ _INFERENCE_PATHS: frozenset[str] = frozenset(
 )
 
 
+# In-process record of inbound request headers, populated by
+# RequestHeaderRecorderMiddleware for inference paths. Tests can inspect this
+# via `GET /test/recorded_headers` (and clear it via `POST .../clear`) to
+# assert on-the-wire header fidelity end-to-end. Lives at module scope because
+# the mock server is run in a child process per uvicorn worker; tests use the
+# HTTP endpoints rather than the list directly.
+_RECORDED_INBOUND_HEADERS: list[dict[str, Any]] = []
+
+
+class RequestHeaderRecorderMiddleware:
+    """Records inbound HTTP headers for inference paths.
+
+    Wire-level test hook: per-request the middleware appends
+    `{"path": <path>, "headers": {<lowercased name>: <value>, ...}}` to
+    `_RECORDED_INBOUND_HEADERS`. Non-inference paths (health, metrics, the
+    `/test/*` introspection endpoints themselves) are skipped to keep the
+    list focused on requests the benchmark loop actually emits.
+    """
+
+    def __init__(self, inner_app: ASGIApp) -> None:
+        self.app = inner_app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope.get("path") in _INFERENCE_PATHS:
+            headers = {
+                name.decode("latin-1").lower(): value.decode("latin-1")
+                for name, value in scope.get("headers", [])
+            }
+            _RECORDED_INBOUND_HEADERS.append(
+                {"path": scope["path"], "headers": headers}
+            )
+        await self.app(scope, receive, send)
+
+
 class InferenceReadinessMiddleware:
     """Returns HTTP 503 on inference paths while within the configured
     startup delay. Used by readiness-probe tests to simulate a server
@@ -233,8 +267,35 @@ class InferenceReadinessMiddleware:
         await self.app(scope, receive, send)
 
 
-# Wrap FastAPI with ASGI middleware for earliest possible timing
-asgi_app = InferenceReadinessMiddleware(TimingMiddleware(app))
+# Wrap FastAPI with ASGI middleware for earliest possible timing. The header
+# recorder sits outermost so it sees the original inbound headers before any
+# transformation by downstream middleware or FastAPI itself.
+asgi_app = RequestHeaderRecorderMiddleware(
+    InferenceReadinessMiddleware(TimingMiddleware(app))
+)
+
+
+@app.get("/test/recorded_headers", response_model=None)
+async def get_recorded_headers() -> Response:
+    """Return the list of inbound headers captured on inference paths.
+
+    Tests use this to assert end-to-end header fidelity through the
+    aiohttp transport. Each entry is `{"path": "...", "headers": {...}}`
+    with lowercased header names.
+    """
+    return ORJSONResponse(list(_RECORDED_INBOUND_HEADERS))
+
+
+@app.post("/test/recorded_headers/clear", response_model=None)
+async def clear_recorded_headers() -> Response:
+    """Reset the recorded-headers buffer.
+
+    Tests call this before exercising a code path so that recorded entries
+    only reflect the requests of interest (the mock server is shared across
+    tests in the integration package).
+    """
+    _RECORDED_INBOUND_HEADERS.clear()
+    return ORJSONResponse({"cleared": True})
 
 
 # ============================================================================

--- a/tests/harness/utils.py
+++ b/tests/harness/utils.py
@@ -73,6 +73,30 @@ class AIPerfMockServer:
         """
         return [self.server_metrics_urls[t] for t in server_types]
 
+    def recorded_headers(self) -> list[dict[str, Any]]:
+        """Return the inbound headers the mock server saw on inference paths.
+
+        Each entry is `{"path": "...", "headers": {<lowercased name>: <value>}}`.
+        Useful for asserting end-to-end header fidelity through the aiohttp
+        transport. Call `clear_recorded_headers()` first to scope the result
+        to a single test (the mock server is shared across the package).
+        """
+        import urllib.request
+
+        with urllib.request.urlopen(f"{self.url}/test/recorded_headers") as resp:
+            import json
+
+            return json.loads(resp.read())
+
+    def clear_recorded_headers(self) -> None:
+        """Reset the mock server's inbound-header recorder."""
+        import urllib.request
+
+        req = urllib.request.Request(
+            f"{self.url}/test/recorded_headers/clear", method="POST"
+        )
+        urllib.request.urlopen(req).close()
+
 
 @dataclass(frozen=True)
 class VideoDetails:

--- a/tests/integration/test_mooncake_trace.py
+++ b/tests/integration/test_mooncake_trace.py
@@ -197,15 +197,21 @@ class TestMooncakeTraceIntegration:
     async def test_mooncake_trace_with_per_row_headers(
         self,
         cli: AIPerfCLI,
-        aiperf_mock_server: AIPerfMockServer,
+        mock_server_factory,
         tmp_path: Path,
     ):
-        """Trace rows carrying a `headers` dict run end-to-end without errors.
+        """End-to-end wire fidelity for per-row trace headers.
 
-        Header-on-wire fidelity is covered by unit tests on
-        `BaseEndpoint.get_endpoint_headers`; this is a pipeline-regression smoke
-        test that the new field does not break dataset loading, Turn
-        construction, payload formatting, or the request loop.
+        Asserts that the `headers` dict on each trace row reaches the
+        inference server as actual HTTP headers, exercising the full
+        loader -> Turn -> endpoint merge -> aiohttp transport chain.
+        Catches regressions in any step that could drop or rewrite the
+        trace-supplied headers.
+
+        Uses a single-worker mock server because the header recorder is
+        per-process module state; multi-worker uvicorn would partition
+        recorded requests across worker pids and the test would see only a
+        subset.
         """
         traces = [
             {"timestamp": 0, "text_input": "hello", "output_length": 10, "headers": {"x-session-token": "tok-A"}},
@@ -215,23 +221,46 @@ class TestMooncakeTraceIntegration:
         trace_file = create_mooncake_trace_file(tmp_path, traces)
         request_count = len(traces)
 
-        result = await cli.run(
-            f"""
-            aiperf profile \
-                --model {defaults.model} \
-                --url {aiperf_mock_server.url} \
-                --endpoint-type chat \
-                --input-file {trace_file} \
-                --custom-dataset-type mooncake_trace \
-                --request-count {request_count} \
-                --fixed-schedule \
-                --workers-max {defaults.workers_max} \
-                --ui {defaults.ui}
-            """
-        )
+        async with mock_server_factory(fast=True, workers=1) as server:
+            server.clear_recorded_headers()
+            result = await cli.run(
+                f"""
+                aiperf profile \
+                    --model {defaults.model} \
+                    --url {server.url} \
+                    --endpoint-type chat \
+                    --input-file {trace_file} \
+                    --custom-dataset-type mooncake_trace \
+                    --request-count {request_count} \
+                    --fixed-schedule \
+                    --workers-max {defaults.workers_max} \
+                    --ui {defaults.ui}
+                """
+            )
 
-        assert result.request_count == request_count
-        assert result.has_all_outputs
+            assert result.request_count == request_count
+            assert result.has_all_outputs
+
+            # On-wire assertion: every trace row's `headers` dict appears
+            # verbatim on the inbound request the mock server received.
+            # Headers are captured with lowercased names. Order is governed
+            # by the fixed schedule (sorted by timestamp), so we compare on
+            # sets to keep the test robust against arrival-order jitter.
+            recorded = server.recorded_headers()
+            assert len(recorded) == request_count, (
+                f"expected {request_count} recorded requests, got "
+                f"{len(recorded)}: {recorded!r}"
+            )
+            session_tokens = {r["headers"].get("x-session-token") for r in recorded}
+            baggage_values = {r["headers"].get("baggage") for r in recorded}
+            assert session_tokens == {"tok-A", "tok-B", None}, (
+                f"x-session-token values mismatch: {session_tokens}"
+            )
+            assert baggage_values == {
+                None,
+                "userId=alice,sessionId=tok-B",
+                "userId=bob",
+            }, f"baggage values mismatch: {baggage_values}"
 
     async def test_mooncake_trace_text_input_with_synthesis_speedup(
         self,

--- a/tests/integration/test_mooncake_trace.py
+++ b/tests/integration/test_mooncake_trace.py
@@ -194,6 +194,45 @@ class TestMooncakeTraceIntegration:
         assert result.request_count == request_count
         assert result.has_all_outputs
 
+    async def test_mooncake_trace_with_per_row_headers(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ):
+        """Trace rows carrying a `headers` dict run end-to-end without errors.
+
+        Header-on-wire fidelity is covered by unit tests on
+        `BaseEndpoint.get_endpoint_headers`; this is a pipeline-regression smoke
+        test that the new field does not break dataset loading, Turn
+        construction, payload formatting, or the request loop.
+        """
+        traces = [
+            {"timestamp": 0, "text_input": "hello", "output_length": 10, "headers": {"x-session-token": "tok-A"}},
+            {"timestamp": 100, "text_input": "world", "output_length": 10, "headers": {"x-session-token": "tok-B", "baggage": "userId=alice,sessionId=tok-B"}},
+            {"timestamp": 200, "messages": [{"role": "user", "content": "hi"}], "output_length": 10, "headers": {"baggage": "userId=bob"}},
+        ]  # fmt: skip
+        trace_file = create_mooncake_trace_file(tmp_path, traces)
+        request_count = len(traces)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {trace_file} \
+                --custom-dataset-type mooncake_trace \
+                --request-count {request_count} \
+                --fixed-schedule \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.request_count == request_count
+        assert result.has_all_outputs
+
     async def test_mooncake_trace_text_input_with_synthesis_speedup(
         self,
         cli: AIPerfCLI,

--- a/tests/unit/dataset/loader/test_mooncake_trace_headers.py
+++ b/tests/unit/dataset/loader/test_mooncake_trace_headers.py
@@ -59,6 +59,16 @@ class TestMooncakeBuildTurnForwardsHeaders:
         turn = loader._build_turn(trace, "")
         assert turn.headers == {"baggage": "userId=alice"}
 
+    def test_build_turn_payload_path_carries_headers(self):
+        loader = self._loader()
+        trace = MooncakeTrace(
+            payload={"prompt": "hi", "max_tokens": 4},
+            output_length=4,
+            headers={"x-session-token": "tok-C"},
+        )
+        turn = loader._build_turn(trace, "")
+        assert turn.headers == {"x-session-token": "tok-C"}
+
     def test_build_turn_no_headers_yields_none(self):
         loader = self._loader()
         trace = MooncakeTrace(text_input="hi", output_length=4)

--- a/tests/unit/dataset/loader/test_mooncake_trace_headers.py
+++ b/tests/unit/dataset/loader/test_mooncake_trace_headers.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MooncakeTrace per-row HTTP headers."""
+
+import pytest
+from pydantic import ValidationError
+
+from aiperf.dataset.loader.models import MooncakeTrace
+from aiperf.dataset.loader.mooncake_trace import MooncakeTraceDatasetLoader
+
+
+class TestMooncakeHeadersValidation:
+    """Pydantic-level validation of the new optional ``headers`` field."""
+
+    def test_headers_default_is_none(self):
+        trace = MooncakeTrace(text_input="hi")
+        assert trace.headers is None
+
+    def test_headers_accepts_str_str_dict(self):
+        headers = {"x-session-token": "tok-1", "baggage": "k=v,a=b"}
+        trace = MooncakeTrace(text_input="hi", headers=headers)
+        assert trace.headers == headers
+
+    def test_headers_rejects_non_string_value(self):
+        with pytest.raises(ValidationError):
+            MooncakeTrace(text_input="hi", headers={"x": 1})  # type: ignore[arg-type]
+
+    def test_headers_round_trip_through_json(self):
+        raw = '{"text_input":"hi","headers":{"x-session-token":"tok-1"}}'
+        trace = MooncakeTrace.model_validate_json(raw)
+        assert trace.headers == {"x-session-token": "tok-1"}
+
+
+class TestMooncakeBuildTurnForwardsHeaders:
+    """``MooncakeTraceDatasetLoader._build_turn`` carries headers onto the Turn."""
+
+    def _loader(self) -> MooncakeTraceDatasetLoader:
+        # Bypass __init__ so we can call _build_turn without a real config.
+        return MooncakeTraceDatasetLoader.__new__(MooncakeTraceDatasetLoader)
+
+    def test_build_turn_text_input_path_carries_headers(self):
+        loader = self._loader()
+        trace = MooncakeTrace(
+            text_input="hi",
+            output_length=4,
+            headers={"x-session-token": "tok-A"},
+        )
+        turn = loader._build_turn(trace, "hi")
+        assert turn.headers == {"x-session-token": "tok-A"}
+
+    def test_build_turn_messages_path_carries_headers(self):
+        loader = self._loader()
+        trace = MooncakeTrace(
+            messages=[{"role": "user", "content": "hi"}],
+            output_length=4,
+            headers={"baggage": "userId=alice"},
+        )
+        turn = loader._build_turn(trace, "")
+        assert turn.headers == {"baggage": "userId=alice"}
+
+    def test_build_turn_no_headers_yields_none(self):
+        loader = self._loader()
+        trace = MooncakeTrace(text_input="hi", output_length=4)
+        turn = loader._build_turn(trace, "hi")
+        assert turn.headers is None
+
+
+class TestMooncakeSynthesisPreservesHeaders:
+    """Synthesis must not mutate or drop the ``headers`` field."""
+
+    def test_synthesis_excludes_headers(self):
+        loader = MooncakeTraceDatasetLoader.__new__(MooncakeTraceDatasetLoader)
+        assert "headers" in loader._synthesis_exclude_fields()
+
+    def test_reconstruct_traces_reattaches_original_headers(self):
+        loader = MooncakeTraceDatasetLoader.__new__(MooncakeTraceDatasetLoader)
+        originals = [
+            MooncakeTrace(
+                text_input="hi", output_length=4, headers={"x-session-token": "tok-A"}
+            ),
+            MooncakeTrace(
+                text_input="bye", output_length=4, headers={"x-session-token": "tok-B"}
+            ),
+        ]
+        # Simulate post-synthesis dicts (no ``headers`` key — it was excluded).
+        synth_dicts = [
+            {"text_input": "hi-syn", "output_length": 4},
+            {"text_input": "bye-syn", "output_length": 4},
+        ]
+        rebuilt = loader._reconstruct_traces(originals, synth_dicts)
+        assert rebuilt[0].headers == {"x-session-token": "tok-A"}
+        assert rebuilt[1].headers == {"x-session-token": "tok-B"}
+
+    def test_reconstruct_traces_without_originals_keeps_none(self):
+        loader = MooncakeTraceDatasetLoader.__new__(MooncakeTraceDatasetLoader)
+        synth_dicts = [{"text_input": "hi", "output_length": 4}]
+        rebuilt = loader._reconstruct_traces([], synth_dicts)
+        assert rebuilt[0].headers is None

--- a/tests/unit/endpoints/test_base_endpoint.py
+++ b/tests/unit/endpoints/test_base_endpoint.py
@@ -4,6 +4,7 @@
 import pytest
 
 from aiperf.common.models import ParsedResponse, TextResponse, TextResponseData
+from aiperf.common.models.dataset_models import Turn
 from aiperf.common.models.record_models import (
     InferenceServerResponse,
     RequestInfo,
@@ -88,6 +89,80 @@ class TestBaseEndpoint:
 
         for key, value in expected_headers.items():
             assert headers[key] == value
+
+    def test_get_endpoint_headers_merges_per_turn_headers(
+        self, endpoint, model_endpoint
+    ):
+        """Per-turn headers are merged on top of endpoint headers."""
+        model_endpoint.endpoint.api_key = None
+        model_endpoint.endpoint.headers = [("X-Static", "static-value")]
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[Turn(headers={"x-session-token": "tok-A"})],
+        )
+
+        headers = endpoint.get_endpoint_headers(request_info)
+
+        assert headers["X-Static"] == "static-value"
+        assert headers["x-session-token"] == "tok-A"
+
+    def test_get_endpoint_headers_per_turn_overrides_endpoint(
+        self, endpoint, model_endpoint
+    ):
+        """On key conflict, per-turn headers win over endpoint config headers."""
+        model_endpoint.endpoint.api_key = None
+        model_endpoint.endpoint.headers = [("baggage", "from-config")]
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[Turn(headers={"baggage": "from-trace"})],
+        )
+
+        headers = endpoint.get_endpoint_headers(request_info)
+
+        assert headers["baggage"] == "from-trace"
+
+    def test_get_endpoint_headers_no_turns(self, endpoint, model_endpoint):
+        """Empty turns list does not break header construction."""
+        model_endpoint.endpoint.api_key = "k"
+        model_endpoint.endpoint.headers = None
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
+
+        headers = endpoint.get_endpoint_headers(request_info)
+
+        assert headers == {"Authorization": "Bearer k"}
+
+    def test_get_endpoint_headers_turn_without_headers(self, endpoint, model_endpoint):
+        """A Turn with headers=None is a no-op for the merge."""
+        model_endpoint.endpoint.api_key = None
+        model_endpoint.endpoint.headers = [("X-Static", "v")]
+        request_info = create_request_info(
+            model_endpoint=model_endpoint, turns=[Turn(headers=None)]
+        )
+
+        headers = endpoint.get_endpoint_headers(request_info)
+
+        assert headers == {"X-Static": "v"}
+
+    def test_get_endpoint_headers_uses_current_turn_in_multi_turn_session(
+        self, endpoint, model_endpoint
+    ):
+        """Multi-turn DELTAS_WITHOUT_RESPONSES sessions accumulate prior turns
+        in `turns`; the merge must read headers from the current (last) turn.
+        """
+        model_endpoint.endpoint.api_key = None
+        model_endpoint.endpoint.headers = None
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[
+                Turn(headers={"x-session-token": "tok-A"}),  # earlier user turn
+                Turn(headers=None),  # accumulated assistant response
+                Turn(headers={"x-session-token": "tok-B"}),  # current user turn
+            ],
+        )
+
+        headers = endpoint.get_endpoint_headers(request_info)
+
+        assert headers["x-session-token"] == "tok-B"
 
     @pytest.mark.parametrize(
         "url_params,expected_params",

--- a/tests/unit/endpoints/test_base_endpoint.py
+++ b/tests/unit/endpoints/test_base_endpoint.py
@@ -164,6 +164,33 @@ class TestBaseEndpoint:
 
         assert headers["x-session-token"] == "tok-B"
 
+    def test_get_endpoint_headers_per_turn_overrides_endpoint_case_insensitively(
+        self, endpoint, model_endpoint
+    ):
+        """A per-turn header with different casing replaces the endpoint-config
+        header rather than producing two duplicate wire headers (HTTP header
+        names are case-insensitive per RFC 7230).
+        """
+        model_endpoint.endpoint.api_key = "secret"
+        model_endpoint.endpoint.headers = [("Baggage", "from-config")]
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[
+                Turn(headers={"baggage": "from-trace", "authorization": "Bearer t"})
+            ],
+        )
+
+        headers = endpoint.get_endpoint_headers(request_info)
+
+        # Only one entry per case-insensitive key, and the trace value/casing wins.
+        keys_lower = [k.lower() for k in headers]
+        assert keys_lower.count("baggage") == 1
+        assert keys_lower.count("authorization") == 1
+        assert headers["baggage"] == "from-trace"
+        assert headers["authorization"] == "Bearer t"
+        assert "Baggage" not in headers
+        assert "Authorization" not in headers
+
     @pytest.mark.parametrize(
         "url_params,expected_params",
         [

--- a/tests/unit/workers/test_inference_client.py
+++ b/tests/unit/workers/test_inference_client.py
@@ -435,3 +435,46 @@ class TestInferenceClient:
         assert not pydantic_warnings, (
             f"Unexpected Pydantic serialization warnings for {base_url!r}: {pydantic_warnings}"
         )
+
+    def test_finalize_request_record_redacts_sensitive_per_turn_headers(
+        self, inference_client
+    ):
+        """Sensitive per-turn headers (e.g. Authorization) carried by trace
+        rows must be redacted on `record.turns[*].headers` so they don't
+        leak into serialised ZMQ records.
+        """
+        original_turn = Turn(
+            texts=[Text(contents=["hello"])],
+            role="user",
+            headers={"Authorization": "Bearer secret", "x-app-id": "app-1"},
+        )
+        # Hold a reference so we can assert the original (session-owned) Turn
+        # is not mutated by the enrichment pass.
+        original_turn_headers_before = dict(original_turn.headers)
+        request_info = RequestInfo(
+            model_endpoint=inference_client.model_endpoint,
+            turns=[original_turn],
+            turn_index=0,
+            credit_num=0,
+            credit_phase=CreditPhase.PROFILING,
+            x_request_id="rid",
+            x_correlation_id="cid",
+            conversation_id="conv",
+        )
+        record = RequestRecord(
+            request_info=request_info,
+            start_perf_ns=1000,
+            timestamp_ns=1000,
+            end_perf_ns=2000,
+        )
+
+        result = inference_client._finalize_request_record(
+            record=record, request_info=request_info
+        )
+
+        # Original session-owned Turn is untouched.
+        assert original_turn.headers == original_turn_headers_before
+        # record.turns carries scrubbed copies (Authorization redacted,
+        # non-sensitive header preserved).
+        assert result.turns[0].headers["Authorization"] != "Bearer secret"
+        assert result.turns[0].headers["x-app-id"] == "app-1"

--- a/tools/ergonomics_baseline.json
+++ b/tools/ergonomics_baseline.json
@@ -183,6 +183,11 @@
     ],
     [
       "file-size",
+      "src/aiperf/endpoints/base_endpoint.py",
+      ""
+    ],
+    [
+      "file-size",
       "src/aiperf/exporters/mlflow_data_exporter.py",
       ""
     ],


### PR DESCRIPTION
Adds an optional \`headers: dict[str, str]\` field to MooncakeTrace so each row in a JSONL trace can carry custom HTTP headers (e.g. \`x-session-token\` for routing affinity, W3C \`baggage\` for tracing context). Headers ride on the resulting Turn and are merged into the outgoing request by BaseEndpoint.get_endpoint_headers; on key conflict the trace value wins over endpoint-config headers. Headers are excluded from synthesis serialization and re-attached verbatim from the originals in \`_reconstruct_traces\`.

The endpoint reads from the current turn at \`turns[-1]\` to match how the worker accumulates prior turns in DELTAS_WITHOUT_RESPONSES mode (see \`inference_client.py\`); a regression test covers this against multi-turn sessions.

## Changes

- \`MooncakeTrace.headers\`: new optional \`dict[str, str]\` field
- \`Turn.headers\`: new optional field that carries per-turn headers through the worker
- \`BaseEndpoint.get_endpoint_headers\`: RFC 7230 case-insensitive merge; trace headers win on conflict
- \`MooncakeTraceDatasetLoader._build_turn\`: forwards headers (defensive dict copy) across all three input modes: \`text_input\`, \`messages\`, and \`payload\`
- \`InferenceClient._finalize_request_record\`: redacts per-turn headers on the stored \`record.turns\` copies so sensitive values don't leak into serialized ZMQ records; session-owned turns are not mutated
- Synthesis: \`headers\` excluded from synthesis fields, re-attached verbatim from originals in \`_reconstruct_traces\`
- Integration test: on-wire assertion via mock server header recorder
- Docs: Per-Request HTTP Headers section with merge semantics and security note

## Bug fix (post-review)

The \`payload\` input mode used an early \`return\` in \`_build_turn\` that bypassed the \`turn.headers\` assignment, silently dropping headers for trace rows combining \`payload\` + \`headers\`. Fixed by converting to \`if/elif/else\` so all three input modes reach the header attachment. Regression test added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-request HTTP headers in Mooncake trace replay. Each trace row can now carry custom HTTP headers that override endpoint-level headers on key conflicts. Trace headers are applied after authentication headers, allowing override of configured credentials.

* **Documentation**
  * Updated documentation explaining the new per-request headers field, merge semantics, and security implications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->