### PR TITLE
chore: bump aiperf version to 0.10.0

### DIFF
--- a/docs/plugins/creating-your-first-plugin.md
+++ b/docs/plugins/creating-your-first-plugin.md
@@ -234,7 +234,7 @@ You should see both packages listed in the same environment:
 
 ```text
 Name: aiperf
-Version: 0.8.0
+Version: 0.10.0
 Location: ...
 Requires: ...
 Required-by: my-aiperf-plugins

--- a/docs/server-metrics/server-metrics-json-schema.md
+++ b/docs/server-metrics/server-metrics-json-schema.md
@@ -60,7 +60,7 @@ data["metrics"]["metric_name"]["series"][0]["stats"]["p99"]
 ```json
 {
   "schema_version": "1.0",
-  "aiperf_version": "0.8.0",
+  "aiperf_version": "0.10.0",
   "benchmark_id": "550e8400-e29b-41d4-a716-446655440000",
   "summary": { ... },
   "metrics": { ... },
@@ -71,7 +71,7 @@ data["metrics"]["metric_name"]["series"][0]["stats"]["p99"]
 | Field | Type | Description |
 |-------|------|-------------|
 | `schema_version` | string | Schema version for this export format (e.g., `"1.0"`) |
-| `aiperf_version` | string or null | AIPerf version that generated this export (e.g., `"0.8.0"`). `null` if version unavailable. |
+| `aiperf_version` | string or null | AIPerf version that generated this export (e.g., `"0.10.0"`). `null` if version unavailable. |
 | `benchmark_id` | string or null | Unique UUID identifying this benchmark run. `null` if not available. |
 | [`summary`](#summary-section) | object | Collection metadata and endpoint information |
 | [`metrics`](#metrics-section) | object | Metrics keyed by name, each containing type info and series data |
@@ -878,7 +878,7 @@ for series in metric["series"]:
 ```json
 {
   "schema_version": "1.0",
-  "aiperf_version": "0.8.0",
+  "aiperf_version": "0.10.0",
   "benchmark_id": "550e8400-e29b-41d4-a716-446655440000",
   "summary": {
     "endpoints_configured": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ allow-direct-references = true
 
 [project]
 name = "aiperf"
-version = "0.8.0"
+version = "0.10.0"
 description = "AIPerf is a package for performance testing of AI models"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/aiperf_mock_server/pyproject.toml
+++ b/tests/aiperf_mock_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiperf-mock-server"
-version = "0.8.0"
+version = "0.10.0"
 description = "AIPerf FastAPI-based OpenAI mock server for AI performance testing"
 authors = []
 dependencies = [

--- a/tests/unit/orchestrator/search_planner/test_sla_helpers_observed.py
+++ b/tests/unit/orchestrator/search_planner/test_sla_helpers_observed.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import pytest
 
+from aiperf import __version__ as aiperf_version
 from aiperf.common.models.export_models import JsonMetricResult
 from aiperf.config.sweep.adaptive import SLAFilter
 from aiperf.orchestrator.models import RunResult
@@ -404,7 +405,7 @@ def test_project_summary_dict_to_sla_filter_end_to_end() -> None:
     # with full percentile dicts.
     payload: dict[str, Any] = {
         "schema_version": "1.1",
-        "aiperf_version": "0.8.0",
+        "aiperf_version": aiperf_version,
         "request_throughput": {"unit": "req/sec", "avg": 1.5, "p95": 1.6},
         "request_latency": {"unit": "ms", "avg": 1500.0, "p95": 2000.0},
         "time_to_first_token": {


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` and `tests/aiperf_mock_server/pyproject.toml` from 0.8.0 to 0.10.0 on `main`, opening the next development cycle.
- Refreshes the example version strings in `docs/plugins/creating-your-first-plugin.md` and `docs/server-metrics/server-metrics-json-schema.md` so tutorial output matches what users running `main` will see.
- Mirrors the file set used in the 0.9.0 bump (PR #952), which targets `release/0.9.0`.

## Test plan
- [ ] `pre-commit run --all-files` passes locally.
- [ ] `uv run python -c "from importlib.metadata import version; print(version('aiperf'))"` reports `0.10.0` after `uv sync`.
- [ ] `uv run pytest tests/unit/ -n auto` passes.
- [ ] `grep -rn "0\.8\.0" --include="*.toml" --include="*.md" .` returns no in-scope hits.

Generated with [Claude Code](https://claude.com/claude-code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped project and mock-server package versions to 0.10.0 and updated documentation examples (installation and server metrics) to reflect the new version.

* **Tests**
  * Updated a unit test to read the runtime package version instead of using a hardcoded version string.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->