### PR TITLE
fix: restore dcgm_fakers after lifespan tests

### DIFF
--- a/tests/unit/aiperf_mock_server/test_app_lifespan.py
+++ b/tests/unit/aiperf_mock_server/test_app_lifespan.py
@@ -12,6 +12,27 @@ from aiperf_mock_server.config import MockServerConfig
 from fastapi import FastAPI
 
 
+@pytest.fixture(autouse=True)
+def _restore_dcgm_fakers():
+    """Snapshot and restore the module-level ``dcgm_fakers`` list.
+
+    ``lifespan`` unconditionally appends two ``DCGMFaker`` entries to the
+    module-level list at ``aiperf_mock_server.app.dcgm_fakers``. Running
+    ``async with lifespan(...)`` here leaks those appends into every
+    subsequent test that imports ``aiperf_mock_server.app`` — e.g.
+    ``tests/unit/server/test_app.py::test_dcgm_metrics_invalid_instance``
+    starts seeing ``/dcgm3/metrics`` return 200 instead of 404 because the
+    list is no longer length-2.
+    """
+    from aiperf_mock_server.app import dcgm_fakers
+
+    snapshot = list(dcgm_fakers)
+    try:
+        yield
+    finally:
+        dcgm_fakers[:] = snapshot
+
+
 @pytest.mark.asyncio
 async def test_lifespan_closes_recorder_when_scheduler_shutdown_raises(
     tmp_path, monkeypatch


### PR DESCRIPTION
The lifespan tests drive `async with lifespan(fastapi_app)` directly, which unconditionally appends two `DCGMFaker` entries to the module-level `aiperf_mock_server.app.dcgm_fakers` list. Those appends leak across files: `tests/unit/server/test_app.py::test_dcgm_metrics_invalid_instance` asks for `/dcgm3/metrics` expecting 404, but with 4 fakers in the list it gets 200.

Add an autouse fixture that snapshots `dcgm_fakers` on entry and restores it in `finally`, isolating the leak regardless of whether the lifespan body errors out before yield.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by fixing test isolation issues to prevent interference between mock server tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->