### PR TITLE
fix(server-metrics): robust handling of malformed Prometheus sample values

### DIFF
--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -757,6 +757,7 @@ usage_prompt_cache_read_tokens = response.usage.cache_read_input_tokens  # from 
 - Taken from the API response `usage` object, not computed by AIPerf.
 - OpenAI surfaces cache reads as `prompt_tokens_details.cached_tokens` (or `input_tokens_details.cached_tokens`); writes are transparent and not reported.
 - Anthropic surfaces cache reads at the top level as `cache_read_input_tokens`; writes are reported separately as [Usage Prompt Cache Write Tokens](#usage-prompt-cache-write-tokens).
+- **Self-hosted servers gate this behind a flag:** vLLM needs `--enable-prompt-tokens-details` and SGLang needs `--enable-cache-report` (both default off); TRT-LLM emits `cached_tokens` by default. Without the flag these metrics read all-None even when the server is caching — see [Vendor Usage Field Reference](reference/vendor-usage-fields.md).
 - For streaming responses, uses the last non-None value reported.
 
 ---

--- a/docs/reference/vendor-usage-fields.md
+++ b/docs/reference/vendor-usage-fields.md
@@ -19,7 +19,9 @@ The verification work behind this document was performed by inspecting each prov
 | Vendor | Wrapper | Token-count fields | Cache fields | Notable extras |
 |---|---|---|---|---|
 | OpenAI | flat `usage` | `prompt_tokens`, `completion_tokens`, `total_tokens` | `prompt_tokens_details.cached_tokens` (read-only) | nested `*_tokens_details` for audio / reasoning / prediction |
-| vLLM | flat `usage` | OpenAI-shape | `prompt_tokens_details.cached_tokens` | matches OpenAI; sometimes emits `prompt_tokens_details: null` |
+| vLLM | flat `usage` | OpenAI-shape | `prompt_tokens_details.cached_tokens` (opt-in) | OpenAI-shape; `cached_tokens` emitted only with `--enable-prompt-tokens-details` (default off), else `prompt_tokens_details: null` |
+| SGLang | flat `usage` | OpenAI-shape | `prompt_tokens_details.cached_tokens` (opt-in) | OpenAI-compatible; `cached_tokens` emitted only with `--enable-cache-report` (default off) |
+| TRT-LLM | flat `usage` | OpenAI-shape | `prompt_tokens_details.cached_tokens` | OpenAI-compatible; `cached_tokens` emitted by default (no flag) |
 | Anthropic | flat `usage` | `input_tokens`, `output_tokens` | `cache_creation_input_tokens`, `cache_read_input_tokens` | `cache_creation` TTL sub-object; `service_tier`; `server_tool_use` |
 | Google Gemini | `usageMetadata` envelope (camelCase) | `promptTokenCount`, `candidatesTokenCount`, `totalTokenCount` | `cachedContentTokenCount` (read-only) | `thoughtsTokenCount`, `toolUsePromptTokenCount`, modality `*Details[]` arrays |
 | AWS Bedrock | flat `usage` (camelCase) | `inputTokens`, `outputTokens`, `totalTokens` | `cacheReadInputTokens`, `cacheWriteInputTokens` | `cacheDetails[]` TTL array |
@@ -93,6 +95,20 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
 ```
 
 vLLM is OpenAI-compatible. Its `prompt_tokens_details` is narrower than OpenAI's (only `cached_tokens`, no `audio_tokens`). vLLM may emit `prompt_tokens_details: null` and `completion_tokens_details: null` explicitly; AIPerf's nested-field walk handles that case (the `isinstance(details, dict)` guard returns False, and the property returns None).
+
+**Enablement (opt-in):** vLLM populates `cached_tokens` only when the server is launched with `--enable-prompt-tokens-details` (default off, per [vllm-project/vllm#10174](https://github.com/vllm-project/vllm/pull/10174) — "guarded by a flag ... OFF by default"). Without the flag, `prompt_tokens_details` is `null` and AIPerf's cache-read metrics are all-None even when prefix caching is active. The flag is independent of `--enable-prefix-caching` (the cache must still be on for `cached_tokens` to be non-zero).
+
+### SGLang
+
+**Verified against:** `sglang` / `python/sglang/srt/entrypoints/openai/serving_chat.py` → `usage_processor.py` (`v0.5.12.post1`).
+
+SGLang is OpenAI-compatible and surfaces cache reads as `prompt_tokens_details.cached_tokens` — but **only when the server is launched with `--enable-cache-report`** (`server_args.enable_cache_report`, default off, per [sgl-project/sglang#1599](https://github.com/sgl-project/sglang/pull/1599) — kept opt-in "to limit the impact to current users"). Without the flag the field is absent and AIPerf's cache-read metrics are all-None. SGLang also exposes a prefix-cache hit rate as a scraped Prometheus gauge (`sglang:cache_hit_rate`), but that gauge is *instantaneous* — its windowed average badly understates steady-state reuse, so prefer the usage-derived `cached_tokens` for cache reporting.
+
+### TRT-LLM
+
+**Verified against:** `TensorRT-LLM` / `tensorrt_llm/serve/postprocess_handlers.py` (`v1.3.0rc15.post1`).
+
+TensorRT-LLM (`trtllm-serve`) is OpenAI-compatible and populates `prompt_tokens_details.cached_tokens` **by default** — `postprocess_handlers.py` sets it unconditionally from the engine's KV-cache reuse, so no flag is needed. This is separate from exposing Prometheus `/metrics` (which requires `return_perf_metrics: true`); the `usage` cache field works regardless.
 
 ### Anthropic
 

--- a/docs/server-metrics/server-metrics.md
+++ b/docs/server-metrics/server-metrics.md
@@ -70,6 +70,18 @@ AIPerf automatically collects metrics from Prometheus-compatible endpoints expos
 | `sglang:prompt_tokens` | counter | Prefill throughput (`stats.rate`) |
 | `sglang:generation_tokens` | counter | Decode throughput (`stats.rate`) |
 
+> [!IMPORTANT]
+> **SGLang server-side setup is required.** SGLang does not expose Prometheus exposition format at `/metrics` by default. Launch the server with `--enable-metrics`:
+>
+> ```bash
+> python -m sglang.launch_server \
+>   --model-path <model> \
+>   --enable-metrics \
+>   --host 0.0.0.0 --port 8000
+> ```
+>
+> Without this flag, `GET /metrics` returns 404 and AIPerf's auto-discovery silently falls back to no server-metrics collection (`server_metrics_export.*` files will not be produced).
+
 </Accordion>
 
 <Accordion title="TRT-LLM">
@@ -91,7 +103,7 @@ AIPerf automatically collects metrics from Prometheus-compatible endpoints expos
 | `trtllm_kv_cache_hit_rate` | gauge | KV cache reuse efficiency (`stats.avg`) |
 
 > [!IMPORTANT]
-> **TRT-LLM server-side setup is required.** Unlike vLLM and SGLang, `trtllm-serve` does not expose Prometheus exposition format at `/metrics` by default — the default `/metrics` returns an iteration-stats JSON array (`application/json`), which is not parseable as Prometheus. Two consequences:
+> **TRT-LLM server-side setup is required.** Unlike vLLM, `trtllm-serve` does not expose Prometheus exposition format at `/metrics` by default — the default `/metrics` returns an iteration-stats JSON array (`application/json`), which is not parseable as Prometheus. Two consequences:
 >
 > 1. **Enable Prometheus on the server.** Pass `return_perf_metrics: true` in your `extra_llm_api_options.yaml`. This mounts the proper Prometheus exposition at `/prometheus/metrics` (a non-standard path). Add `enable_iter_perf_stats: true` when you want iteration-derived queue/KV/memory metrics from the PyTorch backend.
 > 2. **AIPerf auto-detects and falls back.** When AIPerf hits `/metrics` and gets `application/json`, it automatically probes `<base>/prometheus/metrics` once. If the alt path serves Prometheus, AIPerf swaps the URL and continues — no manual override needed. If the alt path also fails (e.g. `return_perf_metrics` was not set), the collector auto-disables for the remainder of the run with a single warning.

--- a/src/aiperf/common/models/server_metrics_models.py
+++ b/src/aiperf/common/models/server_metrics_models.py
@@ -109,15 +109,15 @@ class MetricSample(AIPerfBaseModel):
     value: FiniteFloat | None = Field(
         default=None, description="Simple metric value (counter/gauge)"
     )
-    buckets: dict[str, float] | None = Field(
+    buckets: dict[str, FiniteFloat] | None = Field(
         default=None,
         description='Histogram bucket upper bounds (le="less than or equal") to counts. Keys are strings like "0.01", "0.1", "1.0"',
     )
-    sum: float | None = Field(
+    sum: FiniteFloat | None = Field(
         default=None,
         description="Sum of all observed values (for histogram only)",
     )
-    count: float | None = Field(
+    count: FiniteFloat | None = Field(
         default=None,
         description="Total number of observations (for histogram only)",
     )

--- a/src/aiperf/common/models/server_metrics_models.py
+++ b/src/aiperf/common/models/server_metrics_models.py
@@ -106,7 +106,7 @@ class MetricSample(AIPerfBaseModel):
         default=None,
         description="Metric labels (excluding histogram special labels). None if no labels.",
     )
-    value: float | None = Field(
+    value: FiniteFloat | None = Field(
         default=None, description="Simple metric value (counter/gauge)"
     )
     buckets: dict[str, float] | None = Field(

--- a/src/aiperf/exporters/console_metrics_exporter.py
+++ b/src/aiperf/exporters/console_metrics_exporter.py
@@ -13,6 +13,10 @@ from aiperf.common.exceptions import MetricTypeError
 from aiperf.common.mixins import AIPerfLoggerMixin
 from aiperf.common.models import MetricResult
 from aiperf.exporters.exporter_config import ExporterConfig
+from aiperf.metrics.cache_reporting_hint import (
+    CACHE_REPORTING_HINT,
+    usage_without_cache_in_results,
+)
 from aiperf.metrics.metric_registry import MetricRegistry
 
 
@@ -73,6 +77,11 @@ class ConsoleMetricsExporter(AIPerfLoggerMixin):
         if renderable is None:
             return
         self._print_renderable(console, renderable)
+
+        # Persist the cache-reporting hint in the final summary (the mid-run log
+        # line is ephemeral in dashboard mode); see cache_reporting_hint.
+        if usage_without_cache_in_results(self._results.records):
+            console.print(f"\n[yellow]{CACHE_REPORTING_HINT}[/yellow]")
 
     def _print_renderable(self, console: Console, renderable: RenderableType) -> None:
         console.print("\n")

--- a/src/aiperf/metrics/cache_reporting_hint.py
+++ b/src/aiperf/metrics/cache_reporting_hint.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Detect when a server reports token usage but not prompt-cache reads.
+
+A server that supports prefix/KV caching but hasn't been told to report
+``usage.prompt_tokens_details.cached_tokens`` (vLLM ``--enable-prompt-tokens-details``,
+SGLang ``--enable-cache-report``; TRT-LLM reports it by default) produces empty
+prompt-cache metrics that look like a bug. These helpers detect that case so
+AIPerf can hint the user both mid-run (per streamed record) and in the
+end-of-run summary (aggregated results), sharing one message and one definition.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+from aiperf.common.models import MetricResult
+from aiperf.metrics.types.usage_cache_metrics import UsagePromptCacheReadTokensMetric
+from aiperf.metrics.types.usage_metrics import UsagePromptTokensMetric
+from aiperf.metrics.types.usage_total_metrics import (
+    TotalUsagePromptCacheReadTokensMetric,
+    TotalUsagePromptTokensMetric,
+)
+
+CACHE_REPORTING_HINT = (
+    "Token usage is reported but no prompt-cache read tokens were seen "
+    "(usage.prompt_tokens_details.cached_tokens absent). If your server uses "
+    "prefix/KV caching, enable cache reporting so AIPerf can populate the "
+    "prompt-cache metrics: vLLM --enable-prompt-tokens-details, SGLang "
+    "--enable-cache-report (TRT-LLM reports it by default)."
+)
+
+_RESULT_VALUE_FIELDS = ("avg", "sum", "min", "max", "p50", "current")
+
+
+def usage_without_cache_in_record(record: Mapping[str, Any]) -> bool:
+    """Return True if a per-record metric map reports prompt tokens but no cache reads.
+
+    Used mid-run on streamed ``MetricRecordsData.results`` dicts. A cache-read
+    value of 0 (caching on, no hits) counts as reported; only an absent value
+    (cache reporting off) triggers the hint.
+    """
+    return (
+        record.get(UsagePromptTokensMetric.tag) is not None
+        and record.get(UsagePromptCacheReadTokensMetric.tag) is None
+    )
+
+
+def usage_without_cache_in_results(results: list[MetricResult]) -> bool:
+    """Return True if aggregated results report prompt tokens but no cache-read total.
+
+    Used at end-of-run. No-value metrics flow through with ``count=0`` and all
+    stats ``None``, so this checks the value fields rather than mere tag presence
+    (a reported total of 0 counts as reported and does not trigger the hint).
+    """
+    by_tag = {result.tag: result for result in results}
+
+    def _has_value(result: MetricResult | None) -> bool:
+        return result is not None and any(
+            getattr(result, field) is not None for field in _RESULT_VALUE_FIELDS
+        )
+
+    return _has_value(by_tag.get(TotalUsagePromptTokensMetric.tag)) and not _has_value(
+        by_tag.get(TotalUsagePromptCacheReadTokensMetric.tag)
+    )

--- a/src/aiperf/records/records_manager.py
+++ b/src/aiperf/records/records_manager.py
@@ -67,6 +67,10 @@ from aiperf.gpu_telemetry.protocols import (
     GPUTelemetryAccumulatorProtocol,
     GPUTelemetryProcessorProtocol,
 )
+from aiperf.metrics.cache_reporting_hint import (
+    CACHE_REPORTING_HINT,
+    usage_without_cache_in_record,
+)
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import PluginType, ResultsProcessorType, UIType
 from aiperf.post_processors.protocols import (
@@ -107,6 +111,9 @@ class RecordsManager(PullClientMixin, BaseComponentService):
     a final_completed_count, the RecordsManager waits until it has processed that
     many records before finalizing results.
     """
+
+    # The "enable cache reporting" server-knob hint fires at most once per run.
+    _warned_missing_cache_reporting: bool = False
 
     def __init__(
         self,
@@ -228,6 +235,8 @@ class RecordsManager(PullClientMixin, BaseComponentService):
             return
 
         record_data = message.to_data()
+
+        self._maybe_hint_missing_cache_reporting(record_data)
 
         await self._send_results_to_results_processors(record_data)
 
@@ -735,6 +744,21 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         ]
 
         return metric_results
+
+    def _maybe_hint_missing_cache_reporting(
+        self, record_data: MetricRecordsData
+    ) -> None:
+        """Warn once, mid-run, when the server reports token usage but no prompt-cache
+        reads — the signature of a cache-capable server that hasn't been told to
+        report ``cached_tokens``. Fires on the first qualifying record so a long run
+        can be aborted and re-launched with the flag set; the end-of-run console
+        exporter emits the same hint for anyone who only reads the final summary.
+        """
+        if self._warned_missing_cache_reporting:
+            return
+        if usage_without_cache_in_record(record_data.metrics):
+            self._warned_missing_cache_reporting = True
+            self.warning(CACHE_REPORTING_HINT)
 
     def _apply_gpu_efficiency_metrics(
         self,

--- a/src/aiperf/server_metrics/data_collector.py
+++ b/src/aiperf/server_metrics/data_collector.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import time
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
@@ -8,6 +9,7 @@ from dataclasses import dataclass, field
 
 from prometheus_client.metrics_core import Metric
 from prometheus_client.parser import text_string_to_metric_families
+from pydantic import ValidationError
 
 from aiperf.common.enums import PrometheusMetricType
 from aiperf.common.environment import Environment
@@ -121,6 +123,13 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         # Keep track of metrics we have already seen (logged once) to avoid spamming the logs
         self._seen_metadata_metrics = set()
         self._seen_summary_metrics = set()
+        # Metric names already warned about for non-finite (NaN/Inf) sample
+        # drops — warn once per name per collector lifetime, not every scrape.
+        self._warned_non_finite_metrics: set[str] = set()
+        # Distinct from the above: metric names already warned about for an
+        # unanticipated MetricSample construction failure (needs investigation),
+        # kept separate so the log distinguishes the two failure classes.
+        self._warned_construction_failed_metrics: set[str] = set()
         # When True, the active endpoint URL has already been swapped (or the
         # probe was attempted unsuccessfully) — never probe twice for the same
         # collector instance.
@@ -331,6 +340,44 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
             is_duplicate=fetch_result.is_duplicate,
         )
 
+    def _warn_dropped_non_finite(self, metric_name: str, dropped_count: int) -> None:
+        """Warn once per metric name when non-finite (NaN/Inf) samples are dropped.
+
+        Non-finite values are filtered at the producer because they would break
+        the ZMQ serialization round-trip (orjson encodes NaN as null) and
+        invalidate the whole batch on the receiver. Surface the loss once per
+        metric rather than at every 333ms scrape.
+        """
+        if dropped_count <= 0 or metric_name in self._warned_non_finite_metrics:
+            return
+        self._warned_non_finite_metrics.add(metric_name)
+        self.warning(
+            f"Dropping non-finite (NaN/Inf) sample(s) from metric "
+            f"{metric_name!r}: {dropped_count} in this scrape; affected data "
+            f"will be missing from server_metrics_export. Further occurrences "
+            f"for this metric name will not be logged."
+        )
+
+    def _warn_construction_failures(self, metric_name: str, failure_count: int) -> None:
+        """Warn once per metric name when MetricSample construction raises.
+
+        Distinct from the non-finite path: this covers unanticipated
+        ValidationErrors the proactive filter does not catch, kept on a separate
+        cache so the log distinguishes the two failure classes.
+        """
+        if (
+            failure_count <= 0
+            or metric_name in self._warned_construction_failed_metrics
+        ):
+            return
+        self._warned_construction_failed_metrics.add(metric_name)
+        self.warning(
+            f"Dropped {failure_count} sample(s) from metric {metric_name!r} due "
+            f"to MetricSample construction failure; this metric's data will be "
+            f"incomplete in server_metrics_export. Further occurrences for this "
+            f"metric name will not be logged."
+        )
+
     def _process_simple_family(self, family: Metric) -> list[MetricSample]:
         """Process counter, gauge, or untyped metrics with de-duplication.
 
@@ -338,8 +385,8 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         When multiple samples have identical labels (shouldn't happen in valid
         Prometheus output), keeps the last value encountered.
 
-        Filters out invalid values (None or infinity) which can occur with
-        missing data or uninitialized metrics.
+        Filters out None and non-finite values (NaN, +Inf, -Inf) which can
+        occur with missing data or uninitialized metrics.
 
         Args:
             family: Prometheus metric family from prometheus_client parser containing
@@ -350,18 +397,39 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
             for duplicate label sets). Returns empty list if all samples filtered out.
         """
         samples_by_labels: dict[tuple, float] = {}
+        dropped_non_finite = 0
 
         for sample in family.samples:
-            # Skip samples with None or infinity values (can happen with NaN or missing data)
-            if sample.value is None or sample.value == float("inf"):
+            if sample.value is None:
+                # Ordinary missing data — not a corruption signal, skip silently.
+                continue
+            if not math.isfinite(sample.value):
+                # NaN/+Inf/-Inf would break ZMQ serialization round-trip and
+                # invalidate the entire batch downstream. Drop and count for
+                # the warn-once log below.
+                dropped_non_finite += 1
                 continue
             label_key = tuple(sorted(sample.labels.items()))
             samples_by_labels[label_key] = sample.value
 
-        return [
-            MetricSample(labels=dict(label_tuple) if label_tuple else None, value=value)
-            for label_tuple, value in samples_by_labels.items()
-        ]
+        self._warn_dropped_non_finite(family.name, dropped_non_finite)
+
+        valid_samples: list[MetricSample] = []
+        construction_failures = 0
+        for label_tuple, value in samples_by_labels.items():
+            try:
+                valid_samples.append(
+                    MetricSample(
+                        labels=dict(label_tuple) if label_tuple else None,
+                        value=value,
+                    )
+                )
+            except ValidationError:
+                construction_failures += 1
+
+        self._warn_construction_failures(family.name, construction_failures)
+
+        return valid_samples
 
     def _process_histogram_family(self, family: Metric) -> list[MetricSample]:
         """Process histogram metrics into structured format.
@@ -387,7 +455,19 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         """
         histograms: dict[tuple, HistogramData] = defaultdict(HistogramData)
 
+        dropped_non_finite = 0
+
         for sample in family.samples:
+            if sample.value is None:
+                # Ordinary missing data — not a corruption signal, skip silently.
+                continue
+            if not math.isfinite(sample.value):
+                # NaN/+Inf/-Inf on a bucket/sum/count line breaks the ZMQ orjson
+                # round-trip (NaN -> null) and fails dict[str, float] validation on
+                # the receiver. Drop the offending line, keep the rest of the
+                # histogram, and count for the warn-once log below.
+                dropped_non_finite += 1
+                continue
             base_labels = {k: v for k, v in sample.labels.items() if k != "le"}
             label_key = tuple(sorted(base_labels.items()))
 
@@ -399,8 +479,18 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
             elif sample.name.endswith("_count"):
                 histograms[label_key].count = sample.value
 
-        return [
-            hist.to_metric_sample(label_tuple)
-            for label_tuple, hist in histograms.items()
-            if hist.valid
-        ]
+        self._warn_dropped_non_finite(family.name, dropped_non_finite)
+
+        valid_samples: list[MetricSample] = []
+        construction_failures = 0
+        for label_tuple, hist in histograms.items():
+            if not hist.valid:
+                continue
+            try:
+                valid_samples.append(hist.to_metric_sample(label_tuple))
+            except ValidationError:
+                construction_failures += 1
+
+        self._warn_construction_failures(family.name, construction_failures)
+
+        return valid_samples

--- a/src/aiperf/server_metrics/data_collector.py
+++ b/src/aiperf/server_metrics/data_collector.py
@@ -454,6 +454,7 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
             - labels: Base labels (excluding "le" which is part of bucket structure)
         """
         histograms: dict[tuple, HistogramData] = defaultdict(HistogramData)
+        tainted: set[tuple] = set()
 
         dropped_non_finite = 0
 
@@ -461,15 +462,18 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
             if sample.value is None:
                 # Ordinary missing data — not a corruption signal, skip silently.
                 continue
-            if not math.isfinite(sample.value):
-                # NaN/+Inf/-Inf on a bucket/sum/count line breaks the ZMQ orjson
-                # round-trip (NaN -> null) and fails dict[str, float] validation on
-                # the receiver. Drop the offending line, keep the rest of the
-                # histogram, and count for the warn-once log below.
-                dropped_non_finite += 1
-                continue
             base_labels = {k: v for k, v in sample.labels.items() if k != "le"}
             label_key = tuple(sorted(base_labels.items()))
+
+            if not math.isfinite(sample.value):
+                # NaN/+Inf/-Inf breaks the ZMQ orjson round-trip (NaN -> null) and
+                # fails receiver validation. Drop the ENTIRE histogram for this label
+                # set, not just the offending line: a partial sample stored first
+                # locks a truncated bucket schema in HistogramTimeSeries, which then
+                # ignores the missing bucket on every later valid scrape.
+                dropped_non_finite += 1
+                tainted.add(label_key)
+                continue
 
             if sample.name.endswith("_bucket"):
                 le_value = sample.labels.get("le", "+Inf")
@@ -484,7 +488,7 @@ class ServerMetricsDataCollector(BaseMetricsCollectorMixin[ServerMetricsRecord])
         valid_samples: list[MetricSample] = []
         construction_failures = 0
         for label_tuple, hist in histograms.items():
-            if not hist.valid:
+            if label_tuple in tainted or not hist.valid:
                 continue
             try:
                 valid_samples.append(hist.to_metric_sample(label_tuple))

--- a/tests/unit/exporters/test_console_exporter.py
+++ b/tests/unit/exporters/test_console_exporter.py
@@ -105,6 +105,77 @@ class TestConsoleExporter:
         assert "Request Throughput" in output
         assert "requests/sec" in output
 
+    @pytest.mark.asyncio
+    async def test_export_prints_cache_hint_when_usage_without_cache(
+        self, mock_endpoint_config, capsys
+    ):
+        # Usage reported (total prompt tokens) but no cache-read total → hint.
+        config = make_exporter_config(
+            results=ProfileResults(
+                records=[
+                    MetricResult(
+                        tag="request_latency",
+                        header="Request Latency",
+                        unit="ns",
+                        avg=1.0,
+                    ),
+                    MetricResult(
+                        tag="total_usage_prompt_tokens",
+                        header="Total Usage Prompt Tokens",
+                        unit="tokens",
+                        sum=58250,
+                        avg=1165.0,
+                        count=50,
+                    ),
+                ],
+                start_ns=0,
+                end_ns=0,
+                completed=0,
+            ),
+            cli_config=mock_endpoint_config,
+            telemetry_results=None,
+        )
+        await ConsoleMetricsExporter(config).export(Console(width=115))
+        assert "--enable-prompt-tokens-details" in capsys.readouterr().out
+
+    @pytest.mark.asyncio
+    async def test_export_omits_cache_hint_when_cache_reported(
+        self, mock_endpoint_config, capsys
+    ):
+        config = make_exporter_config(
+            results=ProfileResults(
+                records=[
+                    MetricResult(
+                        tag="request_latency",
+                        header="Request Latency",
+                        unit="ns",
+                        avg=1.0,
+                    ),
+                    MetricResult(
+                        tag="total_usage_prompt_tokens",
+                        header="h",
+                        unit="tokens",
+                        sum=58250,
+                        count=50,
+                    ),
+                    MetricResult(
+                        tag="total_usage_prompt_cache_read_tokens",
+                        header="h",
+                        unit="tokens",
+                        sum=50176,
+                        count=50,
+                    ),
+                ],
+                start_ns=0,
+                end_ns=0,
+                completed=0,
+            ),
+            cli_config=mock_endpoint_config,
+            telemetry_results=None,
+        )
+        await ConsoleMetricsExporter(config).export(Console(width=115))
+        assert "--enable-prompt-tokens-details" not in capsys.readouterr().out
+
     @pytest.mark.parametrize(
         "metric_tag, should_show",
         [

--- a/tests/unit/metrics/test_cache_reporting_hint.py
+++ b/tests/unit/metrics/test_cache_reporting_hint.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the prompt-cache-reporting hint detectors.
+
+Both detectors flag the same condition — token usage reported but no prompt-cache
+read tokens — from two inputs: per-record metric maps (mid-run) and aggregated
+results (end-of-run). A cache-read value of 0 means caching is on but had no
+hits, and must NOT trigger the hint; only an absent value does.
+"""
+
+from aiperf.common.models import MetricResult
+from aiperf.metrics.cache_reporting_hint import (
+    usage_without_cache_in_record,
+    usage_without_cache_in_results,
+)
+
+USAGE_TAG = "usage_prompt_tokens"
+CACHE_TAG = "usage_prompt_cache_read_tokens"
+TOTAL_USAGE_TAG = "total_usage_prompt_tokens"
+TOTAL_CACHE_TAG = "total_usage_prompt_cache_read_tokens"
+
+
+class TestUsageWithoutCacheInRecord:
+    """Mid-run, per-record metric maps (``MetricRecordsData.results`` dicts)."""
+
+    def test_usage_present_cache_absent_returns_true(self):
+        assert usage_without_cache_in_record({USAGE_TAG: 1024}) is True
+
+    def test_usage_present_cache_zero_returns_false(self):
+        # Cache reporting on, no hits this request → reported, not missing.
+        assert usage_without_cache_in_record({USAGE_TAG: 1024, CACHE_TAG: 0}) is False
+
+    def test_usage_present_cache_nonzero_returns_false(self):
+        assert usage_without_cache_in_record({USAGE_TAG: 1024, CACHE_TAG: 512}) is False
+
+    def test_usage_absent_returns_false(self):
+        # No usage reported at all → different problem; stay quiet.
+        assert usage_without_cache_in_record({"output_sequence_length": 32}) is False
+
+    def test_empty_record_returns_false(self):
+        assert usage_without_cache_in_record({}) is False
+
+
+class TestUsageWithoutCacheInResults:
+    """End-of-run, aggregated ``MetricResult`` totals."""
+
+    def _usage(self, **stats) -> MetricResult:
+        return MetricResult(
+            tag=TOTAL_USAGE_TAG,
+            header="Total Usage Prompt Tokens",
+            unit="tokens",
+            **stats,
+        )
+
+    def _cache(self, **stats) -> MetricResult:
+        return MetricResult(
+            tag=TOTAL_CACHE_TAG,
+            header="Total Usage Prompt Cache Read Tokens",
+            unit="tokens",
+            **stats,
+        )
+
+    def test_usage_present_cache_no_value_returns_true(self):
+        # No-value metrics come through with count=0 and None stats.
+        results = [self._usage(sum=58250, avg=1165.0, count=50), self._cache(count=0)]
+        assert usage_without_cache_in_results(results) is True
+
+    def test_usage_present_cache_tag_missing_returns_true(self):
+        results = [self._usage(sum=58250, avg=1165.0, count=50)]
+        assert usage_without_cache_in_results(results) is True
+
+    def test_cache_reported_zero_returns_false(self):
+        results = [
+            self._usage(sum=58250, avg=1165.0, count=50),
+            self._cache(sum=0, avg=0.0, count=50),
+        ]
+        assert usage_without_cache_in_results(results) is False
+
+    def test_cache_reported_nonzero_returns_false(self):
+        results = [
+            self._usage(sum=58250, avg=1165.0, count=50),
+            self._cache(sum=50176, avg=1003.5, count=50),
+        ]
+        assert usage_without_cache_in_results(results) is False
+
+    def test_usage_absent_returns_false(self):
+        assert usage_without_cache_in_results([self._cache(count=0)]) is False

--- a/tests/unit/property/_numeric_bounds_baseline.txt
+++ b/tests/unit/property/_numeric_bounds_baseline.txt
@@ -234,10 +234,6 @@ MetricResult.p95: numeric field has no ge/gt/le/lt bound and is not FiniteFloat.
 MetricResult.p99: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 MetricResult.std: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 MetricResult.sum: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
-MetricSample.buckets: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
-MetricSample.count: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
-MetricSample.sum: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
-MetricSample.value: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 MetricSizeUnitInfo.num_bytes: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 MetricStats.max: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 MetricStats.mean: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.

--- a/tests/unit/records/test_records_manager.py
+++ b/tests/unit/records/test_records_manager.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,6 +29,7 @@ from aiperf.credit.messages import (
     CreditPhaseStartMessage,
     CreditsCompleteMessage,
 )
+from aiperf.metrics.cache_reporting_hint import CACHE_REPORTING_HINT
 from aiperf.plugin.enums import TimingMode
 from aiperf.records.records_manager import RecordsManager
 from aiperf.records.records_tracker import RecordsTracker
@@ -1052,3 +1054,35 @@ class TestRecordsManagerInitialization:
             "OTel metrics streamer is disabled and will not be used" in message
             for message in info_messages
         )
+
+
+class TestMidRunCacheReportingHint:
+    """RecordsManager warns once, mid-run, when token usage is reported but no
+    prompt-cache read tokens appear in the streamed records (detection logic
+    itself is covered in tests/unit/metrics/test_cache_reporting_hint.py)."""
+
+    def _manager(self) -> RecordsManager:
+        manager = RecordsManager.__new__(RecordsManager)
+        manager.warning = MagicMock()
+        return manager
+
+    def test_warns_once_on_first_qualifying_record(self):
+        manager = self._manager()
+        record_data = SimpleNamespace(metrics={"usage_prompt_tokens": 1024})
+        manager._maybe_hint_missing_cache_reporting(record_data)
+        manager._maybe_hint_missing_cache_reporting(record_data)  # a later record
+        manager.warning.assert_called_once_with(CACHE_REPORTING_HINT)
+
+    def test_no_warning_when_cache_reported(self):
+        manager = self._manager()
+        record_data = SimpleNamespace(
+            metrics={"usage_prompt_tokens": 1024, "usage_prompt_cache_read_tokens": 0}
+        )
+        manager._maybe_hint_missing_cache_reporting(record_data)
+        manager.warning.assert_not_called()
+
+    def test_no_warning_when_usage_absent(self):
+        manager = self._manager()
+        record_data = SimpleNamespace(metrics={"output_sequence_length": 32})
+        manager._maybe_hint_missing_cache_reporting(record_data)
+        manager.warning.assert_not_called()

--- a/tests/unit/server_metrics/test_server_metrics_data_collector.py
+++ b/tests/unit/server_metrics/test_server_metrics_data_collector.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -260,6 +261,242 @@ test_metric 1.0
         assert record.endpoint_url == "http://localhost:8081/metrics"
         assert record.endpoint_latency_ns == 5_000_000
         assert record.timestamp_ns > 0
+
+    def test_nan_gauge_sample_is_filtered(self):
+        """NaN gauge values (e.g. sglang:fwd_occupancy with no recent traffic)
+        must be filtered before the sample is constructed; otherwise the value
+        survives into ZMQ transport, fails to round-trip through serialization,
+        and the receiver rejects the whole batch (silent metrics loss)."""
+        metrics_text = """# HELP sglang:fwd_occupancy Forward pass GPU occupancy percentage.
+# TYPE sglang:fwd_occupancy gauge
+sglang:fwd_occupancy{engine_type="unified",model_name="m",moe_ep_rank="0",pp_rank="0",tp_rank="0"} NaN
+# HELP sglang:cache_hit_rate Prefix cache hit rate.
+# TYPE sglang:cache_hit_rate gauge
+sglang:cache_hit_rate{model_name="m"} 0.42
+"""
+        collector = ServerMetricsDataCollector("http://localhost:8081/metrics")
+        record = collector._parse_metrics_to_records(make_fetch_result(metrics_text))
+
+        assert record is not None
+        # The healthy metric survives.
+        assert "sglang:cache_hit_rate" in record.metrics
+        assert len(record.metrics["sglang:cache_hit_rate"].samples) == 1
+        assert record.metrics["sglang:cache_hit_rate"].samples[0].value == 0.42
+        # The NaN-only metric family is dropped entirely (no valid samples → family suppressed).
+        assert "sglang:fwd_occupancy" not in record.metrics
+
+    def test_nan_histogram_bucket_is_filtered(self):
+        """A NaN value on a single histogram bucket must be dropped before the
+        sample is constructed. Otherwise it survives into MetricSample.buckets
+        (dict[str, float]), orjson encodes NaN -> null on the ZMQ hop, and the
+        receiver's dict[str, float] validation rejects the entire batch — the
+        same silent-loss bug as the simple-gauge path, via a histogram."""
+        metrics_text = """# HELP my_hist Latency.
+# TYPE my_hist histogram
+my_hist_bucket{model_name="m",le="0.1"} NaN
+my_hist_bucket{model_name="m",le="+Inf"} 50.0
+my_hist_sum{model_name="m"} 17.494
+my_hist_count{model_name="m"} 50.0
+"""
+        collector = ServerMetricsDataCollector("http://localhost:8081/metrics")
+        record = collector._parse_metrics_to_records(make_fetch_result(metrics_text))
+
+        assert record is not None
+        assert "my_hist" in record.metrics
+        sample = record.metrics["my_hist"].samples[0]
+        # The NaN bucket is gone; healthy bucket/sum/count survive.
+        assert "0.1" not in sample.buckets
+        assert sample.buckets["+Inf"] == 50.0
+        assert sample.sum == 17.494
+        assert sample.count == 50.0
+        # And no non-finite value leaked into the surviving buckets.
+        assert all(math.isfinite(v) for v in sample.buckets.values())
+
+    def test_nan_sample_logs_warning_once_per_metric(self, caplog):
+        """When a NaN sample is filtered, emit a one-time warning naming the
+        metric so silent metric loss is surfaced. Same metric across multiple
+        scrapes warns once (de-duped) to prevent log spam at 333ms cadence."""
+        import logging
+
+        metrics_text = """# TYPE sglang:fwd_occupancy gauge
+sglang:fwd_occupancy{rank="0"} NaN
+"""
+        collector = ServerMetricsDataCollector("http://localhost:8081/metrics")
+
+        with caplog.at_level(logging.WARNING, logger="aiperf"):
+            # Scrape twice — both produce NaN for the same metric.
+            collector._parse_metrics_to_records(make_fetch_result(metrics_text))
+            collector._parse_metrics_to_records(make_fetch_result(metrics_text))
+
+        # Exactly one warning, naming the metric.
+        nan_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "sglang:fwd_occupancy" in r.message
+        ]
+        assert len(nan_warnings) == 1, (
+            f"Expected exactly one warning for sglang:fwd_occupancy across two scrapes, "
+            f"got {len(nan_warnings)}: {[r.message for r in nan_warnings]}"
+        )
+        assert (
+            "non-finite" in nan_warnings[0].message.lower()
+            or "nan" in nan_warnings[0].message.lower()
+        )
+
+    def test_metric_sample_construction_failure_in_simple_family_drops_only_offender(
+        self, caplog, monkeypatch
+    ):
+        """If MetricSample construction raises ValidationError for any reason
+        (future schema change, unanticipated input shape, etc.), the producer
+        must drop only the offending sample, keep the rest of the batch, and
+        log a warn-once warning naming the metric. Future-proofs against
+        failure modes the proactive NaN/Inf filter doesn't anticipate."""
+        import logging
+
+        from aiperf.server_metrics import data_collector as dc_mod
+
+        metrics_text = """# TYPE my_gauge gauge
+my_gauge{which="bad"} 1.0
+my_gauge{which="good"} 2.0
+"""
+        original_metric_sample = dc_mod.MetricSample
+
+        def selective_metric_sample(labels=None, value=None, **kwargs):
+            if labels and labels.get("which") == "bad":
+                # Trigger a genuine MetricSample ValidationError to simulate an
+                # unanticipated construction failure (a value/buckets/sum/count
+                # combination the model rejects), independent of the NaN/Inf path.
+                original_metric_sample(value=1.0, buckets={"+Inf": 1.0})
+            return original_metric_sample(labels=labels, value=value, **kwargs)
+
+        monkeypatch.setattr(dc_mod, "MetricSample", selective_metric_sample)
+
+        collector = dc_mod.ServerMetricsDataCollector("http://localhost:8081/metrics")
+        with caplog.at_level(logging.WARNING, logger="aiperf"):
+            # Scrape twice to verify warn-once.
+            record = collector._parse_metrics_to_records(
+                make_fetch_result(metrics_text)
+            )
+            collector._parse_metrics_to_records(make_fetch_result(metrics_text))
+
+        # The bad sample is dropped, but the good one survives the batch.
+        assert record is not None
+        assert "my_gauge" in record.metrics
+        assert len(record.metrics["my_gauge"].samples) == 1
+        assert record.metrics["my_gauge"].samples[0].labels == {"which": "good"}
+        assert record.metrics["my_gauge"].samples[0].value == 2.0
+
+        # Exactly one warn-once warning across the two scrapes.
+        construction_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "my_gauge" in r.message
+            and "construction" in r.message.lower()
+        ]
+        assert len(construction_warnings) == 1, (
+            f"Expected exactly one construction-failure warning for my_gauge across "
+            f"two scrapes, got {len(construction_warnings)}: "
+            f"{[r.message for r in construction_warnings]}"
+        )
+
+    def test_metric_sample_construction_failure_in_histogram_family_drops_only_offender(
+        self, caplog, monkeypatch
+    ):
+        """Parallel to the simple-family test, but for histograms. If
+        hist.to_metric_sample() construction raises, the producer must drop
+        only that one histogram's MetricSample and keep healthy histograms."""
+        import logging
+
+        from aiperf.server_metrics import data_collector as dc_mod
+
+        metrics_text = """# TYPE my_histogram histogram
+my_histogram_bucket{which="bad",le="0.1"} 5.0
+my_histogram_bucket{which="bad",le="+Inf"} 10.0
+my_histogram_sum{which="bad"} 0.5
+my_histogram_count{which="bad"} 10.0
+my_histogram_bucket{which="good",le="0.1"} 3.0
+my_histogram_bucket{which="good",le="+Inf"} 7.0
+my_histogram_sum{which="good"} 0.3
+my_histogram_count{which="good"} 7.0
+"""
+        original_metric_sample = dc_mod.MetricSample
+
+        def selective_metric_sample(labels=None, **kwargs):
+            if labels and labels.get("which") == "bad":
+                # Trigger a genuine MetricSample ValidationError to simulate an
+                # unanticipated construction failure on this histogram.
+                original_metric_sample(value=1.0, buckets={"+Inf": 1.0})
+            return original_metric_sample(labels=labels, **kwargs)
+
+        monkeypatch.setattr(dc_mod, "MetricSample", selective_metric_sample)
+
+        collector = dc_mod.ServerMetricsDataCollector("http://localhost:8081/metrics")
+        with caplog.at_level(logging.WARNING, logger="aiperf"):
+            record = collector._parse_metrics_to_records(
+                make_fetch_result(metrics_text)
+            )
+
+        assert record is not None
+        assert "my_histogram" in record.metrics
+        samples = record.metrics["my_histogram"].samples
+        assert len(samples) == 1
+        assert samples[0].labels == {"which": "good"}
+
+        failures = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "my_histogram" in r.message
+            and "construction" in r.message.lower()
+        ]
+        assert len(failures) == 1
+
+    def test_realistic_sglang_payload_with_nan_gauge_drops_only_offender(self):
+        """Realistic sglang scrape with a NaN gauge AND a NaN histogram bucket
+        alongside healthy metrics. Verifies the full _parse_metrics_to_records path:
+          - NaN gauge is dropped (family suppressed since it had only one sample)
+          - Healthy gauge survives
+          - Histogram survives with its NaN bucket dropped and healthy buckets/sum/count intact
+          - The resulting record can be constructed without raising
+        Regression test for the silent-loss bug observed against sglang
+        --enable-metrics where sglang:fwd_occupancy emitted NaN, extended to
+        cover the parallel histogram-path filter (Task 1b)."""
+        metrics_text = """# HELP sglang:fwd_occupancy Forward pass GPU occupancy percentage.
+# TYPE sglang:fwd_occupancy gauge
+sglang:fwd_occupancy{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} NaN
+# HELP sglang:cache_hit_rate Prefix cache hit rate.
+# TYPE sglang:cache_hit_rate gauge
+sglang:cache_hit_rate{model_name="Qwen/Qwen3-0.6B"} 0.873
+# HELP sglang:num_running_reqs Number of running requests.
+# TYPE sglang:num_running_reqs gauge
+sglang:num_running_reqs{model_name="Qwen/Qwen3-0.6B"} 4
+# HELP sglang:time_to_first_token_seconds TTFT histogram
+# TYPE sglang:time_to_first_token_seconds histogram
+sglang:time_to_first_token_seconds_bucket{model_name="Qwen/Qwen3-0.6B",le="0.05"} NaN
+sglang:time_to_first_token_seconds_bucket{model_name="Qwen/Qwen3-0.6B",le="0.1"} 46.0
+sglang:time_to_first_token_seconds_bucket{model_name="Qwen/Qwen3-0.6B",le="+Inf"} 50.0
+sglang:time_to_first_token_seconds_sum{model_name="Qwen/Qwen3-0.6B"} 17.494
+sglang:time_to_first_token_seconds_count{model_name="Qwen/Qwen3-0.6B"} 50.0
+"""
+        collector = ServerMetricsDataCollector("http://localhost:8081/metrics")
+        record = collector._parse_metrics_to_records(make_fetch_result(metrics_text))
+
+        assert record is not None
+        # Healthy metrics survive.
+        assert "sglang:cache_hit_rate" in record.metrics
+        assert record.metrics["sglang:cache_hit_rate"].samples[0].value == 0.873
+        assert "sglang:num_running_reqs" in record.metrics
+        assert record.metrics["sglang:num_running_reqs"].samples[0].value == 4.0
+        # Histogram survives; the NaN bucket is dropped, healthy buckets/sum/count remain.
+        assert "sglang:time_to_first_token_seconds" in record.metrics
+        ttft = record.metrics["sglang:time_to_first_token_seconds"].samples[0]
+        assert ttft.count == 50.0
+        assert "0.05" not in ttft.buckets
+        assert ttft.buckets["0.1"] == 46.0
+        assert all(math.isfinite(v) for v in ttft.buckets.values())
+        # Offender gauge dropped.
+        assert "sglang:fwd_occupancy" not in record.metrics
 
 
 class TestMetricDeduplication:

--- a/tests/unit/server_metrics/test_server_metrics_data_collector.py
+++ b/tests/unit/server_metrics/test_server_metrics_data_collector.py
@@ -285,32 +285,45 @@ sglang:cache_hit_rate{model_name="m"} 0.42
         # The NaN-only metric family is dropped entirely (no valid samples → family suppressed).
         assert "sglang:fwd_occupancy" not in record.metrics
 
-    def test_nan_histogram_bucket_is_filtered(self):
-        """A NaN value on a single histogram bucket must be dropped before the
-        sample is constructed. Otherwise it survives into MetricSample.buckets
-        (dict[str, float]), orjson encodes NaN -> null on the ZMQ hop, and the
-        receiver's dict[str, float] validation rejects the entire batch — the
-        same silent-loss bug as the simple-gauge path, via a histogram."""
+    def test_nan_histogram_bucket_drops_whole_label_set_sample(self):
+        """A NaN on any bucket/sum/count line must drop the ENTIRE histogram
+        sample for that label set, not just the offending line.
+
+        Emitting a partial sample is worse than dropping it: HistogramTimeSeries
+        locks its bucket schema from the first stored sample, then ignores any
+        bucket missing from that schema on every later scrape. So a truncated
+        first sample would permanently drop the NaN'd bucket even once the server
+        reports finite values for it. The label set must be dropped wholesale so
+        the first stored sample always carries a complete, finite schema.
+
+        Per-label-set granularity: a sibling label set with all-finite lines is
+        unaffected — only the tainted set is dropped."""
         metrics_text = """# HELP my_hist Latency.
 # TYPE my_hist histogram
 my_hist_bucket{model_name="m",le="0.1"} NaN
 my_hist_bucket{model_name="m",le="+Inf"} 50.0
 my_hist_sum{model_name="m"} 17.494
 my_hist_count{model_name="m"} 50.0
+my_hist_bucket{model_name="ok",le="0.1"} 5.0
+my_hist_bucket{model_name="ok",le="+Inf"} 30.0
+my_hist_sum{model_name="ok"} 9.0
+my_hist_count{model_name="ok"} 30.0
 """
         collector = ServerMetricsDataCollector("http://localhost:8081/metrics")
         record = collector._parse_metrics_to_records(make_fetch_result(metrics_text))
 
         assert record is not None
         assert "my_hist" in record.metrics
-        sample = record.metrics["my_hist"].samples[0]
-        # The NaN bucket is gone; healthy bucket/sum/count survive.
-        assert "0.1" not in sample.buckets
-        assert sample.buckets["+Inf"] == 50.0
-        assert sample.sum == 17.494
-        assert sample.count == 50.0
-        # And no non-finite value leaked into the surviving buckets.
-        assert all(math.isfinite(v) for v in sample.buckets.values())
+        samples = record.metrics["my_hist"].samples
+        # The tainted "m" label set is gone entirely; only the finite "ok" set
+        # survives — no partial sample for "m".
+        assert len(samples) == 1
+        survivor = samples[0]
+        assert survivor.labels == {"model_name": "ok"}
+        assert survivor.buckets == {"0.1": 5.0, "+Inf": 30.0}
+        assert survivor.sum == 9.0
+        assert survivor.count == 30.0
+        assert all(math.isfinite(v) for v in survivor.buckets.values())
 
     def test_nan_sample_logs_warning_once_per_metric(self, caplog):
         """When a NaN sample is filtered, emit a one-time warning naming the
@@ -457,7 +470,9 @@ my_histogram_count{which="good"} 7.0
         alongside healthy metrics. Verifies the full _parse_metrics_to_records path:
           - NaN gauge is dropped (family suppressed since it had only one sample)
           - Healthy gauge survives
-          - Histogram survives with its NaN bucket dropped and healthy buckets/sum/count intact
+          - Histogram label set is dropped wholesale because one bucket is NaN
+            (family suppressed since it had only the one tainted label set) — a
+            partial sample would lock a truncated bucket schema downstream
           - The resulting record can be constructed without raising
         Regression test for the silent-loss bug observed against sglang
         --enable-metrics where sglang:fwd_occupancy emitted NaN, extended to
@@ -488,13 +503,10 @@ sglang:time_to_first_token_seconds_count{model_name="Qwen/Qwen3-0.6B"} 50.0
         assert record.metrics["sglang:cache_hit_rate"].samples[0].value == 0.873
         assert "sglang:num_running_reqs" in record.metrics
         assert record.metrics["sglang:num_running_reqs"].samples[0].value == 4.0
-        # Histogram survives; the NaN bucket is dropped, healthy buckets/sum/count remain.
-        assert "sglang:time_to_first_token_seconds" in record.metrics
-        ttft = record.metrics["sglang:time_to_first_token_seconds"].samples[0]
-        assert ttft.count == 50.0
-        assert "0.05" not in ttft.buckets
-        assert ttft.buckets["0.1"] == 46.0
-        assert all(math.isfinite(v) for v in ttft.buckets.values())
+        # Histogram's only label set had a NaN bucket -> the whole label set is
+        # dropped, suppressing the family. Dropping only the NaN line would emit a
+        # partial sample that locks a truncated bucket schema in HistogramTimeSeries.
+        assert "sglang:time_to_first_token_seconds" not in record.metrics
         # Offender gauge dropped.
         assert "sglang:fwd_occupancy" not in record.metrics
 

--- a/tests/unit/server_metrics/test_server_metrics_models.py
+++ b/tests/unit/server_metrics/test_server_metrics_models.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import pytest
+from pydantic import ValidationError
 
 from aiperf.common.models import ErrorDetails, ErrorDetailsCount
 from aiperf.common.models.server_metrics_models import (
@@ -83,6 +86,38 @@ class TestMetricSampleValidation:
             ValueError, match="If value is set, sum and count must not be set"
         ):
             MetricSample(value=42.0, count=100)
+
+
+class TestMetricSampleFiniteContract:
+    """MetricSample.value must reject NaN/Inf at construction time to enforce
+    the project's NaN/Inf Discipline contract for serializable metric models."""
+
+    def test_value_rejects_nan(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MetricSample(value=math.nan)
+        assert "finite" in str(exc_info.value).lower()
+
+    def test_value_rejects_positive_inf(self):
+        with pytest.raises(ValidationError):
+            MetricSample(value=math.inf)
+
+    def test_value_rejects_negative_inf(self):
+        with pytest.raises(ValidationError):
+            MetricSample(value=-math.inf)
+
+    def test_value_accepts_zero(self):
+        sample = MetricSample(value=0.0)
+        assert sample.value == 0.0
+
+    def test_value_accepts_normal_float(self):
+        sample = MetricSample(value=0.42)
+        assert sample.value == 0.42
+
+    def test_value_accepts_none_when_buckets_provided(self):
+        # Histogram-style sample: value=None is valid as long as buckets are present.
+        sample = MetricSample(value=None, buckets={"+Inf": 10.0}, sum=5.0, count=10.0)
+        assert sample.value is None
+        assert sample.buckets == {"+Inf": 10.0}
 
 
 class TestServerMetricsRecordConversion:

--- a/tests/unit/server_metrics/test_server_metrics_models.py
+++ b/tests/unit/server_metrics/test_server_metrics_models.py
@@ -119,6 +119,32 @@ class TestMetricSampleFiniteContract:
         assert sample.value is None
         assert sample.buckets == {"+Inf": 10.0}
 
+    @pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+    def test_bucket_value_rejects_non_finite(self, bad):
+        # A non-finite bucket count would orjson-encode to null on the ZMQ hop
+        # and, if it slipped past the producer filter, poison HistogramTimeSeries.
+        with pytest.raises(ValidationError) as exc_info:
+            MetricSample(buckets={"0.1": 5.0, "+Inf": bad}, sum=5.0, count=10.0)
+        assert "finite" in str(exc_info.value).lower()
+
+    @pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+    def test_sum_rejects_non_finite(self, bad):
+        with pytest.raises(ValidationError) as exc_info:
+            MetricSample(buckets={"+Inf": 10.0}, sum=bad, count=10.0)
+        assert "finite" in str(exc_info.value).lower()
+
+    @pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+    def test_count_rejects_non_finite(self, bad):
+        with pytest.raises(ValidationError) as exc_info:
+            MetricSample(buckets={"+Inf": 10.0}, sum=5.0, count=bad)
+        assert "finite" in str(exc_info.value).lower()
+
+    def test_histogram_accepts_finite_buckets_sum_count(self):
+        sample = MetricSample(buckets={"0.1": 5.0, "+Inf": 10.0}, sum=5.0, count=10.0)
+        assert sample.buckets == {"0.1": 5.0, "+Inf": 10.0}
+        assert sample.sum == 5.0
+        assert sample.count == 10.0
+
 
 class TestServerMetricsRecordConversion:
     """Test ServerMetricsRecord to slim format conversion."""

--- a/tests/unit/server_metrics/test_storage_edge_cases.py
+++ b/tests/unit/server_metrics/test_storage_edge_cases.py
@@ -197,7 +197,7 @@ class TestScalarTimeSeriesNumericEdgeCases:
     """Test numeric edge cases."""
 
     @pytest.mark.parametrize("value", [1e308, 1e-308, -100.5, 0.0])
-    def test_extreme_values(self, value: float) -> None:
+    def test_append_extreme_finite_value_stores_exact_value(self, value: float) -> None:
         """Test that extreme (but finite) numeric values are stored correctly.
 
         Non-finite values (NaN/+-Inf) are intentionally excluded: the

--- a/tests/unit/server_metrics/test_storage_edge_cases.py
+++ b/tests/unit/server_metrics/test_storage_edge_cases.py
@@ -196,18 +196,18 @@ class TestScalarTimeSeriesEmpty:
 class TestScalarTimeSeriesNumericEdgeCases:
     """Test numeric edge cases."""
 
-    @pytest.mark.parametrize(
-        "value", [1e308, 1e-308, -100.5, 0.0, float("inf"), float("-inf"), float("nan")]
-    )
+    @pytest.mark.parametrize("value", [1e308, 1e-308, -100.5, 0.0])
     def test_extreme_values(self, value: float) -> None:
-        """Test that extreme numeric values are stored correctly."""
+        """Test that extreme (but finite) numeric values are stored correctly.
+
+        Non-finite values (NaN/+-Inf) are intentionally excluded: the
+        MetricSample.value FiniteFloat contract forbids constructing a sample
+        with a non-finite value, so such a value can never reach the series.
+        """
         ts = ScalarTimeSeries()
         ts.append(_NS, MetricSample(value=value))
 
-        if np.isnan(value):
-            assert np.isnan(ts.values[0])
-        else:
-            assert ts.values[0] == value or np.isinf(ts.values[0])
+        assert ts.values[0] == value
 
     def test_none_value_raises(self) -> None:
         """Test that None value raises ValueError."""


### PR DESCRIPTION
## TL;DR

One stray `NaN` from a single sglang gauge was silently discarding **every** server metric for that scrape — no error, no export file, just `1/1 endpoint(s) reachable` followed by nothing. This hardens the server-metrics pipeline so a single malformed sample can't take down the whole batch, makes the loss loud when it does happen, and fixes the docs gaps around per-server metric enablement.

## What people were seeing

You point aiperf at an sglang server, see the reassuring line in the logs:

```
Server Metrics: Started 1 collector(s) successfully
Server metrics enabled - 1/1 endpoint(s) reachable.
```

…and then `server_metrics_export.{csv,json}` never shows up. Everything reports healthy; nothing is produced. No error in the foreground — just a missing file.

## Why it happened

sglang emits `sglang:fwd_occupancy NaN` whenever there's been no recent forward-pass activity (it's a ratio with a zero denominator). That one `NaN` was enough to throw away the entire scrape — including `sglang:cache_hit_rate`, the metric you actually came for.

The chain:

1. The producer-side filter only skipped `None` and `+Inf`; `NaN` (and `-Inf`) slipped through.
2. A `MetricSample(value=NaN)` was constructed — pydantic accepted it because the field was typed `float | None`.
3. The record crosses a ZMQ boundary serialized with orjson, which encodes `NaN` as `null`.
4. On the **receiver** side, the model now sees `value=null` *and* `buckets=null`, and its mutual-exclusivity validator rejects the sample — which fails the entire `ServerMetricsRecordMessage`.
5. That rejection happens on a background task, so it never surfaces to you. The net effect is a silently dropped batch and no export file.

One bad value → whole batch lost → no signal. The histogram path had the identical hole: a `NaN` bucket value would survive into a `dict[str, float]`, become `null` over the wire, and fail validation the same way.

## What this changes

Defense in depth, all at the producer (closest to the bad input, keeps malformed values off the wire, and gives the warning the most context):

- **Filter non-finite values** (`NaN`/`+Inf`/`-Inf`) in both the gauge/counter path and the histogram path.
- **Make the invariant explicit** — `MetricSample.value` is now `FiniteFloat | None`, so a non-finite value fails loudly at construction instead of silently corrupting a downstream batch.
- **Turn silent loss into loud loss** — warn once per metric name when samples are dropped, de-duped so it doesn't spam the log at the 333 ms scrape cadence.
- **Make the pipeline resilient** — wrap sample construction in `try/except` in both paths, so any *unanticipated* validation failure drops only the offending sample and keeps the rest of the batch.

Docs, part of the same story:

- Document that sglang requires `--enable-metrics` to expose `/metrics` at all (without it you get a 404 and silent no-collection), and correct the TRT-LLM note that incorrectly claimed sglang exposes `/metrics` by default.
- Document that the response-`usage` prompt-cache metrics are **opt-in** on self-hosted servers — vLLM `--enable-prompt-tokens-details`, sglang `--enable-cache-report` (both default off), TRT-LLM default-on — in `docs/reference/vendor-usage-fields.md` (vLLM note + new SGLang/TRT-LLM entries) with a cross-reference from `docs/metrics-reference.md`, so `usage_prompt_cache_read_*` metrics aren't mysteriously all-None.

## What it unblocks

- Server metrics now actually land on disk when running against sglang — or any server that emits a NaN-prone gauge.
- `sglang:cache_hit_rate` survives into the export, which is the input needed for the live KV-cache-hit-rate work.
- More broadly: the server-metrics pipeline is no longer all-or-nothing per batch — one malformed sample can't sink the rest.

## Testing

- New unit tests: NaN gauge filtered; NaN histogram bucket filtered; warn-once dedup across scrapes; per-sample construction-failure resilience for both the gauge and histogram paths; and a realistic mixed sglang payload (NaN gauge + NaN bucket + healthy gauge + histogram) proving only the offenders are dropped.
- New model-contract tests for `FiniteFloat` on `MetricSample.value`.
- Updated one existing storage edge-case test that had been asserting the old (buggy) "NaN is stored" behavior.
- Full server-metrics unit + integration suites pass (727 unit, 169 integration); property/invariant suite passes (59); ruff format/lint and the ergonomics/complexity baselines are clean.
- **Manually validated against real vLLM, sglang, and TRT-LLM servers** (Qwen3-0.6B, concurrency 4): `server_metrics_export.{json,csv}` is produced for all three; sglang's NaN `fwd_occupancy` is dropped with exactly one warning while the rest of the batch (incl. `sglang:cache_hit_rate`) survives; TRT-LLM's `/prometheus/metrics` fallback probes-and-swaps cleanly. With the usage flags enabled, `overall_usage_prompt_cache_read_pct` populates for all three (vLLM 86.1% / sglang 81.5% / TRT-LLM 85.1%).

## Out of scope / follow-ups

- **Live KV cache hit rate** (surfacing the scraped cache-hit gauges into the console table + dashboard) — a separate feature; this PR hardens its data source.
- **Tightening `FiniteFloat` on histogram `sum`/`count`/bucket values** at the model layer — the producer-side filter covers the observed risk; deferred until there's evidence it's needed.
- **A runtime hint when a run's `usage` is otherwise populated but every prompt-cache-read value is None** (likely a forgotten server flag) — the per-server enablement is now documented (above), but the proactive runtime nudge is left as a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-metrics robustness: non-finite metric values (NaN/±Inf) are dropped, sample-construction failures are isolated, and repeated warnings reduced (warn-once per metric). Validation now enforces finite numeric values for non-histogram samples.

* **Documentation**
  * Clarified SGLang/TRT-LLM Prometheus endpoint requirements, TRT-LLM fallback probe behavior, and added example configuration.
  * Documented vendor-specific flags and cache-read metric behaviors for vLLM, SGLang, and TRT-LLM.

* **Tests**
  * Added unit/regression tests covering non-finite handling, construction failures, and warn-once logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->