### PR TITLE
docs(fern): fix broken source links in frozen v0.9.0 patterns snapshot

### DIFF
--- a/fern/pages-v0.9.0/dev/patterns.md
+++ b/fern/pages-v0.9.0/dev/patterns.md
@@ -401,9 +401,9 @@ GPU power and energy come from telemetry scrapes, not from request
 records, so their values must be injected by the accumulator that owns
 the sensor data rather than derived by the standard registry walk.
 
-Reference file: [`src/aiperf/metrics/types/power_efficiency_metrics.py`](../../src/aiperf/metrics/types/power_efficiency_metrics.py).
+Reference file: [`src/aiperf/metrics/types/power_efficiency_metrics.py`](https://github.com/ai-dynamo/aiperf/blob/v0.9.0/src/aiperf/metrics/types/power_efficiency_metrics.py).
 Injection site: `GPUTelemetryAccumulator.compute_efficiency_metrics`
-([`src/aiperf/gpu_telemetry/accumulator.py`](../../src/aiperf/gpu_telemetry/accumulator.py)).
+([`src/aiperf/gpu_telemetry/accumulator.py`](https://github.com/ai-dynamo/aiperf/blob/v0.9.0/src/aiperf/gpu_telemetry/accumulator.py)).
 
 ### The three-part contract
 
@@ -481,7 +481,7 @@ values are not overwritten.
 ### Test contract
 
 The error-message invariants are pinned by
-[`tests/unit/metrics/test_power_efficiency_metrics.py`](../../tests/unit/metrics/test_power_efficiency_metrics.py)
+[`tests/unit/metrics/test_power_efficiency_metrics.py`](https://github.com/ai-dynamo/aiperf/blob/v0.9.0/tests/unit/metrics/test_power_efficiency_metrics.py)
 (parametrized over the three classes): every `_derive_value` call must
 raise `NoMetricValue` with a message that names the tag, the operation
 source (`MetricResultsDict`), and the injection site


### PR DESCRIPTION
## Problem

The `Validate (and publish on main) synced docs` check fails with **9 broken-link errors**, all from `fern/pages-v0.9.0/dev/patterns.md`. The `fern check --strict-broken-links` step validates the entire `docs-website` branch, including frozen version snapshots, and three relative source-file links in that snapshot resolve to paths that don't exist on the docs site:

- `../../src/aiperf/metrics/types/power_efficiency_metrics.py`
- `../../src/aiperf/gpu_telemetry/accumulator.py`
- `../../tests/unit/metrics/test_power_efficiency_metrics.py`

(3 links × 3 resolution contexts — `latest`, `v0.9.0`, unversioned — = 9 errors.)

`src/` and `tests/` are not published to the docs site, so no relative path to them resolves. The whole `docs/` corpus links source via full `github.com/.../blob/<ref>/...` URLs for this reason.

## Why this snapshot froze broken

The `release-version` job rewrites `blob/main` → `blob/vX.Y.Z` in place via `sed` when freezing a snapshot. At v0.9.0 release time `patterns.md` still used *relative* links, so the substitution matched nothing and left them broken.

## Fix

Convert the three links by hand to the `blob/v0.9.0` URLs the `sed` substitution would have produced — matching every other source link already in this snapshot.

The source-side fix (`docs/dev/patterns.md` → `blob/main`) landed in #1015, so future version snapshots self-correct automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)