### PR TITLE
fix(config): restore profile image source CLI flag (cherry-pick to release/0.9.0)

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -619,6 +619,11 @@ Image file format for generated images. Choose `png` for lossless compression (l
 | `jpeg` |  | JPEG format. Lossy compression, smaller file sizes, good for photos. |
 | `random` |  | Randomly select PNG or JPEG for each image. |
 
+#### `--image-source` `<str>`
+
+Source image generation mode (default `noise`). `noise` generates random noise images on the fly at the requested dimensions — no files on disk required, and the pool is effectively unbounded so servers cannot dedupe on identical inputs. `assets` loads images from the built-in `assets/source_images` directory (ships with a small set of 4 images) and resizes them to the requested dimensions. A path to a directory loads images from the given directory (e.g. `--image-source ./source_images`). Note: random-noise images are roughly incompressible, so payload bytes are larger than equivalent natural images.
+<br/>_Default: `noise`_
+
 ### Video Input
 
 #### `--video-batch-size`, `--batch-size-video` `<int>`
@@ -1932,6 +1937,11 @@ Image file format for generated images. Choose `png` for lossless compression (l
 | `png` | _default_ | PNG format. Lossless compression, larger file sizes, best quality. |
 | `jpeg` |  | JPEG format. Lossy compression, smaller file sizes, good for photos. |
 | `random` |  | Randomly select PNG or JPEG for each image. |
+
+#### `--image-source` `<str>`
+
+Source image generation mode (default `noise`). `noise` generates random noise images on the fly at the requested dimensions — no files on disk required, and the pool is effectively unbounded so servers cannot dedupe on identical inputs. `assets` loads images from the built-in `assets/source_images` directory (ships with a small set of 4 images) and resizes them to the requested dimensions. A path to a directory loads images from the given directory (e.g. `--image-source ./source_images`). Note: random-noise images are roughly incompressible, so payload bytes are larger than equivalent natural images.
+<br/>_Default: `noise`_
 
 ### Video Input
 

--- a/src/aiperf/config/flags/_converter_dataset.py
+++ b/src/aiperf/config/flags/_converter_dataset.py
@@ -186,6 +186,8 @@ def _build_images(cli: CLIConfig) -> dict[str, Any]:
         out["batch_size"] = cli.image_batch_size
     if "image_format" in s:
         out["format"] = cli.image_format
+    if "image_source" in s:
+        out["source"] = cli.image_source
     return out
 
 
@@ -426,6 +428,7 @@ def _apply_implicit_media_batch(d: dict[str, Any], cli: CLIConfig) -> None:
             "image_height_mean",
             "image_height_stddev",
             "image_batch_size",
+            "image_source",
         ),
         "audio": ("audio_length_mean", "audio_length_stddev", "audio_batch_size"),
         "video": (
@@ -483,6 +486,7 @@ _FILE_DATASET_INCOMPATIBLE_TRIGGERS: tuple[tuple[str, str], ...] = (
     ("prompt_batch_size", "--prompt-batch-size/--batch-size-text"),
     ("prompt_sequence_distribution", "--seq-dist/--sequence-distribution"),
     ("image_batch_size", "--image-batch-size"),
+    ("image_source", "--image-source"),
     ("audio_batch_size", "--audio-batch-size"),
     ("video_batch_size", "--video-batch-size"),
 )

--- a/src/aiperf/config/flags/_section_fields.py
+++ b/src/aiperf/config/flags/_section_fields.py
@@ -81,6 +81,7 @@ INPUT_FIELDS: frozenset[str] = frozenset(
         "image_height_stddev",
         "image_batch_size",
         "image_format",
+        "image_source",
         # ----- audio modality -----
         "audio_batch_size",
         "audio_length_mean",

--- a/src/aiperf/config/flags/cli_config.py
+++ b/src/aiperf/config/flags/cli_config.py
@@ -44,6 +44,7 @@ from aiperf.common.enums import (
     ExportLevel,
     GPUTelemetryMode,
     ImageFormat,
+    ImageSource,
     ModelSelectionStrategy,
     RequestContentType,
     ServerMetricsFormat,
@@ -1243,6 +1244,24 @@ class CLIConfig(BaseConfig):
             group=Groups.IMAGE_INPUT,
         ),
     ] = ImageFormat.PNG
+
+    image_source: Annotated[
+        ImageSource | Path,
+        Field(
+            default=ImageSource.NOISE,
+            description="Source image generation mode (default `noise`). "
+            "`noise` generates random noise images on the fly at the requested dimensions — no files on disk required, "
+            "and the pool is effectively unbounded so servers cannot dedupe on identical inputs. "
+            "`assets` loads images from the built-in `assets/source_images` directory (ships with a small set of 4 images) "
+            "and resizes them to the requested dimensions. "
+            "A path to a directory loads images from the given directory (e.g. `--image-source ./source_images`). "
+            "Note: random-noise images are roughly incompressible, so payload bytes are larger than equivalent natural images.",
+        ),
+        CLIParameter(
+            name=("--image-source",),
+            group=Groups.IMAGE_INPUT,
+        ),
+    ]
 
     ##############################################################################
     # Video Input

--- a/tests/component_integration/timing/test_invariants.py
+++ b/tests/component_integration/timing/test_invariants.py
@@ -174,11 +174,11 @@ class TestConcurrencyInvariants:
 class TestRateLimitingInvariants:
     """Tests for rate limiting enforcement invariants."""
 
-    def test_actual_rate_approximately_matches_configured(self, cli: AIPerfCLI):
-        """Verify actual throughput approximately matches configured rate.
+    def test_actual_rate_does_not_exceed_configured(self, cli: AIPerfCLI):
+        """Verify actual throughput does not materially exceed configured rate.
 
-        The actual rate should be within a reasonable tolerance of the configured
-        rate. Too fast = rate limiting not working. Too slow = performance bug.
+        Rate limiting correctness means credits are not issued too fast. CI runner
+        scheduling can make a short component test slower than the target rate.
         """
         target_qps = 400.0
         config = TimingTestConfig(
@@ -197,12 +197,11 @@ class TestRateLimitingInvariants:
         duration_sec = (issue_times[-1] - issue_times[0]) / NANOS_PER_SECOND
         actual_rate = (len(issue_times) - 1) / duration_sec if duration_sec > 0 else 0
 
-        # Allow 40% tolerance (rate limiting has inherent variability)
-        tolerance = target_qps * 0.4
-        assert abs(actual_rate - target_qps) < tolerance, (
-            f"Actual rate {actual_rate:.1f} QPS differs from target {target_qps:.1f} QPS "
-            f"by more than {tolerance:.1f} (40%). "
-            f"Rate limiting may not be working correctly."
+        # Allow 40% overshoot tolerance (rate limiting has inherent variability).
+        max_allowed_rate = target_qps * 1.4
+        assert actual_rate <= max_allowed_rate, (
+            f"Actual rate {actual_rate:.1f} QPS exceeds target {target_qps:.1f} QPS "
+            f"by more than 40%. Rate limiting may not be working correctly."
         )
 
     def test_rate_not_exceeded_burst_stress(self, cli: AIPerfCLI):

--- a/tests/unit/config/test_cli_image_source.py
+++ b/tests/unit/config/test_cli_image_source.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aiperf.common.enums import ImageSource
+from aiperf.config.dataset import SyntheticDataset
+from aiperf.config.flags._converter_dataset import build_dataset
+from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.config.flags.converter import convert_cli_to_aiperf
+
+
+def _synthetic_cli(**kwargs: object) -> CLIConfig:
+    return CLIConfig(
+        model_names=["test-model"],
+        prompt_input_tokens_mean=16,
+        prompt_output_tokens_mean=8,
+        image_batch_size=1,
+        image_width_mean=64,
+        image_height_mean=64,
+        **kwargs,
+    )
+
+
+def test_cli_image_source_noise_flows_to_synthetic_dataset() -> None:
+    user = _synthetic_cli(image_source="noise")
+
+    ds_dict = build_dataset(user)
+    assert ds_dict["images"]["source"] is ImageSource.NOISE
+
+    aiperf_config = convert_cli_to_aiperf(user)
+    main_dataset = aiperf_config.benchmark.get_default_dataset()
+    assert isinstance(main_dataset, SyntheticDataset)
+    assert main_dataset.images.source is ImageSource.NOISE
+
+
+def test_cli_image_source_path_flows_to_synthetic_dataset(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source_images"
+    source_dir.mkdir()
+    user = _synthetic_cli(image_source=str(source_dir))
+
+    ds_dict = build_dataset(user)
+    assert ds_dict["images"]["source"] == source_dir
+
+    aiperf_config = convert_cli_to_aiperf(user)
+    main_dataset = aiperf_config.benchmark.get_default_dataset()
+    assert isinstance(main_dataset, SyntheticDataset)
+    assert main_dataset.images.source == source_dir
+
+
+def test_cli_image_source_rejected_for_file_dataset(tmp_path: Path) -> None:
+    input_file = tmp_path / "inputs.jsonl"
+    input_file.write_text("{}\n")
+    user = CLIConfig(input_file=str(input_file), image_source="assets")
+
+    with pytest.raises(ValueError, match="--image-source is only supported"):
+        build_dataset(user)

--- a/tests/unit/config/test_loader_adversarial.py
+++ b/tests/unit/config/test_loader_adversarial.py
@@ -19,7 +19,7 @@ import textwrap
 import pytest
 from pydantic import ValidationError
 
-from aiperf.config.loader.core import load_config_from_string
+from aiperf.config.loader.core import _MAX_CONFIG_NESTING_DEPTH, load_config_from_string
 from aiperf.config.loader.errors import ConfigurationError
 
 _VALID_BENCHMARK = textwrap.dedent("""\
@@ -99,8 +99,9 @@ def test_yaml_cycle_raises_configuration_error() -> None:
 
 def test_yaml_deep_nesting_raises_configuration_error() -> None:
     """A pathologically deep config must raise ConfigurationError, not RecursionError."""
-    # Build a deeply nested mapping under the `variables` envelope key.
-    depth = 1000
+    # Stay just above AIPerf's explicit depth guard without forcing PyYAML itself
+    # into interpreter-level recursion warnings before the guard can run.
+    depth = _MAX_CONFIG_NESTING_DEPTH + 1
     nested = "leaf: 1"
     for _ in range(depth):
         nested = "a:\n  " + nested.replace("\n", "\n  ")


### PR DESCRIPTION
## Summary
- Cherry-pick of c36476561 from `main` into `release/0.9.0`
- Original PR: #975 — fix(config): restore profile image source CLI flag

## Conflicts
None — clean cherry-pick.