### PR TITLE
docs: fix broken source-file links in dev/patterns.md

### DIFF
--- a/docs/dev/patterns.md
+++ b/docs/dev/patterns.md
@@ -401,9 +401,9 @@ GPU power and energy come from telemetry scrapes, not from request
 records, so their values must be injected by the accumulator that owns
 the sensor data rather than derived by the standard registry walk.
 
-Reference file: [`src/aiperf/metrics/types/power_efficiency_metrics.py`](../../src/aiperf/metrics/types/power_efficiency_metrics.py).
+Reference file: [`src/aiperf/metrics/types/power_efficiency_metrics.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/metrics/types/power_efficiency_metrics.py).
 Injection site: `GPUTelemetryAccumulator.compute_efficiency_metrics`
-([`src/aiperf/gpu_telemetry/accumulator.py`](../../src/aiperf/gpu_telemetry/accumulator.py)).
+([`src/aiperf/gpu_telemetry/accumulator.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/gpu_telemetry/accumulator.py)).
 
 ### The three-part contract
 
@@ -481,7 +481,7 @@ values are not overwritten.
 ### Test contract
 
 The error-message invariants are pinned by
-[`tests/unit/metrics/test_power_efficiency_metrics.py`](../../tests/unit/metrics/test_power_efficiency_metrics.py)
+[`tests/unit/metrics/test_power_efficiency_metrics.py`](https://github.com/ai-dynamo/aiperf/blob/main/tests/unit/metrics/test_power_efficiency_metrics.py)
 (parametrized over the three classes): every `_derive_value` call must
 raise `NoMetricValue` with a message that names the tag, the operation
 source (`MetricResultsDict`), and the injection site


### PR DESCRIPTION
## Summary

Fern's link checker in CI fails on `docs/dev/patterns.md` because three links use `../../`-relative paths into source files:

```
broken link to ../../src/aiperf/metrics/types/power_efficiency_metrics.py
fix here: pages-v0.9.0/dev/patterns.md:404
```

Fern resolves these against the published docs site (where `src/` and `tests/` are not present), so they break. The rest of `docs/` already links source files via full GitHub blob URLs (`https://github.com/ai-dynamo/aiperf/blob/main/...`). This converts the three offenders to that same convention:

- `docs/dev/patterns.md:404` → `src/aiperf/metrics/types/power_efficiency_metrics.py`
- `docs/dev/patterns.md:406` → `src/aiperf/gpu_telemetry/accumulator.py`
- `docs/dev/patterns.md:484` → `tests/unit/metrics/test_power_efficiency_metrics.py`

A repo-wide grep confirms these were the only `../../`-relative source/test links in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation references to use absolute URLs for improved link reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->