### PR TITLE
chore: bump aiperf version to 0.9.0

### DIFF
--- a/docs/plugins/creating-your-first-plugin.md
+++ b/docs/plugins/creating-your-first-plugin.md
@@ -234,7 +234,7 @@ You should see both packages listed in the same environment:
 
 ```text
 Name: aiperf
-Version: 0.8.0
+Version: 0.9.0
 Location: ...
 Requires: ...
 Required-by: my-aiperf-plugins

--- a/docs/server-metrics/server-metrics-json-schema.md
+++ b/docs/server-metrics/server-metrics-json-schema.md
@@ -60,7 +60,7 @@ data["metrics"]["metric_name"]["series"][0]["stats"]["p99"]
 ```json
 {
   "schema_version": "1.0",
-  "aiperf_version": "0.8.0",
+  "aiperf_version": "0.9.0",
   "benchmark_id": "550e8400-e29b-41d4-a716-446655440000",
   "summary": { ... },
   "metrics": { ... },
@@ -71,7 +71,7 @@ data["metrics"]["metric_name"]["series"][0]["stats"]["p99"]
 | Field | Type | Description |
 |-------|------|-------------|
 | `schema_version` | string | Schema version for this export format (e.g., `"1.0"`) |
-| `aiperf_version` | string or null | AIPerf version that generated this export (e.g., `"0.8.0"`). `null` if version unavailable. |
+| `aiperf_version` | string or null | AIPerf version that generated this export (e.g., `"0.9.0"`). `null` if version unavailable. |
 | `benchmark_id` | string or null | Unique UUID identifying this benchmark run. `null` if not available. |
 | [`summary`](#summary-section) | object | Collection metadata and endpoint information |
 | [`metrics`](#metrics-section) | object | Metrics keyed by name, each containing type info and series data |
@@ -878,7 +878,7 @@ for series in metric["series"]:
 ```json
 {
   "schema_version": "1.0",
-  "aiperf_version": "0.8.0",
+  "aiperf_version": "0.9.0",
   "benchmark_id": "550e8400-e29b-41d4-a716-446655440000",
   "summary": {
     "endpoints_configured": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ allow-direct-references = true
 
 [project]
 name = "aiperf"
-version = "0.8.0"
+version = "0.9.0"
 description = "AIPerf is a package for performance testing of AI models"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/aiperf_mock_server/pyproject.toml
+++ b/tests/aiperf_mock_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiperf-mock-server"
-version = "0.8.0"
+version = "0.9.0"
 description = "AIPerf FastAPI-based OpenAI mock server for AI performance testing"
 authors = []
 dependencies = [


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` and `tests/aiperf_mock_server/pyproject.toml` from 0.8.0 to 0.9.0.
- Refreshes the example version strings shown in `docs/plugins/creating-your-first-plugin.md` and `docs/server-metrics/server-metrics-json-schema.md` so users following tutorials in 0.9.0 see matching output.
- Targets `release/0.9.0` rather than `main` so the bump lands on the release branch.

## Test plan
- [ ] `pre-commit run --all-files` passes locally.
- [ ] `uv run python -c "from importlib.metadata import version; print(version('aiperf'))"` reports `0.9.0` after `uv sync`.
- [ ] `uv run pytest tests/unit/ -n auto` passes.
- [ ] `grep -rn "0\.8\.0" --include="*.toml" --include="*.md" .` returns no in-scope hits (only the deliberately-skipped `.github/workflows/nightly.yml` comment).

Generated with [Claude Code](https://claude.com/claude-code).