### PR TITLE
fix: handle unrecognized OpenAI response object type without crashing

### DIFF
--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -166,8 +166,11 @@ class ChatEndpoint(BaseEndpoint):
             case "chat.completion.chunk":
                 data_key = "delta"
             case _:
-                object_type = json_obj.get("object")
-                raise ValueError(f"Unsupported OpenAI object type: {object_type!r}")
+                # Unrecognized object: the server can return arbitrary bodies
+                # (error JSON, proxy pages, truncated streams on crash). Degrade
+                # to None like the no-choices/no-data cases below rather than
+                # raising, so the worker records a failure and keeps going.
+                return None
 
         choices = json_obj.get("choices")
         if not choices:

--- a/src/aiperf/endpoints/openai_completions.py
+++ b/src/aiperf/endpoints/openai_completions.py
@@ -115,5 +115,8 @@ class CompletionsEndpoint(BaseEndpoint):
                     return None
                 return self.make_text_response_data(choices[0].get("text"))
             case _:
-                object_type = json_obj.get("object")
-                raise ValueError(f"Unsupported OpenAI object type: {object_type!r}")
+                # Unrecognized object: the server can return arbitrary bodies
+                # (error JSON, proxy pages, truncated streams on crash). Degrade
+                # to None like the no-choices case above rather than raising, so
+                # the worker records a failure and keeps going.
+                return None

--- a/tests/unit/endpoints/test_chat_endpoint_parse_response.py
+++ b/tests/unit/endpoints/test_chat_endpoint_parse_response.py
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for ChatEndpoint parse_response functionality."""
 
+import orjson
 import pytest
+from pytest import param
 
 from aiperf.common.models.record_models import (
     ReasoningResponseData,
+    RequestRecord,
+    TextResponse,
     TextResponseData,
     ToolCallResponseData,
 )
@@ -377,3 +381,45 @@ class TestChatEndpointParseResponse:
         assert parsed is not None
         assert isinstance(parsed.data, ReasoningResponseData)
         assert parsed.data.reasoning == "Thinking..."
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            param(
+                {"choices": [{"message": {"content": "hi"}}]}, id="missing-object"
+            ),
+            param(
+                {"object": "error", "message": "backend died", "code": 500},
+                id="vllm-error-object",
+            ),
+            param({"error": {"message": "Internal Server Error"}}, id="error-body"),
+        ],
+    )  # fmt: skip
+    def test_parse_response_unrecognized_object_returns_none(self, endpoint, body):
+        """Malformed/error bodies (server crash, proxy errors) degrade to None
+        instead of raising, so the worker records a failure and continues."""
+        assert endpoint.parse_response(create_mock_response(1, body)) is None
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            param(
+                {"choices": [{"message": {"content": "hi"}}]}, id="missing-object"
+            ),
+            param(
+                {"object": "error", "message": "backend died", "code": 500},
+                id="vllm-error-object",
+            ),
+            param({"error": {"message": "Internal Server Error"}}, id="error-body"),
+        ],
+    )  # fmt: skip
+    def test_build_assistant_turn_unrecognized_object_returns_none(
+        self, endpoint, body
+    ):
+        """build_assistant_turn (DAG/multi-turn replay path) must not raise on a
+        malformed/error response - it returns None so no assistant turn is stored."""
+        record = RequestRecord(
+            model_name="m",
+            responses=[TextResponse(perf_ns=1, text=orjson.dumps(body).decode())],
+        )
+        assert endpoint.build_assistant_turn(record) is None

--- a/tests/unit/endpoints/test_completions_endpoint_parse_response.py
+++ b/tests/unit/endpoints/test_completions_endpoint_parse_response.py
@@ -5,6 +5,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from pytest import param
 
 from aiperf.common.enums import ModelSelectionStrategy
 from aiperf.common.models.model_endpoint_info import (
@@ -211,3 +212,22 @@ class TestCompletionsEndpointParseResponse:
 
         assert parsed is not None
         assert parsed.data.text == long_text
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            param({"choices": [{"text": "hi"}]}, id="missing-object"),
+            param(
+                {"object": "error", "message": "backend died", "code": 500},
+                id="vllm-error-object",
+            ),
+            param({"error": {"message": "Internal Server Error"}}, id="error-body"),
+        ],
+    )  # fmt: skip
+    def test_parse_response_unrecognized_object_returns_none(self, endpoint, body):
+        """Malformed/error bodies (server crash, proxy errors) degrade to None
+        instead of raising, so the worker records a failure and continues."""
+        mock_response = Mock(spec=InferenceServerResponse)
+        mock_response.perf_ns = 123456789
+        mock_response.get_json.return_value = body
+        assert endpoint.parse_response(mock_response) is None

--- a/tests/unit/endpoints/test_openai_chat_attack.py
+++ b/tests/unit/endpoints/test_openai_chat_attack.py
@@ -242,11 +242,16 @@ class TestChatParseResponseHostile:
         calling extract_chat_response_data. Graceful skip."""
         assert endpoint.parse_response(create_mock_response(1, {})) is None
 
-    def test_unknown_object_type_raises(self, endpoint):
-        with pytest.raises(ValueError, match="Unsupported OpenAI object type"):
+    def test_unknown_object_type_returns_none(self, endpoint):
+        """An unrecognized object type is server output, not an invariant
+        violation - parse_response degrades to None instead of raising so the
+        worker records a failed request and keeps benchmarking."""
+        assert (
             endpoint.parse_response(
                 create_mock_response(1, {"object": "garbage", "choices": []})
             )
+            is None
+        )
 
     def test_none_json_returns_none(self, endpoint):
         """When the response body is non-JSON, get_json returns None and the

--- a/tests/unit/records/test_inference_result_parser.py
+++ b/tests/unit/records/test_inference_result_parser.py
@@ -496,6 +496,7 @@ class TestContextPromptISL:
         assert parsed_record.responses == []
 
 
+@pytest.mark.asyncio
 class TestMalformedResponseEndToEnd:
     """End-to-end: a malformed/error response body (server crash, proxy error)
     must flow through the parser as a clean failed record, not crash the parser

--- a/tests/unit/records/test_inference_result_parser.py
+++ b/tests/unit/records/test_inference_result_parser.py
@@ -3,15 +3,19 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import orjson
 import pytest
+from pytest import param
 
 from aiperf.common.models import (
     ErrorDetails,
     ParsedResponse,
     RequestRecord,
+    TextResponse,
     TextResponseData,
     Usage,
 )
+from aiperf.endpoints.openai_chat import ChatEndpoint
 from tests.unit.records.conftest import create_invalid_record, create_test_request_info
 
 
@@ -490,3 +494,46 @@ class TestContextPromptISL:
 
         assert parsed_record.token_counts.input == 19
         assert parsed_record.responses == []
+
+
+class TestMalformedResponseEndToEnd:
+    """End-to-end: a malformed/error response body (server crash, proxy error)
+    must flow through the parser as a clean failed record, not crash the parser
+    or get mislabeled as a parser bug."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            param({"choices": [{"message": {"content": "hi"}}]}, id="missing-object"),
+            param(
+                {"object": "error", "message": "backend died", "code": 500},
+                id="vllm-error-object",
+            ),
+            param({"error": {"message": "Internal Server Error"}}, id="error-body"),
+        ],
+    )  # fmt: skip
+    async def test_malformed_response_recorded_as_failure_not_parser_crash(
+        self, inference_result_parser, sample_turn, body
+    ):
+        # Real ChatEndpoint (not a MagicMock) so the actual extraction path runs.
+        inference_result_parser.endpoint = ChatEndpoint(
+            model_endpoint=create_test_request_info().model_endpoint
+        )
+        inference_result_parser.disable_tokenization = True
+
+        record = RequestRecord(
+            model_name="test-model",
+            request_info=create_test_request_info(turns=[sample_turn]),
+            turns=[sample_turn],
+            responses=[TextResponse(perf_ns=1000, text=orjson.dumps(body).decode())],
+        )
+
+        # Must not raise (pre-fix this crashed with ValueError in extraction).
+        result = await inference_result_parser.parse_request_record(record)
+
+        assert record.has_error
+        # Honest cause: "no content from server", NOT a parser-internal ValueError.
+        assert record.error.type == "InvalidInferenceResultError"
+        assert "No responses with actual content" in str(record.error)
+        assert "Unsupported OpenAI object type" not in str(record.error)
+        assert result.responses == []


### PR DESCRIPTION
## Problem

- `extract_chat_response_data` (and completions equivalent) raised `ValueError: Unsupported OpenAI object type` when a response had a missing/unrecognized `object` field.
- Triggered by normal server misbehavior: backend crash mid-stream, proxy error page, vLLM `{"object":"error"}` body, truncated stream.
- Response bodies are untrusted server output, not an invariant — raising is wrong for a benchmarking tool.
- Effects: masks the real error (report blames the parser, not the dead backend), and spams a traceback per failed request.
- Reachable from `parse_response`, the records pipeline, and `build_assistant_turn` (multi-turn/DAG path).

## Fix

- `case _` now returns `None` instead of raising, matching the existing no-choices/no-data branches.
- `None` isn't swallowed: `create_error_from_invalid` records the request as a failure with an honest cause ("No responses with actual content received").
- Applied to both chat and completions endpoints.

## Tests

- `parse_response` + `build_assistant_turn` (chat) and `parse_response` (completions) return `None` for missing-`object`, `{"object":"error"}`, `{"error":...}`.
- End-to-end: real `ChatEndpoint` through real `InferenceResultParser` → malformed response becomes an `InvalidInferenceResultError` record, not a crash.
- Confirmed tests fail with the original `ValueError` when the fix is reverted.
- Updated the attack test that had encoded the buggy raise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful handling of unexpected or malformed OpenAI responses: unrecognized response shapes no longer cause crashes and are recorded as failures so processing can continue.

* **Tests**
  * Expanded test coverage for malformed, unrecognized, and error-shaped responses across chat and completion flows to ensure robust end-to-end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->