### PR TITLE
fix: Fix pytest warning filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ filterwarnings = [
     "ignore:Argument ``constraints_func`` is an experimental feature.*:optuna.exceptions.ExperimentalWarning",
     "ignore:ORJSONResponse is deprecated.*:fastapi.exceptions.FastAPIDeprecationWarning",
     "ignore:CUDA initialization.*The NVIDIA driver on your system is too old.*:UserWarning",
-    "ignore:The model inputs are of type torch.float32.*:botorch.exceptions.warnings.InputDataWarning",
+    "ignore:The model inputs are of type torch.float32.*",
     "ignore:Optimization failed in `gen_candidates_scipy`.*:RuntimeWarning",
     "ignore:Optimization failed on the second try.*:RuntimeWarning",
     "ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning",

--- a/tests/unit/config/test_envelope_restructure.py
+++ b/tests/unit/config/test_envelope_restructure.py
@@ -8,6 +8,7 @@ Spec: (deleted)
 
 from __future__ import annotations
 
+import logging
 import textwrap
 
 import pytest
@@ -38,12 +39,18 @@ class TestFlatShapeRejection:
               - {name: profiling, type: concurrency, requests: 10, concurrency: 1}
         """).strip()
 
+        logging.getLogger(__name__).warning("unrelated flat shape setup noise")
+
         cfg = load_config_from_string(flat, substitute_env=False)
         assert cfg.benchmark.models.items[0].name == "test/model"
         # Deprecation warning should fire pointing at the migrate tool.
-        warnings = [r for r in caplog.records if "flat shape" in r.getMessage()]
+        warnings = [
+            r
+            for r in caplog.records
+            if "flat shape" in r.getMessage()
+            and "migrate_config_yaml.py" in r.getMessage()
+        ]
         assert warnings, "expected deprecation warning for flat-shape YAML"
-        assert "migrate_config_yaml.py" in warnings[0].getMessage()
 
     def test_envelope_shape_loads_cleanly(self):
         envelope = textwrap.dedent("""


### PR DESCRIPTION
## Summary
- Avoid importing the optional BoTorch warning category during pytest startup
- Make the flat-shape migration warning test resilient to unrelated caplog records

## Test plan
- [x] `uv run pytest -n auto tests/unit/config/test_envelope_restructure.py -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal warning filter configuration for improved warning management consistency.

* **Tests**
  * Enhanced test coverage with improved log message filtering and assertion logic for migration validation tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->