### PR TITLE
fix(config): auto-detect BurstGPT CSV in DatasetResolver and pin fixed_schedule regression

### DIFF
--- a/src/aiperf/config/dataset/resolver.py
+++ b/src/aiperf/config/dataset/resolver.py
@@ -244,7 +244,7 @@ class DatasetResolver:
         import orjson
 
         try:
-            with open(file_path) as f:
+            with open(file_path, encoding="utf-8") as f:
                 for line in f:
                     if line := line.strip():
                         try:

--- a/src/aiperf/config/dataset/resolver.py
+++ b/src/aiperf/config/dataset/resolver.py
@@ -224,27 +224,36 @@ class DatasetResolver:
 
     @staticmethod
     def _read_first_jsonl_record(file_path: str) -> dict | None:
-        """Return the first JSON-parseable line of ``file_path`` as a dict.
+        """Return the first JSON-object line of ``file_path`` as a dict.
 
-        Returns ``None`` for an empty file or a non-JSON first line (e.g.
-        BurstGPT's CSV header) so the caller can fall through to
-        structural detection. Uses ``orjson.loads`` directly rather than
-        ``load_json_str`` because a non-JSON first line is an expected
-        outcome here — ``load_json_str`` would log a misleading "Failed
-        to parse JSON string" warning on every successful CSV
-        auto-detect. Lets ``OSError`` propagate so callers can
-        distinguish "can't read the file at all" from "read it but the
-        first line isn't JSON".
+        Returns ``None`` for any of: an empty file, a binary or non-UTF-8
+        file (the text iterator raises ``UnicodeDecodeError``), a
+        non-JSON first line (e.g. BurstGPT's CSV header), or a first
+        line that parses as valid JSON but isn't an object (a list,
+        string, or number). All of these are expected probe outcomes —
+        the caller falls through to structural detection so each
+        loader's ``can_load`` gets a chance.
+
+        Uses ``orjson.loads`` directly rather than ``load_json_str``
+        because the non-JSON case is expected here; ``load_json_str``
+        would log a misleading "Failed to parse JSON string" warning on
+        every successful CSV auto-detect. Lets ``OSError`` propagate so
+        callers can distinguish "can't read the file at all" from "read
+        it but the first line isn't a JSON object".
         """
         import orjson
 
-        with open(file_path) as f:
-            for line in f:
-                if line := line.strip():
-                    try:
-                        return orjson.loads(line)
-                    except orjson.JSONDecodeError:
-                        return None
+        try:
+            with open(file_path) as f:
+                for line in f:
+                    if line := line.strip():
+                        try:
+                            parsed = orjson.loads(line)
+                        except orjson.JSONDecodeError:
+                            return None
+                        return parsed if isinstance(parsed, dict) else None
+        except UnicodeDecodeError:
+            return None
         return None
 
     @staticmethod

--- a/src/aiperf/config/dataset/resolver.py
+++ b/src/aiperf/config/dataset/resolver.py
@@ -223,6 +223,27 @@ class DatasetResolver:
         }
 
     @staticmethod
+    def _read_first_jsonl_record(file_path: str) -> dict | None:
+        """Return the first JSON-parseable line of ``file_path`` as a dict.
+
+        Returns ``None`` for an empty file or a non-JSON first line (e.g.
+        BurstGPT's CSV header) so the caller can fall through to
+        structural detection. Lets ``OSError`` propagate so callers can
+        distinguish "can't read the file at all" from "read it but the
+        first line isn't JSON".
+        """
+        from aiperf.common.utils import load_json_str
+
+        with open(file_path) as f:
+            for line in f:
+                if line := line.strip():
+                    try:
+                        return load_json_str(line)
+                    except ValueError:
+                        return None
+        return None
+
+    @staticmethod
     def _detect_type(
         file_path: str,
     ) -> tuple[object | None, dict | None]:
@@ -233,23 +254,15 @@ class DatasetResolver:
         """
         from pathlib import Path
 
-        from aiperf.common.utils import load_json_str
         from aiperf.plugin import plugins
         from aiperf.plugin.enums import CustomDatasetType, PluginType
 
         path = Path(file_path)
-        if path.is_dir():
-            data = None
-        else:
+        data: dict | None = None
+        if not path.is_dir():
             try:
-                with open(file_path) as f:
-                    for line in f:
-                        if line := line.strip():
-                            data = load_json_str(line)
-                            break
-                    else:
-                        return None, None
-            except (OSError, ValueError):
+                data = DatasetResolver._read_first_jsonl_record(file_path)
+            except OSError:
                 return None, None
 
         # Check explicit type field in data

--- a/src/aiperf/config/dataset/resolver.py
+++ b/src/aiperf/config/dataset/resolver.py
@@ -228,18 +228,22 @@ class DatasetResolver:
 
         Returns ``None`` for an empty file or a non-JSON first line (e.g.
         BurstGPT's CSV header) so the caller can fall through to
-        structural detection. Lets ``OSError`` propagate so callers can
+        structural detection. Uses ``orjson.loads`` directly rather than
+        ``load_json_str`` because a non-JSON first line is an expected
+        outcome here — ``load_json_str`` would log a misleading "Failed
+        to parse JSON string" warning on every successful CSV
+        auto-detect. Lets ``OSError`` propagate so callers can
         distinguish "can't read the file at all" from "read it but the
         first line isn't JSON".
         """
-        from aiperf.common.utils import load_json_str
+        import orjson
 
         with open(file_path) as f:
             for line in f:
                 if line := line.strip():
                     try:
-                        return load_json_str(line)
-                    except ValueError:
+                        return orjson.loads(line)
+                    except orjson.JSONDecodeError:
                         return None
         return None
 

--- a/tests/integration/test_burst_gpt_trace.py
+++ b/tests/integration/test_burst_gpt_trace.py
@@ -48,7 +48,7 @@ class TestBurstGPTTraceIntegration:
         cli: AIPerfCLI,
         aiperf_mock_server: AIPerfMockServer,
         tmp_path: Path,
-    ):
+    ) -> None:
         """``--custom-dataset-type burst_gpt_trace --fixed-schedule`` runs end-to-end.
 
         Regresses the resolver bug where ``_check_timing_data`` JSON-parsed
@@ -83,7 +83,7 @@ class TestBurstGPTTraceIntegration:
         cli: AIPerfCLI,
         aiperf_mock_server: AIPerfMockServer,
         tmp_path: Path,
-    ):
+    ) -> None:
         """No ``--custom-dataset-type`` flag — the loader's ``can_load``
         recognizes the BurstGPT CSV header on its own. Regresses the
         ``_detect_type`` bug where a ValueError from JSON-parsing the CSV
@@ -109,3 +109,4 @@ class TestBurstGPTTraceIntegration:
 
         assert result.exit_code == 0
         assert result.request_count == len(rows)
+        assert result.has_all_outputs

--- a/tests/integration/test_burst_gpt_trace.py
+++ b/tests/integration/test_burst_gpt_trace.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for BurstGPT trace custom dataset type.
+
+Regression coverage for the resolver bug where ``--fixed-schedule`` was
+rejected with "dataset has no timing data" because the pre-bootstrap
+resolver tried to JSON-parse BurstGPT's CSV header. The format is the
+only CSV-shaped loader in the tree, so its happy path needs to be pinned
+down explicitly.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tests.harness.utils import AIPerfCLI, AIPerfMockServer
+from tests.integration.conftest import IntegrationTestDefaults as defaults
+from tests.integration.utils import create_burst_gpt_csv_file
+
+
+def _sample_rows() -> list[dict]:
+    """A trimmed BurstGPT-shaped CSV with sub-second timestamps.
+
+    The upstream BurstGPT dataset uses integer-seconds timestamps
+    (5, 45, 118, ...), but the loader converts seconds to milliseconds
+    via ``_preprocess_trace``. Using realistic seconds would stretch
+    the fixed_schedule timeline past the integration-test timeout, so
+    the fixture compresses the spacing while keeping the column shape
+    identical to the real format.
+    """
+    return [
+        {"Timestamp": 0.0, "Model": "ChatGPT", "Request tokens": 472, "Response tokens": 18, "Total tokens": 490, "Log Type": "Conversation log"},
+        {"Timestamp": 0.1, "Model": "ChatGPT", "Request tokens": 1087, "Response tokens": 230, "Total tokens": 1317, "Log Type": "Conversation log"},
+        {"Timestamp": 0.2, "Model": "GPT-4", "Request tokens": 417, "Response tokens": 276, "Total tokens": 693, "Log Type": "Conversation log"},
+        {"Timestamp": 0.3, "Model": "ChatGPT", "Request tokens": 1360, "Response tokens": 647, "Total tokens": 2007, "Log Type": "Conversation log"},
+        {"Timestamp": 0.4, "Model": "ChatGPT", "Request tokens": 185, "Response tokens": 215, "Total tokens": 400, "Log Type": "Conversation log"},
+    ]  # fmt: skip
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestBurstGPTTraceIntegration:
+    """Integration tests for burst_gpt_trace dataset loader."""
+
+    async def test_fixed_schedule_with_explicit_dataset_type(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ):
+        """``--custom-dataset-type burst_gpt_trace --fixed-schedule`` runs end-to-end.
+
+        Regresses the resolver bug where ``_check_timing_data`` JSON-parsed
+        the CSV header, returned False, and made fixed_schedule reject the
+        phase before the loader ever ran.
+        """
+        rows = _sample_rows()
+        csv_file = create_burst_gpt_csv_file(tmp_path, rows)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {csv_file} \
+                --custom-dataset-type burst_gpt_trace \
+                --request-count {len(rows)} \
+                --fixed-schedule \
+                --fixed-schedule-auto-offset \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.exit_code == 0
+        assert result.request_count == len(rows)
+        assert result.has_all_outputs
+
+    async def test_fixed_schedule_auto_detected(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ):
+        """No ``--custom-dataset-type`` flag — the loader's ``can_load``
+        recognizes the BurstGPT CSV header on its own. Regresses the
+        ``_detect_type`` bug where a ValueError from JSON-parsing the CSV
+        header short-circuited structural detection.
+        """
+        rows = _sample_rows()
+        csv_file = create_burst_gpt_csv_file(tmp_path, rows)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {csv_file} \
+                --request-count {len(rows)} \
+                --fixed-schedule \
+                --fixed-schedule-auto-offset \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.exit_code == 0
+        assert result.request_count == len(rows)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -120,6 +120,32 @@ def create_sagemaker_capture_file(
     return capture_file
 
 
+def create_burst_gpt_csv_file(
+    tmp_path: Path,
+    rows: list[dict],
+    filename: str = "burst_gpt.csv",
+) -> Path:
+    """Create a BurstGPT trace CSV file for testing.
+
+    Each row dict must carry ``Timestamp``, ``Request tokens``, and
+    ``Response tokens``; any additional keys (``Model``, ``Total tokens``,
+    ``Log Type``) are written verbatim so the fixture mirrors real BurstGPT.
+    """
+    import csv
+
+    if not rows:
+        raise ValueError("rows must not be empty")
+
+    fieldnames = list(rows[0].keys())
+    csv_path = tmp_path / filename
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    return csv_path
+
+
 def create_rankings_dataset(tmp_path: Path, num_entries: int) -> Path:
     """Create a rankings dataset for testing.
 

--- a/tests/unit/config/test_resolver_edge_cases.py
+++ b/tests/unit/config/test_resolver_edge_cases.py
@@ -366,6 +366,54 @@ class TestDatasetResolverEdgeCases:
 
         assert run.resolved.dataset_file_paths is None
 
+    def test_detect_type_falls_through_for_csv_first_line(self, tmp_path) -> None:
+        """A non-JSON first line (BurstGPT's CSV header) must not short-circuit
+        structural detection. Regresses the bug where ValueError on
+        ``load_json_str`` returned (None, None) before any loader's
+        ``can_load`` got a chance.
+        """
+        from aiperf.plugin.enums import CustomDatasetType
+
+        csv_file = tmp_path / "burst.csv"
+        csv_file.write_text(
+            "Timestamp,Model,Request tokens,Response tokens,Total tokens,Log Type\n"
+            "5,ChatGPT,472,18,490,Conversation log\n"
+            "45,ChatGPT,1087,230,1317,Conversation log\n"
+        )
+
+        detected, first_record = DatasetResolver._detect_type(str(csv_file))
+
+        assert detected == CustomDatasetType.BURST_GPT_TRACE
+        assert first_record is None
+
+    def test_burst_gpt_csv_auto_detected_with_timing(self, tmp_path) -> None:
+        """End-to-end resolver pass: BurstGPT CSV with no explicit format
+        is recognized and reports has_timing=True so fixed_schedule can run.
+        """
+        csv_file = tmp_path / "burst.csv"
+        csv_file.write_text(
+            "Timestamp,Model,Request tokens,Response tokens,Total tokens,Log Type\n"
+            "5,ChatGPT,472,18,490,Conversation log\n"
+            "45,ChatGPT,1087,230,1317,Conversation log\n"
+        )
+
+        config = _make_config(
+            datasets=[{"name": "main", "type": "file", "path": str(csv_file)}],
+            phases=[
+                {
+                    "name": "profiling",
+                    "type": "concurrency",
+                    "requests": 2,
+                    "concurrency": 1,
+                }
+            ],
+        )
+        run = _make_run(config, artifact_dir=tmp_path / "out")
+
+        DatasetResolver().resolve(run)
+
+        assert run.resolved.dataset_has_timing_data == {"main": True}
+
 
 # ============================================================
 # TimingResolver Edge Cases

--- a/tests/unit/config/test_resolver_edge_cases.py
+++ b/tests/unit/config/test_resolver_edge_cases.py
@@ -386,6 +386,30 @@ class TestDatasetResolverEdgeCases:
         assert detected == CustomDatasetType.BURST_GPT_TRACE
         assert first_record is None
 
+    def test_detect_type_does_not_warn_on_csv_first_line(
+        self, tmp_path, caplog
+    ) -> None:
+        """Auto-detecting a CSV must not emit a JSON-parse warning.
+
+        ``load_json_str`` logs ``WARNING: Failed to parse JSON string``
+        before re-raising, so probing the first line with it would
+        produce a misleading warning on every successful BurstGPT CSV
+        auto-detect. The helper uses ``orjson.loads`` directly to keep
+        the expected non-JSON path silent.
+        """
+        import logging
+
+        csv_file = tmp_path / "burst.csv"
+        csv_file.write_text(
+            "Timestamp,Model,Request tokens,Response tokens,Total tokens,Log Type\n"
+            "5,ChatGPT,472,18,490,Conversation log\n"
+        )
+
+        with caplog.at_level(logging.WARNING):
+            DatasetResolver._detect_type(str(csv_file))
+
+        assert not any("Failed to parse JSON" in rec.message for rec in caplog.records)
+
     def test_burst_gpt_csv_auto_detected_with_timing(self, tmp_path) -> None:
         """End-to-end resolver pass: BurstGPT CSV with no explicit format
         is recognized and reports has_timing=True so fixed_schedule can run.

--- a/tests/unit/config/test_resolver_edge_cases.py
+++ b/tests/unit/config/test_resolver_edge_cases.py
@@ -410,6 +410,60 @@ class TestDatasetResolverEdgeCases:
 
         assert not any("Failed to parse JSON" in rec.message for rec in caplog.records)
 
+    def test_read_first_jsonl_record_returns_none_for_binary_file(
+        self, tmp_path
+    ) -> None:
+        """A non-UTF-8 dataset path must fall through gracefully.
+
+        The original ``except (OSError, ValueError)`` swallowed
+        ``UnicodeDecodeError`` too (it's a ValueError subclass), so
+        pointing the resolver at a binary file produced "no detection"
+        instead of crashing. The narrower handlers in the refactor
+        re-introduced the crash unless ``UnicodeDecodeError`` is caught
+        explicitly.
+        """
+        binary_file = tmp_path / "weights.bin"
+        binary_file.write_bytes(b"\x80\x81\x82\xff\xfe\xfd")
+
+        assert DatasetResolver._read_first_jsonl_record(str(binary_file)) is None
+
+    def test_read_first_jsonl_record_returns_none_for_non_dict_json(
+        self, tmp_path
+    ) -> None:
+        """A first line that's valid JSON but not an object must return None.
+
+        The helper's declared return type is ``dict | None``; downstream
+        callers (``_detect_type``'s explicit-type branch) call
+        ``data.get("type")``, which would ``AttributeError`` on a list.
+        """
+        list_file = tmp_path / "list.jsonl"
+        list_file.write_text("[1, 2, 3]\n")
+
+        assert DatasetResolver._read_first_jsonl_record(str(list_file)) is None
+
+    def test_read_first_jsonl_record_returns_none_for_empty_file(
+        self, tmp_path
+    ) -> None:
+        """An empty file (or a file with only blank lines) returns None."""
+        empty_file = tmp_path / "empty.jsonl"
+        empty_file.write_text("\n   \n\n")
+
+        assert DatasetResolver._read_first_jsonl_record(str(empty_file)) is None
+
+    def test_detect_type_returns_none_none_when_file_unreadable(self, tmp_path) -> None:
+        """OSError on file open bails the whole detection with (None, None).
+
+        Pointing at a directory that exists but contains nothing the
+        helper can open by name reaches the OSError branch in
+        ``_detect_type``.
+        """
+        nonexistent = tmp_path / "does_not_exist.jsonl"
+
+        detected, first_record = DatasetResolver._detect_type(str(nonexistent))
+
+        assert detected is None
+        assert first_record is None
+
     def test_burst_gpt_csv_auto_detected_with_timing(self, tmp_path) -> None:
         """End-to-end resolver pass: BurstGPT CSV with no explicit format
         is recognized and reports has_timing=True so fixed_schedule can run.


### PR DESCRIPTION
## Summary

- `DatasetResolver._detect_type` bailed out of structural detection when the first line of an input file wasn't valid JSON. BurstGPT is the only CSV-format loader in the tree, so dropping a bare BurstGPT CSV (no `--custom-dataset-type`) tripped the `ValueError` on the CSV header and returned `(None, None)` — even though `BurstGPTTraceDatasetLoader.can_load` recognizes the format from its header columns on its own. Extracted a small `_read_first_jsonl_record` helper that returns `None` (instead of bailing) on a non-JSON first line so loaders' filename-based `can_load` checks still get a chance. `OSError` still bails the whole detection — that case genuinely cannot proceed.
- Added regression coverage that was missing for `burst_gpt_trace + --fixed-schedule`: one integration test with explicit `--custom-dataset-type`, one with auto-detect (the second pins the `_detect_type` fix specifically). Plus two unit tests in `test_resolver_edge_cases.py` covering the `_detect_type` contract and the full-resolver `has_timing` pass for a bare CSV.

Note: the related `_check_timing_data` fix for BurstGPT already shipped to main in `83bdcd92` ("fix the nightly..."). That fix is still missing on `release/0.9.0`, where the user-reported bug was reproduced .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset auto-detection to avoid mis-parsing CSV headers as JSON, handle unreadable or non-JSON-first-line files gracefully, and restore fixed-schedule runs when dataset type isn’t provided.

* **Tests**
  * Added integration and unit tests plus a test utility to validate BurstGPT-style CSV detection, timing behavior, and end-to-end fixed-schedule execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->