### PR TITLE
fix(plot): cherry-pick #1004 (plot data loader 2) to release/0.9.0

### DIFF
--- a/src/aiperf/cli_runner/_sweep_aggregate.py
+++ b/src/aiperf/cli_runner/_sweep_aggregate.py
@@ -45,6 +45,38 @@ still surface the parameter combination for reporting.
 """
 
 
+def _resolve_model_name_for_variation(
+    plan: BenchmarkPlan, key: VariationKey
+) -> str | None:
+    """Resolve the first model name for the variation identified by ``key``.
+
+    Matches ``plan.variations[i].label`` against ``_key_label(key)`` and
+    returns ``plan.configs[i].models.items[0].name``. Falls back to
+    ``configs[0]`` when no variation matches (non-sweep plans or label
+    mismatch), and returns ``None`` if the resolved config has no model
+    items.
+
+    The aggregate exporter stamps this onto ``metadata["model"]`` so the
+    plot loader can recover the model name for aggregate-only runs
+    (``profile_export_aiperf_aggregate.json`` carries no
+    ``input_config`` block).
+    """
+    if not plan.configs:
+        return None
+
+    target_label = _key_label(key)
+    config = plan.configs[0]
+    for variation in plan.variations:
+        if variation.label == target_label and 0 <= variation.index < len(plan.configs):
+            config = plan.configs[variation.index]
+            break
+
+    items = getattr(getattr(config, "models", None), "items", None) or []
+    if items and getattr(items[0], "name", None):
+        return items[0].name
+    return None
+
+
 def _plan_iteration_order(plan: BenchmarkPlan) -> Any:
     """Resolve the sweep iteration order, defaulting to REPEATED outside grids."""
     from aiperf.common.enums import SweepMode
@@ -421,6 +453,8 @@ async def _export_one_variation_aggregate(
     aggregate_result.metadata["variation_label"] = variation_label
     aggregate_result.metadata["variation_values"] = dict(_key_values(key))
     aggregate_result.metadata["sweep_mode"] = str(_plan_iteration_order(plan))
+    if model := _resolve_model_name_for_variation(plan, key):
+        aggregate_result.metadata["model"] = model
 
     from aiperf.config.sweep import _format_dir_name
 

--- a/src/aiperf/plot/core/data_loader.py
+++ b/src/aiperf/plot/core/data_loader.py
@@ -1610,6 +1610,44 @@ class DataLoader(AIPerfLoggerMixin):
         return result
 
     @staticmethod
+    def _extract_load_field(
+        config: dict[str, Any], v2_field: str, legacy_field: str
+    ) -> Any | None:
+        """Resolve a per-phase load characteristic across YAML v2 and legacy.
+
+        YAML v2 attaches per-phase fields (``concurrency``, ``requests``)
+        to entries under ``input_config.phases[]`` and leaves the flat
+        ``input_config.loadgen`` block as ``null``. Legacy artifacts put
+        the same values directly on ``loadgen`` under their old names
+        (``concurrency`` / ``request_count``).
+
+        Prefer the v2 value (read from the ``profiling`` phase when
+        present, else the first phase) so v2 artifacts resolve
+        deterministically. Fall back to ``loadgen[legacy_field]`` for
+        legacy artifacts, then to ``None``.
+        """
+        phases = config.get("phases")
+        if isinstance(phases, list) and phases:
+            profiling_phase = next(
+                (
+                    p
+                    for p in phases
+                    if isinstance(p, dict) and p.get("name") == "profiling"
+                ),
+                None,
+            )
+            candidate = profiling_phase or next(
+                (p for p in phases if isinstance(p, dict)), None
+            )
+            if candidate is not None and v2_field in candidate:
+                return candidate[v2_field]
+
+        loadgen = config.get("loadgen")
+        if isinstance(loadgen, dict) and legacy_field in loadgen:
+            return loadgen[legacy_field]
+        return None
+
+    @staticmethod
     def _extract_model_name(config: dict[str, Any]) -> str | None:
         """Resolve the model name from an ``input_config`` block.
 
@@ -1666,12 +1704,10 @@ class DataLoader(AIPerfLoggerMixin):
             config = aggregated["input_config"]
 
             model = self._extract_model_name(config)
-
-            if "loadgen" in config and "concurrency" in config["loadgen"]:
-                concurrency = config["loadgen"]["concurrency"]
-
-            if "loadgen" in config and "request_count" in config["loadgen"]:
-                request_count = config["loadgen"]["request_count"]
+            concurrency = self._extract_load_field(config, "concurrency", "concurrency")
+            request_count = self._extract_load_field(
+                config, "requests", "request_count"
+            )
 
             if "endpoint" in config and "type" in config["endpoint"]:
                 endpoint_type = config["endpoint"]["type"]
@@ -1680,6 +1716,17 @@ class DataLoader(AIPerfLoggerMixin):
             start_time = aggregated.get("start_time")
             end_time = aggregated.get("end_time")
             was_cancelled = aggregated.get("was_cancelled", False)
+
+            # Aggregate-only runs (sweep cells) carry no ``input_config``; the
+            # sweep exporter stamps the resolved model into ``metadata.model``
+            # instead. See ``_resolve_model_name_for_variation`` in
+            # ``aiperf.cli_runner._sweep_aggregate``.
+            if model is None:
+                meta_block = aggregated.get("metadata")
+                if isinstance(meta_block, dict):
+                    stamped = meta_block.get("model")
+                    if isinstance(stamped, str) and stamped:
+                        model = stamped
 
         duration_seconds = None
         if (

--- a/src/aiperf/plot/exporters/png/multi_run.py
+++ b/src/aiperf/plot/exporters/png/multi_run.py
@@ -61,8 +61,14 @@ class MultiRunPNGExporter(BasePNGExporter):
 
         for spec in plot_specs:
             try:
-                if not self._can_generate_plot(spec, df):
-                    self.debug(f"Skipping {spec.name} - required columns not available")
+                missing = self._missing_required_columns(spec, df)
+                if missing:
+                    self.warning(
+                        f"Skipping plot '{spec.name}': required metric column(s) "
+                        f"missing from run data: {missing}. Verify the benchmark "
+                        f"recorded these metrics (e.g. 'time_to_first_token' "
+                        f"only exists for streaming runs)."
+                    )
                     continue
 
                 fig = self._create_plot_from_spec(spec, df, available_metrics)
@@ -79,21 +85,19 @@ class MultiRunPNGExporter(BasePNGExporter):
 
         return generated_files
 
-    def _can_generate_plot(self, spec: PlotSpec, df: pd.DataFrame) -> bool:
-        """
-        Check if a plot can be generated based on column availability.
+    def _missing_required_columns(self, spec: PlotSpec, df: pd.DataFrame) -> list[str]:
+        """Return the spec's required metric columns that aren't in ``df``.
 
-        Args:
-            spec: Plot specification
-            df: DataFrame with aggregated metrics
-
-        Returns:
-            True if the plot can be generated, False otherwise
+        Empty list means the plot can be generated. ``concurrency`` is
+        treated as always-available because the DataFrame builder
+        materializes it from ``RunMetadata.concurrency`` (with a fallback)
+        even when the input JSON has no corresponding metric.
         """
-        for metric in spec.metrics:
-            if metric.name not in df.columns and metric.name != "concurrency":
-                return False
-        return True
+        return [
+            metric.name
+            for metric in spec.metrics
+            if metric.name not in df.columns and metric.name != "concurrency"
+        ]
 
     def _create_plot_from_spec(
         self, spec: PlotSpec, df: pd.DataFrame, available_metrics: dict

--- a/src/aiperf/plot/exporters/png/single_run.py
+++ b/src/aiperf/plot/exporters/png/single_run.py
@@ -57,8 +57,14 @@ class SingleRunPNGExporter(BasePNGExporter):
 
         for spec in plot_specs:
             try:
-                if not self._can_generate_plot(spec, run):
-                    self.debug(f"Skipping {spec.name} - required data not available")
+                missing = self._missing_data_sources(spec, run)
+                if missing:
+                    self.warning(
+                        f"Skipping plot '{spec.name}': required data source(s) "
+                        f"missing or empty: {missing}. Verify the benchmark "
+                        f"produced this data (e.g. 'gpu_telemetry' requires "
+                        f"--gpu-telemetry-url)."
+                    )
                     continue
 
                 fig = self._create_plot_from_spec(spec, run, available_metrics)
@@ -75,35 +81,29 @@ class SingleRunPNGExporter(BasePNGExporter):
 
         return generated_files
 
-    def _can_generate_plot(self, spec: PlotSpec, run: RunData) -> bool:
-        """
-        Check if a plot can be generated based on data availability.
+    def _missing_data_sources(self, spec: PlotSpec, run: RunData) -> list[str]:
+        """Return the data sources required by ``spec`` that are missing/empty.
 
-        Args:
-            spec: Plot specification
-            run: RunData object
-
-        Returns:
-            True if the plot can be generated, False otherwise
+        Deduplicated and sorted so the warning message is stable. Empty
+        list means the plot can be generated. A spec metric counts as
+        missing when its declared ``source`` resolves to ``None`` or an
+        empty DataFrame on the RunData.
         """
+        missing: set[str] = set()
         for metric in spec.metrics:
-            if (
-                (
-                    metric.source == DataSource.REQUESTS
-                    and (run.requests is None or run.requests.empty)
-                )
-                or (
-                    metric.source == DataSource.TIMESLICES
-                    and (run.timeslices is None or run.timeslices.empty)
-                )
-                or (
-                    metric.source == DataSource.GPU_TELEMETRY
-                    and (run.gpu_telemetry is None or run.gpu_telemetry.empty)
-                )
+            if metric.source == DataSource.REQUESTS and (
+                run.requests is None or run.requests.empty
             ):
-                return False
-
-        return True
+                missing.add("requests")
+            elif metric.source == DataSource.TIMESLICES and (
+                run.timeslices is None or run.timeslices.empty
+            ):
+                missing.add("timeslices")
+            elif metric.source == DataSource.GPU_TELEMETRY and (
+                run.gpu_telemetry is None or run.gpu_telemetry.empty
+            ):
+                missing.add("gpu_telemetry")
+        return sorted(missing)
 
     def _create_plot_from_spec(
         self, spec: PlotSpec, run: RunData, available_metrics: dict

--- a/tests/unit/plot/test_data_loader.py
+++ b/tests/unit/plot/test_data_loader.py
@@ -392,6 +392,130 @@ class TestDataLoaderExtractMetadata:
 
         assert metadata.model == "legacy-model"
 
+    def test_extract_metadata_model_from_aggregate_metadata_block(
+        self, tmp_path: Path
+    ) -> None:
+        """Aggregate-only runs carry no input_config; model is stamped onto
+        ``aggregated["metadata"]["model"]`` by the sweep exporter."""
+        loader = DataLoader()
+        aggregated = {
+            "metadata": {
+                "aggregation_type": "confidence",
+                "model": "Qwen/Qwen3-0.6B",
+                "variation_label": "concurrency_10",
+            },
+        }
+
+        metadata = loader._extract_metadata(tmp_path / "run", None, aggregated)
+
+        assert metadata.model == "Qwen/Qwen3-0.6B"
+
+    def test_extract_metadata_input_config_model_takes_precedence_over_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        """When both shapes carry a model, the input_config value wins because
+        per-trial artifacts are richer and the metadata-block stamp is a
+        fallback for aggregate-only runs."""
+        loader = DataLoader()
+        aggregated = {
+            "input_config": {
+                "endpoint": {"model_names": ["from-input-config"]},
+            },
+            "metadata": {"model": "from-aggregate-metadata"},
+        }
+
+        metadata = loader._extract_metadata(tmp_path / "run", None, aggregated)
+
+        assert metadata.model == "from-input-config"
+
+    def test_extract_metadata_concurrency_from_yaml_v2_phases(
+        self, tmp_path: Path
+    ) -> None:
+        """YAML v2 stores concurrency on the profiling phase, not on loadgen."""
+        loader = DataLoader()
+        aggregated = {
+            "input_config": {
+                "loadgen": None,
+                "phases": [
+                    {"name": "profiling", "concurrency": 15, "requests": 200},
+                ],
+            },
+        }
+
+        metadata = loader._extract_metadata(tmp_path / "run", None, aggregated)
+
+        assert metadata.concurrency == 15
+        assert metadata.request_count == 200
+
+    def test_extract_metadata_concurrency_yaml_v2_prefers_profiling_phase(
+        self, tmp_path: Path
+    ) -> None:
+        """When multiple phases exist, the profiling phase wins over warmup."""
+        loader = DataLoader()
+        aggregated = {
+            "input_config": {
+                "phases": [
+                    {"name": "warmup", "concurrency": 1, "requests": 10},
+                    {"name": "profiling", "concurrency": 25, "requests": 500},
+                ],
+            },
+        }
+
+        metadata = loader._extract_metadata(tmp_path / "run", None, aggregated)
+
+        assert metadata.concurrency == 25
+        assert metadata.request_count == 500
+
+    def test_extract_metadata_concurrency_yaml_v2_takes_precedence_over_legacy(
+        self, tmp_path: Path
+    ) -> None:
+        """Mirror the model-name precedence: v2 phases win when both shapes are present."""
+        loader = DataLoader()
+        aggregated = {
+            "input_config": {
+                "loadgen": {"concurrency": 1, "request_count": 1},
+                "phases": [{"name": "profiling", "concurrency": 42, "requests": 99}],
+            },
+        }
+
+        metadata = loader._extract_metadata(tmp_path / "run", None, aggregated)
+
+        assert metadata.concurrency == 42
+        assert metadata.request_count == 99
+
+    def test_extract_metadata_concurrency_from_legacy_loadgen(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy artifacts with no phases still resolve via loadgen."""
+        loader = DataLoader()
+        aggregated = {
+            "input_config": {
+                "loadgen": {"concurrency": 8, "request_count": 64},
+            },
+        }
+
+        metadata = loader._extract_metadata(tmp_path / "run", None, aggregated)
+
+        assert metadata.concurrency == 8
+        assert metadata.request_count == 64
+
+    def test_extract_metadata_concurrency_handles_null_loadgen(
+        self, tmp_path: Path
+    ) -> None:
+        """``loadgen: null`` in v2 artifacts must not crash the lookup."""
+        loader = DataLoader()
+        aggregated = {
+            "input_config": {
+                "loadgen": None,
+                "phases": [],
+            },
+        }
+
+        metadata = loader._extract_metadata(tmp_path / "run", None, aggregated)
+
+        assert metadata.concurrency is None
+        assert metadata.request_count is None
+
 
 class TestDataLoaderReloadWithDetails:
     """Tests for DataLoader.reload_with_details method."""

--- a/tests/unit/plot/test_png_exporter.py
+++ b/tests/unit/plot/test_png_exporter.py
@@ -873,6 +873,95 @@ class TestSingleRunPNGExporter:
         # Should return empty list when no data available
         assert len(generated_files) == 0
 
+    def test_single_run_missing_data_sources_helper(
+        self, single_run_exporter, tmp_path
+    ):
+        """Helper returns deduplicated sorted set of missing data sources."""
+        spec = PlotSpec(
+            name="needs_requests_and_gpu",
+            plot_type=PlotType.SCATTER,
+            metrics=[
+                MetricSpec(name="request_number", source=DataSource.REQUESTS, axis="x"),
+                MetricSpec(
+                    name="time_to_first_token",
+                    source=DataSource.REQUESTS,
+                    axis="y",
+                ),
+                MetricSpec(
+                    name="gpu_utilization",
+                    source=DataSource.GPU_TELEMETRY,
+                    axis="y2",
+                ),
+            ],
+            title="t",
+            filename="t.png",
+        )
+        run = RunData(
+            metadata=RunMetadata(
+                run_name="r", run_path=tmp_path / "r", model="m", concurrency=1
+            ),
+            requests=None,
+            aggregated={},
+            timeslices=None,
+            gpu_telemetry=None,
+        )
+
+        # Two distinct metrics share `requests`; we want one dedup'd entry.
+        assert single_run_exporter._missing_data_sources(spec, run) == [
+            "gpu_telemetry",
+            "requests",
+        ]
+
+    def test_single_run_skipped_plot_emits_warning_with_source_name(
+        self, single_run_exporter, sample_available_metrics, tmp_path, caplog
+    ):
+        """Skipping a single-run plot logs WARNING naming the missing source."""
+        gpu_spec = PlotSpec(
+            name="gpu_utilization_and_throughput",
+            plot_type=PlotType.DUAL_AXIS,
+            metrics=[
+                MetricSpec(name="timestamp_s", source=DataSource.REQUESTS, axis="x"),
+                MetricSpec(
+                    name="throughput_tokens_per_sec",
+                    source=DataSource.REQUESTS,
+                    axis="y",
+                ),
+                MetricSpec(
+                    name="gpu_utilization",
+                    source=DataSource.GPU_TELEMETRY,
+                    axis="y2",
+                ),
+            ],
+            title="t",
+            filename="gpu.png",
+        )
+        run = RunData(
+            metadata=RunMetadata(
+                run_name="r", run_path=tmp_path / "r", model="m", concurrency=1
+            ),
+            requests=pd.DataFrame(
+                {"timestamp_s": [1, 2, 3], "throughput_tokens_per_sec": [1, 2, 3]}
+            ),
+            aggregated={},
+            timeslices=None,
+            gpu_telemetry=None,  # Missing → should trigger skip.
+        )
+
+        with caplog.at_level("WARNING"):
+            generated = single_run_exporter.export(
+                run, sample_available_metrics, [gpu_spec]
+            )
+
+        assert generated == []
+        skip_warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "Skipping" in r.message
+        ]
+        assert skip_warnings, "expected a WARNING for the skipped plot"
+        assert "gpu_telemetry" in skip_warnings[0].message
+        assert "gpu_utilization_and_throughput" in skip_warnings[0].message
+
     def test_per_request_to_dataframe(self, sample_single_run_data):
         """Test conversion of per-request data to DataFrame."""
         df = prepare_request_timeseries(sample_single_run_data)
@@ -1442,6 +1531,97 @@ class TestSharedExporterFunctionality:
 
         # May generate fewer plots if metrics are missing
         assert isinstance(generated_files, list)
+
+    def test_multi_run_missing_required_columns_helper(self, tmp_path):
+        """Helper names every required spec column that's missing from the df."""
+        exporter = MultiRunPNGExporter(tmp_path / "plots")
+        spec = PlotSpec(
+            name="needs_two_metrics",
+            plot_type=PlotType.SCATTER_LINE,
+            metrics=[
+                MetricSpec(
+                    name="time_to_first_token",
+                    source=DataSource.AGGREGATED,
+                    axis="x",
+                    stat="avg",
+                ),
+                MetricSpec(
+                    name="request_throughput",
+                    source=DataSource.AGGREGATED,
+                    axis="y",
+                    stat="avg",
+                ),
+            ],
+            title="t",
+            filename="t.png",
+        )
+        # df has throughput but not TTFT
+        df = pd.DataFrame({"request_throughput": [1.0]})
+
+        assert exporter._missing_required_columns(spec, df) == ["time_to_first_token"]
+
+        # Both columns present -> no missing
+        df_complete = pd.DataFrame(
+            {"time_to_first_token": [1.0], "request_throughput": [2.0]}
+        )
+        assert exporter._missing_required_columns(spec, df_complete) == []
+
+    def test_multi_run_skipped_plot_emits_warning_with_column_name(
+        self, tmp_path, sample_available_metrics, caplog
+    ):
+        """Skipping a plot for missing columns logs WARNING naming the column."""
+        exporter = MultiRunPNGExporter(tmp_path / "plots")
+        ttft_spec = PlotSpec(
+            name="ttft_vs_throughput",
+            plot_type=PlotType.SCATTER_LINE,
+            metrics=[
+                MetricSpec(
+                    name="time_to_first_token",
+                    source=DataSource.AGGREGATED,
+                    axis="x",
+                    stat="avg",
+                ),
+                MetricSpec(
+                    name="request_throughput",
+                    source=DataSource.AGGREGATED,
+                    axis="y",
+                    stat="avg",
+                ),
+            ],
+            title="t",
+            filename="t.png",
+        )
+        non_streaming_run = RunData(
+            metadata=RunMetadata(
+                run_name="r",
+                run_path=tmp_path / "r",
+                model="m",
+                concurrency=1,
+            ),
+            requests=None,
+            aggregated={
+                # Non-streaming: TTFT is absent.
+                "request_latency": {"avg": 100.0, "unit": "ms"},
+                "request_throughput": {"avg": 5.0, "unit": "requests/sec"},
+            },
+            timeslices=None,
+            slice_duration=None,
+        )
+
+        with caplog.at_level("WARNING"):
+            generated = exporter.export(
+                [non_streaming_run], sample_available_metrics, [ttft_spec]
+            )
+
+        assert generated == []
+        skip_warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "Skipping" in r.message
+        ]
+        assert skip_warnings, "expected a WARNING for the skipped plot"
+        assert "time_to_first_token" in skip_warnings[0].message
+        assert "ttft_vs_throughput" in skip_warnings[0].message
 
 
 class TestSingleRunGPUPlots:

--- a/tests/unit/test_cli_runner_sweep_helpers.py
+++ b/tests/unit/test_cli_runner_sweep_helpers.py
@@ -234,6 +234,9 @@ async def test_aggregate_per_variation_writes_aggregate_per_cell_independent(
             f"phases.profiling.concurrency={concurrency}"
         )
         assert str(meta["sweep_mode"]).lower() == "independent"
+        # The model is stamped so the plot loader can recover it for
+        # aggregate-only runs (no input_config in the aggregate JSON).
+        assert meta["model"] == "test-model"
 
 
 @pytest.mark.asyncio
@@ -490,3 +493,61 @@ def test_execute_multi_benchmark_skips_table_when_suppressed() -> None:
 
     kwargs = mock_orch_cls.call_args.kwargs
     assert kwargs.get("cell_callback") is None
+
+
+class TestResolveModelNameForVariation:
+    """Unit tests for ``_resolve_model_name_for_variation``."""
+
+    def test__resolve_model_name_for_variation_single_config_no_variations_returns_first_model(
+        self,
+    ):
+        from aiperf.cli_runner._sweep_aggregate import (
+            _resolve_model_name_for_variation,
+        )
+
+        plan = _make_plan()  # one config with models=["test-model"], no variations
+        key = ("any-label", ())
+
+        assert _resolve_model_name_for_variation(plan, key) == "test-model"
+
+    def test__resolve_model_name_for_variation_multi_config_matches_variation_index_returns_expected(
+        self,
+    ):
+        from aiperf.cli_runner._sweep_aggregate import (
+            _resolve_model_name_for_variation,
+        )
+        from aiperf.config.sweep.config import SweepVariation
+
+        cfg_a = BenchmarkConfig(**{**_MINIMAL_CONFIG_KWARGS, "models": ["model-a"]})
+        cfg_b = BenchmarkConfig(**{**_MINIMAL_CONFIG_KWARGS, "models": ["model-b"]})
+        plan = BenchmarkPlan(
+            configs=[cfg_a, cfg_b],
+            variations=[
+                SweepVariation(index=0, label="cell_a", values={}),
+                SweepVariation(index=1, label="cell_b", values={}),
+            ],
+        )
+
+        assert _resolve_model_name_for_variation(plan, ("cell_a", ())) == "model-a"
+        assert _resolve_model_name_for_variation(plan, ("cell_b", ())) == "model-b"
+
+    def test__resolve_model_name_for_variation_unmatched_label_falls_back_to_first_config(
+        self,
+    ):
+        from aiperf.cli_runner._sweep_aggregate import (
+            _resolve_model_name_for_variation,
+        )
+        from aiperf.config.sweep.config import SweepVariation
+
+        cfg_a = BenchmarkConfig(**{**_MINIMAL_CONFIG_KWARGS, "models": ["model-a"]})
+        cfg_b = BenchmarkConfig(**{**_MINIMAL_CONFIG_KWARGS, "models": ["model-b"]})
+        plan = BenchmarkPlan(
+            configs=[cfg_a, cfg_b],
+            variations=[
+                SweepVariation(index=0, label="cell_a", values={}),
+                SweepVariation(index=1, label="cell_b", values={}),
+            ],
+        )
+
+        # Unmatched label -> fall back to configs[0].
+        assert _resolve_model_name_for_variation(plan, ("ghost_label", ())) == "model-a"


### PR DESCRIPTION
## Summary
- Cherry-picks #1004 (`fix: plot data loader 2`) onto `release/0.9.0`.
- Clean cherry-pick via `git cherry-pick -x d797629d18747ec20ebaf1591584011144080186` — no conflicts.

## Test plan
- [ ] CI on `release/0.9.0` passes against the cherry-picked commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)