### PR TITLE
Fallback when OS rejects large HTTP socket buffers

### DIFF
--- a/src/aiperf/transports/http_defaults.py
+++ b/src/aiperf/transports/http_defaults.py
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+import errno
+import logging
 import socket
 from dataclasses import dataclass
 from typing import Any
 
 from aiperf.common.enums.enums import IPVersion
 from aiperf.common.environment import Environment
+
+_logger = logging.getLogger(__name__)
 
 
 def _get_socket_family() -> socket.AddressFamily:
@@ -16,6 +20,15 @@ def _get_socket_family() -> socket.AddressFamily:
     elif ip_version == IPVersion.AUTO:
         return socket.AF_UNSPEC
     return socket.AF_INET  # Default to IPv4
+
+
+def _get_socket_option_label(option_name: int) -> str:
+    """Return a readable socket option label for logging."""
+    if option_name == socket.SO_RCVBUF:
+        return "SO_RCVBUF"
+    if option_name == socket.SO_SNDBUF:
+        return "SO_SNDBUF"
+    return str(option_name)
 
 
 @dataclass(frozen=True)
@@ -30,6 +43,31 @@ class SocketDefaults:
     SO_LINGER = 0  # Disable linger
     SO_REUSEADDR = 1  # Enable reuse address
     SO_REUSEPORT = 1  # Enable reuse port
+
+    @staticmethod
+    def _set_socket_buffer(
+        sock: socket.socket, option_name: int, value: int
+    ) -> None:
+        """Set a socket buffer, reducing it if the OS rejects the requested size."""
+        candidate = value
+        while candidate >= 1024:
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, option_name, candidate)
+                if candidate != value:
+                    _logger.warning(
+                        "%s=%d was rejected by the OS with ENOBUFS; using %d instead",
+                        _get_socket_option_label(option_name),
+                        value,
+                        candidate,
+                    )
+                return
+            except OSError as e:
+                # Some operating systems (e.g. macOS) may raise ENOBUFS
+                # when requested socket buffer sizes exceed kernel limits.
+                if e.errno != errno.ENOBUFS:
+                    raise
+                candidate //= 2
+        sock.setsockopt(socket.SOL_SOCKET, option_name, 1024)
 
     @classmethod
     def apply_to_socket(cls, sock: socket.socket) -> None:
@@ -53,9 +91,8 @@ class SocketDefaults:
                 socket.SOL_TCP, socket.TCP_KEEPCNT, Environment.HTTP.TCP_KEEPCNT
             )
 
-        # Buffer size optimizations for streaming
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, Environment.HTTP.SO_RCVBUF)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, Environment.HTTP.SO_SNDBUF)
+        cls._set_socket_buffer(sock, socket.SO_RCVBUF, Environment.HTTP.SO_RCVBUF)
+        cls._set_socket_buffer(sock, socket.SO_SNDBUF, Environment.HTTP.SO_SNDBUF)
 
         # Linux-specific TCP optimizations
         if hasattr(socket, "TCP_QUICKACK"):

--- a/src/aiperf/transports/http_defaults.py
+++ b/src/aiperf/transports/http_defaults.py
@@ -45,9 +45,7 @@ class SocketDefaults:
     SO_REUSEPORT = 1  # Enable reuse port
 
     @staticmethod
-    def _set_socket_buffer(
-        sock: socket.socket, option_name: int, value: int
-    ) -> None:
+    def _set_socket_buffer(sock: socket.socket, option_name: int, value: int) -> None:
         """Set a socket buffer, reducing it if the OS rejects the requested size."""
         candidate = value
         while candidate >= 1024:

--- a/tests/unit/transports/test_tcp_connector.py
+++ b/tests/unit/transports/test_tcp_connector.py
@@ -6,6 +6,8 @@ This module tests the create_tcp_connector function, which is used to create a
 TCP connector for use with aiohttp.ClientSession.
 """
 
+import errno
+import logging
 import socket
 import ssl
 from unittest.mock import Mock, patch
@@ -18,7 +20,11 @@ from aiohttp import web
 from aiperf.common.enums import IPVersion
 from aiperf.common.environment import Environment, _HTTPSettings
 from aiperf.transports.aiohttp_client import create_tcp_connector
-from aiperf.transports.http_defaults import AioHttpDefaults, _get_socket_family
+from aiperf.transports.http_defaults import (
+    AioHttpDefaults,
+    SocketDefaults,
+    _get_socket_family,
+)
 
 ################################################################################
 # Test create_tcp_connector
@@ -121,6 +127,38 @@ class TestCreateTcpConnector:
                 mock_socket.setsockopt.assert_any_call(
                     option_level, option_name, option_value
                 )
+
+    def test_socket_buffer_falls_back_when_os_rejects_large_value(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test socket buffer setup retries smaller values after ENOBUFS."""
+        mock_socket = Mock()
+        mock_socket.setsockopt.side_effect = [
+            OSError(errno.ENOBUFS, "No buffer space available"),
+            OSError(errno.ENOBUFS, "No buffer space available"),
+            None,
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            SocketDefaults._set_socket_buffer(mock_socket, socket.SO_RCVBUF, 4096)
+
+        assert mock_socket.setsockopt.call_args_list == [
+            ((socket.SOL_SOCKET, socket.SO_RCVBUF, 4096),),
+            ((socket.SOL_SOCKET, socket.SO_RCVBUF, 2048),),
+            ((socket.SOL_SOCKET, socket.SO_RCVBUF, 1024),),
+        ]
+        assert (
+            "SO_RCVBUF=4096 was rejected by the OS with ENOBUFS; "
+            "using 1024 instead"
+        ) in caplog.text
+
+    def test_socket_buffer_reraises_non_buffer_errors(self) -> None:
+        """Test socket buffer setup only handles ENOBUFS."""
+        mock_socket = Mock()
+        mock_socket.setsockopt.side_effect = OSError(errno.EPERM, "blocked")
+
+        with pytest.raises(OSError):
+            SocketDefaults._set_socket_buffer(mock_socket, socket.SO_RCVBUF, 4096)
 
     # Only run these tests on Linux
     if hasattr(socket, "TCP_KEEPIDLE"):

--- a/tests/unit/transports/test_tcp_connector.py
+++ b/tests/unit/transports/test_tcp_connector.py
@@ -148,8 +148,7 @@ class TestCreateTcpConnector:
             ((socket.SOL_SOCKET, socket.SO_RCVBUF, 1024),),
         ]
         assert (
-            "SO_RCVBUF=4096 was rejected by the OS with ENOBUFS; "
-            "using 1024 instead"
+            "SO_RCVBUF=4096 was rejected by the OS with ENOBUFS; using 1024 instead"
         ) in caplog.text
 
     def test_socket_buffer_reraises_non_buffer_errors(self) -> None:


### PR DESCRIPTION
AIPerf configures 10 MiB send/receive buffers for HTTP streaming sockets during startup. 
On some macOS systems, the default kern.ipc.maxsockbuf limit is lower than the requested size. In this case, socket initialization fails with:
```
OSError(55, 'No buffer space available')
```
Without this fix, the only workaround was manually increasing the kernel limit:
```
sysctl -w kern.ipc.maxsockbuf=16777216
```
The error message itself does not make the root cause obvious, while the configured socket buffer size is only a performance optimization rather than a correctness requirement.

This PR adds a fallback mechanism that retries socket initialization with progressively smaller buffer sizes when the OS rejects the requested value with ENOBUFS. A warning is logged when fallback happens, and unrelated socket errors continue to be raised normally.

The PR also adds tests covering the fallback behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust socket buffer handling: when the OS rejects large buffer requests the system now gracefully falls back to smaller sizes and logs both the rejected and accepted sizes for clearer diagnostics.

* **Tests**
  * Added tests covering buffer fallback behavior and proper error propagation when non-buffer errors occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->