### PR TITLE
fix(nightly): unblank CONTAINER_IMAGE in GitLab trigger + forward ARTIFACTORY_REPO_NAME

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -839,8 +839,6 @@ jobs:
     runs-on: prod-aiperf-default-v1
     environment: automated-release
     if: ${{ needs.prepare-nightly.outputs.release == 'true' }}
-    outputs:
-      container_image: ${{ steps.copy.outputs.container_image }}
     env:
       CRANE_VERSION: v0.20.2
       CRANE_SHA256: ''
@@ -876,7 +874,6 @@ jobs:
             --username "${NGC_USERNAME}" --password-stdin
 
       - name: Copy multi-arch images ECR → NGC staging
-        id: copy
         env:
           AWS_ACCOUNT_ID:         ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_DEFAULT_REGION:     ${{ secrets.AWS_DEFAULT_REGION }}
@@ -902,7 +899,12 @@ jobs:
             --manifest "${NGC_STAGING_IMAGE_BASE}/aiperf-nightly:${CONTAINER_TAG}-arm64" \
             --tag      "${CONTAINER_IMAGE}"
           echo "Container staged: ${CONTAINER_IMAGE}"
-          echo "container_image=${CONTAINER_IMAGE}" >> "${GITHUB_OUTPUT}"
+          # CONTAINER_IMAGE is intentionally NOT emitted as a job output: it
+          # contains the NGC_STAGING_IMAGE_BASE secret, and GitHub Actions
+          # blanks any cross-job output that includes a secret value (the
+          # `Skip output '<name>' since it may contain secret.` annotation).
+          # trigger-gitlab-security-scan reconstructs the image string from
+          # the same secret + container_tag instead.
 
   stage-nightly-wheel:
     name: Stage Wheel (S3 → Artifactory)
@@ -1006,11 +1008,12 @@ jobs:
           WHEEL_FILENAME:         ${{ needs.prepare-nightly.outputs.wheel_filename }}
           NIGHTLY_WHEEL_FILENAME: ${{ needs.prepare-nightly.outputs.nightly_wheel_filename }}
           CONTAINER_TAG:          ${{ needs.prepare-nightly.outputs.container_tag }}
-          CONTAINER_IMAGE:        ${{ needs.stage-nightly-container.outputs.container_image }}
+          NGC_STAGING_IMAGE_BASE: ${{ secrets.NGC_STAGING_IMAGE_BASE }}
           RESOLVED_SHA:           ${{ needs.prepare-nightly.outputs.resolved_sha }}
           TIMESTAMP:              ${{ needs.prepare-nightly.outputs.run_timestamp }}
           STAGE_SUBPATH:          ${{ needs.prepare-nightly.outputs.stage_subpath }}
           ARTIFACTORY_PYPI_URL:   ${{ secrets.ARTIFACTORY_PYPI_URL }}
+          ARTIFACTORY_REPO_NAME:  ${{ secrets.ARTIFACTORY_REPO_NAME }}
         run: |
           set -euo pipefail
 
@@ -1018,6 +1021,13 @@ jobs:
           if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
             RELEASE_TYPE="nightly"
           fi
+
+          # Reconstructed here rather than read from
+          # stage-nightly-container.outputs because GitHub Actions blanks
+          # cross-job outputs that include a secret value (here:
+          # NGC_STAGING_IMAGE_BASE). Build it inline from the same secret
+          # plus the non-secret container_tag.
+          CONTAINER_IMAGE="${NGC_STAGING_IMAGE_BASE}/aiperf-nightly:${CONTAINER_TAG}"
 
           # Repo-relative paths to the staged wheels. STAGE_SUBPATH is
           # "nightly/<YYYYMMDD>" for scheduled runs and
@@ -1049,6 +1059,7 @@ jobs:
             --form "variables[GITHUB_RUN_ID]=${GITHUB_RUN_ID}" \
             --form "variables[ARTIFACTS]=wheel,container" \
             --form "variables[ARTIFACTORY_PYPI_URL]=${ARTIFACTORY_PYPI_URL}" \
+            --form "variables[ARTIFACTORY_REPO_NAME]=${ARTIFACTORY_REPO_NAME}" \
             --form "variables[ARTIFACTORY_WHEEL_PATH]=${ARTIFACTORY_WHEEL_PATH}" \
             --form "variables[ARTIFACTORY_NIGHTLY_WHEEL_PATH]=${ARTIFACTORY_NIGHTLY_WHEEL_PATH}" \
             --form "variables[TIMESTAMP]=${TIMESTAMP}" \


### PR DESCRIPTION
## Summary

- Last night's nightly ([run 26219832007](https://github.com/ai-dynamo/aiperf/actions/runs/26219832007)) successfully triggered the GitLab compliance pipeline, but several of the variables forwarded to it were **blank** — most importantly `CONTAINER_IMAGE`.
- Root cause: GitHub Actions silently blanks any **cross-job output whose value contains a repo secret**. `stage-nightly-container` was emitting `container_image="${NGC_STAGING_IMAGE_BASE}/aiperf-nightly:${CONTAINER_TAG}"` as a job output; because `NGC_STAGING_IMAGE_BASE` is a secret, GitHub stripped it with the annotation `Skip output 'container_image' since it may contain secret.` The downstream `trigger-gitlab-security-scan` then read `needs.stage-nightly-container.outputs.container_image` and got an empty string, so the GitLab POST sent `variables[CONTAINER_IMAGE]=` (verified against the env dump from the run: `CONTAINER_IMAGE: ` blank, everything else populated).
- Fix: drop the unused job output and reconstruct the image string inline inside the trigger job from the same secret + non-secret `container_tag`. This is the same value, but read directly from `secrets.NGC_STAGING_IMAGE_BASE` (which is masked in logs but not stripped from form-data the way cross-job outputs are).
- Also forward `ARTIFACTORY_REPO_NAME` (already exists in the `automated-release` environment) so the GitLab side no longer has to derive it from `ARTIFACTORY_URL`.

## Test plan

- [ ] Trigger the nightly via `workflow_dispatch` from `main` against this branch's workflow file (released to main first, or via temporary push to main behind a feature flag).
- [ ] Confirm the `Stage Container (ECR → NGC Staging)` job no longer emits the `Skip output 'container_image' since it may contain secret.` annotation.
- [ ] Confirm in the `Trigger GitLab pipeline` step that `CONTAINER_IMAGE` resolves to the full `<NGC>/aiperf-nightly:<container_tag>` string (it will be masked in logs as `***/aiperf-nightly:<tag>`, which is the expected behavior — only the secret prefix is hidden).
- [ ] On the GitLab side, confirm the triggered compliance pipeline now sees non-empty `CONTAINER_IMAGE` and `ARTIFACTORY_REPO_NAME` variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential security issue by preventing sensitive container image values from being exported between CI/CD workflow jobs

* **Chores**
  * Updated container build workflow to reconstruct parameters directly within jobs instead of using exported outputs
  * Modified security scan job configuration to handle additional staging and repository parameters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->