### PR TITLE
fix(api): cherry-pick #989 (keep /api/results listener open, DYN-701) to release/0.9.0

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -40,6 +40,7 @@ API server settings. Controls the host and port of the API server.
 | `AIPERF_API_SERVER_PORT` | `None` | ≥ 1, ≤ 65535 | Port to bind the API server to |
 | `AIPERF_API_SERVER_CORS_ORIGINS` | `[]` | — | List of CORS origins to allow (empty = no CORS, ['*'] = all origins) |
 | `AIPERF_API_SERVER_SHUTDOWN_TIMEOUT` | `5.0` | ≥ 1.0, ≤ 300.0 | Timeout in seconds for graceful API server shutdown before force-cancelling |
+| `AIPERF_API_SERVER_POST_COMPLETE_GRACE` | `5.0` | ≥ 0.0, ≤ 300.0 | Seconds the API listener stays open after a benchmark terminates so polling clients can observe the final status before the server shuts down. Set to 0 to skip the grace window and shut down immediately. |
 
 ## COMPRESSION
 

--- a/src/aiperf/api/api_service.py
+++ b/src/aiperf/api/api_service.py
@@ -170,6 +170,20 @@ class FastAPIService(BaseComponentService):
     @on_stop
     async def _stop_api_server(self) -> None:
         """Stop the FastAPI server."""
+        # Keep the listener open for a grace window so clients polling /api/results
+        # can observe terminal status before connection-refused. See
+        # Environment.API_SERVER.POST_COMPLETE_GRACE. Skip when there's no live
+        # serve task (startup failure, server crashed, or already finished) — a
+        # closed listener can't be kept open.
+        grace = Environment.API_SERVER.POST_COMPLETE_GRACE
+        server_running = self._server_task is not None and not self._server_task.done()
+        if grace > 0 and server_running:
+            self.info(
+                f"Holding API listener open for {grace:.1f}s "
+                "to let polling clients observe terminal status."
+            )
+            await asyncio.sleep(grace)
+
         self.info("Stopping AIPerf FastAPI server...")
 
         if self._server:

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -85,6 +85,14 @@ class _APIServerSettings(BaseSettings):
         default=5.0,
         description="Timeout in seconds for graceful API server shutdown before force-cancelling",
     )
+    POST_COMPLETE_GRACE: float = Field(
+        ge=0.0,
+        le=300.0,
+        default=5.0,
+        description="Seconds the API listener stays open after a benchmark terminates "
+        "so polling clients can observe the final status before the server shuts down. "
+        "Set to 0 to skip the grace window and shut down immediately.",
+    )
 
 
 class _CompressionSettings(BaseSettings):

--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -18,6 +18,7 @@ from aiperf.common.base_service import BaseService
 from aiperf.common.enums import (
     CommandResponseStatus,
     CommandType,
+    LifecycleState,
     MessageType,
     ServiceRegistrationStatus,
 )
@@ -163,6 +164,7 @@ class SystemController(SignalHandlerMixin, BaseService):
 
         self._shutdown_triggered = False
         self._shutdown_lock = asyncio.Lock()
+        self._api_enabled = False
         self._telemetry_endpoints_configured: list[str] = []
         self._telemetry_endpoints_reachable: list[str] = []
         self._server_metrics_endpoints_configured: list[str] = []
@@ -264,6 +266,7 @@ class SystemController(SignalHandlerMixin, BaseService):
         if api_port is not None and api_host is not None:
             self.info(f"Starting AIPerf API server at http://{api_host}:{api_port}/")
             await self.service_manager.run_service(ServiceType.API)
+            self._api_enabled = True
 
         async with self.try_operation_or_stop("Register Services"):
             await self.service_manager.wait_for_all_services_registration(
@@ -686,6 +689,40 @@ class SystemController(SignalHandlerMixin, BaseService):
             self._should_wait_for_server_metrics = False
             await self._check_and_trigger_shutdown()
 
+    def _is_api_service_alive(self) -> bool:
+        """Return True iff the API service is registered and its process is live.
+
+        Used to gate the POST_COMPLETE_GRACE extension at shutdown: if the API
+        never registered (startup failure) or has transitioned to FAILED/STOPPED,
+        there is no listener for clients to reach, so the extended wait would
+        only delay shutdown without serving anyone.
+
+        BaseComponentService._on_state_change suppresses StatusMessage publishes
+        once stop_requested is set, so service_map[ServiceType.API][*].state
+        stays frozen at RUNNING even after the API process self-stopped, crashed,
+        or transitioned to FAILED. On the multiprocess backend we cross-check
+        process.is_alive() as the authoritative signal; other backends fall back
+        to the registration/state check.
+        """
+        api_services = self.service_manager.service_map.get(ServiceType.API, [])
+        terminal_states = (LifecycleState.STOPPED, LifecycleState.FAILED)
+        registered = any(
+            info.registration_status == ServiceRegistrationStatus.REGISTERED
+            and info.state not in terminal_states
+            for info in api_services
+        )
+        if not registered:
+            return False
+        mp_info = getattr(self.service_manager, "multi_process_info", None)
+        if not isinstance(mp_info, list):
+            return True
+        return any(
+            rec.service_type == ServiceType.API
+            and rec.process is not None
+            and rec.process.is_alive()
+            for rec in mp_info
+        )
+
     async def _check_and_trigger_shutdown(self) -> None:
         """Check if all required results are received and trigger unified export + shutdown.
 
@@ -912,7 +949,17 @@ class SystemController(SignalHandlerMixin, BaseService):
         # time to deliver the broadcast to every subscriber before we start joining
         # processes. 500ms is empirically sufficient under normal load and well
         # under the per-process join timeout in _wait_for_process.
-        await asyncio.sleep(0.5)
+        # When the API server is enabled AND still alive, extend the wait so the
+        # API process can honor its POST_COMPLETE_GRACE window before
+        # _wait_for_process SIGKILLs it. If the API never registered or has
+        # already failed/stopped, the extension would only delay shutdown without
+        # serving any client, so skip it.
+        delivery_grace = 0.5
+        if self._api_enabled and self._is_api_service_alive():
+            delivery_grace = max(
+                delivery_grace, Environment.API_SERVER.POST_COMPLETE_GRACE
+            )
+        await asyncio.sleep(delivery_grace)
 
         await self.service_manager.shutdown_all_services()
         await self.comms.stop()

--- a/tests/unit/api/test_api_service.py
+++ b/tests/unit/api/test_api_service.py
@@ -215,6 +215,91 @@ class TestFastAPIServiceStartStop:
         assert mock_server.should_exit is True
 
     @pytest.mark.asyncio
+    async def test_stop_holds_grace_window_before_should_exit(
+        self, mock_fastapi_service: FastAPIService, time_traveler
+    ) -> None:
+        """Grace sleep must precede setting should_exit so the listener stays open.
+
+        Uses time_traveler.sleeps_for(grace) to assert the function spends exactly
+        the grace duration in asyncio.sleep — any sleep AFTER should_exit was set
+        would push the duration past the asserted value.
+        """
+        mock_server = MagicMock()
+        completed = asyncio.Event()
+
+        async def fake_serve():
+            """Pretend to be uvicorn.serve(): block until completed is set."""
+            await completed.wait()
+
+        mock_server.should_exit = False
+        task = asyncio.create_task(fake_serve())
+        mock_fastapi_service._server = mock_server
+        mock_fastapi_service._server_task = task
+        completed.set()
+
+        with (
+            patch(
+                "aiperf.api.api_service.Environment.API_SERVER.POST_COMPLETE_GRACE",
+                2.5,
+            ),
+            time_traveler.sleeps_for(2.5),
+        ):
+            await mock_fastapi_service._stop_api_server()
+
+        assert mock_server.should_exit is True
+
+    @pytest.mark.asyncio
+    async def test_stop_skips_grace_when_zero(
+        self, mock_fastapi_service: FastAPIService, time_traveler
+    ) -> None:
+        """POST_COMPLETE_GRACE=0 must skip the sleep entirely (back-compat path)."""
+        mock_server = MagicMock()
+        completed = asyncio.Event()
+
+        async def fake_serve():
+            """Pretend to be uvicorn.serve(): block until completed is set."""
+            await completed.wait()
+
+        task = asyncio.create_task(fake_serve())
+        mock_fastapi_service._server = mock_server
+        mock_fastapi_service._server_task = task
+        completed.set()
+
+        with (
+            patch(
+                "aiperf.api.api_service.Environment.API_SERVER.POST_COMPLETE_GRACE",
+                0.0,
+            ),
+            time_traveler.sleeps_for(0.0),
+        ):
+            await mock_fastapi_service._stop_api_server()
+
+        assert mock_server.should_exit is True
+
+    @pytest.mark.asyncio
+    async def test_stop_skips_grace_when_server_task_done(
+        self, mock_fastapi_service: FastAPIService, time_traveler
+    ) -> None:
+        """Grace must be skipped when there is no live serve task to keep open."""
+        mock_server = MagicMock()
+        # Finished task simulates a crashed/exited server.
+        finished_task = asyncio.create_task(asyncio.sleep(0))
+        await finished_task
+        mock_fastapi_service._server = mock_server
+        mock_fastapi_service._server_task = finished_task
+
+        with (
+            patch(
+                "aiperf.api.api_service.Environment.API_SERVER.POST_COMPLETE_GRACE",
+                5.0,
+            ),
+            time_traveler.sleeps_for(0.0),
+        ):
+            await mock_fastapi_service._stop_api_server()
+
+        assert mock_server.should_exit is True
+
+    @pytest.mark.asyncio
     async def test_stop_cancels_on_timeout(
         self, mock_fastapi_service: FastAPIService
     ) -> None:

--- a/tests/unit/common/test_environment.py
+++ b/tests/unit/common/test_environment.py
@@ -178,6 +178,42 @@ class TestAPIServerSettings:
         assert hasattr(env, "API_SERVER")
         assert isinstance(env.API_SERVER, _APIServerSettings)
 
+    def test_api_server_settings_post_complete_grace_default(self) -> None:
+        """POST_COMPLETE_GRACE defaults to 5.0 seconds when no env var is set."""
+        settings = _APIServerSettings()
+        assert settings.POST_COMPLETE_GRACE == 5.0
+
+    def test_api_server_settings_env_post_complete_grace_overrides_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AIPERF_API_SERVER_POST_COMPLETE_GRACE env var overrides the default."""
+        monkeypatch.setenv("AIPERF_API_SERVER_POST_COMPLETE_GRACE", "2.5")
+        settings = _APIServerSettings()
+        assert settings.POST_COMPLETE_GRACE == 2.5
+
+    def test_api_server_settings_post_complete_grace_zero_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Zero is a valid value (recovers pre-fix immediate-shutdown behavior)."""
+        monkeypatch.setenv("AIPERF_API_SERVER_POST_COMPLETE_GRACE", "0")
+        settings = _APIServerSettings()
+        assert settings.POST_COMPLETE_GRACE == 0.0
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            param("-0.1", id="below_minimum"),
+            param("301", id="above_maximum"),
+        ],
+    )  # fmt: skip
+    def test_api_server_settings_post_complete_grace_out_of_range_raises(
+        self, bad_value: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Values outside [0.0, 300.0] are rejected at settings construction."""
+        monkeypatch.setenv("AIPERF_API_SERVER_POST_COMPLETE_GRACE", bad_value)
+        with pytest.raises(ValueError):
+            _APIServerSettings()
+
 
 class TestCompressionSettings:
     """Test _CompressionSettings defaults and validation."""

--- a/tests/unit/controller/test_system_controller.py
+++ b/tests/unit/controller/test_system_controller.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aiperf.common.enums import CommandType
+from aiperf.common.enums import (
+    CommandType,
+    LifecycleState,
+    ServiceRegistrationStatus,
+)
 from aiperf.common.environment import Environment
 from aiperf.common.exceptions import LifecycleOperationError
 from aiperf.common.messages.command_messages import CommandErrorResponse
@@ -447,3 +451,174 @@ class TestSSLVerificationWarning:
             await system_controller._profile_configure_all_services()
 
             mock_warning.assert_not_called()
+
+
+class TestShutdownDeliveryGrace:
+    """Test that _stop_system_controller respects POST_COMPLETE_GRACE when API enabled."""
+
+    @staticmethod
+    def _register_api_service(
+        controller: SystemController,
+        state: LifecycleState = LifecycleState.RUNNING,
+    ) -> None:
+        """Populate service_map with an API ServiceRunInfo in the given lifecycle state."""
+        from aiperf.common.models import ServiceRunInfo
+        from aiperf.plugin.enums import ServiceType
+
+        info = ServiceRunInfo(
+            service_type=ServiceType.API,
+            registration_status=ServiceRegistrationStatus.REGISTERED,
+            service_id="api-1",
+            state=state,
+        )
+        controller.service_manager.service_map = {ServiceType.API: [info]}
+
+    @staticmethod
+    async def _drive_stop(
+        controller: SystemController, monkeypatch: pytest.MonkeyPatch
+    ) -> list[float]:
+        """Invoke _stop_system_controller and return all asyncio.sleep call durations."""
+        import aiperf.controller.system_controller as sc_module
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            """Record each asyncio.sleep duration without actually sleeping."""
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(sc_module.asyncio, "sleep", fake_sleep)
+        # _stop_system_controller ends in os._exit(); mute it so the test process survives.
+        monkeypatch.setattr(sc_module.os, "_exit", lambda code: None)
+
+        controller.publish = AsyncMock()
+        controller.ui = AsyncMock()
+        controller.comms = AsyncMock()
+        controller.proxy_manager = AsyncMock()
+        controller._print_post_benchmark_info_and_metrics = AsyncMock()
+        controller._print_exit_errors_and_log_file = MagicMock()
+
+        await controller._stop_system_controller()
+        return sleeps
+
+    @pytest.mark.asyncio
+    async def test_uses_default_05s_when_api_disabled(
+        self,
+        system_controller: SystemController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When API is disabled, the original 0.5s ZMQ-delivery wait is preserved."""
+        system_controller._api_enabled = False
+        sleeps = await self._drive_stop(system_controller, monkeypatch)
+        assert sleeps[0] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_extends_to_grace_when_api_enabled_and_alive(
+        self,
+        system_controller: SystemController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """API enabled + registered RUNNING service: wait stretches to POST_COMPLETE_GRACE."""
+        system_controller._api_enabled = True
+        self._register_api_service(system_controller, LifecycleState.RUNNING)
+        monkeypatch.setattr(Environment.API_SERVER, "POST_COMPLETE_GRACE", 7.0)
+        sleeps = await self._drive_stop(system_controller, monkeypatch)
+        assert sleeps[0] == 7.0
+
+    @pytest.mark.asyncio
+    async def test_floors_at_05s_when_api_alive_with_small_grace(
+        self,
+        system_controller: SystemController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Even with grace < 0.5s, ZMQ-delivery floor of 0.5s is preserved."""
+        system_controller._api_enabled = True
+        self._register_api_service(system_controller, LifecycleState.RUNNING)
+        monkeypatch.setattr(Environment.API_SERVER, "POST_COMPLETE_GRACE", 0.1)
+        sleeps = await self._drive_stop(system_controller, monkeypatch)
+        assert sleeps[0] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_skips_grace_when_api_enabled_but_never_registered(
+        self,
+        system_controller: SystemController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """API startup failure: _api_enabled is True but no service ever registered."""
+        system_controller._api_enabled = True
+        system_controller.service_manager.service_map = {}
+        monkeypatch.setattr(Environment.API_SERVER, "POST_COMPLETE_GRACE", 7.0)
+        sleeps = await self._drive_stop(system_controller, monkeypatch)
+        assert sleeps[0] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_skips_grace_when_api_failed(
+        self,
+        system_controller: SystemController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """API registered but transitioned to FAILED: grace serves no one, skip it."""
+        system_controller._api_enabled = True
+        self._register_api_service(system_controller, LifecycleState.FAILED)
+        monkeypatch.setattr(Environment.API_SERVER, "POST_COMPLETE_GRACE", 7.0)
+        sleeps = await self._drive_stop(system_controller, monkeypatch)
+        assert sleeps[0] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_skips_grace_when_api_stopped(
+        self,
+        system_controller: SystemController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """API registered but transitioned to STOPPED before shutdown: skip grace."""
+        system_controller._api_enabled = True
+        self._register_api_service(system_controller, LifecycleState.STOPPED)
+        monkeypatch.setattr(Environment.API_SERVER, "POST_COMPLETE_GRACE", 7.0)
+        sleeps = await self._drive_stop(system_controller, monkeypatch)
+        assert sleeps[0] == 0.5
+
+    @staticmethod
+    def _set_api_process_liveness(controller: SystemController, alive: bool) -> None:
+        """Populate multi_process_info with an API process record reporting `alive`."""
+        from aiperf.plugin.enums import ServiceType
+
+        proc = MagicMock()
+        proc.is_alive.return_value = alive
+        rec = MagicMock()
+        rec.service_type = ServiceType.API
+        rec.process = proc
+        controller.service_manager.multi_process_info = [rec]
+
+    @pytest.mark.asyncio
+    async def test_skips_grace_when_api_process_dead_despite_running_state(
+        self,
+        system_controller: SystemController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """API process exited but service_map state stayed at RUNNING.
+
+        BaseComponentService._on_state_change suppresses StatusMessage publishes
+        once stop_requested is set, so the controller's view of the API service
+        state is frozen at RUNNING even after the API process self-stopped,
+        crashed, or transitioned to FAILED. Cross-check process.is_alive() so
+        we do not extend the grace on a dead listener.
+        """
+        system_controller._api_enabled = True
+        self._register_api_service(system_controller, LifecycleState.RUNNING)
+        self._set_api_process_liveness(system_controller, alive=False)
+        monkeypatch.setattr(Environment.API_SERVER, "POST_COMPLETE_GRACE", 7.0)
+        sleeps = await self._drive_stop(system_controller, monkeypatch)
+        assert sleeps[0] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_extends_grace_when_api_process_alive_and_running(
+        self,
+        system_controller: SystemController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """API service RUNNING and process is alive: extend grace as before."""
+        system_controller._api_enabled = True
+        self._register_api_service(system_controller, LifecycleState.RUNNING)
+        self._set_api_process_liveness(system_controller, alive=True)
+        monkeypatch.setattr(Environment.API_SERVER, "POST_COMPLETE_GRACE", 7.0)
+        sleeps = await self._drive_stop(system_controller, monkeypatch)
+        assert sleeps[0] == 7.0


### PR DESCRIPTION
## Summary
- Cherry-pick of #989 (`607977c1`) onto `release/0.9.0`: keeps the `/api/results` listener open after benchmark completes (DYN-701).
- Applied cleanly with `git cherry-pick -x`; auto-merge on `docs/environment-variables.md` and `src/aiperf/common/environment.py`, no conflicts.

## Test plan
- [ ] CI green on `release/0.9.0` base
- [ ] `tests/unit/api/test_api_service.py`, `tests/unit/common/test_environment.py`, `tests/unit/controller/test_system_controller.py` pass

Refs: #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)