### PR TITLE
chore: bump codespell from v2.2.4 to v2.4.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.4.2
     hooks:
     - id: codespell
       additional_dependencies: [tomli]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ accuracy = [
 [dependency-groups]
 dev = [
     "hypothesis>=6.152.4",
+    "pre-commit>=4.6.0",
 ]
 
 [tool.ruff]
@@ -202,4 +203,4 @@ filterwarnings = [
 
 [tool.codespell]
 skip = "*.pyc,*build*,tests/unit/transports/test_aiohttp_sse.py,tests/integration/assets/canary_reference_inputs.json,src/aiperf/server_metrics/units.py,src/aiperf/api/static/dashboard.html"
-ignore-words-list = "timeslice,timeslices"
+ignore-words-list = "timeslice,timeslices,optiona"


### PR DESCRIPTION
Add "optiona" to the ignore-words-list to suppress a false positive introduced by the new version flagging the intentional test string. "Optiona" is an expected return value in testing.