### PR TITLE
build(docker): exclude dev dependency-group from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -236,8 +236,15 @@ COPY --from=python-licenses /opt/licenses/ /
 ############################################
 ############### Test Image #################
 ############################################
-# Test stage: env-builder has aiperf, just add curl
+# Test stage: env-builder installs only runtime deps now, so reinstall aiperf
+# with the [test] extra (pytest, hypothesis, etc.) from the already-built wheel,
+# and add curl for server health checks.
 FROM env-builder AS test
+
+COPY --from=wheel-builder /dist /tmp/dist
+RUN WHEEL=$(ls /tmp/dist/aiperf-*.whl) \
+    && uv pip install "aiperf[test] @ file://${WHEEL}" \
+    && rm -rf /tmp/dist
 
 RUN apt-get update -y && \
     apt-get install -y curl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,9 +166,11 @@ RUN mkdir -p /app /app/artifacts /app/.cache \
     && chown -R 1000:1000 /app \
     && chmod -R 755 /app
 
-# Install only the dependencies using uv
+# Install only the runtime dependencies using uv. --no-default-groups excludes
+# the PEP 735 dev group (hypothesis, pre-commit) so dev-only tooling does not
+# leak into the runtime image; the test/dev extras are not installed here either.
 COPY pyproject.toml .
-RUN uv sync --active --no-install-project
+RUN uv sync --active --no-install-project --no-default-groups
 
 # Copy the rest of the application
 COPY --from=wheel-builder /dist /dist


### PR DESCRIPTION
## Summary

Two related fixes to dependency installation in the `Dockerfile`.

### 1. Exclude the dev dependency-group from the runtime image

The `env-builder` stage ran:

```dockerfile
RUN uv sync --active --no-install-project
```

By default `uv sync` installs the PEP 735 `dev` dependency-group declared in `pyproject.toml`'s `[dependency-groups]` (`hypothesis`, `pre-commit`). That venv (`/opt/aiperf/venv`) is copied **wholesale** into the `runtime` image, so dev-only tooling was shipping in the production container. (Confirmed by the installed versions matching the `[dependency-groups]` pins, not the looser `[project.optional-dependencies]` extras.)

This adds `--no-default-groups` so only the **core runtime dependencies** are installed:

```diff
-RUN uv sync --active --no-install-project
+RUN uv sync --active --no-install-project --no-default-groups
```

### 2. Make the `test` stage actually able to run tests

With the dev group no longer installed, the `test` stage (`FROM env-builder`) had no test tooling — and it never had `pytest` even before, since `pytest` lives in the `[test]` extra, not the dev group. The stage now reinstalls aiperf with the `[test]` extra from the already-built wheel:

```dockerfile
COPY --from=wheel-builder /dist /tmp/dist
RUN WHEEL=$(ls /tmp/dist/aiperf-*.whl) \
    && uv pip install "aiperf[test] @ file://${WHEEL}" \
    && rm -rf /tmp/dist
```

This pulls `pytest`, `pytest-asyncio`, `pytest-cov`, `pytest-xdist`, `hypothesis`, `httpx`, `jsonschema`, `looptime`, and `trustme` into the test image.

## Why change #1 is safe

- **CI unit/integration tests are unaffected.** They install on the GitHub runner via `make ci-install` / `make first-time-setup` → `make install` → `uv pip install -e ".[dev]"` (the `[dev]` *extra*), an entirely separate path from the Dockerfile's `uv sync` *dependency-group*. The container is never used to run those tests.
- **The `test` Docker stage is not built in CI.** The only targets built (in `nightly.yml`) are `wheel-artifact`, `runtime`, and `licenses-artifact`; there is no `--target test` anywhere in `.github/`, `Makefile`, or docs. Change #2 nonetheless makes that stage correct for anyone who does build it locally.

## Impact

- `runtime` (production) image: drops `hypothesis`, `pre-commit`, and their unique transitive deps — pure bloat removal. `[dependency-groups]` defines only the `dev` group, so no other group is affected.
- `test` image: now has a working test toolchain instead of a half-populated venv.
- Core runtime deps (`tqdm`, `pydantic`, `transformers`, etc.) are unchanged — they live in `[project.dependencies]` and are always installed.

## Testing

- `git grep`-verified there is no `--target test` consumer in CI/Makefile/docs.
- Changes are confined to the `Dockerfile` (`env-builder` sync flag + `test` stage); no application code touched. The `aiperf[test] @ file://…` form is standard PEP 508 direct-reference-with-extras syntax supported by uv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)