### PR TITLE
feat(api): add /api/run endpoint exposing run-identity metadata

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -207,6 +207,8 @@ navigation:
     path: reference/vendor-usage-fields.md
   - page: JSON Export Schema
     path: reference/json-export-schema.md
+  - page: HTTP API Endpoints
+    path: reference/api-endpoints.md
   - page: YAML Config Roadmap
     path: reference/yaml-config-roadmap.md
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1,0 +1,52 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: HTTP API Endpoints
+---
+
+# HTTP API Endpoints
+
+When `aiperf profile` is launched with `--api-port <PORT>` (or `AIPERF_API_SERVER_PORT` is set), AIPerf starts an in-process FastAPI server alongside the benchmark and exposes HTTP and Prometheus endpoints for the lifetime of the run. The server is opt-in — if `--api-port` is not set, no listener is created.
+
+`--api-host` (default `127.0.0.1`) controls the bind address; pass `--api-host 0.0.0.0` to expose externally (e.g. in Kubernetes).
+
+The router classes that back these routes live under [`src/aiperf/api/routers/`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/api/routers/) and are loaded via the `api_router` plugin category in [`plugins.yaml`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/plugin/plugins.yaml).
+
+## Endpoints
+
+| Method | Path | Response shape | Description |
+|---|---|---|---|
+| `GET` | `/api/config` | `BenchmarkConfig` | Declarative benchmark configuration for the current run. `endpoint.api_key` is excluded. Run-identity fields (`benchmark_id`, `cli_command`, etc.) live on `/api/run`, not here. |
+| `GET` | `/api/run` | `RunInfo` | Run-identity metadata: `benchmark_id`, `sweep_id`, `trial`, `random_seed`, `run_label`, `variation_*`, and the redacted `cli_command`. Same shape as the `run_info` block in `profile_export_aiperf.json`. |
+| `GET` | `/api/metrics` | `MetricsResponse` | Live metric values (JSON). Updated as the benchmark progresses. |
+| `GET` | `/metrics` | `text/plain` | Prometheus exposition format. Scrape target for Prometheus and compatible collectors. |
+| `GET` | `/api/progress` | `ProgressResponse` | Per-phase credit/request progress. |
+| `GET` | `/api/workers` | `WorkersResponse` | Per-worker stats (request counts, errors, lifecycle state). |
+| `GET` | `/api/results` | `BenchmarkResultsResponse` | Final benchmark results once profiling has completed. |
+| `GET` | `/api/results/list` | `ResultsListResponse` | List of result artifact files under the artifact directory. |
+| `GET` | `/api/results/files/{filename}` | file stream | Download an individual artifact file by relative path. |
+| `GET` | `/healthz` | `text/plain` (`ok` / `unhealthy`) | Kubernetes liveness probe. 503 when the service is in `FAILED` state. |
+| `GET` | `/readyz` | `text/plain` (`ok` / `not ready`) | Kubernetes readiness probe. 200 only when the service is `RUNNING`. |
+| `GET` | `/docs`, `/redoc`, `/openapi.json` | (FastAPI defaults) | Auto-generated OpenAPI documentation. |
+
+## Secret redaction
+
+`cli_command` is captured from `sys.argv` at `BenchmarkRun` construction and redacted by [`build_cli_command()`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/common/redact.py) before it is stored — so the string returned from `/api/run` and written to `profile_export_aiperf.json` is the same redacted form. `--api-key`-shaped flags, credential-bearing `--header` values (e.g. `Authorization: Bearer …`), and userinfo embedded in URL-typed flags (`--url`, `-u`, `--otel-url`, `--mlflow-tracking-uri`) are all scrubbed to `<redacted>`.
+
+`/api/config` independently excludes `endpoint.api_key` from its response.
+
+## Example
+
+```bash
+aiperf profile --model my-model --url http://localhost:8000 \
+    --api-key sk-secret-12345 --api-port 9097 --request-count 1000 &
+
+# Inspect the redacted launch command
+curl -s http://127.0.0.1:9097/api/run | jq .cli_command
+# "aiperf profile --model 'my-model' --url 'http://localhost:8000' \
+#  --api-key '<redacted>' --api-port 9097 --request-count 1000"
+
+# Liveness probe
+curl -s http://127.0.0.1:9097/healthz
+# ok
+```

--- a/src/aiperf/api/routers/core.py
+++ b/src/aiperf/api/routers/core.py
@@ -39,12 +39,18 @@ async def get_config(svc: ServiceDep) -> dict[str, Any]:
     )
 
 
-@core_router.get("/api/run", response_model=RunInfo, tags=["API"])
+@core_router.get(
+    "/api/run",
+    response_model=RunInfo,
+    response_model_exclude_none=True,
+    tags=["API"],
+)
 async def get_run(svc: ServiceDep) -> RunInfo:
     """Get run-identity metadata for the currently executing benchmark run.
 
-    Same shape as ``run_info`` in ``profile_export_aiperf.json``, so a live
-    reader sees identical fields to the on-disk export. Includes the redacted
+    Same shape as ``run_info`` in ``profile_export_aiperf.json`` — including
+    the matching exclude-None projection, so unset optional fields are omitted
+    from the response rather than serialized as ``null``. Includes the redacted
     ``cli_command``, ``benchmark_id``, ``sweep_id``, ``trial``, ``random_seed``,
     and sweep variation coordinates.
     """

--- a/src/aiperf/api/routers/core.py
+++ b/src/aiperf/api/routers/core.py
@@ -3,25 +3,26 @@
 
 """Core API router for AIPerf API.
 
-Provides config, health, and readiness endpoints.
+Provides config, run-identity, health, and readiness endpoints.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 
 from aiperf.api.api_service import ServiceDep
 from aiperf.api.routers.base_router import BaseRouter
+from aiperf.common.models.export_models import RunInfo
 from aiperf.config.config import BenchmarkConfig
 
 core_router = APIRouter()
 
 
 class CoreRouter(BaseRouter):
-    """Config, health, and readiness endpoints."""
+    """Config, run-identity, health, and readiness endpoints."""
 
     def get_router(self) -> APIRouter:
         return core_router
@@ -36,6 +37,21 @@ async def get_config(svc: ServiceDep) -> dict[str, Any]:
         exclude_none=True,
         exclude={"endpoint": {"api_key"}},
     )
+
+
+@core_router.get("/api/run", response_model=RunInfo, tags=["API"])
+async def get_run(svc: ServiceDep) -> RunInfo:
+    """Get run-identity metadata for the currently executing benchmark run.
+
+    Same shape as ``run_info`` in ``profile_export_aiperf.json``, so a live
+    reader sees identical fields to the on-disk export. Includes the redacted
+    ``cli_command``, ``benchmark_id``, ``sweep_id``, ``trial``, ``random_seed``,
+    and sweep variation coordinates.
+    """
+    info = RunInfo.from_run(svc.run)
+    if info is None:
+        raise HTTPException(status_code=503, detail="No active benchmark run.")
+    return info
 
 
 @core_router.get("/healthz", include_in_schema=False)

--- a/src/aiperf/common/models/export_models.py
+++ b/src/aiperf/common/models/export_models.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import ConfigDict, Field
 
@@ -10,6 +12,9 @@ from aiperf.common.models.base_models import AIPerfBaseModel
 from aiperf.common.models.branch_stats import BranchStats
 from aiperf.common.models.error_models import ErrorDetailsCount
 from aiperf.config.config import BenchmarkConfig
+
+if TYPE_CHECKING:
+    from aiperf.config import BenchmarkRun
 
 # =============================================================================
 # JSON Metric Result
@@ -61,7 +66,7 @@ class JsonMetricResult(AIPerfBaseModel):
     )
 
     @staticmethod
-    def project_summary_dict(payload: dict[str, Any]) -> dict[str, "JsonMetricResult"]:
+    def project_summary_dict(payload: dict[str, Any]) -> dict[str, JsonMetricResult]:
         return {
             key: JsonMetricResult.model_validate(value)
             for key, value in payload.items()
@@ -216,6 +221,29 @@ class RunInfo(AIPerfBaseModel):
             "the run was constructed without a CLI context."
         ),
     )
+
+    @classmethod
+    def from_run(cls, run: BenchmarkRun | None) -> RunInfo | None:
+        """Project a ``BenchmarkRun`` envelope onto its run-identity shape.
+
+        Single source of truth shared by ``profile_export_aiperf.json`` and the
+        live ``GET /api/run`` endpoint, so the on-disk and live shapes cannot
+        diverge.
+        """
+        if run is None:
+            return None
+        variation = run.variation
+        return cls(
+            benchmark_id=run.benchmark_id,
+            sweep_id=run.sweep_id,
+            random_seed=run.random_seed,
+            trial=run.trial,
+            run_label=run.label or None,
+            variation_label=variation.label if variation is not None else None,
+            variation_index=variation.index if variation is not None else None,
+            variation_values=dict(variation.values) if variation is not None else None,
+            cli_command=run.cli_command,
+        )
 
 
 # =============================================================================

--- a/src/aiperf/exporters/metrics_json_exporter.py
+++ b/src/aiperf/exporters/metrics_json_exporter.py
@@ -73,7 +73,7 @@ class MetricsJsonExporter(MetricsBaseExporter):
             aiperf_version=aiperf_version,
             benchmark_id=self._run.benchmark_id if self._run is not None else None,
             input_config=self._cfg,
-            run_info=_build_run_metadata(self._run),
+            run_info=RunInfo.from_run(self._run),
             was_cancelled=self._results.was_cancelled,
             error_summary=self._results.error_summary,
             start_time=start_time,
@@ -124,24 +124,3 @@ class MetricsJsonExporter(MetricsBaseExporter):
         """
         prepared = self._prepare_metrics(metric_results)
         return {tag: result.to_json_result() for tag, result in prepared.items()}
-
-
-def _build_run_metadata(run) -> RunInfo | None:
-    # Why: surfacing per-run reproducibility in profile_export_aiperf.json
-    # eliminates the need for a downstream reader to also load the internal
-    # run_config.json handoff file (which is multi-run only and absent on
-    # single-run paths).
-    if run is None:
-        return None
-    variation = getattr(run, "variation", None)
-    return RunInfo(
-        benchmark_id=run.benchmark_id,
-        sweep_id=getattr(run, "sweep_id", None),
-        random_seed=run.random_seed,
-        trial=run.trial,
-        run_label=run.label or None,
-        variation_label=variation.label if variation is not None else None,
-        variation_index=variation.index if variation is not None else None,
-        variation_values=dict(variation.values) if variation is not None else None,
-        cli_command=getattr(run, "cli_command", None),
-    )

--- a/tests/unit/api/routers/test_core.py
+++ b/tests/unit/api/routers/test_core.py
@@ -95,6 +95,38 @@ class TestRunEndpoint:
         assert "--api-key" in cli_command
         assert "<redacted>" in cli_command
 
+    def test_run_omits_unset_optional_fields(self, api_test_client: TestClient) -> None:
+        """The endpoint promises shape parity with ``run_info`` in
+        ``profile_export_aiperf.json``, which uses ``exclude_none=True``.
+        Optional ``RunInfo`` fields that the fixture doesn't populate
+        (``sweep_id``, ``random_seed``, ``variation_*``) must be omitted from
+        the response — not serialized as ``null``."""
+        data = api_test_client.get("/api/run").json()
+        for field in (
+            "sweep_id",
+            "random_seed",
+            "variation_label",
+            "variation_index",
+            "variation_values",
+        ):
+            assert field not in data, (
+                f"{field} should be omitted when unset, not serialized as null"
+            )
+
+    def test_run_returns_503_when_no_active_run(
+        self,
+        api_test_client: TestClient,
+        mock_fastapi_service: FastAPIService,
+    ) -> None:
+        """The router has an explicit 503 branch for missing run context. The
+        type system says ``svc.run`` is non-Optional, so this branch is
+        effectively defensive — the test locks the contract for any future
+        change that makes ``run`` optional or nullable."""
+        mock_fastapi_service.run = None
+        response = api_test_client.get("/api/run")
+        assert response.status_code == 503
+        assert response.json() == {"detail": "No active benchmark run."}
+
 
 class TestHealthzEndpoint:
     """Test Kubernetes liveness probe /healthz."""

--- a/tests/unit/api/routers/test_core.py
+++ b/tests/unit/api/routers/test_core.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the core API router (config, healthz, readyz)."""
+"""Tests for the core API router (config, run, healthz, readyz)."""
+
+import sys
 
 import pytest
 from pytest import param
@@ -9,6 +11,8 @@ from starlette.testclient import TestClient
 
 from aiperf.api.api_service import FastAPIService
 from aiperf.common.enums import LifecycleState
+from aiperf.config.flags.cli_config import CLIConfig
+from tests.unit.conftest import make_run_from_cli
 
 
 class TestConfigEndpoint:
@@ -21,6 +25,75 @@ class TestConfigEndpoint:
         data = response.json()
         assert "endpoint" in data
         assert "artifacts" in data
+
+    def test_config_does_not_expose_run_identity(
+        self, api_test_client: TestClient
+    ) -> None:
+        """/api/config is purely BenchmarkConfig. Run-identity fields belong on
+        /api/run; this guards against re-introducing the pre-refactor grab-bag."""
+        data = api_test_client.get("/api/config").json()
+        assert "cli_command" not in data
+        assert "benchmark_id" not in data
+        assert "sweep_id" not in data
+
+
+class TestRunEndpoint:
+    """Test the /api/run endpoint."""
+
+    def test_run_returns_identity_block(self, api_test_client: TestClient) -> None:
+        """/api/run returns the RunInfo-shaped identity block, with cli_command
+        populated from the test process's sys.argv via build_cli_command."""
+        response = api_test_client.get("/api/run")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["benchmark_id"] == "test-bench"
+        assert isinstance(data["cli_command"], str)
+        assert data["cli_command"].startswith("aiperf")
+
+    def test_run_does_not_expose_config_or_secrets(
+        self, api_test_client: TestClient
+    ) -> None:
+        """/api/run exposes run-identity only — never the BenchmarkConfig or
+        secrets that live inside it."""
+        data = api_test_client.get("/api/run").json()
+        assert "cfg" not in data
+        assert "endpoint" not in data
+        assert "api_key" not in data
+        assert "artifact_dir" not in data
+        assert "variables" not in data
+
+    def test_run_does_not_leak_api_key_in_cli_command(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_zmq,
+        api_cfg: CLIConfig,
+    ) -> None:
+        """End-to-end: ``--api-key <secret>`` in sys.argv must not leak through
+        ``/api/run.cli_command``. Mirrors the QA ``test_api_key_redaction``
+        contract by constructing a fresh ``BenchmarkRun`` under a sys.argv
+        containing a secret, then asserting the secret never appears in the
+        API response body."""
+        secret = "sk-secret-DO-NOT-LEAK-9876543210"
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["aiperf", "profile", "--model", "test-model", "--api-key", secret],
+        )
+        run = make_run_from_cli(api_cfg)
+        run.benchmark_id = "test-bench"
+        run.cfg.runtime.api_host = "127.0.0.1"
+        run.cfg.runtime.api_port = 9999
+
+        service = FastAPIService(run=run, service_id="api-redaction-test")
+        client = TestClient(service.app)
+
+        response = client.get("/api/run")
+        assert response.status_code == 200
+        assert secret not in response.text
+
+        cli_command = response.json()["cli_command"]
+        assert "--api-key" in cli_command
+        assert "<redacted>" in cli_command
 
 
 class TestHealthzEndpoint:


### PR DESCRIPTION
# `/api/run`: how a "regression fix" turned into a design choice

**Branch:** `mkotila/api-run-endpoint` · **Commit:** `047d59dd` · **Tickets:** NVBugs 6204764 / JIRA DYN-699

## The story

A QA test broke. The reporter framed it as a regression: `curl /api/config | jq .cli_command` used to return the redacted launch command, now it returns `null`. The bug ticket arrived with a one-paragraph "AI suggestion" recommending the obvious fix — stitch `cli_command` back onto `/api/config` and call it done.

The obvious fix was wrong. Here's why.

The break came from PR #912 (the YAML-native v2 config refactor). Before that refactor, a single `UserConfig` class held everything: declarative spec (`endpoint`, `loadgen`, `tokenizer`, …) and per-run identity (`benchmark_id`, `cli_command`, …) jammed together at one level. `/api/config` dumped the whole grab-bag. PR #912 split it cleanly — declarative parts into `BenchmarkConfig`, identity into a new `BenchmarkRun` envelope. That split is the right shape: a CLI command isn't part of *"the config,"* it's run-execution metadata — the thing that *produced* a config. The endpoint was migrated to return only `BenchmarkConfig`, which is honest, but it silently dropped `cli_command` and `benchmark_id` along with it.

So you see the trap. Option A from the bug ticket — stitch `cli_command` back onto `/api/config` — would re-create the category error PR #912 just cleaned up. You'd paper over the architectural improvement to preserve a stale API shape.

Option B is the move: add a new endpoint, `/api/run`, that exposes the `BenchmarkRun` envelope. `cli_command` lives there because that's where the field actually lives in the model. `/api/config` stays pure. As a bonus, the response is shaped as `RunInfo` — the same model already used in `profile_export_aiperf.json` — so the live API and the on-disk export can't drift.

The cost is one line in QA's test (`/api/config` → `/api/run`). No in-tree consumers to migrate; the web dashboard that would have read it was on an unmerged branch and never landed.

## What shipped

| File | Change |
|---|---|
| `src/aiperf/common/models/export_models.py` | `RunInfo.from_run(run)` classmethod — single projection from `BenchmarkRun` |
| `src/aiperf/exporters/metrics_json_exporter.py` | Replaced private `_build_run_metadata` with the new classmethod (one source of truth) |
| `src/aiperf/api/routers/core.py` | New `GET /api/run` → `RunInfo` |
| `tests/unit/api/routers/test_core.py` | +5 tests: `/api/config` no-grab-bag guard; `/api/run` shape + no-secrets; end-to-end redaction test (`sys.argv` with `--api-key sk-secret-…` → asserts secret not in response) |
| `docs/reference/api-endpoints.md` *(new)* | Full HTTP API surface documented for the first time |
| `docs/index.yml` | Fern index registration for the new page |

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit/api/ tests/unit/exporters/` | 347 passed, 1 skipped |
| `ruff format --check` + `ruff check` (touched files) | clean |
| `tools/check_docs_index.py` | OK: all 102 docs listed |
| Live FastAPI startup log | `/api/run` present in route table |
| `pre-commit run --all-files` (host) | passed |
| Every claim in `api-endpoints.md` re-checked against code | passed (2 minor edits applied) |

## Decisions worth remembering

- **Endpoint name `/api/run`** — bare singular noun matches `/api/config`'s convention; `RunInfo` is the internal model name, not the route's job.
- **Reference doc over tutorial** — the API surface had been undocumented since PR #717 landed without the `api-service.md` from `ajc/websocket-dashboard-ui`; a compact reference table closes the gap without expanding scope.
- **Single commit** — code + tests + docs in one self-contained unit.

## Follow-ups

- QA test: migrate `test_api_key_redaction` from `/api/config` → `/api/run`. The new in-tree `test_run_does_not_leak_api_key_in_cli_command` mirrors the same contract.
- Comment on NVBugs 6204764 / DYN-699 with fix summary + the QA migration note.
- If 0.9.0 backport is needed: cherry-pick `047d59dd`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /api/run endpoint exposing active run identity/metadata with automatic redaction of API keys and sensitive CLI/credential values; omits unset optional fields and returns 503 when no active run.

* **Bug Fixes**
  * /api/config no longer exposes run-identity fields.

* **Documentation**
  * Added comprehensive HTTP API reference with endpoints, Prometheus/metrics, health checks, results/artifacts, OpenAPI and curl examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->