### PR TITLE
test(fern): gate broken/relative markdown links in test-fern-docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ component-integration-tests-verbose test-component-integration-verbose: #? run c
 	$(activate_venv) && MALLOC_ARENA_MAX=2 pytest tests/component_integration/ -m 'component_integration and not stress and not performance and not slow' -vv -s --tb=short --log-cli-level=INFO --capture=no $(args)
 	@printf "$(bold)$(green)AIPerf Fake Component Integration tests passed!$(reset)\n"
 
-test-fern-docs: #? validate Fern documentation (check, strict check, dev server).
+test-fern-docs: #? validate Fern documentation (check, strict broken-link + broken-links checks, dev server).
 	@printf "$(bold)$(blue)Running Fern documentation checks...$(reset)\n"
 	$(activate_venv) && pytest tests/unit/fern/ -m fern -v --tb=short $(args)
 	@printf "$(bold)$(green)Fern documentation checks passed!$(reset)\n"

--- a/tests/unit/fern/test_fern_docs.py
+++ b/tests/unit/fern/test_fern_docs.py
@@ -15,7 +15,9 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -38,11 +40,46 @@ pytestmark = [
     pytest.mark.skipif(not _fern_installed, reason="fern CLI not installed"),
 ]
 
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
-def test_fern_check() -> None:
-    """Validate the Fern definition has no errors."""
+
+@pytest.fixture(scope="session")
+def staged_fern_docs(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Stage and convert docs the way CI and ``make fern-preview`` do.
+
+    Copies ``fern/`` and ``docs/`` into a temp tree, runs ``md_to_mdx.py`` to
+    convert GitHub Markdown to Fern MDX, then returns the staged ``fern/``
+    directory. Fern link validation must run against converted content: raw
+    ``docs/`` contains HTML comments that Fern's MDX parser rejects, which
+    breaks the link-check rules with a false error.
+    """
+    staged = tmp_path_factory.mktemp("fern-docs")
+    shutil.copytree(
+        _REPO_ROOT / "fern",
+        staged / "fern",
+        ignore=shutil.ignore_patterns(".local-preview", ".preview", ".definition"),
+    )
+    shutil.copytree(_REPO_ROOT / "docs", staged / "docs")
+    subprocess.run(
+        [
+            sys.executable,
+            str(staged / "fern" / "md_to_mdx.py"),
+            "--dir",
+            str(staged / "docs"),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return staged / "fern"
+
+
+def test_fern_check(staged_fern_docs: Path) -> None:
+    """Validate the Fern definition (converted content) has no errors."""
     result = subprocess.run(
         ["fern", "check"],
+        cwd=staged_fern_docs,
         capture_output=True,
         text=True,
         timeout=60,
@@ -53,7 +90,7 @@ def test_fern_check() -> None:
     )
 
 
-def test_fern_docs_dev_starts() -> None:
+def test_fern_docs_dev_starts(staged_fern_docs: Path) -> None:
     """Verify fern docs dev builds and starts without errors.
 
     Starts ``fern docs dev`` in a subprocess, monitors stdout for the
@@ -64,6 +101,7 @@ def test_fern_docs_dev_starts() -> None:
     port = _get_free_port()
     proc = subprocess.Popen(
         ["fern", "docs", "dev", "--port", str(port)],
+        cwd=staged_fern_docs,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -110,3 +148,38 @@ def test_fern_docs_dev_starts() -> None:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5)
+
+
+def test_fern_check_strict(staged_fern_docs: Path) -> None:
+    """Strict validation: broken or relative markdown links must fail.
+
+    ``--strict-broken-links`` promotes broken/relative-link warnings to errors;
+    ``--warnings`` just surfaces remaining non-link warnings (auth-skipped
+    redirects, accent contrast) in the output without failing the check.
+    """
+    result = subprocess.run(
+        ["fern", "check", "--warnings", "--strict-broken-links"],
+        cwd=staged_fern_docs,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"fern check --strict-broken-links failed (exit {result.returncode}):\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_fern_broken_links(staged_fern_docs: Path) -> None:
+    """Verify Fern finds no broken links in the converted content."""
+    result = subprocess.run(
+        ["fern", "docs", "broken-links"],
+        cwd=staged_fern_docs,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"fern docs broken-links failed (exit {result.returncode}):\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
## Problem

The required docs PR check (`fern-checks` → `make test-fern-docs`) ran plain `fern check`, which **does not validate links**. Broken or relative markdown links to source files passed pre-merge and only surfaced later in the **non-blocking** `docs-website` strict validation — by which point they could already freeze into a version snapshot.

This is exactly the gap that let the relative `../../src/...` links in `docs/dev/patterns.md` merge (fixed source-side in #1015) and froze broken into the v0.9.0 docs snapshot.

## Fix

Close it at the source so broken links fail **on the PR branch, before merge**. The `test-fern-docs` suite now stages docs the way CI's snapshot validation and `make fern-preview` do — copy `fern/` + `docs/` into a temp tree and run `md_to_mdx.py` to convert GitHub Markdown to Fern MDX (raw `docs/` has HTML comments Fern's MDX parser rejects) — then runs the same strict checks CI uses:

- **`test_fern_check_strict`** → `fern check --warnings --strict-broken-links`
- **`test_fern_broken_links`** → `fern docs broken-links`

The existing `fern check` and `fern docs dev` tests are re-pointed at the same staged tree via a shared session-scoped `staged_fern_docs` fixture.

## Verification

- Full `make test-fern-docs` suite passes on current docs (the `fern docs dev` test requires network to download its preview bundle).
- **Negative test:** injecting `[broken](./this-page-does-not-exist.md)` into a source doc makes `test_fern_check_strict` fail with a `valid-markdown-links` error pointing at the exact file:line — proving the guard catches the bug class that previously slipped through.

## Scope

Test-infra only — no production code, no user-facing surface. These tests carry `pytest.mark.fern` and skip when the `fern` CLI is absent (so the default unit-test job is unaffected); they run in the `fern-checks` job, which installs the pinned CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified help text for documentation validation to reflect strict link-checking behavior.

* **Tests**
  * Added strict broken-link validation test.
  * Added verification test for documentation link integrity.
  * Enhanced test infrastructure to properly stage documentation before validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->