### PR TITLE
fix(endpoints): include type=message on Responses API input items (cherry-pick to release/0.8.0)

### DIFF
--- a/src/aiperf/endpoints/openai_responses.py
+++ b/src/aiperf/endpoints/openai_responses.py
@@ -91,6 +91,7 @@ class ResponsesEndpoint(BaseEndpoint):
         if user_context_message:
             items.append(
                 {
+                    "type": "message",
                     "role": _DEFAULT_ROLE,
                     "content": user_context_message,
                 }
@@ -98,6 +99,7 @@ class ResponsesEndpoint(BaseEndpoint):
 
         for turn in turns:
             item: dict[str, Any] = {
+                "type": "message",
                 "role": turn.role or _DEFAULT_ROLE,
             }
             self._set_item_content(item, turn)

--- a/tests/unit/endpoints/test_responses_endpoint.py
+++ b/tests/unit/endpoints/test_responses_endpoint.py
@@ -178,6 +178,32 @@ class TestResponsesEndpoint:
         assert payload["input"][0]["content"] == "Background context here."
         assert payload["input"][1]["content"] == "Hello"
 
+    def test_format_payload_all_input_items_have_type_message(
+        self, endpoint, model_endpoint
+    ):
+        """Every input item carries type='message' so Dynamo and other strict
+        untagged-enum deserializers can disambiguate the variant."""
+        turn1 = Turn(texts=[Text(contents=["First"])], model="test-model")
+        turn2 = Turn(
+            texts=[Text(contents=["Describe"])],
+            images=[Image(contents=["data:image/png;base64,abc"])],
+            model="test-model",
+            role="assistant",
+        )
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[turn1, turn2],
+            user_context_message="Background.",
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert [item.get("type") for item in payload["input"]] == [
+            "message",
+            "message",
+            "message",
+        ]
+
     def test_format_payload_max_tokens_becomes_max_output_tokens(
         self, endpoint, model_endpoint
     ):


### PR DESCRIPTION
## Summary

Cherry-pick of `ce2a848a` from `main` into `release/0.8.0`.

Original PR: #931 — fix(endpoints): include type=message on Responses API input items

## Conflicts

None — clean cherry-pick.