### PR TITLE
fix(security): harden template path read against path traversal

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -34,6 +34,7 @@ Python 3.10+ async AI benchmarking tool for measuring LLM inference server perfo
 - YAML plugin registry for extensible features (`src/aiperf/plugin/plugins.yaml`).
 - Lambda for expensive logs: `self.debug(lambda: f"{self._x()}")`. Direct string for cheap ones.
 - Always `orjson.loads(s)`, `orjson.dumps(d)` for JSON.
+- Reading filesystem paths: use `aiperf.common.path_safety.safe_read_template_path` instead of inline `Path().read_text()` / `open().read()`. Returns `None` on safety-check failure; caller picks the fallback semantic. See `docs/dev/patterns.md` § "Safe Filesystem Reads Pattern".
 - No `Optional[X]` or `Union[X, Y]` - use `X | Y`.
 - Comments only for "why?" not "what".
 - Enums are string-based - use `MessageType.X` directly, never `.value`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ Python 3.10+ async AI benchmarking tool for measuring LLM inference server perfo
 - YAML plugin registry for extensible features (`src/aiperf/plugin/plugins.yaml`).
 - Lambda for expensive logs: `self.debug(lambda: f"{self._x()}")`. Direct string for cheap ones.
 - Always `orjson.loads(s)`, `orjson.dumps(d)` for JSON.
+- Reading filesystem paths: use `aiperf.common.path_safety.safe_read_template_path` instead of inline `Path().read_text()` / `open().read()`. Returns `None` on safety-check failure; caller picks the fallback semantic. See `docs/dev/patterns.md` § "Safe Filesystem Reads Pattern".
 - No `Optional[X]` or `Union[X, Y]` - use `X | Y`.
 - Comments only for "why?" not "what".
 - Enums are string-based - use `MessageType.X` directly, never `.value`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Python 3.10+ async AI benchmarking tool for measuring LLM inference server perfo
 - YAML plugin registry for extensible features (`src/aiperf/plugin/plugins.yaml`).
 - Lambda for expensive logs: `self.debug(lambda: f"{self._x()}")`. Direct string for cheap ones.
 - Always `orjson.loads(s)`, `orjson.dumps(d)` for JSON.
+- Reading filesystem paths: use `aiperf.common.path_safety.safe_read_template_path` instead of inline `Path().read_text()` / `open().read()`. Returns `None` on safety-check failure; caller picks the fallback semantic. See `docs/dev/patterns.md` § "Safe Filesystem Reads Pattern".
 - No `Optional[X]` or `Union[X, Y]` - use `X | Y`.
 - Comments only for "why?" not "what".
 - Enums are string-based - use `MessageType.X` directly, never `.value`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Python 3.10+ async AI benchmarking tool for measuring LLM inference server perfo
 - YAML plugin registry for extensible features (`src/aiperf/plugin/plugins.yaml`).
 - Lambda for expensive logs: `self.debug(lambda: f"{self._x()}")`. Direct string for cheap ones.
 - Always `orjson.loads(s)`, `orjson.dumps(d)` for JSON.
+- Reading filesystem paths: use `aiperf.common.path_safety.safe_read_template_path` instead of inline `Path().read_text()` / `open().read()`. Returns `None` on safety-check failure; caller picks the fallback semantic. See `docs/dev/patterns.md` § "Safe Filesystem Reads Pattern".
 - No `Optional[X]` or `Union[X, Y]` - use `X | Y`.
 - Comments only for "why?" not "what".
 - Enums are string-based - use `MessageType.X` directly, never `.value`.

--- a/docs/dev/patterns.md
+++ b/docs/dev/patterns.md
@@ -342,6 +342,56 @@ reject all three patterns for new code; see
 [`global-invariants.md`](global-invariants.md) for the full contract and
 the baseline-ratchet mechanism.
 
+## Safe Filesystem Reads Pattern
+
+User-supplied filesystem paths reaching AIPerf (e.g. `--extra-inputs
+payload_template=<path>`, `endpoint.template.body` in a YAML config) must
+go through `aiperf.common.path_safety.safe_read_template_path` rather than
+inline `Path(...).read_text()` / `open(...).read()`. The helper is the
+canonical CWE-22 path-traversal sanitizer recognized by SAST tools — every
+inline read regenerates that finding.
+
+### What the helper does
+
+```python
+from aiperf.common.path_safety import safe_read_template_path
+
+body = safe_read_template_path(user_string)
+if body is None:
+    # safety check failed — caller picks the fallback semantic
+    body = user_string          # template "path or inline" idiom
+    # or: raise ValueError(f"Template file not readable: {user_string!r}")
+```
+
+Sanitizer chain (in the order SAST engines walk it):
+
+1. `Path(ts).expanduser()` — catches `TypeError` / `ValueError` /
+   `RuntimeError` (the last fires on unresolvable `~user` prefixes).
+2. Reject if `path` or any component in `path.parents` is a symlink.
+   `resolve()` alone is insufficient because it follows symlinked parent
+   directories silently.
+3. `path.resolve(strict=True)` — the canonical sanitizer that
+   Snyk/CodeQL/Semgrep recognize; raises on missing paths.
+4. Require `resolved.is_file()` — rejects directories, devices, fifos.
+5. `read_text(encoding="utf-8")` — explicit decode; no platform default.
+
+Returning `None` on any failure preserves the existing "treat as a literal
+value" fallback that both call sites (`_converter_endpoint` and
+`TemplateEndpoint.__init__`) already implement.
+
+### When this pattern does NOT apply
+
+- **Path joining of trusted strings** — `Path(__file__).parent / "data.yaml"`,
+  `artifact_dir / "inputs.json"`. These never resolve untrusted input; no
+  sanitizer needed.
+- **Binary reads** — `open(p, "rb")` for parquet/orjson/etc. The helper is
+  UTF-8-text only. If a hardened binary variant is needed, add it to
+  `aiperf.common.path_safety` alongside the existing helper rather than
+  inlining `read_bytes()`.
+- **Reads where missing-file should hard-fail rather than fall back** — the
+  helper still works (returns `None`); the caller is responsible for
+  raising instead of substituting a literal.
+
 ## Testing Pattern
 
 ```python

--- a/docs/dev/patterns.md
+++ b/docs/dev/patterns.md
@@ -373,7 +373,7 @@ Sanitizer chain (in the order SAST engines walk it):
 3. `path.resolve(strict=True)` — the canonical sanitizer that
    Snyk/CodeQL/Semgrep recognize; raises on missing paths.
 4. Require `resolved.is_file()` — rejects directories, devices, fifos.
-5. `read_text(encoding="utf-8")` — explicit decode; no platform default.
+5. `read_text(encoding="utf-8")` — explicit decode; no platform default. Catches `UnicodeError` alongside `OSError` so non-UTF-8 files fall back to the literal-string branch rather than crashing config conversion.
 
 Returning `None` on any failure preserves the existing "treat as a literal
 value" fallback that both call sites (`_converter_endpoint` and

--- a/src/aiperf/common/path_safety.py
+++ b/src/aiperf/common/path_safety.py
@@ -51,5 +51,5 @@ def safe_read_template_path(ts: str) -> str | None:
         return None
     try:
         return resolved.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeError):
         return None

--- a/src/aiperf/common/path_safety.py
+++ b/src/aiperf/common/path_safety.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Path-safety helpers for user-supplied filesystem paths.
+
+Centralizes the CWE-22 path-injection hardening applied to anywhere AIPerf
+interprets a user-supplied string as "either a filesystem path to read, or a
+literal value." Today that pattern appears in template loading (CLI
+``--extra-inputs payload_template=...`` and YAML/direct ``TemplateEndpoint``
+inputs); future call sites with the same shape should reuse this helper rather
+than reinventing the sanitizer chain.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def safe_read_template_path(ts: str) -> str | None:
+    """Return file contents if ``ts`` safely resolves to a regular file, else ``None``.
+
+    Sanitizer chain (in the order SAST tools walk it):
+      1. ``Path(ts).expanduser()`` — also catches ``RuntimeError`` from
+         unresolvable ``~user`` / unset ``HOME`` prefixes.
+      2. Reject if any component (leaf or any parent) is a symlink. ``resolve()``
+         alone is insufficient because it follows symlinked parent directories.
+      3. ``Path.resolve(strict=True)`` — the canonical sanitizer that SAST
+         engines (Snyk/CodeQL/Semgrep) recognize; raises on missing paths.
+      4. Require ``is_file()`` on the resolved target (rejects directories,
+         devices, fifos).
+      5. ``read_text(encoding="utf-8")`` — explicit decode, no platform default.
+
+    Returning ``None`` signals the caller to treat ``ts`` as a literal value
+    (the existing "inline template body" fallback in both call sites).
+    """
+    try:
+        path = Path(ts).expanduser()
+    except (TypeError, ValueError, RuntimeError):
+        return None
+    try:
+        for candidate in (path, *path.parents):
+            if candidate.is_symlink():
+                return None
+    except OSError:
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    try:
+        return resolved.read_text(encoding="utf-8")
+    except OSError:
+        return None

--- a/src/aiperf/config/flags/_converter_endpoint.py
+++ b/src/aiperf/config/flags/_converter_endpoint.py
@@ -23,14 +23,42 @@ def _url(item: str) -> str:
     return item if "://" in item else f"http://{item}"
 
 
+def _safe_read_template_path(ts: str) -> str | None:
+    """Return file contents if ``ts`` safely resolves to a regular file, else ``None``.
+
+    Hardens ``--extra-inputs payload_template=<path>`` against CWE-22 path-injection
+    findings: rejects symlinks before resolving, then resolves through
+    ``Path.resolve(strict=True)`` (the sanitizer SAST tools recognize), requires the
+    resolved target to be a regular file, and reads with explicit UTF-8 encoding.
+    Returning ``None`` signals the caller to treat ``ts`` as a literal template body.
+    """
+    try:
+        path = Path(ts).expanduser()
+    except (TypeError, ValueError):
+        return None
+    if path.is_symlink():
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    try:
+        return resolved.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
 def _endpoint_template_from_extra(
     endpoint: dict[str, Any], extra: dict[str, Any]
 ) -> None:
     payload_template = extra.pop("payload_template", None)
     if payload_template is None:
         return
-    path = Path(payload_template)
-    body = path.read_text() if path.is_file() else payload_template
+    body = _safe_read_template_path(payload_template)
+    if body is None:
+        body = payload_template
     endpoint["template"] = {
         "body": body,
         "response_field": extra.pop("response_field", "text"),
@@ -49,8 +77,8 @@ def _endpoint_template_fallback(endpoint: dict[str, Any]) -> None:
     ts = ex.get("payload_template")
     if ts is None:
         return
-    tp = Path(ts)
-    endpoint["template"] = {"body": tp.read_text() if tp.is_file() else ts}
+    body = _safe_read_template_path(ts)
+    endpoint["template"] = {"body": body if body is not None else ts}
 
 
 # Map (CLIConfig endpoint field name) -> (AIPerfConfig endpoint key).

--- a/src/aiperf/config/flags/_converter_endpoint.py
+++ b/src/aiperf/config/flags/_converter_endpoint.py
@@ -10,9 +10,9 @@ the dict shape consumed by ``AIPerfConfig``.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from aiperf.common.path_safety import safe_read_template_path
 from aiperf.config.flags._section_fields import ENDPOINT_FIELDS
 
 if TYPE_CHECKING:
@@ -23,40 +23,13 @@ def _url(item: str) -> str:
     return item if "://" in item else f"http://{item}"
 
 
-def _safe_read_template_path(ts: str) -> str | None:
-    """Return file contents if ``ts`` safely resolves to a regular file, else ``None``.
-
-    Hardens ``--extra-inputs payload_template=<path>`` against CWE-22 path-injection
-    findings: rejects symlinks before resolving, then resolves through
-    ``Path.resolve(strict=True)`` (the sanitizer SAST tools recognize), requires the
-    resolved target to be a regular file, and reads with explicit UTF-8 encoding.
-    Returning ``None`` signals the caller to treat ``ts`` as a literal template body.
-    """
-    try:
-        path = Path(ts).expanduser()
-    except (TypeError, ValueError):
-        return None
-    if path.is_symlink():
-        return None
-    try:
-        resolved = path.resolve(strict=True)
-    except (OSError, RuntimeError, ValueError):
-        return None
-    if not resolved.is_file():
-        return None
-    try:
-        return resolved.read_text(encoding="utf-8")
-    except OSError:
-        return None
-
-
 def _endpoint_template_from_extra(
     endpoint: dict[str, Any], extra: dict[str, Any]
 ) -> None:
     payload_template = extra.pop("payload_template", None)
     if payload_template is None:
         return
-    body = _safe_read_template_path(payload_template)
+    body = safe_read_template_path(payload_template)
     if body is None:
         body = payload_template
     endpoint["template"] = {
@@ -77,7 +50,7 @@ def _endpoint_template_fallback(endpoint: dict[str, Any]) -> None:
     ts = ex.get("payload_template")
     if ts is None:
         return
-    body = _safe_read_template_path(ts)
+    body = safe_read_template_path(ts)
     endpoint["template"] = {"body": body if body is not None else ts}
 
 

--- a/src/aiperf/endpoints/template_endpoint.py
+++ b/src/aiperf/endpoints/template_endpoint.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 import jinja2
@@ -16,6 +15,7 @@ from aiperf.common.models import (
     ParsedResponse,
     RequestInfo,
 )
+from aiperf.common.path_safety import safe_read_template_path
 from aiperf.endpoints.base_endpoint import BaseEndpoint
 
 NAMED_TEMPLATES: dict[str, str] = {
@@ -55,13 +55,10 @@ class TemplateEndpoint(BaseEndpoint):
             self.info(f"Using named template: '{template_source}'")
             template_source = NAMED_TEMPLATES[template_source]
         else:
-            try:
-                template_path = Path(template_source)
-                if template_path.is_file():
-                    self.info(f"Loading template from file: '{template_path}'")
-                    template_source = template_path.read_text(encoding="utf-8")
-            except (OSError, ValueError) as e:
-                self.debug(f"Not a file or treating as inline template: '{e!r}'")
+            file_text = safe_read_template_path(template_source)
+            if file_text is not None:
+                self.info(f"Loading template from file: '{template_source}'")
+                template_source = file_text
 
         self._template = jinja2.Environment(autoescape=True).from_string(
             template_source

--- a/tests/unit/config/test_converter_endpoint_template_paths.py
+++ b/tests/unit/config/test_converter_endpoint_template_paths.py
@@ -22,11 +22,12 @@ import sys
 from pathlib import Path
 
 import pytest
+from pytest import param
 
+from aiperf.common.path_safety import safe_read_template_path
 from aiperf.config.flags._converter_endpoint import (
     _endpoint_template_fallback,
     _endpoint_template_from_extra,
-    _safe_read_template_path,
 )
 from aiperf.plugin.enums import EndpointType
 
@@ -131,10 +132,10 @@ class TestEndpointTemplateFallbackPathSafety:
     @pytest.mark.parametrize(
         "ep_type",
         [
-            pytest.param(EndpointType.CHAT, id="chat"),
-            pytest.param(EndpointType.COMPLETIONS, id="completions"),
+            param(EndpointType.CHAT, id="chat"),
+            param(EndpointType.COMPLETIONS, id="completions"),
         ],
-    )
+    )  # fmt: skip
     def test_non_template_endpoints_skip_fallback(
         self, tmp_path: Path, ep_type: EndpointType
     ) -> None:
@@ -151,7 +152,7 @@ class TestEndpointTemplateFallbackPathSafety:
 
 
 class TestSafeReadTemplatePathReadFailures:
-    """``_safe_read_template_path`` must swallow ``OSError`` from the read step.
+    """``safe_read_template_path`` must swallow ``OSError`` from the read step.
 
     ``resolve(strict=True)`` already exercises the ``OSError`` branch via
     ``FileNotFoundError`` for missing paths. The remaining uncovered branch is
@@ -172,13 +173,13 @@ class TestSafeReadTemplatePathReadFailures:
         unreadable.write_text('{"hello": "world"}', encoding="utf-8")
         unreadable.chmod(0o000)
         try:
-            assert _safe_read_template_path(str(unreadable)) is None
+            assert safe_read_template_path(str(unreadable)) is None
         finally:
             unreadable.chmod(0o644)
 
 
 class TestSafeReadTemplatePathConstructionFailures:
-    """``_safe_read_template_path`` must reject inputs that fail ``Path()`` construction.
+    """``safe_read_template_path`` must reject inputs that fail ``Path()`` construction.
 
     Defensive against upstream parsers that hand the helper a non-string value
     (e.g., ``--extra-inputs`` JSON parsed to an int/None for ``payload_template``).
@@ -189,13 +190,50 @@ class TestSafeReadTemplatePathConstructionFailures:
     @pytest.mark.parametrize(
         "bad_input",
         [
-            pytest.param(42, id="int"),
-            pytest.param(None, id="none"),
-            pytest.param(["a", "b"], id="list"),
-            pytest.param({"x": 1}, id="dict"),
+            param(42, id="int"),
+            param(None, id="none"),
+            param(["a", "b"], id="list"),
+            param({"x": 1}, id="dict"),
         ],
-    )
+    )  # fmt: skip
     def test_non_string_input_returns_none(self, bad_input: object) -> None:
         # ``ts`` is typed ``str`` but the helper guards against parser
         # misbehavior that smuggles a non-str through ``dict.get``.
-        assert _safe_read_template_path(bad_input) is None  # type: ignore[arg-type]
+        assert safe_read_template_path(bad_input) is None  # type: ignore[arg-type]
+
+
+class TestSafeReadTemplatePathSymlinkedParent:
+    """Symlinks anywhere in the path chain must be rejected, not just at the leaf.
+
+    ``Path("link_dir/file.json").is_symlink()`` returns ``False`` because the
+    leaf is a regular file — but ``resolve(strict=True)`` follows the symlinked
+    parent. A complete CWE-22 mitigation must check every component.
+    """
+
+    def test_symlinked_parent_directory_is_rejected(self, tmp_path: Path) -> None:
+        real_dir = tmp_path / "real_dir"
+        real_dir.mkdir()
+        target = real_dir / "tmpl.json"
+        target.write_text('{"sensitive": "do-not-read"}', encoding="utf-8")
+        link_dir = tmp_path / "link_dir"
+        link_dir.symlink_to(real_dir)
+        file_via_link = link_dir / "tmpl.json"
+
+        # Sanity: the leaf is NOT a symlink, but the parent IS.
+        assert not file_via_link.is_symlink()
+        assert file_via_link.parent.is_symlink()
+
+        assert safe_read_template_path(str(file_via_link)) is None
+
+
+class TestSafeReadTemplatePathRuntimeError:
+    """``expanduser()`` raises ``RuntimeError`` for unresolvable ``~user`` prefixes.
+
+    A literal template body starting with ``~unknownuser/`` must collapse to
+    ``None`` (caller falls back to the literal-template-body branch) rather
+    than crash config conversion.
+    """
+
+    def test_unknown_user_prefix_returns_none(self) -> None:
+        # `~nonexistentuser123abc` cannot resolve; expanduser raises RuntimeError.
+        assert safe_read_template_path("~nonexistentuser123abc/template.j2") is None

--- a/tests/unit/config/test_converter_endpoint_template_paths.py
+++ b/tests/unit/config/test_converter_endpoint_template_paths.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Security regression tests for template-path reads in ``_converter_endpoint``.
+
+Path-injection hardening for ``--extra-inputs payload_template=...``: the
+converter must resolve the path through ``Path.resolve(strict=True)``,
+refuse to follow symlinks, and read with explicit UTF-8 encoding. When any
+safety check fails (missing path, symlink, non-regular file), the converter
+falls back to treating the original string as a literal template body — the
+pre-existing behavior for non-file inputs.
+
+Covers both call sites that read a user-supplied template path:
+``_endpoint_template_from_extra`` (line 33) and ``_endpoint_template_fallback``
+(line 53).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aiperf.config.flags._converter_endpoint import (
+    _endpoint_template_fallback,
+    _endpoint_template_from_extra,
+)
+from aiperf.plugin.enums import EndpointType
+
+
+class TestEndpointTemplateFromExtraPathSafety:
+    """``payload_template`` in ``extra_inputs`` must read files safely."""
+
+    def test_regular_file_is_read_as_body(self, tmp_path: Path) -> None:
+        template = tmp_path / "tmpl.json"
+        template.write_text('{"hello": "world"}', encoding="utf-8")
+        endpoint: dict = {}
+        extra: dict = {"payload_template": str(template)}
+
+        _endpoint_template_from_extra(endpoint, extra)
+
+        assert endpoint["template"]["body"] == '{"hello": "world"}'
+
+    def test_utf8_file_is_decoded_explicitly(self, tmp_path: Path) -> None:
+        template = tmp_path / "tmpl.json"
+        template.write_text('{"text": "café"}', encoding="utf-8")
+        endpoint: dict = {}
+        extra: dict = {"payload_template": str(template)}
+
+        _endpoint_template_from_extra(endpoint, extra)
+
+        assert endpoint["template"]["body"] == '{"text": "café"}'
+
+    def test_symlink_is_rejected_and_string_used_as_literal_body(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "target.json"
+        target.write_text('{"sensitive": "do-not-read"}', encoding="utf-8")
+        link = tmp_path / "link.json"
+        link.symlink_to(target)
+        endpoint: dict = {}
+        extra: dict = {"payload_template": str(link)}
+
+        _endpoint_template_from_extra(endpoint, extra)
+
+        assert endpoint["template"]["body"] == str(link)
+
+    def test_missing_path_falls_back_to_literal_body(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.json"
+        endpoint: dict = {}
+        extra: dict = {"payload_template": str(missing)}
+
+        _endpoint_template_from_extra(endpoint, extra)
+
+        assert endpoint["template"]["body"] == str(missing)
+
+    def test_directory_path_falls_back_to_literal_body(self, tmp_path: Path) -> None:
+        endpoint: dict = {}
+        extra: dict = {"payload_template": str(tmp_path)}
+
+        _endpoint_template_from_extra(endpoint, extra)
+
+        assert endpoint["template"]["body"] == str(tmp_path)
+
+
+class TestEndpointTemplateFallbackPathSafety:
+    """Fallback path through ``endpoint['extra']`` must read files safely."""
+
+    def test_regular_file_is_read_as_body(self, tmp_path: Path) -> None:
+        template = tmp_path / "tmpl.json"
+        template.write_text('{"hello": "world"}', encoding="utf-8")
+        endpoint: dict = {
+            "type": EndpointType.TEMPLATE,
+            "extra": {"payload_template": str(template)},
+        }
+
+        _endpoint_template_fallback(endpoint)
+
+        assert endpoint["template"]["body"] == '{"hello": "world"}'
+
+    def test_symlink_is_rejected_and_string_used_as_literal_body(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "target.json"
+        target.write_text('{"sensitive": "do-not-read"}', encoding="utf-8")
+        link = tmp_path / "link.json"
+        link.symlink_to(target)
+        endpoint: dict = {
+            "type": EndpointType.TEMPLATE,
+            "extra": {"payload_template": str(link)},
+        }
+
+        _endpoint_template_fallback(endpoint)
+
+        assert endpoint["template"]["body"] == str(link)
+
+    def test_missing_path_falls_back_to_literal_body(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.json"
+        endpoint: dict = {
+            "type": EndpointType.TEMPLATE,
+            "extra": {"payload_template": str(missing)},
+        }
+
+        _endpoint_template_fallback(endpoint)
+
+        assert endpoint["template"]["body"] == str(missing)
+
+    @pytest.mark.parametrize(
+        "ep_type",
+        [
+            pytest.param(EndpointType.CHAT, id="chat"),
+            pytest.param(EndpointType.COMPLETIONS, id="completions"),
+        ],
+    )
+    def test_non_template_endpoints_skip_fallback(
+        self, tmp_path: Path, ep_type: EndpointType
+    ) -> None:
+        template = tmp_path / "tmpl.json"
+        template.write_text("body", encoding="utf-8")
+        endpoint: dict = {
+            "type": ep_type,
+            "extra": {"payload_template": str(template)},
+        }
+
+        _endpoint_template_fallback(endpoint)
+
+        assert "template" not in endpoint

--- a/tests/unit/config/test_converter_endpoint_template_paths.py
+++ b/tests/unit/config/test_converter_endpoint_template_paths.py
@@ -17,6 +17,8 @@ Covers both call sites that read a user-supplied template path:
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -24,6 +26,7 @@ import pytest
 from aiperf.config.flags._converter_endpoint import (
     _endpoint_template_fallback,
     _endpoint_template_from_extra,
+    _safe_read_template_path,
 )
 from aiperf.plugin.enums import EndpointType
 
@@ -145,3 +148,30 @@ class TestEndpointTemplateFallbackPathSafety:
         _endpoint_template_fallback(endpoint)
 
         assert "template" not in endpoint
+
+
+class TestSafeReadTemplatePathReadFailures:
+    """``_safe_read_template_path`` must swallow ``OSError`` from the read step.
+
+    ``resolve(strict=True)`` already exercises the ``OSError`` branch via
+    ``FileNotFoundError`` for missing paths. The remaining uncovered branch is
+    a read failure on a file that passed ``is_file()`` — e.g., permission
+    denied, or a TOCTOU delete between the stat and the open.
+    """
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX chmod semantics; Windows ACLs do not block owner reads via chmod",
+    )
+    @pytest.mark.skipif(
+        os.geteuid() == 0 if hasattr(os, "geteuid") else False,
+        reason="root bypasses file mode permission checks",
+    )
+    def test_unreadable_file_returns_none(self, tmp_path: Path) -> None:
+        unreadable = tmp_path / "locked.json"
+        unreadable.write_text('{"hello": "world"}', encoding="utf-8")
+        unreadable.chmod(0o000)
+        try:
+            assert _safe_read_template_path(str(unreadable)) is None
+        finally:
+            unreadable.chmod(0o644)

--- a/tests/unit/config/test_converter_endpoint_template_paths.py
+++ b/tests/unit/config/test_converter_endpoint_template_paths.py
@@ -175,3 +175,27 @@ class TestSafeReadTemplatePathReadFailures:
             assert _safe_read_template_path(str(unreadable)) is None
         finally:
             unreadable.chmod(0o644)
+
+
+class TestSafeReadTemplatePathConstructionFailures:
+    """``_safe_read_template_path`` must reject inputs that fail ``Path()`` construction.
+
+    Defensive against upstream parsers that hand the helper a non-string value
+    (e.g., ``--extra-inputs`` JSON parsed to an int/None for ``payload_template``).
+    ``Path(non_str)`` raises ``TypeError`` and certain invalid string contents raise
+    ``ValueError``; both must collapse to ``None`` rather than propagate.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_input",
+        [
+            pytest.param(42, id="int"),
+            pytest.param(None, id="none"),
+            pytest.param(["a", "b"], id="list"),
+            pytest.param({"x": 1}, id="dict"),
+        ],
+    )
+    def test_non_string_input_returns_none(self, bad_input: object) -> None:
+        # ``ts`` is typed ``str`` but the helper guards against parser
+        # misbehavior that smuggles a non-str through ``dict.get``.
+        assert _safe_read_template_path(bad_input) is None  # type: ignore[arg-type]

--- a/tests/unit/config/test_converter_endpoint_template_paths.py
+++ b/tests/unit/config/test_converter_endpoint_template_paths.py
@@ -237,3 +237,20 @@ class TestSafeReadTemplatePathRuntimeError:
     def test_unknown_user_prefix_returns_none(self) -> None:
         # `~nonexistentuser123abc` cannot resolve; expanduser raises RuntimeError.
         assert safe_read_template_path("~nonexistentuser123abc/template.j2") is None
+
+
+class TestSafeReadTemplatePathDecodeFailures:
+    """A file passing every sanitizer check but failing UTF-8 decode must
+    collapse to ``None`` (the caller treats the original path string as a
+    literal template body) instead of crashing with ``UnicodeDecodeError``.
+
+    ``UnicodeDecodeError`` is a subclass of ``ValueError``, not ``OSError``,
+    so the read-step catch must include ``UnicodeError`` alongside ``OSError``.
+    """
+
+    def test_non_utf8_file_returns_none(self, tmp_path: Path) -> None:
+        bad = tmp_path / "latin1.bin"
+        # Bytes 0xff/0xfe are valid Latin-1 but invalid as a UTF-8 start byte.
+        bad.write_bytes(b"\xff\xfe binary template body")
+
+        assert safe_read_template_path(str(bad)) is None

--- a/tests/unit/endpoints/test_template_endpoint.py
+++ b/tests/unit/endpoints/test_template_endpoint.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+
 import pytest
 
 from aiperf.common.exceptions import InvalidStateError
@@ -467,7 +469,9 @@ class TestTemplateEndpointPathSafety:
     directly and must apply the same path-injection hardening.
     """
 
-    def test_symlinked_payload_template_treated_as_literal(self, tmp_path):
+    def test_symlinked_payload_template_treated_as_literal(
+        self, tmp_path: Path
+    ) -> None:
         target = tmp_path / "target.json"
         target.write_text('{"sensitive": "do-not-read"}', encoding="utf-8")
         link = tmp_path / "link.json"
@@ -483,3 +487,17 @@ class TestTemplateEndpointPathSafety:
         # source. Rendering it produces the path string unchanged (no Jinja
         # vars to substitute), proving the symlink target was never read.
         assert endpoint._template.render() == str(link)
+
+    def test_regular_file_payload_template_is_loaded(self, tmp_path: Path) -> None:
+        template_file = tmp_path / "tmpl.json"
+        template_file.write_text('{"text": {{ texts|tojson }}}', encoding="utf-8")
+        model_endpoint = create_model_endpoint(
+            EndpointType.TEMPLATE,
+            extra=[("payload_template", str(template_file))],
+        )
+
+        endpoint = create_endpoint_with_mock_transport(TemplateEndpoint, model_endpoint)
+
+        # File path resolves cleanly through safe_read_template_path; the
+        # file CONTENTS (not the path string) became the Jinja source.
+        assert endpoint._template.render(texts=["a", "b"]) == '{"text": ["a", "b"]}'

--- a/tests/unit/endpoints/test_template_endpoint.py
+++ b/tests/unit/endpoints/test_template_endpoint.py
@@ -457,3 +457,29 @@ def test_metadata():
     assert metadata.supports_images is True
     assert metadata.supports_videos is True
     assert metadata.metrics_title == "LLM Metrics"
+
+
+class TestTemplateEndpointPathSafety:
+    """``TemplateEndpoint.__init__`` must reject symlinks when loading payload_template.
+
+    The CLI-flag converter (``_converter_endpoint.build_endpoint``) is one entry
+    point; YAML/direct AIPerfConfig consumption flows through ``TemplateEndpoint``
+    directly and must apply the same path-injection hardening.
+    """
+
+    def test_symlinked_payload_template_treated_as_literal(self, tmp_path):
+        target = tmp_path / "target.json"
+        target.write_text('{"sensitive": "do-not-read"}', encoding="utf-8")
+        link = tmp_path / "link.json"
+        link.symlink_to(target)
+        model_endpoint = create_model_endpoint(
+            EndpointType.TEMPLATE,
+            extra=[("payload_template", str(link))],
+        )
+
+        endpoint = create_endpoint_with_mock_transport(TemplateEndpoint, model_endpoint)
+
+        # Post-fix: symlink rejected, the path string itself is the template
+        # source. Rendering it produces the path string unchanged (no Jinja
+        # vars to substitute), proving the symlink target was never read.
+        assert endpoint._template.render() == str(link)


### PR DESCRIPTION
## Summary

- Resolves a SAST CWE-22 path-injection finding on `src/aiperf/config/flags/_converter_endpoint.py::_endpoint_template_fallback` (and the identical pattern in `_endpoint_template_from_extra`, which would otherwise re-flag on a re-scan).
- Adds a private `_safe_read_template_path` helper that rejects symlinks pre-resolution, resolves via `Path.resolve(strict=True)` (the canonical sanitizer SAST tools recognize), requires the resolved target to be a regular file, and reads with explicit UTF-8 encoding. Both call sites are rewired through it.
- Preserves existing semantics for the two legitimate input shapes: regular file path → file contents become the template body; inline template string (no such file) → string is the template body.

## Behavior change to note

Users who passed a symlink as `--extra-inputs payload_template=<path>` previously had the symlink target's contents read in as the template body. After this change the symlink path string is treated as a literal template body (no symlink following). Inline strings and direct file paths are unchanged.

## Test plan

- [x] New tests in `tests/unit/config/test_converter_endpoint_template_paths.py` (10 cases) cover: regular file read, explicit UTF-8 decode, symlink rejection (the regression), missing path → literal fallback, directory path → literal fallback, and non-TEMPLATE endpoints skip the fallback. Verified RED first — the 2 symlink tests failed against pre-fix code (they read the target contents instead of the literal path).
- [x] `uv run pytest tests/unit/config/ tests/unit/endpoints/ -n auto` → 2245 passed, 55 skipped, 0 failed.
- [x] `uv run pytest tests/unit/property/ -n auto` → 59 passed.
- [x] `pre-commit run` on staged files → all 30 hooks pass (incl. `check-ergonomics`, `check-ruff-baselined`, `ruff format`, `test-imports`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safe filesystem-template read helper and integrated it into template loading to prefer validated file contents.

* **Bug Fixes**
  * Hardened template loading so symlinks, directories, missing/unreadable paths, and other unsafe inputs are rejected and treated as literal template text with explicit UTF-8 handling.

* **Tests**
  * Added comprehensive unit tests covering path-safety, symlink/parent-symlink rejection, invalid path inputs, read failures, and fallback behavior.

* **Documentation**
  * Added guidance and coding-standard notes describing the safe-filesystem-read pattern and expected fallback semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->