### PR TITLE
chore(rename): ARTIFACTORY_REPO_NAME -> ARTIFACTORY_PYPI_REPO_NAME

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1001,19 +1001,19 @@ jobs:
     steps:
       - name: Trigger GitLab pipeline
         env:
-          GITLAB_TRIGGER_TOKEN:   ${{ secrets.GITLAB_TRIGGER_TOKEN }}
-          GITLAB_TRIGGER_URL:     ${{ secrets.GITLAB_PIPELINE_URL }}
-          NIGHTLY_TAG:            ${{ needs.prepare-nightly.outputs.nightly_tag }}
-          WHEEL_VERSION:          ${{ needs.prepare-nightly.outputs.wheel_version }}
-          WHEEL_FILENAME:         ${{ needs.prepare-nightly.outputs.wheel_filename }}
-          NIGHTLY_WHEEL_FILENAME: ${{ needs.prepare-nightly.outputs.nightly_wheel_filename }}
-          CONTAINER_TAG:          ${{ needs.prepare-nightly.outputs.container_tag }}
-          NGC_STAGING_IMAGE_BASE: ${{ secrets.NGC_STAGING_IMAGE_BASE }}
-          RESOLVED_SHA:           ${{ needs.prepare-nightly.outputs.resolved_sha }}
-          TIMESTAMP:              ${{ needs.prepare-nightly.outputs.run_timestamp }}
-          STAGE_SUBPATH:          ${{ needs.prepare-nightly.outputs.stage_subpath }}
-          ARTIFACTORY_PYPI_URL:   ${{ secrets.ARTIFACTORY_PYPI_URL }}
-          ARTIFACTORY_REPO_NAME:  ${{ secrets.ARTIFACTORY_REPO_NAME }}
+          GITLAB_TRIGGER_TOKEN:       ${{ secrets.GITLAB_TRIGGER_TOKEN }}
+          GITLAB_TRIGGER_URL:         ${{ secrets.GITLAB_PIPELINE_URL }}
+          NIGHTLY_TAG:                ${{ needs.prepare-nightly.outputs.nightly_tag }}
+          WHEEL_VERSION:              ${{ needs.prepare-nightly.outputs.wheel_version }}
+          WHEEL_FILENAME:             ${{ needs.prepare-nightly.outputs.wheel_filename }}
+          NIGHTLY_WHEEL_FILENAME:     ${{ needs.prepare-nightly.outputs.nightly_wheel_filename }}
+          CONTAINER_TAG:              ${{ needs.prepare-nightly.outputs.container_tag }}
+          NGC_STAGING_IMAGE_BASE:     ${{ secrets.NGC_STAGING_IMAGE_BASE }}
+          RESOLVED_SHA:               ${{ needs.prepare-nightly.outputs.resolved_sha }}
+          TIMESTAMP:                  ${{ needs.prepare-nightly.outputs.run_timestamp }}
+          STAGE_SUBPATH:              ${{ needs.prepare-nightly.outputs.stage_subpath }}
+          ARTIFACTORY_PYPI_URL:       ${{ secrets.ARTIFACTORY_PYPI_URL }}
+          ARTIFACTORY_PYPI_REPO_NAME: ${{ secrets.ARTIFACTORY_PYPI_REPO_NAME }}
         run: |
           set -euo pipefail
 
@@ -1059,7 +1059,7 @@ jobs:
             --form "variables[GITHUB_RUN_ID]=${GITHUB_RUN_ID}" \
             --form "variables[ARTIFACTS]=wheel,container" \
             --form "variables[ARTIFACTORY_PYPI_URL]=${ARTIFACTORY_PYPI_URL}" \
-            --form "variables[ARTIFACTORY_REPO_NAME]=${ARTIFACTORY_REPO_NAME}" \
+            --form "variables[ARTIFACTORY_PYPI_REPO_NAME]=${ARTIFACTORY_PYPI_REPO_NAME}" \
             --form "variables[ARTIFACTORY_WHEEL_PATH]=${ARTIFACTORY_WHEEL_PATH}" \
             --form "variables[ARTIFACTORY_NIGHTLY_WHEEL_PATH]=${ARTIFACTORY_NIGHTLY_WHEEL_PATH}" \
             --form "variables[TIMESTAMP]=${TIMESTAMP}" \


### PR DESCRIPTION
## Summary

Follow-up to #973. Rename the GitHub secret reference and the GitLab pipeline variable from `ARTIFACTORY_REPO_NAME` to `ARTIFACTORY_PYPI_REPO_NAME` so the PyPI-repo scoping is explicit and the naming matches the sibling `ARTIFACTORY_PYPI_URL` secret.

The env block in the `Trigger GitLab pipeline` step is realigned to accommodate the new (longest) key. No behavioral change beyond the rename and the corresponding env-block whitespace.

## Test plan

- [ ] Confirm the `automated-release` environment has the `ARTIFACTORY_PYPI_REPO_NAME` secret populated (rename or duplicate from the old `ARTIFACTORY_REPO_NAME` before merging this PR).
- [ ] After merge, trigger a manual nightly via `workflow_dispatch` and verify the `Trigger GitLab pipeline` step's env dump shows `ARTIFACTORY_PYPI_REPO_NAME` masked (`***`) — not empty.
- [ ] Confirm the downstream GitLab compliance pipeline now sees `ARTIFACTORY_PYPI_REPO_NAME` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly workflow configuration to align security scan trigger with current environment variable naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->