### PR TITLE
feat(cache-bust): CacheBustTarget plumbing through config / credit / session / orchestrator (PR-A)

### DIFF
--- a/src/aiperf/common/enums/__init__.py
+++ b/src/aiperf/common/enums/__init__.py
@@ -9,6 +9,7 @@ from aiperf.common.enums.base_enums import (
 from aiperf.common.enums.enums import (
     AIPerfLogLevel,
     AudioFormat,
+    CacheBustTarget,
     CommAddress,
     CommandResponseStatus,
     CommandType,
@@ -82,6 +83,7 @@ from aiperf.plugin.enums import DatasetFormat
 __all__ = [
     "AIPerfLogLevel",
     "AudioFormat",
+    "CacheBustTarget",
     "BaseMetricUnit",
     "BaseMetricUnitInfo",
     "BasePydanticBackedStrEnum",

--- a/src/aiperf/common/enums/enums.py
+++ b/src/aiperf/common/enums/enums.py
@@ -46,6 +46,21 @@ class AudioFormat(CaseInsensitiveStrEnum):
     """MP3 format. Compressed audio, smaller file sizes, good quality."""
 
 
+class CacheBustTarget(CaseInsensitiveStrEnum):
+    """Where (and how) to inject a per-conversation cache-bust marker.
+
+    Prefix variants diverge at token 0 of the prompt (most aggressive — defeats
+    KV-cache prefix matching for the entire prompt). Suffix variants append
+    after existing content (preserves leading-prefix caching).
+    """
+
+    NONE = "none"
+    SYSTEM_PREFIX = "system_prefix"
+    SYSTEM_SUFFIX = "system_suffix"
+    FIRST_TURN_PREFIX = "first_turn_prefix"
+    FIRST_TURN_SUFFIX = "first_turn_suffix"
+
+
 class CommAddress(CaseInsensitiveStrEnum):
     """Enum for specifying the address type for communication clients.
     This is used to lookup the address in the communication config."""

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -22,7 +22,12 @@ from pydantic.functional_validators import AfterValidator
 
 from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.common.constants import STAT_KEYS
-from aiperf.common.enums import CreditPhase, MetricValueTypeT, SSEFieldType
+from aiperf.common.enums import (
+    CacheBustTarget,
+    CreditPhase,
+    MetricValueTypeT,
+    SSEFieldType,
+)
 from aiperf.common.exceptions import InvalidInferenceResultError
 from aiperf.common.models.base_models import AIPerfBaseModel
 from aiperf.common.models.branch_stats import BranchStats
@@ -592,6 +597,23 @@ class RecordContext(AIPerfBaseModel):
         description="``audio_duration_seconds`` from the originating turn. Populated at "
         "record-enrichment time so the record processor reads it directly off the record without "
         "the full ``turns`` list on the wire. None for non-ASR requests.",
+    )
+
+    # --- Cache-bust marker (sourced from Credit, exported in raw JSONL) -------
+
+    cache_bust_marker: str | None = Field(
+        default=None,
+        description="Pre-rendered cache-bust marker text for this request, "
+        "sourced from ``Credit.cache_bust_marker``. Already includes whitespace "
+        "boundaries. None when the cache-bust feature is disabled or no marker "
+        "applied to this request. Exported in the raw JSONL so a replay tool "
+        "can correlate the inserted bytes with the originating session.",
+    )
+    cache_bust_target: CacheBustTarget | None = Field(
+        default=None,
+        description="Where the marker was injected for this request, sourced "
+        "from ``Credit.cache_bust_target``. None when cache-bust is disabled. "
+        "Pairs with ``cache_bust_marker`` for raw-JSONL provenance.",
     )
 
     # --- Records-pipeline reads (read by inference_result_parser, raw_record_writer) ----
@@ -1203,6 +1225,20 @@ class MetricRecordInfo(AIPerfBaseModel):
     error: ErrorDetails | None = Field(
         default=None,
         description="The error details if the request failed.",
+    )
+    cache_bust_marker: str | None = Field(
+        default=None,
+        description="Cache-bust marker text injected into the wire payload for "
+        "this request, copied from the originating ``Credit``. None when the "
+        "cache-bust feature is disabled. Surfaced here so raw-JSONL consumers "
+        "can correlate inserted bytes with the originating session without "
+        "re-parsing ``payload``.",
+    )
+    cache_bust_target: CacheBustTarget | None = Field(
+        default=None,
+        description="Where the marker was injected (``system_prefix``, "
+        "``system_suffix``, ``first_turn_prefix``, or ``first_turn_suffix``). "
+        "None when cache-bust is disabled.",
     )
 
 

--- a/src/aiperf/config/dataset/__init__.py
+++ b/src/aiperf/config/dataset/__init__.py
@@ -14,6 +14,7 @@ from aiperf.config.dataset.config import (
 )
 from aiperf.config.dataset.content import (
     AudioConfig,
+    CacheBustConfig,
     ImageConfig,
     PrefixPromptConfig,
     PromptConfig,
@@ -30,6 +31,7 @@ from aiperf.config.dataset.video import (
 __all__ = [
     "VIDEO_AUDIO_CODEC_MAP",
     "AudioConfig",
+    "CacheBustConfig",
     "DatasetConfig",
     "DatasetResolver",
     "FileDataset",

--- a/src/aiperf/config/dataset/content.py
+++ b/src/aiperf/config/dataset/content.py
@@ -25,6 +25,7 @@ from typing_extensions import Self
 
 from aiperf.common.enums import (
     AudioFormat,
+    CacheBustTarget,
     ImageFormat,
     ImageSource,
 )
@@ -54,6 +55,36 @@ def _parse_image_source(value: object) -> object:
         except ValueError:
             return Path(value).expanduser()
     return value
+
+
+class CacheBustConfig(BaseConfig):
+    """Per-conversation cache-bust marker injected into the prompt.
+
+    Prefix variants diverge at token 0 (defeats KV-cache prefix matching for
+    the entire prompt — recommended when a large shared system prompt would
+    otherwise produce inflated cache-hit rates). Suffix variants append after
+    existing content (lighter bust; preserves leading-prefix caching).
+
+    The marker is deterministic from (benchmark_id, recycle_pass,
+    trajectory_index, trace_id) and is identical across reruns. The same
+    marker is used for all turns within a conversation; a fresh marker is
+    minted on each recycle of a trace_id.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target: Annotated[
+        CacheBustTarget,
+        Field(
+            default=CacheBustTarget.NONE,
+            description=(
+                "Where (and how) to inject a per-conversation cache-bust marker. "
+                "Prefix variants prepend at token 0 (most aggressive); "
+                "suffix variants append after existing content. "
+                "'none' disables the feature (default)."
+            ),
+        ),
+    ]
 
 
 class PromptConfig(BaseConfig):
@@ -122,6 +153,18 @@ class PromptConfig(BaseConfig):
             "Each entry specifies {isl, osl, probability}. "
             "Probabilities are percentages (0-100) and must sum to 100. "
             "When specified, requests are sampled from this distribution instead of using isl/osl fields.",
+        ),
+    ]
+
+    cache_bust: Annotated[
+        CacheBustConfig,
+        Field(
+            default_factory=CacheBustConfig,
+            description=(
+                "Per-conversation cache-bust marker configuration. "
+                "Defaults to disabled (target='none'). See CacheBustConfig for "
+                "the prefix vs suffix and system vs first-turn placement options."
+            ),
         ),
     ]
 

--- a/src/aiperf/config/schema/aiperf-config.schema.json
+++ b/src/aiperf/config/schema/aiperf-config.schema.json
@@ -4900,6 +4900,31 @@
         }
       ]
     },
+    "CacheBustConfig": {
+      "additionalProperties": false,
+      "description": "Per-conversation cache-bust marker injected into the prompt.\n\nPrefix variants diverge at token 0 (defeats KV-cache prefix matching for\nthe entire prompt — recommended when a large shared system prompt would\notherwise produce inflated cache-hit rates). Suffix variants append after\nexisting content (lighter bust; preserves leading-prefix caching).\n\nThe marker is deterministic from (benchmark_id, recycle_pass,\ntrajectory_index, trace_id) and is identical across reruns. The same\nmarker is used for all turns within a conversation; a fresh marker is\nminted on each recycle of a trace_id.",
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/CacheBustTarget",
+          "default": "none",
+          "description": "Where (and how) to inject a per-conversation cache-bust marker. Prefix variants prepend at token 0 (most aggressive); suffix variants append after existing content. 'none' disables the feature (default)."
+        }
+      },
+      "title": "CacheBustConfig",
+      "type": "object"
+    },
+    "CacheBustTarget": {
+      "description": "Where (and how) to inject a per-conversation cache-bust marker.\n\nPrefix variants diverge at token 0 of the prompt (most aggressive — defeats\nKV-cache prefix matching for the entire prompt). Suffix variants append\nafter existing content (preserves leading-prefix caching).",
+      "enum": [
+        "none",
+        "system_prefix",
+        "system_suffix",
+        "first_turn_prefix",
+        "first_turn_suffix"
+      ],
+      "title": "CacheBustTarget",
+      "type": "string"
+    },
     "CancellationConfig": {
       "additionalProperties": false,
       "description": "Configuration for request cancellation testing.\n\nEnables testing server behavior when clients cancel requests mid-flight.",
@@ -9324,6 +9349,10 @@
           "default": null,
           "description": "Distribution of (ISL, OSL) pairs with probabilities for mixed workload simulation. Each entry specifies {isl, osl, probability}. Probabilities are percentages (0-100) and must sum to 100. When specified, requests are sampled from this distribution instead of using isl/osl fields.",
           "title": "Sequencedistribution"
+        },
+        "cacheBust": {
+          "$ref": "#/$defs/CacheBustConfig",
+          "description": "Per-conversation cache-bust marker configuration. Defaults to disabled (target='none'). See CacheBustConfig for the prefix vs suffix and system vs first-turn placement options."
         }
       },
       "title": "PromptConfig",

--- a/src/aiperf/credit/structs.py
+++ b/src/aiperf/credit/structs.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from msgspec import Struct
 from typing_extensions import Self
 
-from aiperf.common.enums import ConversationBranchMode, CreditPhase
+from aiperf.common.enums import CacheBustTarget, ConversationBranchMode, CreditPhase
 
 if TYPE_CHECKING:
     from aiperf.common.models.dataset_models import TurnMetadata
@@ -70,6 +70,13 @@ class Credit(
     (i.e. for root sessions). FORK = inherit parent turn_list; SPAWN =
     fresh context. Default FORK keeps wire footprint small via msgspec omit_defaults."""
 
+    cache_bust_marker: str | None = None
+    """Pre-rendered cache-bust marker text (already includes whitespace boundaries).
+    None when the cache-bust feature is disabled."""
+
+    cache_bust_target: CacheBustTarget = CacheBustTarget.NONE
+    """Where (and how) to inject `cache_bust_marker` at request-build time."""
+
     @property
     def is_final_turn(self) -> bool:
         return self.turn_index == self.num_turns - 1
@@ -127,6 +134,13 @@ class TurnToSend(Struct, frozen=True):
     has_forks: bool = False
     branch_mode: ConversationBranchMode = ConversationBranchMode.FORK
 
+    cache_bust_marker: str | None = None
+    """Pre-rendered cache-bust marker text (already includes whitespace boundaries).
+    None when the cache-bust feature is disabled."""
+
+    cache_bust_target: CacheBustTarget = CacheBustTarget.NONE
+    """Where (and how) to inject `cache_bust_marker` at request-build time."""
+
     @property
     def is_final_turn(self) -> bool:
         return self.turn_index == self.num_turns - 1
@@ -152,4 +166,6 @@ class TurnToSend(Struct, frozen=True):
             parent_correlation_id=credit.parent_correlation_id,
             has_forks=next_meta.has_forks if next_meta is not None else False,
             branch_mode=credit.branch_mode,
+            cache_bust_marker=credit.cache_bust_marker,
+            cache_bust_target=credit.cache_bust_target,
         )

--- a/src/aiperf/timing/_branch_orchestrator_spawn.py
+++ b/src/aiperf/timing/_branch_orchestrator_spawn.py
@@ -181,6 +181,7 @@ class BranchOrchestratorSpawnMixin:
                 child_conversation_id=child_conv_id,
                 agent_depth=parent_depth + 1,
                 branch_mode=branch.mode,
+                cache_bust_marker=self._mint_child_marker(child_conv_id),
             )
         except Exception:
             logger.exception("start_branch_child failed for %s", child_conv_id)

--- a/src/aiperf/timing/branch_orchestrator.py
+++ b/src/aiperf/timing/branch_orchestrator.py
@@ -12,7 +12,7 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from aiperf.common.enums import ConversationBranchMode
+from aiperf.common.enums import CacheBustTarget, ConversationBranchMode
 from aiperf.common.environment import Environment
 from aiperf.common.models.branch_stats import BranchStats
 from aiperf.timing._branch_orchestrator_drain import BranchOrchestratorDrainMixin
@@ -84,11 +84,13 @@ class BranchOrchestrator(
         sticky_router: StickyCreditRouter | None = None,
         *,
         benchmark_id: str = "unknown",
+        cache_bust_target: CacheBustTarget = CacheBustTarget.NONE,
     ) -> None:
         self._cs = conversation_source
         self._issuer = credit_issuer
         self._sticky_router = sticky_router
         self._benchmark_id = benchmark_id
+        self._cache_bust_target = cache_bust_target
         self._child_modes: dict[str, ConversationBranchMode] = {}
         # Two-level pending-join state: a "future" join is registered at
         # spawn time and promoted to "active" once the parent reaches the
@@ -124,6 +126,27 @@ class BranchOrchestrator(
         if credit.turn_index >= len(meta.turns):
             return []
         return list(meta.turns[credit.turn_index].branch_ids)
+
+    def _mint_child_marker(self, child_conversation_id: str) -> str | None:
+        """Mint a unique cache-bust marker for a SPAWN child session.
+
+        Children get their own marker (distinct from the parent's) so two
+        subagents in different traces never share a server-side KV-cache
+        prefix. Digest input ``trace_id=child_conversation_id`` already
+        encodes ``parent_trace::sa:agent_id`` so collision-free per child.
+        Returns None when cache-bust is disabled (target=NONE).
+        """
+        from aiperf.timing.strategies.cache_bust import build_cache_bust_marker
+
+        if self._cache_bust_target == CacheBustTarget.NONE:
+            return None
+        return build_cache_bust_marker(
+            self._benchmark_id,
+            0,
+            0,
+            child_conversation_id,
+            target=self._cache_bust_target,
+        )
 
     async def dispatch_pre_session_branches(self) -> None:
         """Pre-dispatch background SPAWN children marked dispatch_timing='pre'.

--- a/src/aiperf/timing/conversation_source.py
+++ b/src/aiperf/timing/conversation_source.py
@@ -18,7 +18,7 @@ Terminology:
 import uuid
 from dataclasses import dataclass
 
-from aiperf.common.enums import ConversationBranchMode
+from aiperf.common.enums import CacheBustTarget, ConversationBranchMode
 from aiperf.common.models import ConversationMetadata, DatasetMetadata, TurnMetadata
 from aiperf.credit.structs import Credit, TurnToSend
 from aiperf.dataset.protocols import DatasetSamplingStrategyProtocol
@@ -46,6 +46,15 @@ class SampledSession:
             parent's accumulated message history and pins to the same worker;
             SPAWN starts with a fresh context. Ignored when
             parent_correlation_id is None.
+        cache_bust_marker: Pre-rendered per-session cache-bust marker text
+            (already includes whitespace boundaries). Minted by the caller
+            (e.g. BranchOrchestrator) for SPAWN children so each subagent
+            context gets its own unique server-side prefix and can't share
+            cached prefix with siblings or unrelated subagents. None when the
+            cache-bust feature is disabled.
+        cache_bust_target: Where to inject ``cache_bust_marker`` at
+            request-build time. Mirrors the CLI knob; ``CacheBustTarget.NONE``
+            when the feature is disabled.
     """
 
     conversation_id: str
@@ -54,6 +63,8 @@ class SampledSession:
     agent_depth: int = 0
     parent_correlation_id: str | None = None
     branch_mode: ConversationBranchMode = ConversationBranchMode.FORK
+    cache_bust_marker: str | None = None
+    cache_bust_target: CacheBustTarget = CacheBustTarget.NONE
 
     @property
     def routing_key(self) -> str:
@@ -82,6 +93,8 @@ class SampledSession:
             parent_correlation_id=self.parent_correlation_id,
             has_forks=first_meta.has_forks if first_meta is not None else False,
             branch_mode=self.branch_mode,
+            cache_bust_marker=self.cache_bust_marker,
+            cache_bust_target=self.cache_bust_target,
         )
 
 
@@ -133,6 +146,8 @@ class ConversationSource:
         agent_depth: int,
         *,
         branch_mode: ConversationBranchMode = ConversationBranchMode.FORK,
+        cache_bust_marker: str | None = None,
+        cache_bust_target: CacheBustTarget = CacheBustTarget.NONE,
     ) -> SampledSession:
         """Build a SampledSession for a DAG child conversation.
 
@@ -143,6 +158,11 @@ class ConversationSource:
         SPAWN-mode children start with a fresh context, but the sticky pin to
         the parent's correlation_id is preserved at this layer — routing
         freedom is enforced upstream by the orchestrator/router.
+
+        ``cache_bust_marker`` / ``cache_bust_target`` are minted by the caller
+        (BranchOrchestrator) so each SPAWN child gets its own unique marker —
+        preventing two subagents in different traces from sharing a server
+        KV-cache prefix and inflating hit-rates artificially.
         """
         metadata = self._metadata_lookup[child_conversation_id]
         return SampledSession(
@@ -152,11 +172,15 @@ class ConversationSource:
             agent_depth=agent_depth,
             parent_correlation_id=parent_correlation_id,
             branch_mode=branch_mode,
+            cache_bust_marker=cache_bust_marker,
+            cache_bust_target=cache_bust_target,
         )
 
     def start_pre_session_child(
         self,
         child_conversation_id: str,
+        cache_bust_marker: str | None = None,
+        cache_bust_target: CacheBustTarget = CacheBustTarget.NONE,
     ) -> SampledSession:
         """Build a SampledSession for a pre-session (turn-0) background SPAWN child.
 
@@ -170,6 +194,10 @@ class ConversationSource:
         Restricted to SPAWN mode with ``dispatch_timing="pre"`` at the validator
         level; FORK pre-dispatch would require inheriting a non-existent
         parent session and is rejected at load time.
+
+        ``cache_bust_marker`` / ``cache_bust_target`` are minted by the caller
+        so background SPAWN children get the same per-session unique-marker
+        treatment as parents.
         """
         metadata = self._metadata_lookup[child_conversation_id]
         return SampledSession(
@@ -179,6 +207,8 @@ class ConversationSource:
             agent_depth=1,
             parent_correlation_id=None,
             branch_mode=ConversationBranchMode.SPAWN,
+            cache_bust_marker=cache_bust_marker,
+            cache_bust_target=cache_bust_target,
         )
 
     def get_next_turn_metadata(self, credit: Credit) -> TurnMetadata:

--- a/src/aiperf/timing/strategies/cache_bust.py
+++ b/src/aiperf/timing/strategies/cache_bust.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic per-conversation cache-bust marker builder.
+
+Same (benchmark_id, recycle_pass, trajectory_index, trace_id) always yields
+the same digest - reproducible across reruns. Position controls whitespace
+placement, not the digest itself.
+
+Adding ``trace_id`` to the four-dimensional digest input ensures every
+(recycle_pass, lane, trace) combination is unique by construction. Without
+``trace_id``, two different traces landing on the same ``(recycle_pass, lane)``
+tuple at different points in time would produce the same marker — empirically
+a 33% collision rate at MVP scale.
+"""
+
+import hashlib
+from typing import Protocol
+
+from aiperf.common.enums import CacheBustTarget
+
+_DIGEST_LEN = 12  # 12 hex chars = 48 bits, ample for in-run uniqueness
+
+_MARKER_TOKEN_SAMPLES = 8
+
+
+class _EncodeOnly(Protocol):
+    def encode(self, text: str, **kwargs) -> list[int]: ...
+
+
+def build_cache_bust_marker(
+    benchmark_id: str,
+    recycle_pass: int,
+    trajectory_index: int,
+    trace_id: str,
+    *,
+    target: CacheBustTarget,
+) -> str | None:
+    """Render the marker text for the given inputs and target position.
+
+    The digest tuple is intentionally phase-agnostic. Spec requires
+    "warmup-coherent" markers: a trajectory's warmup turn ``k_i`` and its
+    first profiling turn ``k_i+1`` must share the same marker so warmup
+    KV-cache work transfers to profiling. Adding phase to the digest
+    would defeat that — keep it out.
+
+    Returns ``None`` when target is NONE so callers can unconditionally pass
+    the result through into ``Credit.cache_bust_marker: str | None``. Returning
+    ``""`` would introduce a third "no marker" value distinct from ``None``.
+    """
+    if target == CacheBustTarget.NONE:
+        return None
+
+    unique_str = f"{benchmark_id}:{recycle_pass}:{trajectory_index}:{trace_id}"
+    digest = hashlib.sha256(unique_str.encode()).hexdigest()[:_DIGEST_LEN]
+    rid = f"[rid:{digest}]"
+
+    if target in (CacheBustTarget.SYSTEM_PREFIX, CacheBustTarget.FIRST_TURN_PREFIX):
+        return f"{rid}\n\n"
+    return f"\n\n{rid}"
+
+
+def estimate_marker_token_cost(
+    target: CacheBustTarget,
+    tokenizer: _EncodeOnly,
+    samples: int = _MARKER_TOKEN_SAMPLES,
+) -> int:
+    """Average token count of the cache-bust marker for a given target.
+
+    Tokenizes ``samples`` distinct markers and rounds the mean to an int.
+    Returns 0 for ``CacheBustTarget.NONE``. The 12-hex digest dominates
+    the variance, so a handful of samples is enough.
+    """
+    if target == CacheBustTarget.NONE:
+        return 0
+
+    total = 0
+    for i in range(samples):
+        marker = build_cache_bust_marker(
+            benchmark_id="estimator",
+            recycle_pass=i,
+            trajectory_index=i,
+            trace_id=f"estimator-{i}",
+            target=target,
+        )
+        total += len(tokenizer.encode(marker))
+    return round(total / samples)

--- a/tests/unit/common/config/test_cache_bust_config.py
+++ b/tests/unit/common/config/test_cache_bust_config.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``CacheBustConfig`` on ``PromptConfig``.
+
+Coverage:
+
+- Default ``target`` is ``CacheBustTarget.NONE``.
+- ``PromptConfig`` constructs with the default empty ``CacheBustConfig``.
+- Every ``CacheBustTarget`` value (other than NONE) round-trips through
+  ``CacheBustConfig`` construction.
+- Invalid string values are rejected.
+- ``model_dump_json`` -> ``model_validate_json`` round-trip preserves the
+  configured target.
+- Nested ``cache_bust`` block under ``PromptConfig`` survives a JSON round-trip
+  via the camelCase alias generator.
+"""
+
+from __future__ import annotations
+
+import orjson
+import pytest
+from pydantic import ValidationError
+
+from aiperf.common.enums import CacheBustTarget
+from aiperf.config.dataset.content import CacheBustConfig, PromptConfig
+
+
+class TestCacheBustConfigDefaults:
+    def test_default_target_is_none(self) -> None:
+        cfg = CacheBustConfig()
+        assert cfg.target == CacheBustTarget.NONE
+
+    def test_prompt_config_has_default_cache_bust_block(self) -> None:
+        prompt = PromptConfig()
+        assert isinstance(prompt.cache_bust, CacheBustConfig)
+        assert prompt.cache_bust.target == CacheBustTarget.NONE
+
+
+class TestCacheBustConfigValid:
+    @pytest.mark.parametrize(
+        "target",
+        [
+            CacheBustTarget.NONE,
+            CacheBustTarget.SYSTEM_PREFIX,
+            CacheBustTarget.SYSTEM_SUFFIX,
+            CacheBustTarget.FIRST_TURN_PREFIX,
+            CacheBustTarget.FIRST_TURN_SUFFIX,
+        ],
+    )
+    def test_construct_from_enum_member(self, target: CacheBustTarget) -> None:
+        cfg = CacheBustConfig(target=target)
+        assert cfg.target == target
+
+    @pytest.mark.parametrize(
+        "target_str,expected",
+        [
+            ("none", CacheBustTarget.NONE),
+            ("system_prefix", CacheBustTarget.SYSTEM_PREFIX),
+            ("system_suffix", CacheBustTarget.SYSTEM_SUFFIX),
+            ("first_turn_prefix", CacheBustTarget.FIRST_TURN_PREFIX),
+            ("first_turn_suffix", CacheBustTarget.FIRST_TURN_SUFFIX),
+        ],
+    )
+    def test_construct_from_string(
+        self, target_str: str, expected: CacheBustTarget
+    ) -> None:
+        cfg = CacheBustConfig(target=target_str)
+        assert cfg.target == expected
+
+
+class TestCacheBustConfigInvalid:
+    def test_unknown_target_string_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CacheBustConfig(target="not_a_real_target")
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CacheBustConfig(target="none", banana=True)
+
+    def test_none_value_rejected(self) -> None:
+        # CacheBustTarget.NONE is a string member; ``None`` itself is not valid.
+        with pytest.raises(ValidationError):
+            CacheBustConfig(target=None)
+
+
+class TestCacheBustConfigRoundTrip:
+    @pytest.mark.parametrize(
+        "target",
+        [
+            CacheBustTarget.NONE,
+            CacheBustTarget.SYSTEM_PREFIX,
+            CacheBustTarget.FIRST_TURN_SUFFIX,
+        ],
+    )
+    def test_json_round_trip(self, target: CacheBustTarget) -> None:
+        original = CacheBustConfig(target=target)
+        restored = CacheBustConfig.model_validate_json(original.model_dump_json())
+        assert restored == original
+        assert restored.target == target
+
+    def test_nested_under_prompt_config_round_trip(self) -> None:
+        prompt = PromptConfig(
+            cache_bust=CacheBustConfig(target=CacheBustTarget.FIRST_TURN_PREFIX),
+        )
+        restored = PromptConfig.model_validate_json(prompt.model_dump_json())
+        assert restored.cache_bust.target == CacheBustTarget.FIRST_TURN_PREFIX
+
+    def test_nested_camel_case_alias_round_trip(self) -> None:
+        # BaseConfig uses camelCase aliases for K8s CRD shape; the nested
+        # block must round-trip via ``cacheBust``.
+        prompt = PromptConfig(
+            cache_bust=CacheBustConfig(target=CacheBustTarget.SYSTEM_SUFFIX),
+        )
+        dumped = prompt.model_dump(by_alias=True)
+        assert "cacheBust" in dumped
+        # The nested enum dumps as its string value.
+        assert dumped["cacheBust"]["target"] == CacheBustTarget.SYSTEM_SUFFIX
+
+        # Re-parse via JSON (mimicking K8s CRD ingest).
+        restored = PromptConfig.model_validate(orjson.loads(orjson.dumps(dumped)))
+        assert restored.cache_bust.target == CacheBustTarget.SYSTEM_SUFFIX

--- a/tests/unit/common/models/test_record_models_cache_bust.py
+++ b/tests/unit/common/models/test_record_models_cache_bust.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Round-trip tests for the cache-bust fields on the records-pipeline models.
+
+Covers Slice 2 of the cache-bust subsystem: ``RecordContext`` and
+``MetricRecordInfo`` carry the marker text + target enum so the raw-JSONL
+consumer can correlate inserted bytes with the originating session.
+"""
+
+import orjson
+
+from aiperf.common.enums import CacheBustTarget, CreditPhase
+from aiperf.common.models.error_models import ErrorDetails
+from aiperf.common.models.record_models import (
+    MetricRecordInfo,
+    MetricRecordMetadata,
+    RecordContext,
+)
+
+
+def _make_record_context(**overrides) -> RecordContext:
+    defaults = dict(
+        credit_num=0,
+        credit_phase=CreditPhase.PROFILING,
+        conversation_id="c",
+        turn_index=0,
+        x_request_id="r",
+        x_correlation_id="x",
+    )
+    defaults.update(overrides)
+    return RecordContext(**defaults)
+
+
+class TestRecordContextCacheBust:
+    def test_defaults(self):
+        ctx = _make_record_context()
+        assert ctx.cache_bust_marker is None
+        assert ctx.cache_bust_target is None
+
+    def test_explicit_fields(self):
+        ctx = _make_record_context(
+            cache_bust_marker="\n<!-- cb:rc -->\n",
+            cache_bust_target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        assert ctx.cache_bust_marker == "\n<!-- cb:rc -->\n"
+        assert ctx.cache_bust_target is CacheBustTarget.SYSTEM_PREFIX
+
+    def test_json_roundtrip_with_values(self):
+        ctx = _make_record_context(
+            cache_bust_marker="\n<!-- cb:json -->\n",
+            cache_bust_target=CacheBustTarget.FIRST_TURN_SUFFIX,
+        )
+        dumped = orjson.dumps(ctx.model_dump(mode="json"))
+        loaded = orjson.loads(dumped)
+        roundtrip = RecordContext.model_validate(loaded)
+        assert roundtrip.cache_bust_marker == "\n<!-- cb:json -->\n"
+        assert roundtrip.cache_bust_target is CacheBustTarget.FIRST_TURN_SUFFIX
+
+    def test_json_roundtrip_defaults_none(self):
+        ctx = _make_record_context()
+        roundtrip = RecordContext.model_validate(
+            orjson.loads(orjson.dumps(ctx.model_dump(mode="json")))
+        )
+        assert roundtrip.cache_bust_marker is None
+        assert roundtrip.cache_bust_target is None
+
+
+class TestMetricRecordInfoCacheBust:
+    def _make(self, **overrides) -> MetricRecordInfo:
+        metadata = MetricRecordMetadata(
+            session_num=0,
+            request_start_ns=1,
+            request_end_ns=2,
+            worker_id="w",
+            record_processor_id="rp",
+            benchmark_phase=CreditPhase.PROFILING,
+        )
+        defaults = dict(metadata=metadata, metrics={})
+        defaults.update(overrides)
+        return MetricRecordInfo(**defaults)
+
+    def test_defaults(self):
+        info = self._make()
+        assert info.cache_bust_marker is None
+        assert info.cache_bust_target is None
+
+    def test_explicit_fields(self):
+        info = self._make(
+            cache_bust_marker="\n<!-- cb:mri -->\n",
+            cache_bust_target=CacheBustTarget.FIRST_TURN_PREFIX,
+        )
+        assert info.cache_bust_marker == "\n<!-- cb:mri -->\n"
+        assert info.cache_bust_target is CacheBustTarget.FIRST_TURN_PREFIX
+
+    def test_json_roundtrip(self):
+        info = self._make(
+            cache_bust_marker="\n<!-- cb:rt -->\n",
+            cache_bust_target=CacheBustTarget.SYSTEM_SUFFIX,
+            error=ErrorDetails(type="x", code=500, message="boom"),
+        )
+        dumped = orjson.dumps(info.model_dump(mode="json"))
+        roundtrip = MetricRecordInfo.model_validate(orjson.loads(dumped))
+        assert roundtrip.cache_bust_marker == "\n<!-- cb:rt -->\n"
+        assert roundtrip.cache_bust_target is CacheBustTarget.SYSTEM_SUFFIX

--- a/tests/unit/credit/test_credit_cache_bust_fields.py
+++ b/tests/unit/credit/test_credit_cache_bust_fields.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Round-trip + plumbing tests for the cache-bust fields on
+``Credit`` / ``CreditContext`` / ``TurnToSend``.
+
+Covers Slice 2 of the cache-bust subsystem: the marker text + target enum
+ride on the credit wire struct, default to ``None`` / ``CacheBustTarget.NONE``,
+and propagate through ``TurnToSend.from_previous_credit`` so subsequent
+turns in a multi-turn session re-emit the same marker.
+"""
+
+import msgspec
+
+from aiperf.common.enums import CacheBustTarget, CreditPhase
+from aiperf.credit.structs import Credit, CreditContext, TurnToSend
+
+
+def _base_credit_kwargs() -> dict:
+    return {
+        "id": 0,
+        "phase": CreditPhase.PROFILING,
+        "conversation_id": "c",
+        "x_correlation_id": "x",
+        "turn_index": 0,
+        "num_turns": 1,
+        "issued_at_ns": 0,
+    }
+
+
+class TestCreditCacheBustFields:
+    def test_credit_defaults(self):
+        c = Credit(**_base_credit_kwargs())
+        assert c.cache_bust_marker is None
+        assert c.cache_bust_target is CacheBustTarget.NONE
+
+    def test_credit_with_target_only(self):
+        c = Credit(
+            **_base_credit_kwargs(),
+            cache_bust_target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        assert c.cache_bust_marker is None
+        assert c.cache_bust_target is CacheBustTarget.SYSTEM_PREFIX
+
+    def test_credit_with_marker_and_target(self):
+        c = Credit(
+            **_base_credit_kwargs(),
+            cache_bust_marker="\n<!-- cb:abc123 -->\n",
+            cache_bust_target=CacheBustTarget.FIRST_TURN_SUFFIX,
+        )
+        assert c.cache_bust_marker == "\n<!-- cb:abc123 -->\n"
+        assert c.cache_bust_target is CacheBustTarget.FIRST_TURN_SUFFIX
+
+    def test_credit_msgspec_roundtrip_defaults_omitted(self):
+        """omit_defaults=True must keep wire footprint small when feature is off."""
+        c = Credit(**_base_credit_kwargs())
+        encoded = msgspec.json.encode(c)
+        assert b"cache_bust_marker" not in encoded
+        assert b"cache_bust_target" not in encoded
+        decoded = msgspec.json.decode(encoded, type=Credit)
+        assert decoded.cache_bust_marker is None
+        assert decoded.cache_bust_target is CacheBustTarget.NONE
+
+    def test_credit_msgspec_roundtrip_with_values(self):
+        c = Credit(
+            **_base_credit_kwargs(),
+            cache_bust_marker="\n<!-- cb:zzz -->\n",
+            cache_bust_target=CacheBustTarget.SYSTEM_SUFFIX,
+        )
+        encoded = msgspec.json.encode(c)
+        decoded = msgspec.json.decode(encoded, type=Credit)
+        assert decoded.cache_bust_marker == "\n<!-- cb:zzz -->\n"
+        assert decoded.cache_bust_target is CacheBustTarget.SYSTEM_SUFFIX
+
+
+class TestCreditContextCarriesCacheBust:
+    def test_context_holds_credit_with_cache_bust_fields(self):
+        credit = Credit(
+            **_base_credit_kwargs(),
+            cache_bust_marker="\n<!-- cb:ctx -->\n",
+            cache_bust_target=CacheBustTarget.FIRST_TURN_PREFIX,
+        )
+        ctx = CreditContext(credit=credit, drop_perf_ns=12345)
+        assert ctx.credit.cache_bust_marker == "\n<!-- cb:ctx -->\n"
+        assert ctx.credit.cache_bust_target is CacheBustTarget.FIRST_TURN_PREFIX
+
+    def test_context_msgspec_roundtrip(self):
+        credit = Credit(
+            **_base_credit_kwargs(),
+            cache_bust_marker="\n<!-- cb:rt -->\n",
+            cache_bust_target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        ctx = CreditContext(credit=credit, drop_perf_ns=99)
+        encoded = msgspec.json.encode(ctx)
+        decoded = msgspec.json.decode(encoded, type=CreditContext)
+        assert decoded.credit.cache_bust_marker == "\n<!-- cb:rt -->\n"
+        assert decoded.credit.cache_bust_target is CacheBustTarget.SYSTEM_PREFIX
+
+
+class TestTurnToSendPropagatesCacheBust:
+    def test_default_fields_on_direct_construct(self):
+        tts = TurnToSend(
+            conversation_id="c",
+            x_correlation_id="x",
+            turn_index=0,
+            num_turns=1,
+        )
+        assert tts.cache_bust_marker is None
+        assert tts.cache_bust_target is CacheBustTarget.NONE
+
+    def test_from_previous_credit_propagates_fields(self):
+        kwargs = _base_credit_kwargs()
+        kwargs["num_turns"] = 2
+        credit = Credit(
+            **kwargs,
+            cache_bust_marker="\n<!-- cb:carry -->\n",
+            cache_bust_target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        tts = TurnToSend.from_previous_credit(credit)
+        assert tts.cache_bust_marker == "\n<!-- cb:carry -->\n"
+        assert tts.cache_bust_target is CacheBustTarget.SYSTEM_PREFIX
+        assert tts.turn_index == 1
+        assert tts.num_turns == 2
+
+    def test_from_previous_credit_no_marker_stays_none(self):
+        credit = Credit(**_base_credit_kwargs())
+        tts = TurnToSend.from_previous_credit(credit)
+        assert tts.cache_bust_marker is None
+        assert tts.cache_bust_target is CacheBustTarget.NONE

--- a/tests/unit/timing/strategies/test_cache_bust.py
+++ b/tests/unit/timing/strategies/test_cache_bust.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the deterministic cache-bust marker builder."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiperf.common.enums import CacheBustTarget
+from aiperf.timing.strategies.cache_bust import (
+    build_cache_bust_marker,
+    estimate_marker_token_cost,
+)
+
+
+class TestBuildCacheBustMarker:
+    """``build_cache_bust_marker`` is the source of per-conversation cache-bust
+    markers consumed by composer/orchestrator. Determinism and
+    position-correctness are load-bearing for warmup-to-profiling coherence
+    (a trajectory's warmup turn k_i and first profiling turn k_i+1 must share
+    the same marker so warmup KV-cache work transfers to profiling)."""
+
+    def test_returns_none_for_target_none(self) -> None:
+        """NONE target short-circuits — composer relies on this to skip
+        injection without re-checking the target."""
+        assert (
+            build_cache_bust_marker(
+                benchmark_id="b",
+                recycle_pass=0,
+                trajectory_index=0,
+                trace_id="t",
+                target=CacheBustTarget.NONE,
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            CacheBustTarget.SYSTEM_PREFIX,
+            CacheBustTarget.SYSTEM_SUFFIX,
+            CacheBustTarget.FIRST_TURN_PREFIX,
+            CacheBustTarget.FIRST_TURN_SUFFIX,
+        ],
+    )
+    def test_same_inputs_same_marker(self, target: CacheBustTarget) -> None:
+        """Determinism: same (benchmark_id, recycle_pass, trajectory_index,
+        trace_id) -> identical marker across calls. Required so reruns
+        produce byte-equivalent prompts."""
+        a = build_cache_bust_marker(
+            benchmark_id="bench-1",
+            recycle_pass=3,
+            trajectory_index=7,
+            trace_id="trace-xyz",
+            target=target,
+        )
+        b = build_cache_bust_marker(
+            benchmark_id="bench-1",
+            recycle_pass=3,
+            trajectory_index=7,
+            trace_id="trace-xyz",
+            target=target,
+        )
+        assert a == b
+        assert a is not None
+
+    def test_different_trace_id_yields_different_marker(self) -> None:
+        """Trace id is in the digest input specifically to prevent the
+        empirical 33%-collision rate seen at MVP scale when two traces
+        shared a (recycle_pass, lane) tuple."""
+        a = build_cache_bust_marker(
+            benchmark_id="b",
+            recycle_pass=0,
+            trajectory_index=0,
+            trace_id="trace-A",
+            target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        b = build_cache_bust_marker(
+            benchmark_id="b",
+            recycle_pass=0,
+            trajectory_index=0,
+            trace_id="trace-B",
+            target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        assert a != b
+
+    def test_different_recycle_pass_yields_different_marker(self) -> None:
+        a = build_cache_bust_marker(
+            benchmark_id="b",
+            recycle_pass=0,
+            trajectory_index=0,
+            trace_id="t",
+            target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        b = build_cache_bust_marker(
+            benchmark_id="b",
+            recycle_pass=1,
+            trajectory_index=0,
+            trace_id="t",
+            target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        assert a != b
+
+    def test_different_trajectory_index_yields_different_marker(self) -> None:
+        a = build_cache_bust_marker(
+            benchmark_id="b",
+            recycle_pass=0,
+            trajectory_index=0,
+            trace_id="t",
+            target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        b = build_cache_bust_marker(
+            benchmark_id="b",
+            recycle_pass=0,
+            trajectory_index=1,
+            trace_id="t",
+            target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        assert a != b
+
+    def test_prefix_targets_have_marker_first(self) -> None:
+        """SYSTEM_PREFIX and FIRST_TURN_PREFIX inject before content — the
+        marker must come before any whitespace separator so it lands at
+        token 0 of the rendered prompt."""
+        for target in (
+            CacheBustTarget.SYSTEM_PREFIX,
+            CacheBustTarget.FIRST_TURN_PREFIX,
+        ):
+            m = build_cache_bust_marker(
+                benchmark_id="b",
+                recycle_pass=0,
+                trajectory_index=0,
+                trace_id="t",
+                target=target,
+            )
+            assert m is not None
+            assert m.startswith("[rid:")
+            assert m.endswith("\n\n")
+
+    def test_suffix_targets_have_marker_last(self) -> None:
+        """SYSTEM_SUFFIX and FIRST_TURN_SUFFIX append after content — the
+        leading separator preserves leading-prefix KV-cache locality."""
+        for target in (
+            CacheBustTarget.SYSTEM_SUFFIX,
+            CacheBustTarget.FIRST_TURN_SUFFIX,
+        ):
+            m = build_cache_bust_marker(
+                benchmark_id="b",
+                recycle_pass=0,
+                trajectory_index=0,
+                trace_id="t",
+                target=target,
+            )
+            assert m is not None
+            assert m.startswith("\n\n")
+            assert m.endswith("]")
+
+    def test_marker_format_is_rid_with_12_hex(self) -> None:
+        """The rid:<digest> shape is what downstream tooling greps for in
+        request logs; the 12-hex width is part of that contract."""
+        marker = build_cache_bust_marker(
+            benchmark_id="b",
+            recycle_pass=0,
+            trajectory_index=0,
+            trace_id="t",
+            target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        assert marker is not None
+        # Strip whitespace separator; verify "[rid:XXXXXXXXXXXX]" shape.
+        core = marker.strip()
+        assert core.startswith("[rid:")
+        assert core.endswith("]")
+        digest = core[len("[rid:") : -1]
+        assert len(digest) == 12
+        assert all(c in "0123456789abcdef" for c in digest)
+
+
+class TestEstimateMarkerTokenCost:
+    def test_returns_zero_for_target_none(self) -> None:
+        """NONE has no marker so the cost is structurally zero, not just
+        empirically — callers branch on this to skip token-budget accounting."""
+        tok = MagicMock()
+        assert estimate_marker_token_cost(CacheBustTarget.NONE, tok) == 0
+        tok.encode.assert_not_called()
+
+    def test_averages_tokenizer_samples(self) -> None:
+        """The estimator tokenizes a handful of distinct markers and rounds
+        the mean. Hard-coding a deterministic tokenizer lets us assert the
+        rounding behavior."""
+        tok = MagicMock()
+        # Pretend the tokenizer always returns 5 tokens.
+        tok.encode.return_value = [0, 1, 2, 3, 4]
+        cost = estimate_marker_token_cost(CacheBustTarget.SYSTEM_PREFIX, tok, samples=4)
+        assert cost == 5
+        assert tok.encode.call_count == 4
+
+    def test_default_sample_count(self) -> None:
+        """The default sample count is fixed at 8 — keep it that way so
+        callers don't need to know about it."""
+        tok = MagicMock()
+        tok.encode.return_value = [0, 1, 2]
+        estimate_marker_token_cost(CacheBustTarget.SYSTEM_PREFIX, tok)
+        assert tok.encode.call_count == 8

--- a/tests/unit/timing/test_branch_orchestrator_cache_bust.py
+++ b/tests/unit/timing/test_branch_orchestrator_cache_bust.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``BranchOrchestrator._mint_child_marker``.
+
+Covers the cache-bust marker minting contract for SPAWN/FORK child
+sessions: returns ``None`` when target is NONE, deterministic for the
+same input, and unique per child conversation id.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiperf.common.enums import CacheBustTarget
+from aiperf.timing.branch_orchestrator import BranchOrchestrator
+
+
+def _make_orch(
+    *,
+    benchmark_id: str = "bench-xyz",
+    cache_bust_target: CacheBustTarget = CacheBustTarget.NONE,
+) -> BranchOrchestrator:
+    cs = MagicMock()
+    # ``BranchOrchestrator.__init__`` reads ``dataset_metadata.conversations``
+    # for its prereq index; an empty list keeps the orchestrator usable for
+    # pure marker-minting unit tests without needing a full dataset.
+    cs.dataset_metadata = MagicMock(conversations=[])
+    issuer = MagicMock()
+    return BranchOrchestrator(
+        conversation_source=cs,
+        credit_issuer=issuer,
+        benchmark_id=benchmark_id,
+        cache_bust_target=cache_bust_target,
+    )
+
+
+def test_mint_child_marker_returns_none_when_target_is_none():
+    orch = _make_orch(cache_bust_target=CacheBustTarget.NONE)
+    assert orch._mint_child_marker("child-conv-1") is None
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        CacheBustTarget.SYSTEM_PREFIX,
+        CacheBustTarget.FIRST_TURN_PREFIX,
+        CacheBustTarget.FIRST_TURN_SUFFIX,
+    ],
+)
+def test_mint_child_marker_is_deterministic_for_same_inputs(target):
+    orch_a = _make_orch(benchmark_id="bench-A", cache_bust_target=target)
+    orch_b = _make_orch(benchmark_id="bench-A", cache_bust_target=target)
+    marker_a = orch_a._mint_child_marker("child-conv-1")
+    marker_b = orch_b._mint_child_marker("child-conv-1")
+    assert marker_a is not None
+    assert marker_a == marker_b
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        CacheBustTarget.SYSTEM_PREFIX,
+        CacheBustTarget.FIRST_TURN_PREFIX,
+        CacheBustTarget.FIRST_TURN_SUFFIX,
+    ],
+)
+def test_mint_child_marker_differs_per_child_conversation_id(target):
+    orch = _make_orch(benchmark_id="bench-A", cache_bust_target=target)
+    markers = {orch._mint_child_marker(f"child-{i}") for i in range(8)}
+    # All eight distinct child_conversation_ids should produce eight
+    # distinct markers (collision probability over 48-bit digest is
+    # negligible for 8 samples).
+    assert len(markers) == 8
+    assert None not in markers
+
+
+def test_mint_child_marker_differs_per_benchmark_id():
+    orch_a = _make_orch(
+        benchmark_id="bench-A", cache_bust_target=CacheBustTarget.SYSTEM_PREFIX
+    )
+    orch_b = _make_orch(
+        benchmark_id="bench-B", cache_bust_target=CacheBustTarget.SYSTEM_PREFIX
+    )
+    assert orch_a._mint_child_marker("child-conv-1") != orch_b._mint_child_marker(
+        "child-conv-1"
+    )

--- a/tests/unit/timing/test_conversation_source_cache_bust.py
+++ b/tests/unit/timing/test_conversation_source_cache_bust.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Cache-bust plumbing tests for ConversationSource / SampledSession.
+
+Covers Slice 2 of the cache-bust subsystem: the marker text + target enum
+ride on a ``SampledSession`` and flow through ``build_first_turn`` into
+``TurnToSend``. Verifies the keyword-only signatures on
+``start_branch_child`` and ``start_pre_session_child`` accept the new
+fields with sensible defaults so existing callers keep working.
+"""
+
+import pytest
+
+from aiperf.common.enums import CacheBustTarget, ConversationBranchMode
+from aiperf.common.models import ConversationMetadata, DatasetMetadata, TurnMetadata
+from aiperf.plugin import plugins
+from aiperf.plugin.enums import DatasetSamplingStrategy, PluginType
+from aiperf.timing.conversation_source import ConversationSource, SampledSession
+
+
+def _mk_source(ds: DatasetMetadata) -> ConversationSource:
+    SamplerClass = plugins.get_class(PluginType.DATASET_SAMPLER, ds.sampling_strategy)
+    sampler = SamplerClass(
+        conversation_ids=[c.conversation_id for c in ds.conversations],
+    )
+    return ConversationSource(ds, sampler)
+
+
+@pytest.fixture
+def src() -> ConversationSource:
+    ds = DatasetMetadata(
+        conversations=[
+            ConversationMetadata(
+                conversation_id="root-conv",
+                turns=[TurnMetadata(timestamp_ms=0.0)],
+                agent_depth=0,
+            ),
+            ConversationMetadata(
+                conversation_id="child-conv",
+                turns=[TurnMetadata(timestamp_ms=0.0)],
+                agent_depth=1,
+                parent_conversation_id="root-conv",
+                is_root=False,
+            ),
+        ],
+        sampling_strategy=DatasetSamplingStrategy.SEQUENTIAL,
+    )
+    return _mk_source(ds)
+
+
+class TestSampledSessionCacheBustDefaults:
+    def test_defaults_when_constructed_directly(self):
+        meta = ConversationMetadata(
+            conversation_id="c",
+            turns=[TurnMetadata(timestamp_ms=0.0)],
+        )
+        s = SampledSession(
+            conversation_id="c",
+            metadata=meta,
+            x_correlation_id="x",
+        )
+        assert s.cache_bust_marker is None
+        assert s.cache_bust_target is CacheBustTarget.NONE
+
+    def test_explicit_fields_set(self):
+        meta = ConversationMetadata(
+            conversation_id="c",
+            turns=[TurnMetadata(timestamp_ms=0.0)],
+        )
+        s = SampledSession(
+            conversation_id="c",
+            metadata=meta,
+            x_correlation_id="x",
+            cache_bust_marker="\n<!-- cb:s -->\n",
+            cache_bust_target=CacheBustTarget.SYSTEM_SUFFIX,
+        )
+        assert s.cache_bust_marker == "\n<!-- cb:s -->\n"
+        assert s.cache_bust_target is CacheBustTarget.SYSTEM_SUFFIX
+
+    def test_build_first_turn_carries_cache_bust(self):
+        meta = ConversationMetadata(
+            conversation_id="c",
+            turns=[TurnMetadata(timestamp_ms=0.0)],
+        )
+        s = SampledSession(
+            conversation_id="c",
+            metadata=meta,
+            x_correlation_id="x",
+            cache_bust_marker="\n<!-- cb:first -->\n",
+            cache_bust_target=CacheBustTarget.FIRST_TURN_PREFIX,
+        )
+        tts = s.build_first_turn()
+        assert tts.cache_bust_marker == "\n<!-- cb:first -->\n"
+        assert tts.cache_bust_target is CacheBustTarget.FIRST_TURN_PREFIX
+
+
+class TestStartBranchChildCacheBust:
+    def test_default_no_cache_bust(self, src: ConversationSource):
+        child = src.start_branch_child(
+            parent_correlation_id="parent-corr",
+            child_conversation_id="child-conv",
+            agent_depth=1,
+        )
+        assert child.cache_bust_marker is None
+        assert child.cache_bust_target is CacheBustTarget.NONE
+
+    def test_caller_mints_marker_for_spawn_child(self, src: ConversationSource):
+        child = src.start_branch_child(
+            parent_correlation_id="parent-corr",
+            child_conversation_id="child-conv",
+            agent_depth=1,
+            branch_mode=ConversationBranchMode.SPAWN,
+            cache_bust_marker="\n<!-- cb:spawn-1 -->\n",
+            cache_bust_target=CacheBustTarget.SYSTEM_PREFIX,
+        )
+        assert child.cache_bust_marker == "\n<!-- cb:spawn-1 -->\n"
+        assert child.cache_bust_target is CacheBustTarget.SYSTEM_PREFIX
+        # Marker flows through to the TurnToSend so the worker sees it.
+        tts = child.build_first_turn()
+        assert tts.cache_bust_marker == "\n<!-- cb:spawn-1 -->\n"
+        assert tts.cache_bust_target is CacheBustTarget.SYSTEM_PREFIX
+
+
+class TestStartPreSessionChildCacheBust:
+    def test_default_no_cache_bust(self, src: ConversationSource):
+        child = src.start_pre_session_child(child_conversation_id="child-conv")
+        assert child.cache_bust_marker is None
+        assert child.cache_bust_target is CacheBustTarget.NONE
+
+    def test_caller_mints_marker_for_pre_session(self, src: ConversationSource):
+        child = src.start_pre_session_child(
+            child_conversation_id="child-conv",
+            cache_bust_marker="\n<!-- cb:pre -->\n",
+            cache_bust_target=CacheBustTarget.FIRST_TURN_SUFFIX,
+        )
+        assert child.cache_bust_marker == "\n<!-- cb:pre -->\n"
+        assert child.cache_bust_target is CacheBustTarget.FIRST_TURN_SUFFIX
+        tts = child.build_first_turn()
+        assert tts.cache_bust_marker == "\n<!-- cb:pre -->\n"
+        assert tts.cache_bust_target is CacheBustTarget.FIRST_TURN_SUFFIX


### PR DESCRIPTION
## Summary

**PR-A of the AgentX → main reconciliation effort.**

Adds the `CacheBustTarget` enum + the deterministic `build_cache_bust_marker` builder, plus end-to-end plumbing of the marker through `PromptConfig` → `Credit` / `CreditContext` → `SampledSession` → `BranchOrchestrator._mint_child_marker`. **No actual marker injection** — that lives at the worker layer in the source-of-truth (`cjq/agentx-v0.3:workers/worker.py:_apply_cache_bust*`) and is deferred to a follow-up PR-A2 that matches that split.

## Base branch

Filed against `cjq/agentx-on-main-runtime` (PR #966). Will auto-retarget to `main` once #966 merges.

## Commits

| SHA | Title |
|---|---|
| `92d13427` | `feat(cache-bust): add CacheBustTarget enum + deterministic marker builder` — foundation |
| `c9819673` | `feat(cache-bust): wire CacheBustTarget through config / credit / session / orchestrator (PR-A)` — integration |

## What's added

### Foundation (`92d13427`)
- `CacheBustTarget` enum (`NONE` / `SYSTEM_PREFIX` / `SYSTEM_SUFFIX` / `FIRST_TURN_PREFIX` / `FIRST_TURN_SUFFIX`)
- `build_cache_bust_marker(benchmark_id, recycle_pass, trajectory_index, trace_id, *, target) -> str | None` — deterministic, includes `trace_id` to prevent the 33%-collision rate empirically observed at MVP scale
- `estimate_marker_token_cost(target, tokenizer)` — for ISL-budget compensation (consumed by a future composer-side PR)

### Integration (`c9819673`)
- `PromptConfig.cache_bust: CacheBustConfig` block (`target: CacheBustTarget = NONE`)
- `Credit` + `CreditContext` gain `cache_bust_target` + `cache_bust_marker` fields (msgspec `omit_defaults` keeps wire footprint clean when disabled)
- `SampledSession` carries the same fields; `ConversationSource.start_branch_child` / `start_pre_session_child` accept them as keyword-only kwargs with sensible defaults
- `RecordContext` + `MetricRecordInfo` gain `cache_bust_target` field for raw-JSONL export
- `BranchOrchestrator._mint_child_marker(child_conversation_id) -> str | None` — calls the foundation builder with stored `_benchmark_id` + `_cache_bust_target`
- Spawn-mixin invokes `_mint_child_marker` and passes the result to `start_branch_child(cache_bust_marker=...)`

## Architectural note (important for reviewers)

`cjq/agentx-v0.3` injects cache-bust markers at the **worker layer** (`workers/worker.py:_apply_cache_bust*` lines 87/257/858+) — the composer there only does **ISL-budget compensation** for marker tokens (`composer/base.py` lines 130-175). This PR deliberately:

- ✅ Adds the marker fields + minting machinery
- ✅ Adds the deterministic builder + token-cost estimator
- ❌ Does NOT add compose-time injection (would double-inject when the worker layer lands)
- ❌ Does NOT add worker-layer injection (out of scope; follow-up PR)

The orchestrator mints markers for SPAWN children and writes them onto sessions, but no code path currently consumes them. PR-A2 will port `workers/worker.py:_apply_cache_bust` to read `credit.cache_bust_marker` and inject at request-build time.

## Note on ScenarioSpec

An earlier revision of this PR added a minimal `src/aiperf/common/scenario/{__init__.py,base.py}` with a `ScenarioSpec` primitive carrying a `require_cache_bust` field. Removed in `c9819673` — the data structure has no consumer in this PR (no `_run_scenario_validator`, no scenario registry, no CLI surface), so it would be dead code until PR-F (InferenceX AgentX-MVP scenario) introduces an actual scenario that uses it. `ScenarioSpec` lands with PR-F.

## Test plan

- [x] **Unit suite: 12,755 passed, 79 skipped, 0 failed** (+66 over post-#966 baseline)
  - `tests/unit/common/config/test_cache_bust_config.py` — 19 tests (CacheBustConfig defaults, validation, round-trip)
  - `tests/unit/credit/test_credit_cache_bust_fields.py` — 10 tests (Credit/CreditContext defaults + explicit + msgspec round-trip)
  - `tests/unit/timing/test_conversation_source_cache_bust.py` — 7 tests (SampledSession + start_*_child plumbing)
  - `tests/unit/common/models/test_record_models_cache_bust.py` — 7 tests (RecordContext + MetricRecordInfo round-trip)
  - `tests/unit/timing/test_branch_orchestrator_cache_bust.py` — 8 tests (`_mint_child_marker` determinism + uniqueness)
  - `tests/unit/timing/strategies/test_cache_bust.py` — 14 tests on the foundation builder
- [x] `pre-commit run --files <touched>` clean (including auto-regenerated `config/schema/aiperf-config.schema.json` and `ruff format`)
- [ ] End-to-end with a real `agentic_replay` workload — blocked on worker-layer PR-A2 (the marker fields are populated but nothing reads them yet)

## Cross-PR TODOs

1. **`PhaseRunner` construction site** needs to thread `cache_bust_target=user_config.input.prompt.cache_bust.target` and the real `benchmark_id` into `BranchOrchestrator(...)`. Until done, `_mint_child_marker` always returns `None` — safe default.
2. **Worker-layer follow-up** (PR-A2, out of scope here) — port `_apply_cache_bust_to_system_message` + `_apply_cache_bust` from `cjq/agentx-v0.3:workers/worker.py:87,257` to read `credit.cache_bust_marker` / `credit.cache_bust_target` and inject the marker into the wire payload.
3. **Raw-record export path** needs to copy `credit.cache_bust_marker` onto `RecordContext` + `MetricRecordInfo` so JSONL captures the rid.
4. **ScenarioSpec primitive** lands with PR-F (the first scenario that uses it).
5. **CLI surface** — `--cache-bust` flag not yet wired through the v2 converter (`config/flags/_converter_dataset.py`). Likely small follow-up.

## Implementation

Fanned out across 4 agents (config+scenario / credit+session / composer / orchestrator) per `superpowers:dispatching-parallel-agents`, each with disjoint file ownership. Two slices were trimmed before merge:
- **Slice 3 (composer)** added a compose-time injection path that diverged from the source-of-truth's worker-layer architecture — reverted.
- **Slice 1 (scenario)** added a `ScenarioSpec` primitive with no consumer in this PR — reverted, will land with PR-F instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)