### PR TITLE
fix(endpoints): include type=message on Responses API input items

### DIFF
--- a/src/aiperf/endpoints/openai_responses.py
+++ b/src/aiperf/endpoints/openai_responses.py
@@ -91,6 +91,7 @@ class ResponsesEndpoint(BaseEndpoint):
         if user_context_message:
             items.append(
                 {
+                    "type": "message",
                     "role": _DEFAULT_ROLE,
                     "content": user_context_message,
                 }
@@ -98,6 +99,7 @@ class ResponsesEndpoint(BaseEndpoint):
 
         for turn in turns:
             item: dict[str, Any] = {
+                "type": "message",
                 "role": turn.role or _DEFAULT_ROLE,
             }
             self._set_item_content(item, turn)

--- a/tests/unit/endpoints/test_responses_endpoint.py
+++ b/tests/unit/endpoints/test_responses_endpoint.py
@@ -178,6 +178,32 @@ class TestResponsesEndpoint:
         assert payload["input"][0]["content"] == "Background context here."
         assert payload["input"][1]["content"] == "Hello"
 
+    def test_format_payload_all_input_items_have_type_message(
+        self, endpoint, model_endpoint
+    ):
+        """Every input item carries type='message' so Dynamo and other strict
+        untagged-enum deserializers can disambiguate the variant."""
+        turn1 = Turn(texts=[Text(contents=["First"])], model="test-model")
+        turn2 = Turn(
+            texts=[Text(contents=["Describe"])],
+            images=[Image(contents=["data:image/png;base64,abc"])],
+            model="test-model",
+            role="assistant",
+        )
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[turn1, turn2],
+            user_context_message="Background.",
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert [item.get("type") for item in payload["input"]] == [
+            "message",
+            "message",
+            "message",
+        ]
+
     def test_format_payload_max_tokens_becomes_max_output_tokens(
         self, endpoint, model_endpoint
     ):


### PR DESCRIPTION
## Summary

AIPerf's `--endpoint-type responses` emits input items without a `type` field, e.g.:

```json
{"role": "user", "content": [{"type": "input_image", "image_url": "data:image/..."}]}
```

The OpenAI Responses API spec treats `type` as optional on input message items — but Dynamo's `async-openai` (Rust) defines `InputItem` as an **untagged** serde enum tried in order `ItemReference` → `Item` → `EasyInputMessage`. Without `type: "message"` present, serde can't disambiguate the variant and every request fails with HTTP 400:

```
Failed to deserialize the JSON body into the target type:
data did not match any variant of untagged enum InputParam
```

This affects all AIPerf Responses API requests against Dynamo backends regardless of content type (text-only or multimodal).

## Fix

`_create_input_items` in `src/aiperf/endpoints/openai_responses.py` now emits `"type": "message"` on both the user-context item and per-turn items. The value is consistent with OpenAI's `EasyInputMessage` schema (`Literal["message"]`, default `"message"`), so the change is a no-op against compliant OpenAI servers and unblocks strict consumers like Dynamo.

## Test plan

- [x] Added `test_format_payload_all_input_items_have_type_message` asserting `type=="message"` on user-context + per-turn items (text and multimodal).
- [x] `uv run pytest tests/unit/endpoints/test_responses_endpoint.py -n auto` — 59 passed.
- [x] `uv run pytest tests/unit/endpoints/ -n auto` — 507 passed.
- [x] `ruff format` and `ruff check` clean on touched files.
- [ ] End-to-end: profile against Dynamo + vLLM with `--endpoint-type responses` and a multimodal model (e.g. `Qwen/Qwen2-VL-2B-Instruct`) and confirm HTTP 200s — left to the reporter to re-verify on hardware.

## References

- OpenAI schema: `openai/openai-python` → `src/openai/types/responses/easy_input_message_param.py` (`type: Literal["message"]`, optional via `TypedDict, total=False`)
- Dynamo schema: `dynamo` → `lib/async-openai/src/types/responses/response.rs` (untagged enum `InputItem`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message payloads now explicitly include a type field for every input item, ensuring consistent message formatting and improved API compatibility.

* **Tests**
  * Added unit test coverage to verify all input items in multi-turn message payloads are marked with the required type.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/931)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/931)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->