### PR TITLE
ci: Fix Fern docs version publishing

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -273,7 +273,7 @@ jobs:
           echo "Successfully synced dev docs to docs-website branch"
 
       - name: Publish Docs
-        if: steps.ctx.outputs.is_main == 'true' && steps.changes.outputs.has_changes == 'true'
+        if: steps.ctx.outputs.is_main == 'true' && (steps.changes.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch')
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         working-directory: docs-checkout/fern
@@ -641,13 +641,13 @@ jobs:
           echo "Updating $DOCS_FILE to include $TAG..."
 
           # Check if version already in docs.yml
-          if yq ".products[0].versions[] | select(.display-name == \"$TAG\")" "$DOCS_FILE" | grep -q .; then
+          if yq -e ".products[0].versions[] | select(.\"display-name\" == \"$TAG\")" "$DOCS_FILE" > /dev/null 2>&1; then
             echo "Version $TAG already in docs.yml, skipping update"
             exit 0
           fi
 
           # Find the index of the "dev" entry and insert new version right after it
-          DEV_IDX=$(yq '.products[0].versions | to_entries | map(select(.value.display-name == "dev")) | .[0].key' "$DOCS_FILE")
+          DEV_IDX=$(yq '.products[0].versions | to_entries | map(select(.value."display-name" == "dev")) | .[0].key' "$DOCS_FILE")
           INSERT_IDX=$((DEV_IDX + 1))
 
           yq -i "
@@ -664,6 +664,8 @@ jobs:
           # Update the "Latest" entry to point to the new version
           yq -i ".products[0].versions[0].path = \"./versions/$TAG.yml\"" "$DOCS_FILE"
           yq -i ".products[0].versions[0].display-name = \"Latest ($TAG)\"" "$DOCS_FILE"
+          yq -i ".products[0].versions[0].slug = \"latest\"" "$DOCS_FILE"
+          yq -i ".products[0].versions[0].availability = \"stable\"" "$DOCS_FILE"
 
           echo "Updated docs.yml products/versions section:"
           yq '.products[0].versions' "$DOCS_FILE"


### PR DESCRIPTION
## Summary
- keep the Fern release job's Latest entry shaped like the docs-website branch expects
- quote yq selectors for display-name fields with hyphens
- let manual no-tag workflow dispatch publish even when the dev sync has no branch changes

## Root cause
The v0.7.0 release run promoted the first version entry to Latest. On AIPerf, that first entry was dev, so the published docs lost the dev version entry. The docs-website branch has been manually repaired to the Dynamo-style shape with separate Latest, dev, and stable version entries.

## Validation
- `git diff --check -- .github/workflows/fern-docs.yml`
- Ruby YAML parse for `.github/workflows/fern-docs.yml`
- yq simulation against the repaired docs-website version list
- `SKIP=no-commit-to-branch PRE_COMMIT_HOME=/tmp/aiperf-pre-commit-cache uv run pre-commit run --files .github/workflows/fern-docs.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced documentation publishing workflow to improve version tracking and deployment reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->