### PR TITLE
fix(build): narrow cherry-pick of PR #965 — uv required-environments + aarch64 install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ source venv/bin/activate
 pip install aiperf
 ```
 
+> [!NOTE]
+> On Linux **aarch64** (`arm64`), one of AIPerf's dependencies (`crick`)
+> ships only an sdist and needs a C compiler at install time. Install
+> the system build toolchain before `pip install aiperf` —
+> `sudo apt install build-essential` (Debian/Ubuntu),
+> `sudo yum groupinstall "Development Tools"` (RHEL/CentOS), or
+> equivalent. Linux x86_64, macOS, and Windows install from pre-built
+> wheels and need no toolchain.
+
 Optional integrations:
 - `pip install "aiperf[mlflow]"` enables MLflow uploads and live telemetry streaming
 - `pip install "aiperf[otel]"` enables OpenTelemetry metric streaming

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,20 +84,22 @@ otel = [
   "opentelemetry-exporter-otlp-proto-http>=1.24.0,<2.0.0",
   "opentelemetry-sdk>=1.24.0,<2.0.0",
 ]
-dev = [
-  "aiperf[mlflow,otel]",
-  "black>=25.1.0",
+test = [
   "httpx>=0.27.0",
   "hypothesis>=6.0.0",
   "jsonschema>=4.0.0",
   "looptime>=0.5",
-  "pre-commit>=4.2.0",
+  "pytest>=7.0.0",
   "pytest-asyncio",
   "pytest-cov",
-  "pytest>=7.0.0",
   "pytest-xdist>=3.8.0",
-  "ruff>=0.14.0,<0.15.0",
   "trustme>=1.0.0",
+]
+dev = [
+  "aiperf[mlflow,otel,test]",
+  "black>=25.1.0",
+  "pre-commit>=4.2.0",
+  "ruff>=0.14.0,<0.15.0",
 ]
 botorch = [
   "optuna-integration>=3.6",
@@ -122,6 +124,20 @@ accuracy = [
 dev = [
     "hypothesis>=6.152.4",
     "pre-commit>=4.6.0",
+]
+
+# uv resolver constraints. ``required-environments`` makes uv refuse
+# to resolve to any package version that lacks a wheel or sdist for
+# every platform listed, which auto-backtracks past partial-upload
+# PyPI releases (e.g. yarl 1.24.0 + greenlet 3.5.1 on 2026-05-{19,20}
+# both shipped without cp313/linux wheels and broke cold builds).
+# Sdist counts as installable — crick ships only sdist on Linux
+# aarch64 and is unaffected (env-builder compiles it from source).
+[tool.uv]
+required-environments = [
+  "sys_platform == 'linux' and platform_machine == 'x86_64'",
+  "sys_platform == 'linux' and platform_machine == 'aarch64'",
+  "sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

Narrow sub-pick of PR #965 (commit `83bdcd92`) onto `release/0.9.0`. The full PR is a 28-file change whose primary purpose was fixing the nightly + test-docs-end-to-end CI; the bulk of it does not apply to this branch. This PR takes only the two pieces that genuinely matter for the 0.9.0 release.

**What's included:**

1. **`pyproject.toml` — `[tool.uv] required-environments`** — protects cold `uv sync` against partial-upload PyPI releases (the kind that broke builds with `yarl 1.24.0` + `greenlet 3.5.1` on 2026-05-19/20). The accompanying split of `dev` into `test` + `dev` is a pure refactor with no behavior change.
2. **`README.md`** — aarch64 `build-essential` note for the `crick` sdist dependency, so users installing aiperf 0.9.0 on Linux arm64 know to install a C toolchain first.

## Why narrow

Most of PR #965 is dead weight on this branch:

| File group | Why skipped |
|---|---|
| `.github/workflows/nightly.yml` | Cron always runs on the default branch (`main`); never fires on `release/0.9.0`. |
| `.github/workflows/test-docs-end-to-end.yml`, `resolve-check.yml` | Triggered on PRs to `main` only. |
| `.github/workflows/fern-docs.yml` | Only publishes when `GITHUB_REF == refs/heads/main`. |
| `tests/ci/test_docs_end_to_end/*`, `tools/suggest_test_docs_weights.py` | Only invoked by the test-docs workflow above. |
| `docs/tutorials/{aimo,blazedit,burst-gpt-trace,custom-dataset,goodput,sharegpt,synthetic-dataset}.md` | `weight=N` annotations consumed by the test-docs runner — no rendered change. |
| `src/aiperf/config/dataset/resolver.py`, `tests/unit/config/test_resolvers.py` | BurstGPT fix already on this branch via PR #988 (`0c3d0d8b`). |

## Test plan

- [ ] `uv sync` resolves cleanly against `release/0.9.0` with the new `required-environments` constraint
- [ ] `uv run pytest tests/unit/` passes (mock server installed via `make install-mock-server`)
- [ ] README renders the new aarch64 callout correctly on GitHub

Refs: #965, #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)