### PR TITLE
fix: preserve auth for CLI concurrency sweeps

### DIFF
--- a/src/aiperf/config/loader/plan.py
+++ b/src/aiperf/config/loader/plan.py
@@ -47,7 +47,10 @@ def build_benchmark_plan(config: AIPerfConfig) -> BenchmarkPlan:
             sweep_dict = envelope_dict.pop("sweep", None)
         else:
             envelope_dict = config.model_dump(
-                mode="json", exclude_none=True, exclude_unset=True
+                mode="python",
+                exclude_none=True,
+                exclude_unset=True,
+                context={"include_secrets": True},
             )
             sweep_dict = envelope_dict.pop("sweep", None)
         configs, variations = _expand_envelope_variations(envelope_dict, sweep_dict)

--- a/tests/unit/config/test_cli_magic_list_sugar.py
+++ b/tests/unit/config/test_cli_magic_list_sugar.py
@@ -15,6 +15,7 @@ from pytest import param
 
 from aiperf.config.flags.cli_config import CLIConfig
 from aiperf.config.flags.converter import convert_cli_to_aiperf
+from aiperf.config.loader import build_benchmark_plan
 from aiperf.config.loader.parsing import (
     parse_float_or_float_list,
     parse_int_or_int_list,
@@ -95,6 +96,25 @@ class TestPrefillConcurrencyMagicList:
             "phases.profiling.concurrency": [4, 8],
             "phases.profiling.prefill_concurrency": [1, 2],
         }
+
+    def test_concurrency_sweep_preserves_api_key_in_expanded_plan(self):
+        cli = CLIConfig(
+            model_names=["m"],
+            api_key="sk-real-prod-key",
+            concurrency="1,2",
+            request_count=1,
+        )
+
+        plan = build_benchmark_plan(convert_cli_to_aiperf(cli))
+
+        assert [c.endpoint.api_key for c in plan.configs] == [
+            "sk-real-prod-key",
+            "sk-real-prod-key",
+        ]
+        assert [
+            next(p for p in c.phases if p.name == "profiling").concurrency
+            for c in plan.configs
+        ] == [1, 2]
 
 
 class TestRequestRateMagicList:


### PR DESCRIPTION
Comma-list concurrency runs expand into separate benchmark configs before execution. Keep runtime-only expansion faithful so each generated run can authenticate while exported artifacts continue to redact secrets.

Signed-off-by: Aaron Batilo <abatilo@coreweave.com>