### PR TITLE
fix: nightly trigger: send PIPELINE_TYPE=security (was invalid 'nightly')

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1045,7 +1045,7 @@ jobs:
             --request POST \
             --form "token=<${TOKEN_FILE}" \
             --form "ref=main" \
-            --form "variables[PIPELINE_TYPE]=nightly" \
+            --form "variables[PIPELINE_TYPE]=security" \
             --form "variables[RELEASE_TYPE]=${RELEASE_TYPE}" \
             --form "variables[PROJECT]=aiperf" \
             --form "variables[SOURCE_BRANCH]=main" \


### PR DESCRIPTION
## What

The nightly workflow's downstream trigger sends `PIPELINE_TYPE=nightly`. That is not a recognized pipeline type — the downstream pipeline validates `PIPELINE_TYPE` against a fixed set and rejects anything else **before any job runs**:

```
rc | security | nspect | publish | release | dep-update
```

As a result every scheduled nightly fails immediately at the first (preflight) step and no scans, registration, or publish ever happen.

## Fix

Send `PIPELINE_TYPE=security` — the scan + nSpect + auto-publish flow that nightlies are meant to run.

`PIPELINE_TYPE` and `RELEASE_TYPE` are two independent dimensions:

| Variable | Question it answers | Nightly value |
|---|---|---|
| `PIPELINE_TYPE` | *Which* pipeline to run | `security` |
| `RELEASE_TYPE` | *What kind* of build it is | `nightly` (scheduled) / `ondemand` (manual) |

`RELEASE_TYPE` is already computed correctly in this step (`nightly` for scheduled runs, `ondemand` for manual dispatch), so this one-line change is all that's required — and it preserves the nightly-vs-ondemand distinction (on-demand publishes stay manually gated; only scheduled nightlies auto-publish).

## Change

```diff
- --form "variables[PIPELINE_TYPE]=nightly" \
+ --form "variables[PIPELINE_TYPE]=security" \
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal pipeline configuration for build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->