### PR TITLE
fix(redact): tighten sensitive-token list to stop matching LLM token-count flags

### DIFF
--- a/src/aiperf/common/redact.py
+++ b/src/aiperf/common/redact.py
@@ -238,7 +238,20 @@ def redact_cli_command(cmd: str) -> str:
     return cmd
 
 
-_CLI_COMMAND_SENSITIVE_TOKENS = ("api-key", "api_key", "authorization", "token")
+# Each entry must contain a `-` or `_` so it can't substring-match an innocent
+# plural (e.g. bare `"token"` would match `--*-tokens-mean` flags carrying LLM
+# token counts). Bare `--token` is intentionally not matched; add a specific
+# compound form (e.g. `"my-token"`) if a new auth flag needs to be covered.
+_CLI_COMMAND_SENSITIVE_TOKENS = (
+    "api-key", "api_key",
+    "api-token", "api_token",
+    "auth-token", "auth_token",
+    "access-token", "access_token",
+    "bearer-token", "bearer_token",
+    "id-token", "id_token",
+    "refresh-token", "refresh_token",
+    "authorization",
+)  # fmt: skip
 
 
 def _redact_cli_args(args: list) -> list:

--- a/tests/unit/common/test_redact.py
+++ b/tests/unit/common/test_redact.py
@@ -1455,6 +1455,56 @@ class TestCliCommandRedaction:
         assert "http://localhost:8000" in cmd
         assert "gpt2" in cmd
 
+    @pytest.mark.parametrize(
+        "flag, value",
+        [
+            param("--input-tokens-mean", "1024", id="input-tokens-mean"),
+            param("--input-tokens-stddev", "0", id="input-tokens-stddev"),
+            param("--output-tokens-mean", "128", id="output-tokens-mean"),
+            param("--output-tokens-stddev", "32", id="output-tokens-stddev"),
+            param(
+                "--synthetic-input-tokens-mean", "1024", id="synthetic-input-tokens-mean",
+            ),
+            param(
+                "--synthetic-input-tokens-stddev",
+                "0",
+                id="synthetic-input-tokens-stddev",
+            ),
+        ],
+    )  # fmt: skip
+    def test_token_count_flags_preserve_value_in_cli_command(self, flag, value):
+        """Regression: flag names containing 'tokens' (plural — LLM token
+        counts) must not be redacted just because they share a substring with
+        auth-token flags. Reported via real-run output where every
+        --*-tokens-* flag value came back as '<redacted>'."""
+        cmd = self._build_cli_command(
+            ["aiperf", "profile", "--model", "gpt2", flag, value]
+        )
+        assert value in cmd, f"{flag} value {value!r} should not be redacted"
+        assert REDACTED_VALUE not in cmd
+
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            param("--api-token", id="api-token"),
+            param("--api_token", id="api_token-underscore"),
+            param("--auth-token", id="auth-token"),
+            param("--access-token", id="access-token"),
+            param("--bearer-token", id="bearer-token"),
+            param("--id-token", id="id-token"),
+            param("--refresh-token", id="refresh-token"),
+        ],
+    )  # fmt: skip
+    def test_auth_token_compound_flags_redacted_in_cli_command(self, flag):
+        """Auth-token flag variants must still be redacted after tightening
+        the sensitive-token list away from the bare-'token' substring match."""
+        secret = "nv-secret-AUTH-TOKEN-9876543210"
+        cmd = self._build_cli_command(
+            ["aiperf", "profile", "--model", "gpt2", flag, secret]
+        )
+        assert secret not in cmd
+        assert REDACTED_VALUE in cmd
+
 
 # =============================================================================
 # ErrorDetails safe repr


### PR DESCRIPTION
## Summary

Fixes a bug where every aiperf flag with `tokens` (plural) in its name had its
value silently replaced with `<redacted>` in the canonical `cli_command` string,
breaking reproducibility of the recorded launch command.

**Before:**
CLI Command: aiperf profile --model 'Qwen/Qwen3-0.6B' ...
  --synthetic-input-tokens-mean ''
  --synthetic-input-tokens-stddev ''
  --output-tokens-mean '' ...

**After:**
CLI Command: aiperf profile --model 'Qwen/Qwen3-0.6B' ...
  --synthetic-input-tokens-mean 1024
  --synthetic-input-tokens-stddev 0
  --output-tokens-mean 128 ...

## Root cause

`src/aiperf/common/redact.py`'s `_CLI_COMMAND_SENSITIVE_TOKENS` included bare
`"token"` as a substring marker. Combined with the substring check in
`_redact_cli_args` (`if any(tok in key for tok in ...)`), this fired on any flag
containing the substring `token` — including LLM token-count flags like
`--*-tokens-mean`, `--*-tokens-stddev`.

Introduced alongside the v2 config refactor in 94a91026 (#912). Test coverage
at the time exercised `--api-key` only; the token-count family was uncovered.

## Fix

Replaced bare `"token"` with the specific auth-token compound forms it was
meant to catch: `api-token`, `auth-token`, `access-token`, `bearer-token`,
`id-token`, `refresh-token` (each with `-` and `_` variants). Every entry now
contains a `-` or `_`, so substring-matching can't fire on innocent plurals.

**Tradeoff:** bare `--token <secret>` is no longer caught. aiperf has no such
flag today; future additions can extend the list explicitly.

## Test plan

- [ ] `uv run pytest tests/unit/common/test_redact.py` — 271 passed
- [ ] Token-count flag family preserves values (new parametrized regression
      cases): `--input-tokens-mean`, `--input-tokens-stddev`,
      `--output-tokens-mean`, `--output-tokens-stddev`,
      `--synthetic-input-tokens-mean`, `--synthetic-input-tokens-stddev`
- [ ] Auth-token compound flags still redact (new parametrized positive cases):
      `--api-token`, `--api_token`, `--auth-token`, `--access-token`,
      `--bearer-token`, `--id-token`, `--refresh-token`
- [ ] Original bug reproducer: `aiperf profile --model 'Qwen/Qwen3-0.6B' ... --synthetic-input-tokens-mean 1024 ...`
      shows literal `1024` (not `<redacted>`) in the printed CLI Command
- [ ] Pre-existing `--api-key sk-secret-XXX` redaction still works

## Related

- #997 — the API-side fix for the same v2-refactor regression family
- 94a91026 / #912 — commit where the buggy substring match was introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credential redaction to cover additional authentication token flag variants (`--api-token`, `--auth-token`, `--access-token`, `--bearer-token`, `--id-token`, `--refresh-token`), providing improved protection for sensitive information in CLI commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/aiperf/pull/1006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->