### PR TITLE
fix(server-metrics): redact credentials in exports and logs

### DIFF
--- a/src/aiperf/common/mixins/base_metrics_collector_mixin.py
+++ b/src/aiperf/common/mixins/base_metrics_collector_mixin.py
@@ -20,6 +20,7 @@ from aiperf.common.exceptions import IncompatibleMetricsEndpointError
 from aiperf.common.hooks import background_task, on_init, on_stop
 from aiperf.common.mixins import AIPerfLifecycleMixin
 from aiperf.common.models import ErrorDetails
+from aiperf.common.redact import redact_url
 from aiperf.transports.http_defaults import AioHttpDefaults
 
 # `create_tcp_connector` is exposed as a module attribute via __getattr__ to
@@ -236,6 +237,10 @@ class BaseMetricsCollectorMixin(AIPerfLifecycleMixin, ABC, Generic[TRecord]):
             **kwargs: Additional arguments passed to super().__init__()
         """
         self._endpoint_url = endpoint_url
+        # Credential-free form of the endpoint URL for logging, record keys,
+        # and exports. The raw _endpoint_url is used only for the actual HTTP
+        # fetch so userinfo never leaks into logs or exported artifacts.
+        self._display_url = redact_url(endpoint_url)
         self._collection_interval = collection_interval
         self._reachability_timeout = reachability_timeout
         self._record_callback = record_callback
@@ -495,7 +500,7 @@ class BaseMetricsCollectorMixin(AIPerfLifecycleMixin, ABC, Generic[TRecord]):
                 return
             self._endpoint_disabled = True
             self.warning(
-                f"Disabling server metrics collection for {self._endpoint_url}: "
+                f"Disabling server metrics collection for {self._display_url}: "
                 f"{e}. To suppress this warning, pass --no-server-metrics."
             )
             if self._error_callback:
@@ -574,7 +579,7 @@ class BaseMetricsCollectorMixin(AIPerfLifecycleMixin, ABC, Generic[TRecord]):
                 # caller can auto-disable instead of looping on parse errors.
                 if content_type.startswith("application/json"):
                     raise IncompatibleMetricsEndpointError(
-                        f"endpoint {self._endpoint_url!r} returned non-Prometheus "
+                        f"endpoint {self._display_url!r} returned non-Prometheus "
                         f"content-type {content_type!r}; expected text/plain "
                         f"(Prometheus exposition format)"
                     )

--- a/src/aiperf/server_metrics/data_collector.py
+++ b/src/aiperf/server_metrics/data_collector.py
@@ -20,6 +20,7 @@ from aiperf.common.models.server_metrics_models import (
     MetricSample,
     ServerMetricsRecord,
 )
+from aiperf.common.redact import redact_url
 
 __all__ = ["ServerMetricsDataCollector"]
 
@@ -195,12 +196,15 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         """
         self._prometheus_fallback_attempted = True
         original_url = self._endpoint_url
+        original_display = self._display_url
         candidate_url = original_url.removesuffix("/metrics") + "/prometheus/metrics"
+        candidate_display = redact_url(candidate_url)
         self.info(
-            f"Endpoint {original_url!r} returned non-Prometheus content; "
-            f"probing fallback {candidate_url!r} (TRT-LLM compatibility path)."
+            f"Endpoint {original_display!r} returned non-Prometheus content; "
+            f"probing fallback {candidate_display!r} (TRT-LLM compatibility path)."
         )
         self._endpoint_url = candidate_url
+        self._display_url = candidate_display
         # Reset response-hash dedup so the alt endpoint's first response is
         # not mistaken for a duplicate of the previous /metrics body.
         self._last_response_hash = None
@@ -208,18 +212,20 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
             await self._fetch_parse_send()
         except IncompatibleMetricsEndpointError:
             self._endpoint_url = original_url
+            self._display_url = original_display
             raise
         except Exception as e:
             self._endpoint_url = original_url
+            self._display_url = original_display
             raise IncompatibleMetricsEndpointError(
-                f"Prometheus fallback {candidate_url!r} also failed ({e!r}); "
-                f"original endpoint {original_url!r} returned non-Prometheus "
+                f"Prometheus fallback {candidate_display!r} also failed ({e!r}); "
+                f"original endpoint {original_display!r} returned non-Prometheus "
                 f"content. For TRT-LLM, set 'return_perf_metrics: true' in "
                 f"extra_llm_api_options.yaml to enable Prometheus exposition "
                 f"at /prometheus/metrics."
             ) from e
         self.info(
-            f"Prometheus fallback succeeded; collector swapped to {candidate_url!r}."
+            f"Prometheus fallback succeeded; collector swapped to {candidate_display!r}."
         )
 
     def _parse_metrics_to_records(
@@ -318,7 +324,7 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         return ServerMetricsRecord(
             timestamp_ns=timestamp_ns,
             endpoint_latency_ns=trace_timing.latency_ns if trace_timing else None,
-            endpoint_url=self._endpoint_url,
+            endpoint_url=self._display_url,
             metrics=metrics_dict,
             request_sent_ns=trace_timing.start_ns if trace_timing else None,
             first_byte_ns=trace_timing.first_byte_ns if trace_timing else None,

--- a/src/aiperf/server_metrics/manager.py
+++ b/src/aiperf/server_metrics/manager.py
@@ -21,6 +21,7 @@ from aiperf.common.messages import (
 from aiperf.common.metric_utils import normalize_metrics_endpoint_url
 from aiperf.common.models import ErrorDetails, ServerMetricsRecord
 from aiperf.common.protocols import PushClientProtocol
+from aiperf.common.redact import redact_url
 from aiperf.server_metrics.data_collector import ServerMetricsDataCollector
 
 if TYPE_CHECKING:
@@ -72,7 +73,8 @@ class ServerMetricsManager(BaseComponentService):
             if normalized_url not in self._server_metrics_endpoints:
                 self._server_metrics_endpoints.append(normalized_url)
         self.info(
-            f"Server Metrics: Discovered {len(self._server_metrics_endpoints)} endpoints: {self._server_metrics_endpoints}"
+            f"Server Metrics: Discovered {len(self._server_metrics_endpoints)} "
+            f"endpoints: {[redact_url(u) for u in self._server_metrics_endpoints]}"
         )
 
         # Add user-specified URLs if provided
@@ -123,7 +125,7 @@ class ServerMetricsManager(BaseComponentService):
                 collection_interval=self._collection_interval,
                 record_callback=self._on_server_metrics_records,
                 error_callback=self._on_server_metrics_error,
-                collector_id=endpoint_url,
+                collector_id=redact_url(endpoint_url),
             )
 
             try:
@@ -140,14 +142,16 @@ class ServerMetricsManager(BaseComponentService):
             except Exception as e:
                 self.error(f"Server Metrics: Exception testing {endpoint_url}: {e}")
 
-        reachable_endpoints = list(self._collectors.keys())
+        reachable_endpoints = [redact_url(u) for u in self._collectors]
 
         if not self._collectors:
             # Server metrics manager shutdown occurs in _on_start_profiling to prevent hang
             await self._send_server_metrics_status(
                 enabled=False,
                 reason="no Prometheus endpoints reachable",
-                endpoints_configured=self._server_metrics_endpoints,
+                endpoints_configured=[
+                    redact_url(u) for u in self._server_metrics_endpoints
+                ],
                 endpoints_reachable=[],
             )
             return
@@ -169,7 +173,9 @@ class ServerMetricsManager(BaseComponentService):
         await self._send_server_metrics_status(
             enabled=True,
             reason=None,
-            endpoints_configured=self._server_metrics_endpoints,
+            endpoints_configured=[
+                redact_url(u) for u in self._server_metrics_endpoints
+            ],
             endpoints_reachable=reachable_endpoints,
         )
 
@@ -207,7 +213,9 @@ class ServerMetricsManager(BaseComponentService):
             await self._send_server_metrics_status(
                 enabled=False,
                 reason="all collectors failed to start",
-                endpoints_configured=self._server_metrics_endpoints,
+                endpoints_configured=[
+                    redact_url(u) for u in self._server_metrics_endpoints
+                ],
                 endpoints_reachable=[],
             )
             self._shutdown_task = self.execute_async(self._delayed_shutdown())

--- a/tests/unit/server_metrics/test_server_metrics_data_collector.py
+++ b/tests/unit/server_metrics/test_server_metrics_data_collector.py
@@ -638,3 +638,45 @@ class TestCollectorCallbackFunctionality:
         await collector._send_records_via_callback([])
 
         record_callback.assert_not_called()
+
+
+class TestServerMetricsDataCollectorCredentialRedaction:
+    """Regression tests for #935: credentials embedded in --url must not leak
+    into logs, record keys, or exported artifacts, while the raw URL is still
+    used for the actual HTTP fetch (so authentication keeps working)."""
+
+    CREDENTIALED_URL = "http://alice:s3cret@127.0.0.1:34883/metrics"
+
+    def test_display_url_is_redacted_but_fetch_url_is_raw(self):
+        """The raw URL (with userinfo) is retained for fetching; the display
+        URL used for logs/records has the credentials stripped."""
+        collector = ServerMetricsDataCollector(endpoint_url=self.CREDENTIALED_URL)
+        # Raw form is kept for the actual HTTP fetch (auth must still work).
+        assert collector._endpoint_url == self.CREDENTIALED_URL
+        assert "s3cret" in collector._endpoint_url
+        # Display form is redacted: no credentials anywhere.
+        assert "s3cret" not in collector._display_url
+        assert "alice" not in collector._display_url
+        assert collector._display_url == "http://<redacted>@127.0.0.1:34883/metrics"
+
+    def test_url_without_credentials_is_unchanged(self):
+        """redact_url is a no-op on credential-free URLs, so display and fetch
+        forms are identical."""
+        plain_url = "http://localhost:8081/metrics"
+        collector = ServerMetricsDataCollector(endpoint_url=plain_url)
+        assert collector._endpoint_url == plain_url
+        assert collector._display_url == plain_url
+
+    def test_record_endpoint_url_is_redacted(self):
+        """The endpoint_url stored on each ServerMetricsRecord feeds every
+        export (csv/json/parquet); it must carry the redacted form."""
+        collector = ServerMetricsDataCollector(endpoint_url=self.CREDENTIALED_URL)
+        metrics_text = (
+            "# HELP test_metric A test metric\n"
+            "# TYPE test_metric counter\n"
+            "test_metric 1.0\n"
+        )
+        record = collector._parse_metrics_to_records(make_fetch_result(metrics_text))
+        assert record is not None
+        assert "s3cret" not in record.endpoint_url
+        assert record.endpoint_url == "http://<redacted>@127.0.0.1:34883/metrics"


### PR DESCRIPTION
## Summary
Credentials embedded in --url user:pass@host leaked verbatim into server_metrics_export.csv, server_metrics_export.json, and logs/aiperf.log via the server-metrics path. profile_export_aiperf.json was already clean (covered by the @field_serializer("urls") redaction in #900); this fixes the parallel server-metrics export/log path.
Closes #935.
## Approach
Following the approach @ajcasagrande outlined in the issue: separate the raw fetch URL from a redacted display form, reusing the existing redact_url().

BaseMetricsCollectorMixin derives _display_url = redact_url(endpoint_url) alongside the raw _endpoint_url. The raw form is used only for the actual HTTP fetch (session.get); the disabling and non-Prometheus log lines now use _display_url.
ServerMetricsDataCollector builds ServerMetricsRecord.endpoint_url (which feeds csv/json/parquet exports) from _display_url. The Prometheus-fallback path keeps _display_url in sync whenever it swaps _endpoint_url, so fallback logs and records stay redacted while the fetch still hits the real path.
ServerMetricsManager redacts collector_id, the "Discovered N endpoints" log, endpoints_configured, and reachable_endpoints (→ endpoints_successful). The internal endpoint list stays raw so fetches still authenticate.

## Verification
Using the repro from the issue, grep -rn s3cret <artifact-dir> is now empty across server_metrics_export.{csv,json} and logs/aiperf.log, while server metrics are still collected (auth via the raw URL works).
Added regression tests in tests/unit/server_metrics/test_server_metrics_data_collector.py asserting the raw/redacted split and that the record's endpoint_url carries the redacted form. Full server-metrics suite green; make lint and make check-fmt pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Endpoint URLs are now redacted in user-facing messages, status reports, and exported metrics records to remove embedded credentials.
  * Fallback endpoint detection during Prometheus probing maintains consistent URL redaction across all logging and status communication paths.

* **Tests**
  * Added regression tests verifying credential redaction behavior for endpoint URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->