### PR TITLE
fix: skip plots with unavailable data instead of erroring in dashboard and PNG export (cherry-pick to release/0.10.0)

### DIFF
--- a/src/aiperf/plot/dashboard/callbacks.py
+++ b/src/aiperf/plot/dashboard/callbacks.py
@@ -81,6 +81,7 @@ from aiperf.plot.dashboard.utils import (
     resolve_single_run_column_name,
     runs_to_dataframe,
 )
+from aiperf.plot.exceptions import DataUnavailableError
 from aiperf.plot.metric_names import (
     get_all_metric_display_names,
     get_gpu_metrics,
@@ -4935,7 +4936,17 @@ def _generate_singlerun_figure(
             HandlerClass = plugins.get_class(PluginType.PLOT, spec.plot_type)
             handler = HandlerClass(plot_generator=plot_gen, logger=None)
             available_metrics = _build_available_metrics_dict(plot_specs)
-            fig = handler.create_plot(spec, run, available_metrics)
+            try:
+                fig = handler.create_plot(spec, run, available_metrics)
+            except (DataUnavailableError, KeyError) as e:
+                # Expected when this run lacks the data the plot needs (e.g.
+                # streaming-only metrics like time_to_first_token in a
+                # non-streaming run). Skip the plot (return None -> the grid
+                # drops it) instead of rendering an error tile.
+                _logger.debug(
+                    f"Skipping plot '{plot_id}': required data not available ({e!r})"
+                )
+                return None
 
             config_title = config.get("title")
             if config_title and config_title != spec.title:
@@ -5040,7 +5051,7 @@ def _render_single_run_plots(
             )
             children.append(container)
         else:
-            _logger.warning(f"Plot '{plot_id}' generation returned None. Skipping.")
+            _logger.debug(f"Plot '{plot_id}' generation returned None. Skipping.")
 
     # Add "+ Create Custom Plot" button at end
     children.append(

--- a/src/aiperf/plot/exporters/png/single_run.py
+++ b/src/aiperf/plot/exporters/png/single_run.py
@@ -17,6 +17,7 @@ from aiperf.plot.core.plot_specs import (
     DataSource,
     PlotSpec,
 )
+from aiperf.plot.exceptions import DataUnavailableError
 from aiperf.plot.exporters.png.base import BasePNGExporter
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import PluginType
@@ -74,6 +75,13 @@ class SingleRunPNGExporter(BasePNGExporter):
                 self.debug(f"Generated {spec.filename}")
                 generated_files.append(path)
 
+            except (DataUnavailableError, KeyError) as e:
+                # Expected when this run lacks the data a plot needs (e.g.
+                # streaming-only metrics in a non-streaming run). Skip the plot
+                # rather than logging an error.
+                self.warning(
+                    f"Skipping plot '{spec.name}': required data not available: {e}"
+                )
             except Exception as e:
                 self.error(f"Failed to generate {spec.name}: {e}")
 

--- a/tests/unit/plot/test_dashboard_callbacks.py
+++ b/tests/unit/plot/test_dashboard_callbacks.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for dashboard single-run figure generation."""
+
+import pandas as pd
+
+from aiperf.plot.constants import PlotTheme
+from aiperf.plot.core.data_loader import RunData, RunMetadata
+from aiperf.plot.core.plot_specs import DataSource, MetricSpec, PlotSpec, PlotType
+from aiperf.plot.dashboard.callbacks import _generate_singlerun_figure
+
+
+def _non_streaming_run(tmp_path) -> RunData:
+    """Run with a non-empty requests table that lacks streaming-only columns
+    (no time_to_first_token / inter_token_latency), as in non-streaming mode."""
+    return RunData(
+        metadata=RunMetadata(
+            run_name="r", run_path=tmp_path / "r", model="m", concurrency=1
+        ),
+        requests=pd.DataFrame(
+            {
+                "request_end_ns": pd.to_datetime(
+                    [1_000_000_000_000 + i * 500_000_000 for i in range(5)],
+                    unit="ns",
+                    utc=True,
+                ),
+                "request_latency": [900.0 + i * 10 for i in range(5)],
+            }
+        ),
+        aggregated={},
+        timeslices=None,
+    )
+
+
+def _spec(name: str, y_metric: str) -> PlotSpec:
+    return PlotSpec(
+        name=name,
+        plot_type=PlotType.SCATTER,
+        metrics=[
+            MetricSpec(name="request_number", source=DataSource.REQUESTS, axis="x"),
+            MetricSpec(name=y_metric, source=DataSource.REQUESTS, axis="y"),
+        ],
+        title=name,
+        filename=f"{name}.png",
+    )
+
+
+class TestGenerateSingleRunFigure:
+    def test_missing_column_returns_none_at_debug(self, tmp_path, caplog):
+        """A streaming-only plot on non-streaming data is skipped (None) and logged
+        at DEBUG - not rendered as an error tile and not logged at ERROR."""
+        run = _non_streaming_run(tmp_path)
+        spec = _spec("ttft_over_time", "time_to_first_token")
+
+        with caplog.at_level("DEBUG"):
+            fig = _generate_singlerun_figure(
+                "ttft_over_time", {"is_default": True}, run, [spec], PlotTheme.DARK
+            )
+
+        assert fig is None
+        assert not [r for r in caplog.records if r.levelname == "ERROR"]
+        assert [
+            r
+            for r in caplog.records
+            if r.levelname == "DEBUG"
+            and "Skipping" in r.message
+            and "ttft_over_time" in r.message
+        ]
+
+    def test_present_column_returns_figure(self, tmp_path):
+        """A plot whose column is present still renders normally."""
+        run = _non_streaming_run(tmp_path)
+        spec = _spec("latency_over_time", "request_latency")
+
+        fig = _generate_singlerun_figure(
+            "latency_over_time", {"is_default": True}, run, [spec], PlotTheme.DARK
+        )
+
+        assert fig is not None
+
+    def test_unexpected_error_still_returns_error_figure(self, tmp_path, caplog):
+        """Genuine, unexpected errors (not missing-data) keep ERROR logging and an
+        error placeholder figure - they are not silently swallowed as a skip."""
+        run = _non_streaming_run(tmp_path)
+        # is_default=False with a config that the custom-plot path cannot build
+        # raises a non-(DataUnavailableError/KeyError) error.
+        with caplog.at_level("DEBUG"):
+            fig = _generate_singlerun_figure(
+                "broken", {"is_default": False}, run, [], PlotTheme.DARK
+            )
+
+        assert fig is not None  # error placeholder figure, not None
+        assert [r for r in caplog.records if r.levelname == "ERROR"]

--- a/tests/unit/plot/test_png_exporter.py
+++ b/tests/unit/plot/test_png_exporter.py
@@ -962,6 +962,74 @@ class TestSingleRunPNGExporter:
         assert "gpu_telemetry" in skip_warnings[0].message
         assert "gpu_utilization_and_throughput" in skip_warnings[0].message
 
+    def test_export_skips_missing_column_without_error(
+        self, single_run_exporter, sample_available_metrics, tmp_path, caplog
+    ):
+        """Non-streaming data: the requests table exists but lacks streaming-only
+        columns (e.g. time_to_first_token). The plot needing the missing column is
+        skipped with a WARNING (not ERROR), and plots whose columns are present
+        still render."""
+        ttft_spec = PlotSpec(
+            name="ttft_over_time",
+            plot_type=PlotType.SCATTER,
+            metrics=[
+                MetricSpec(name="request_number", source=DataSource.REQUESTS, axis="x"),
+                MetricSpec(
+                    name="time_to_first_token", source=DataSource.REQUESTS, axis="y"
+                ),
+            ],
+            title="TTFT",
+            filename="ttft_over_time.png",
+        )
+        latency_spec = PlotSpec(
+            name="latency_over_time",
+            plot_type=PlotType.SCATTER,
+            metrics=[
+                MetricSpec(name="request_number", source=DataSource.REQUESTS, axis="x"),
+                MetricSpec(
+                    name="request_latency", source=DataSource.REQUESTS, axis="y"
+                ),
+            ],
+            title="Latency",
+            filename="latency_over_time.png",
+        )
+        # Non-streaming requests: request_latency present, time_to_first_token absent.
+        run = RunData(
+            metadata=RunMetadata(
+                run_name="r", run_path=tmp_path / "r", model="m", concurrency=1
+            ),
+            requests=pd.DataFrame(
+                {
+                    "request_end_ns": pd.to_datetime(
+                        [1_000_000_000_000 + i * 500_000_000 for i in range(5)],
+                        unit="ns",
+                        utc=True,
+                    ),
+                    "request_latency": [900.0 + i * 10 for i in range(5)],
+                }
+            ),
+            aggregated={},
+            timeslices=None,
+        )
+
+        with caplog.at_level("DEBUG"):
+            generated = single_run_exporter.export(
+                run, sample_available_metrics, [ttft_spec, latency_spec]
+            )
+
+        filenames = {f.name for f in generated}
+        assert "latency_over_time.png" in filenames
+        assert "ttft_over_time.png" not in filenames
+        # The missing column is a skip (WARNING), never an ERROR.
+        assert not [r for r in caplog.records if r.levelname == "ERROR"]
+        assert [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING"
+            and "Skipping" in r.message
+            and "ttft_over_time" in r.message
+        ]
+
     def test_per_request_to_dataframe(self, sample_single_run_data):
         """Test conversion of per-request data to DataFrame."""
         df = prepare_request_timeseries(sample_single_run_data)


### PR DESCRIPTION
## Summary
- Cherry-pick of 6b9aa55f from `main` into `release/0.10.0`
- Original PR: #1027 — fix: skip plots with unavailable data instead of erroring in dashboard and PNG export

## Conflicts
None — clean cherry-pick.