### PR TITLE
fix(credit-router): define register/release_child_routing methods (latent AttributeError on FORK DAGs)

### DIFF
--- a/src/aiperf/common/models/branch.py
+++ b/src/aiperf/common/models/branch.py
@@ -67,6 +67,14 @@ class ConversationBranchInfo(AIPerfBaseModel):
         "Ignored for SPAWN-mode branches (SPAWN parents always continue; use "
         "``DagSpawn.join_at`` to control suspension).",
     )
+    subagent_type: str | None = Field(
+        default=None,
+        description="Optional SPAWN-only sub-agent classification used by DAG "
+        "benchmark bucket metrics and future routing policies. Free-form so "
+        "loaders can pass through whatever the upstream recorder tagged the "
+        "agent as (e.g. 'Explore', 'Codex Subagent', user-defined task types). "
+        "Must be None when mode=FORK (FORK children inherit the parent's role).",
+    )
 
     @field_validator("dispatch_timing")
     @classmethod
@@ -79,5 +87,19 @@ class ConversationBranchInfo(AIPerfBaseModel):
                 "(background pre-session sub-agent dispatch). FORK children "
                 "inherit the parent's context and must dispatch after the "
                 "parent turn - drop dispatch_timing or change mode to SPAWN."
+            )
+        return v
+
+    @field_validator("subagent_type")
+    @classmethod
+    def _validate_subagent_type_requires_spawn(
+        cls, v: str | None, info: ValidationInfo
+    ) -> str | None:
+        if v is not None and info.data.get("mode") == ConversationBranchMode.FORK:
+            raise ValueError(
+                "subagent_type is a SPAWN-only classification (used for "
+                "agentic-benchmark bucket metrics). FORK children inherit the "
+                "parent's role; they have no subagent_type. Drop the field or "
+                "change mode to SPAWN."
             )
         return v

--- a/src/aiperf/credit/sticky_router.py
+++ b/src/aiperf/credit/sticky_router.py
@@ -44,6 +44,22 @@ if TYPE_CHECKING:
 
 
 @dataclass(slots=True)
+class _StickyEntry:
+    """Sticky-routing state for a root correlation id.
+
+    Tracks which worker owns the session and a refcount so DAG children that
+    pin themselves to the parent's worker can keep the entry alive past the
+    parent's own final turn. ``parent_final_seen`` records whether the owning
+    session has finished its final turn; the entry is popped only once both
+    ``ref_count`` hits zero and that flag is set.
+    """
+
+    worker_id: str
+    ref_count: int = 1
+    parent_final_seen: bool = False
+
+
+@dataclass(slots=True)
 class WorkerLoad:
     """Worker load tracking for fair load balancing.
 
@@ -224,10 +240,13 @@ class StickyCreditRouter(CommunicationMixin):
             Callable[[FirstToken], Awaitable[None]] | None
         ) = None
 
-        # Sticky sessions: x_correlation_id -> worker_id
-        # Routes all turns of a conversation to the same worker. Required because
-        # workers cache UserSession state by x_correlation_id.
-        self._sticky_sessions: dict[str, str] = {}
+        # Sticky sessions: routing_key -> _StickyEntry.
+        # routing_key is the parent's x_correlation_id when the credit carries
+        # parent_correlation_id (DAG child pins to parent's worker), otherwise
+        # the credit's own x_correlation_id. The entry's refcount keeps the
+        # sticky binding alive past the owning session's final turn so DAG
+        # children dispatched from that final turn can still co-locate.
+        self._sticky_sessions: dict[str, _StickyEntry] = {}
 
         self._cancellation_pending: bool = False
         self._credits_complete: bool = False
@@ -272,8 +291,10 @@ class StickyCreditRouter(CommunicationMixin):
         if not credit.x_correlation_id:
             raise RuntimeError("x_correlation_id must be set in Credit")
 
-        x_correlation_id = credit.x_correlation_id
-        sticky_worker_id = self._sticky_sessions.get(x_correlation_id)
+        # DAG children pin to their parent's worker; otherwise pin to self.
+        routing_key = credit.parent_correlation_id or credit.x_correlation_id
+        sticky_entry = self._sticky_sessions.get(routing_key)
+        sticky_worker_id = sticky_entry.worker_id if sticky_entry is not None else None
 
         # Use existing sticky session if worker still valid
         if sticky_worker_id and sticky_worker_id in self._workers:
@@ -312,20 +333,42 @@ class StickyCreditRouter(CommunicationMixin):
 
                 worker_id = best_worker_id
 
-            # Only create sticky session if there are more turns coming. Single-turn
-            # conversations don't need routing state since there's no next turn.
-            if not credit.is_final_turn:
-                self._sticky_sessions[x_correlation_id] = worker_id
-                load = self._workers[worker_id]
-                load.active_sessions += 1
-                load.active_session_ids.add(x_correlation_id)
+            # Create or rebind the sticky entry for non-final turns; also create
+            # it when the final turn declares DAG spawns so the orchestrator's
+            # register_child_routing can find it.
+            if not credit.is_final_turn or credit.has_forks:
+                if sticky_entry is None:
+                    sticky_entry = _StickyEntry(worker_id=worker_id)
+                    self._sticky_sessions[routing_key] = sticky_entry
+                    load = self._workers[worker_id]
+                    load.active_sessions += 1
+                    load.active_session_ids.add(routing_key)
+                elif sticky_entry.worker_id not in self._workers:
+                    sticky_entry.worker_id = worker_id
+                    load = self._workers[worker_id]
+                    load.active_sessions += 1
+                    load.active_session_ids.add(routing_key)
 
-        # Cleanup on final turn - only decrement if session was actually tracked
-        # (single-turn sessions never get added to _sticky_sessions)
-        if credit.is_final_turn and self._sticky_sessions.pop(x_correlation_id, None):
-            load = self._workers[worker_id]
-            load.active_sessions -= 1
-            load.active_session_ids.discard(x_correlation_id)
+        # Owning session's final turn: mark parent_final_seen and decrement the
+        # reservation. DAG children never touch the parent entry (managed via
+        # release_child_routing). Skip when sticky_entry is None — that's the
+        # single-turn-root-no-forks degenerate case where no entry was ever
+        # created and there's nothing to update (avoids a wasted dict.get on
+        # the dominant non-DAG single-turn workload). When this turn has DAG
+        # spawns, leave the entry in place so register_child_routing lands on
+        # the same _StickyEntry.
+        if (
+            credit.is_final_turn
+            and credit.parent_correlation_id is None
+            and sticky_entry is not None
+        ):
+            sticky_entry.parent_final_seen = True
+            sticky_entry.ref_count -= 1
+            if sticky_entry.ref_count <= 0 and not credit.has_forks:
+                self._sticky_sessions.pop(routing_key, None)
+                load = self._workers[worker_id]
+                load.active_sessions -= 1
+                load.active_session_ids.discard(routing_key)
 
         self._track_credit_sent(worker_id, credit.id)
 
@@ -371,6 +414,46 @@ class StickyCreditRouter(CommunicationMixin):
     def mark_credits_complete(self) -> None:
         """Mark credits complete - suppresses orphan warnings during shutdown."""
         self._credits_complete = True
+
+    def register_child_routing(self, parent_correlation_id: str) -> None:
+        """Increment the sticky-routing refcount for a parent's entry.
+
+        Called by ``BranchOrchestrator`` before dispatching each DAG child so
+        the parent's sticky entry survives past its own final turn until every
+        descendant child session has terminated. If the parent has no active
+        sticky entry we log a warning and continue without raising — the
+        child will route via least-loaded selection rather than co-locating
+        with the parent's worker, losing prefix-cache locality but not
+        breaking correctness.
+        """
+        entry = self._sticky_sessions.get(parent_correlation_id)
+        if entry is not None:
+            entry.ref_count += 1
+        else:
+            self.warning(
+                lambda: f"register_child_routing: parent "
+                f"{parent_correlation_id!r} has no sticky entry; "
+                f"child will not co-locate with parent's worker"
+            )
+
+    def release_child_routing(self, parent_correlation_id: str) -> None:
+        """Decrement the sticky-routing refcount when a DAG child terminates.
+
+        Called by ``BranchOrchestrator`` when a child session reaches a leaf
+        or errors out. If the refcount reaches zero and the parent's own final
+        turn has already been observed, the sticky entry is evicted.
+        """
+        entry = self._sticky_sessions.get(parent_correlation_id)
+        if entry is None:
+            return
+        entry.ref_count -= 1
+        if entry.ref_count <= 0 and entry.parent_final_seen:
+            worker_id = entry.worker_id
+            self._sticky_sessions.pop(parent_correlation_id, None)
+            load = self._workers.get(worker_id)
+            if load is not None:
+                load.active_sessions -= 1
+                load.active_session_ids.discard(parent_correlation_id)
 
     # =============================================================================
     # Private Methods

--- a/tests/unit/common/models/test_branch_model.py
+++ b/tests/unit/common/models/test_branch_model.py
@@ -68,3 +68,62 @@ class TestConversationBranchInfoSerialization:
         dumped = b.model_dump()
         restored = ConversationBranchInfo.model_validate(dumped)
         assert restored == b
+
+
+class TestConversationBranchInfoSubagentType:
+    def test_spawn_can_set_subagent_type(self):
+        b = ConversationBranchInfo(
+            branch_id="root:0",
+            child_conversation_ids=["c1"],
+            mode=ConversationBranchMode.SPAWN,
+            subagent_type="Explore",
+        )
+        assert b.subagent_type == "Explore"
+
+    def test_spawn_accepts_arbitrary_recorded_string(self):
+        """Free-form so corpus values like 'Codex Subagent' pass through verbatim."""
+        b = ConversationBranchInfo(
+            branch_id="root:0",
+            child_conversation_ids=["c1"],
+            mode=ConversationBranchMode.SPAWN,
+            subagent_type="Codex Subagent",
+        )
+        assert b.subagent_type == "Codex Subagent"
+
+    def test_spawn_default_subagent_type_is_none(self):
+        b = ConversationBranchInfo(
+            branch_id="root:0",
+            child_conversation_ids=["c1"],
+            mode=ConversationBranchMode.SPAWN,
+        )
+        assert b.subagent_type is None
+
+    def test_fork_rejects_subagent_type(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ConversationBranchInfo(
+                branch_id="root:0",
+                child_conversation_ids=["c1"],
+                mode=ConversationBranchMode.FORK,
+                subagent_type="general-purpose",
+            )
+        assert "SPAWN" in str(exc_info.value) or "spawn" in str(exc_info.value)
+
+    def test_fork_with_explicit_none_subagent_type_is_valid(self):
+        b = ConversationBranchInfo(
+            branch_id="root:0",
+            child_conversation_ids=["c1"],
+            mode=ConversationBranchMode.FORK,
+            subagent_type=None,
+        )
+        assert b.subagent_type is None
+
+    def test_subagent_type_round_trip(self):
+        b = ConversationBranchInfo(
+            branch_id="root:0",
+            child_conversation_ids=["c1"],
+            mode=ConversationBranchMode.SPAWN,
+            subagent_type="Plan",
+        )
+        restored = ConversationBranchInfo.model_validate(b.model_dump())
+        assert restored == b
+        assert restored.subagent_type == "Plan"

--- a/tests/unit/credit/test_sticky_router.py
+++ b/tests/unit/credit/test_sticky_router.py
@@ -6,7 +6,7 @@ import pytest
 
 from aiperf.common.enums import CreditPhase
 from aiperf.credit.messages import FirstToken
-from aiperf.credit.sticky_router import StickyCreditRouter
+from aiperf.credit.sticky_router import StickyCreditRouter, _StickyEntry
 from aiperf.credit.structs import Credit
 from tests.unit.timing.conftest import make_credit
 
@@ -45,7 +45,7 @@ class TestStickyCreditRouterFairLoadBalancing:
         worker_id = router._router_client.send_to.call_args[0][0]
         assert worker_id == "worker-2"
         assert len(router._sticky_sessions) == 1
-        assert list(router._sticky_sessions.values())[0] == "worker-2"
+        assert list(router._sticky_sessions.values())[0].worker_id == "worker-2"
 
     async def test_creates_conversation_assignment(self, benchmark_run) -> None:
         router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
@@ -57,7 +57,7 @@ class TestStickyCreditRouterFairLoadBalancing:
         await router.send_credit(credit)
 
         assert len(router._sticky_sessions) == 1
-        assert router._sticky_sessions["test-corr-id"] == "worker-A"
+        assert router._sticky_sessions["test-corr-id"].worker_id == "worker-A"
 
     async def test_error_if_no_workers_available(self, benchmark_run) -> None:
         router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
@@ -77,7 +77,7 @@ class TestStickyCreditRouterStickyRouting:
         router._register_worker("worker-B")
 
         instance_id = "test-instance-123"
-        router._sticky_sessions[instance_id] = "worker-A"
+        router._sticky_sessions[instance_id] = _StickyEntry(worker_id="worker-A")
 
         credit = make_credit(
             id=2,
@@ -91,7 +91,7 @@ class TestStickyCreditRouterStickyRouting:
 
         worker_id = router._router_client.send_to.call_args[0][0]
         assert worker_id == "worker-A"
-        assert router._sticky_sessions[instance_id] == "worker-A"
+        assert router._sticky_sessions[instance_id].worker_id == "worker-A"
 
     async def test_cleans_up_assignment_on_final_turn(self, benchmark_run) -> None:
         router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
@@ -99,7 +99,7 @@ class TestStickyCreditRouterStickyRouting:
         router._register_worker("worker-A")
 
         instance_id = "test-instance-456"
-        router._sticky_sessions[instance_id] = "worker-A"
+        router._sticky_sessions[instance_id] = _StickyEntry(worker_id="worker-A")
 
         credit = make_credit(
             id=5,
@@ -272,7 +272,7 @@ class TestStickyCreditRouterCompleteScenario:
 
         # Route second turns (should be sticky)
         for i, instance_id in enumerate(instance_ids):
-            expected_worker = router._sticky_sessions[instance_id]
+            expected_worker = router._sticky_sessions[instance_id].worker_id
             credit = make_credit(
                 id=100 + i,
                 conv_id="session-test",
@@ -566,7 +566,10 @@ class TestStickyCreditRouterWorkerUnregistration:
         router._register_worker("worker-1")
         router._workers["worker-1"].active_sessions = 2
         router._workers["worker-1"].active_session_ids = {"session-1", "session-2"}
-        router._sticky_sessions = {"session-1": "worker-1", "session-2": "worker-1"}
+        router._sticky_sessions = {
+            "session-1": _StickyEntry(worker_id="worker-1"),
+            "session-2": _StickyEntry(worker_id="worker-1"),
+        }
 
         router._unregister_worker("worker-1")
 
@@ -811,7 +814,10 @@ class TestStickyCreditRouterMarkComplete:
         router._register_worker("worker-1")
         router._workers["worker-1"].active_sessions = 2
         router._workers["worker-1"].active_session_ids = {"s1", "s2"}
-        router._sticky_sessions = {"s1": "worker-1", "s2": "worker-1"}
+        router._sticky_sessions = {
+            "s1": _StickyEntry(worker_id="worker-1"),
+            "s2": _StickyEntry(worker_id="worker-1"),
+        }
 
         router.mark_credits_complete()
 
@@ -835,7 +841,7 @@ class TestStickyCreditRouterStickySessionReassignment:
         router._register_worker("worker-2")
 
         # Create sticky session to worker-1
-        router._sticky_sessions["session-X"] = "worker-1"
+        router._sticky_sessions["session-X"] = _StickyEntry(worker_id="worker-1")
 
         # Unregister worker-1
         router._unregister_worker("worker-1")
@@ -855,4 +861,245 @@ class TestStickyCreditRouterStickySessionReassignment:
         assert worker_id == "worker-2"
 
         # New sticky session should be created
-        assert router._sticky_sessions["session-X"] == "worker-2"
+        assert router._sticky_sessions["session-X"].worker_id == "worker-2"
+
+
+class TestStickyCreditRouterChildRoutingRefcount:
+    """Test register_child_routing / release_child_routing refcount lifecycle.
+
+    These are called by BranchOrchestrator before/after DAG child dispatch so
+    a parent's sticky entry survives past its own final turn until every
+    descendant child has terminated. The entry is evicted only when both
+    ref_count <= 0 AND the owning session's final turn has been seen.
+    """
+
+    def test_register_increments_refcount_on_existing_entry(
+        self, benchmark_run
+    ) -> None:
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._register_worker("worker-A")
+        router._sticky_sessions["parent-corr"] = _StickyEntry(worker_id="worker-A")
+
+        router.register_child_routing("parent-corr")
+        router.register_child_routing("parent-corr")
+
+        assert router._sticky_sessions["parent-corr"].ref_count == 3
+
+    def test_register_logs_warning_when_parent_has_no_entry(
+        self, benchmark_run, caplog
+    ) -> None:
+        """No entry for parent -> warn, no raise, no entry created."""
+        import logging
+
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        with caplog.at_level(logging.WARNING):
+            router.register_child_routing("missing-parent")
+        assert "missing-parent" in caplog.text
+        assert "missing-parent" not in router._sticky_sessions
+
+    def test_release_decrements_refcount_without_eviction_when_parent_not_final(
+        self, benchmark_run
+    ) -> None:
+        """ref_count drops but entry stays because parent_final_seen=False."""
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._register_worker("worker-A")
+        router._sticky_sessions["parent-corr"] = _StickyEntry(
+            worker_id="worker-A", ref_count=3, parent_final_seen=False
+        )
+
+        router.release_child_routing("parent-corr")
+
+        assert router._sticky_sessions["parent-corr"].ref_count == 2
+        assert "parent-corr" in router._sticky_sessions
+
+    def test_release_evicts_entry_only_when_refcount_zero_and_final_seen(
+        self, benchmark_run
+    ) -> None:
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._register_worker("worker-A")
+        router._workers["worker-A"].active_sessions = 1
+        router._workers["worker-A"].active_session_ids.add("parent-corr")
+        router._sticky_sessions["parent-corr"] = _StickyEntry(
+            worker_id="worker-A", ref_count=1, parent_final_seen=True
+        )
+
+        router.release_child_routing("parent-corr")
+
+        assert "parent-corr" not in router._sticky_sessions
+        assert router._workers["worker-A"].active_sessions == 0
+        assert "parent-corr" not in router._workers["worker-A"].active_session_ids
+
+    def test_release_keeps_entry_when_refcount_zero_but_final_not_seen(
+        self, benchmark_run
+    ) -> None:
+        """Parent still has turns to send -> don't evict even at ref_count<=0."""
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._register_worker("worker-A")
+        router._sticky_sessions["parent-corr"] = _StickyEntry(
+            worker_id="worker-A", ref_count=1, parent_final_seen=False
+        )
+
+        router.release_child_routing("parent-corr")
+
+        assert "parent-corr" in router._sticky_sessions
+        assert router._sticky_sessions["parent-corr"].ref_count == 0
+
+    def test_release_is_noop_when_parent_corr_not_in_sticky_sessions(
+        self, benchmark_run
+    ) -> None:
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router.release_child_routing("never-registered")  # must not raise
+
+
+class TestStickyCreditRouterSendCreditFinalTurnLifecycle:
+    """Exercise the send_credit final-turn lifecycle paths the entry-skip
+    optimization touches.
+
+    The optimization (commit message: "drop wasted 2nd dict.get on single-turn
+    root credits") changed the lifecycle gate from ``entry = sticky_entry or
+    self._sticky_sessions.get(routing_key)`` to a direct ``sticky_entry is
+    not None`` check. Cases below cover every branch of the gate.
+    """
+
+    async def test_single_turn_root_no_forks_creates_no_entry(
+        self, benchmark_run
+    ) -> None:
+        """The dominant non-DAG single-turn workload: no entry should ever be
+        created, so the final-turn lifecycle block must be a no-op without
+        triggering a second dict.get."""
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._router_client.send_to = AsyncMock()
+        router._register_worker("worker-A")
+
+        credit = Credit(
+            id=1,
+            phase=CreditPhase.PROFILING,
+            conversation_id="single-turn-conv",
+            x_correlation_id="root-corr-1",
+            turn_index=0,
+            num_turns=1,  # single-turn => is_final_turn=True
+            issued_at_ns=1,
+            parent_correlation_id=None,
+            has_forks=False,
+        )
+        assert credit.is_final_turn is True
+
+        await router.send_credit(credit)
+
+        assert router._sticky_sessions == {}
+        assert router._workers["worker-A"].active_sessions == 0
+
+    async def test_final_turn_with_forks_creates_entry_and_keeps_it(
+        self, benchmark_run
+    ) -> None:
+        """When the parent's final turn declares DAG spawns, the entry must
+        be created AND survive so register_child_routing can find it. The
+        decrement happens, but the pop is suppressed by `not has_forks`."""
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._router_client.send_to = AsyncMock()
+        router._register_worker("worker-A")
+
+        credit = Credit(
+            id=1,
+            phase=CreditPhase.PROFILING,
+            conversation_id="forking-root",
+            x_correlation_id="root-corr-fork",
+            turn_index=0,
+            num_turns=1,
+            issued_at_ns=1,
+            parent_correlation_id=None,
+            has_forks=True,
+        )
+        assert credit.is_final_turn is True
+
+        await router.send_credit(credit)
+
+        entry = router._sticky_sessions["root-corr-fork"]
+        assert entry.worker_id == "worker-A"
+        assert entry.parent_final_seen is True
+        assert entry.ref_count == 0  # decremented but not popped
+        # active_sessions was incremented at creation and not decremented (no pop).
+        assert router._workers["worker-A"].active_sessions == 1
+        assert "root-corr-fork" in router._workers["worker-A"].active_session_ids
+
+    async def test_dag_child_final_turn_does_not_touch_parent_entry(
+        self, benchmark_run
+    ) -> None:
+        """A DAG child's final-turn return must never decrement the parent's
+        ref_count or flip parent_final_seen — release_child_routing owns that
+        lifecycle. The send_credit lifecycle block must short-circuit on
+        parent_correlation_id."""
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._router_client.send_to = AsyncMock()
+        router._register_worker("worker-A")
+
+        # Pre-create the parent's sticky entry with refcount bumped by a
+        # prior register_child_routing.
+        router._sticky_sessions["parent-corr"] = _StickyEntry(
+            worker_id="worker-A", ref_count=2, parent_final_seen=True
+        )
+        router._workers["worker-A"].active_sessions = 1
+        router._workers["worker-A"].active_session_ids.add("parent-corr")
+
+        child_credit = Credit(
+            id=2,
+            phase=CreditPhase.PROFILING,
+            conversation_id="child-conv",
+            x_correlation_id="child-corr",
+            turn_index=0,
+            num_turns=1,
+            issued_at_ns=2,
+            parent_correlation_id="parent-corr",  # pins to parent's worker
+            has_forks=False,
+        )
+
+        await router.send_credit(child_credit)
+
+        # Routed to the parent's worker via the sticky entry.
+        assert router._router_client.send_to.call_args[0][0] == "worker-A"
+
+        # Parent entry untouched: ref_count still 2, parent_final_seen still True.
+        parent_entry = router._sticky_sessions["parent-corr"]
+        assert parent_entry.ref_count == 2
+        assert parent_entry.parent_final_seen is True
+        # No spurious child entry created under the child's own corr_id.
+        assert "child-corr" not in router._sticky_sessions
+
+    async def test_multi_turn_final_turn_pops_entry_when_no_forks(
+        self, benchmark_run
+    ) -> None:
+        """The canonical multi-turn session: entry created on turn 0,
+        decremented + popped on the final turn when ref_count drops to 0
+        and there are no DAG forks. Validates the optimization didn't
+        regress the established eviction path."""
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._router_client.send_to = AsyncMock()
+        router._register_worker("worker-A")
+
+        # Turn 0 of a 3-turn session: creates the entry.
+        turn0 = Credit(
+            id=1,
+            phase=CreditPhase.PROFILING,
+            conversation_id="mt",
+            x_correlation_id="mt-corr",
+            turn_index=0,
+            num_turns=3,
+            issued_at_ns=1,
+        )
+        await router.send_credit(turn0)
+        assert "mt-corr" in router._sticky_sessions
+        assert router._workers["worker-A"].active_sessions == 1
+
+        # Final turn: pop expected.
+        turn2 = Credit(
+            id=3,
+            phase=CreditPhase.PROFILING,
+            conversation_id="mt",
+            x_correlation_id="mt-corr",
+            turn_index=2,
+            num_turns=3,
+            issued_at_ns=3,
+        )
+        await router.send_credit(turn2)
+        assert "mt-corr" not in router._sticky_sessions
+        assert router._workers["worker-A"].active_sessions == 0

--- a/tests/unit/timing/test_race_conditions.py
+++ b/tests/unit/timing/test_race_conditions.py
@@ -391,7 +391,7 @@ class TestStickySessionRace:
             )
         )
         w0 = r._router_client.send_to.call_args[0][0]
-        assert r._sticky_sessions[xcid] == w0
+        assert r._sticky_sessions[xcid].worker_id == w0
         r._cancellation_pending = True
         r._unregister_worker(w0)
         r._min_load = 10

--- a/tools/ergonomics_baseline.json
+++ b/tools/ergonomics_baseline.json
@@ -373,6 +373,11 @@
     ],
     [
       "function-size",
+      "src/aiperf/credit/sticky_router.py",
+      "StickyCreditRouter.send_credit"
+    ],
+    [
+      "function-size",
       "src/aiperf/dataset/agentic_code_gen/reporting/comparison.py",
       "render_comparison_text"
     ],

--- a/tools/ruff_baseline.json
+++ b/tools/ruff_baseline.json
@@ -812,6 +812,11 @@
     ],
     [
       "C901",
+      "src/aiperf/credit/sticky_router.py",
+      "StickyCreditRouter.send_credit"
+    ],
+    [
+      "C901",
       "src/aiperf/common/tokenizer_validator.py",
       "preload_tokenizers"
     ],
@@ -1229,6 +1234,11 @@
       "PLR0912",
       "src/aiperf/common/tokenizer_validator.py",
       "preload_tokenizers"
+    ],
+    [
+      "PLR0912",
+      "src/aiperf/credit/sticky_router.py",
+      "StickyCreditRouter.send_credit"
     ],
     [
       "PLR0912",


### PR DESCRIPTION
## Summary

- **Fixes a latent `AttributeError`** in main's DAG runtime: `BranchOrchestrator` calls `self._sticky_router.register_child_routing(...)` and `release_child_routing(...)` at five sites (`_branch_orchestrator_spawn.py:197,257`, `branch_orchestrator.py:391,455,467`) but those methods were never defined on `StickyCreditRouter`. Test suites mock them so CI is green — the moment a real FORK-mode DAG runs in prod, the orchestrator raises `AttributeError` at the first child dispatch.
- Refactors `_sticky_sessions` from `dict[str, str]` to `dict[str, _StickyEntry]` so the parent's sticky binding can outlive its own final turn while DAG children pinning to its worker are still in-flight (`ref_count` + `parent_final_seen` lifecycle).
- Adds a `subagent_type: str \| None` field on `ConversationBranchInfo` (SPAWN-only) so loaders can pass through upstream-recorded values like `"Explore"` or `"Codex Subagent"` verbatim without enum-narrowing.
- Optimizes `send_credit`: the dominant single-turn-root-no-forks workload (most AIPerf benchmarks) no longer pays an extra `dict.get` per credit — the final-turn lifecycle gates on `sticky_entry is not None` directly instead of falling back to a second dict lookup.

## Hot-path impact

Hot-path performance was a deliberate constraint (per the `StickyCreditRouter` docstring: *"Methods are intentionally large/inlined to avoid function call overhead"*). Per-credit cost analysis:

- **Sticky-hit common case**: +1 attribute deref (`sticky_entry.worker_id`), +1 `or`-eval on routing key. ~15-25ns. Below noise at typical AIPerf throughputs.
- **Single-turn root no-forks (dominant non-DAG workload)**: no `_StickyEntry` allocation, no second `dict.get` (thanks to the optimization). Effectively unchanged from main.
- **Session creation (cold-ish)**: `_StickyEntry(slots=True)` allocation instead of `dict[k] = str`. ~200ns added, once per multi-turn session.
- **Atomicity invariant preserved**: zero new `await`s in `send_credit`.

## Lifecycle (new semantics)

```
                                       parent_correlation_id?  is_final_turn?  has_forks?
                                       ───────────────────────  ──────────────  ──────────
Single-turn root, no forks              None                    True            False     → no entry created, no allocation
Single-turn root, declares spawns       None                    True            True      → entry created + survives (register_child_routing finds it)
Multi-turn root (any non-final turn)    None                    False           any       → entry created/reused
Multi-turn root, final turn, no forks   None                    True            False     → entry decremented + popped
DAG child credit                        set                     any             any       → pins to parent's worker via routing_key, lifecycle block skipped
```

`register_child_routing(parent_corr)` increments refcount; logs a warning if the parent has no entry (graceful degradation — child routes via least-loaded, loses prefix-cache locality but stays correct).

`release_child_routing(parent_corr)` decrements refcount; evicts the entry only when both `ref_count <= 0` AND `parent_final_seen`.

## subagent_type field

Added because the Weka kv-cache-tester trace schema already carries `subagent_type: str` per recorded subagent (real corpus values: `"Explore"`, `"Codex Subagent"`, etc. — free-form, set by upstream Claude Code proxy). Typing the new aiperf-side field as `str \| None` rather than a narrow enum lets loaders pass these through verbatim without filter/map logic and without rejecting new agent types as corpora evolve.

The field validator still enforces the SPAWN-only invariant (FORK children inherit the parent's role, so they have no separate classification).

## Test plan

- [x] `tests/unit/credit/test_sticky_router.py::TestStickyCreditRouterChildRoutingRefcount` (6 tests): register/release refcount semantics, eviction conditions, missing-parent warning, no-op-on-unknown-parent.
- [x] `tests/unit/credit/test_sticky_router.py::TestStickyCreditRouterSendCreditFinalTurnLifecycle` (4 tests): single-turn root no-forks (no entry created), final turn with forks (entry survives for `register_child_routing`), DAG-child final turn (parent untouched), multi-turn final turn (entry popped on no-forks).
- [x] `tests/unit/common/models/test_branch_model.py::TestConversationBranchInfoSubagentType` (6 tests): SPAWN accepts `"Explore"` and arbitrary `"Codex Subagent"`, FORK rejects non-None, round-trip.
- [x] Full unit suite: **12,689 passed**, 79 skipped, 0 failed.
- [x] Component integration (DAG + sticky-routing): `test_dag_adversarial_timing_modes`, `test_dag_combined_pathology`, `test_sticky_routing` — **64 passed**.
- [x] `pre-commit run --files <touched>` clean.
- [ ] Real FORK-DAG benchmark run (any reviewer with hardware): verify the orchestrator no longer raises `AttributeError` on child dispatch.

## Guardrails

`StickyCreditRouter.send_credit` grandfathered in `tools/ergonomics_baseline.json` (function-size 90 > 80) and `tools/ruff_baseline.json` (C901 cyclomatic 12 > 10, PLR0912 branches 13 > 12). The hot path is intentionally inlined per the class docstring; extracting helpers would add per-credit function-call overhead. Baseline additions restricted to exactly these two new entries; unrelated stale entries left untouched.

## Related branches

- `ajc/dag4` (1 commit ahead of main, dated May) had an earlier version of this fix bundled with the Weka loader stack and a narrow `SubagentType` enum — appears abandoned, no merges from main since.
- `ajc/dag5` (17 commits ahead of main, actively being worked) is the successor of PR #891 and still carries the same latent `AttributeError`. Happy to retarget this PR onto `dag5` if you'd prefer to fold the fix into that review cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional `subagent_type` specification in conversation branches for improved branch configuration.
  * Enhanced routing system with reference counting to better manage child session lifecycles in multi-branch conversations.
  * Introduced methods for managing child session routing registration and release.

* **Tests**
  * Added validation tests for branch configuration constraints.
  * Expanded routing tests for complex session lifecycle scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->