### PR TITLE
docs: Cherry-pick Fern release documentation build.

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -80,6 +80,11 @@ on:
         description: 'Version tag to release (e.g., v0.9.0). Leave empty to sync dev docs.'
         required: false
         type: string
+      force_rebuild:
+        description: 'Overwrite an already-released version snapshot (manual dispatch only). Use with care: it replaces pages-$TAG and versions/$TAG.yml, reverting any out-of-band manual corrections.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -543,62 +548,84 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Processing version: $VERSION (tag: $TAG)"
 
+      - name: Checkout source at tag
+        uses: actions/checkout@v6
+        with:
+          # Explicit tag ref so workflow_dispatch (which runs on a branch)
+          # resolves the tag rather than the dispatch ref. Provides the tagged
+          # commit's docs/ (incl. docs/index.yml) and fern/md_to_mdx.py.
+          ref: ${{ steps.version.outputs.tag }}
+          path: source-checkout
+          fetch-depth: 1
+
       - name: Checkout docs-website branch
         uses: actions/checkout@v6
         with:
           ref: docs-website
+          path: docs-checkout
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if version already exists
+        env:
+          # Empty on tag-push events; "true"/"false" only on workflow_dispatch.
+          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
 
-          if [ -d "fern/pages-$TAG" ]; then
-            echo "::error::Version $TAG already exists (fern/pages-$TAG directory found)"
-            exit 1
+          if [ -d "docs-checkout/fern/pages-$TAG" ] || [ -f "docs-checkout/fern/versions/$TAG.yml" ]; then
+            if [ "$FORCE_REBUILD" = "true" ]; then
+              echo "::warning::Version $TAG already exists; force_rebuild=true, overwriting its snapshot (any out-of-band manual corrections will be replaced)."
+            else
+              echo "::error::Version $TAG already exists. Re-run via workflow_dispatch with force_rebuild=true to overwrite it intentionally."
+              exit 1
+            fi
+          else
+            echo "Version $TAG does not exist yet, proceeding with release"
           fi
-
-          if [ -f "fern/versions/$TAG.yml" ]; then
-            echo "::error::Version $TAG already exists (fern/versions/$TAG.yml found)"
-            exit 1
-          fi
-
-          echo "Version $TAG does not exist yet, proceeding with release"
 
       - name: Setup Git
+        working-directory: docs-checkout
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create versioned pages directory
+      - name: Build versioned pages from tagged commit
         run: |
           TAG="${{ steps.version.outputs.tag }}"
 
-          echo "Creating fern/pages-$TAG/ from fern/pages-dev/..."
+          echo "Building docs-checkout/fern/pages-$TAG/ from source @ $TAG docs/..."
 
-          # Copy current pages-dev/ to pages-vX.Y.Z/
-          cp -r fern/pages-dev "fern/pages-$TAG"
+          # Build the snapshot from the tag's raw docs/, not from pages-dev.
+          # pages-dev tracks main and would capture the wrong content under a
+          # version label (tags are cut from release/X.Y.Z branches that diverge
+          # from main). Because the source is raw markdown (not already-converted
+          # MDX), the later md_to_mdx.py pass converts exactly once.
+          rm -rf "docs-checkout/fern/pages-$TAG"
+          mkdir -p "docs-checkout/fern/pages-$TAG"
+          rsync -a --exclude='index.yml' \
+            source-checkout/docs/ "docs-checkout/fern/pages-$TAG/"
 
-          echo "Created fern/pages-$TAG/"
-          ls -la "fern/pages-$TAG/" | head -20
+          echo "Created docs-checkout/fern/pages-$TAG/"
+          ls -la "docs-checkout/fern/pages-$TAG/" | head -20
 
       - name: Update GitHub links to version tag
         run: |
           TAG="${{ steps.version.outputs.tag }}"
 
-          echo "Updating GitHub links from 'tree/main' to 'tree/$TAG' in fern/pages-$TAG/..."
+          echo "Pinning GitHub links from main to $TAG in docs-checkout/fern/pages-$TAG/..."
 
-          # Find all markdown files and replace tree/main with tree/vX.Y.Z
-          find "fern/pages-$TAG" -name "*.md" -o -name "*.mdx" | while read file; do
+          # Pin tree/main and blob/main links to this version's tag, on raw
+          # markdown before MDX conversion.
+          find "docs-checkout/fern/pages-$TAG" -name "*.md" -o -name "*.mdx" | while read file; do
             if grep -q "github.com/ai-dynamo/aiperf/tree/main" "$file"; then
-              echo "Updating: $file"
+              echo "Updating tree links: $file"
               sed -i "s|github.com/ai-dynamo/aiperf/tree/main|github.com/ai-dynamo/aiperf/tree/$TAG|g" "$file"
             fi
           done
 
           # Also update blob/main references (for direct file links)
-          find "fern/pages-$TAG" -name "*.md" -o -name "*.mdx" | while read file; do
+          find "docs-checkout/fern/pages-$TAG" -name "*.md" -o -name "*.mdx" | while read file; do
             if grep -q "github.com/ai-dynamo/aiperf/blob/main" "$file"; then
               echo "Updating blob links: $file"
               sed -i "s|github.com/ai-dynamo/aiperf/blob/main|github.com/ai-dynamo/aiperf/blob/$TAG|g" "$file"
@@ -611,23 +638,27 @@ jobs:
         run: |
           TAG="${{ steps.version.outputs.tag }}"
 
-          echo "Converting GitHub Markdown to Fern MDX format in pages-$TAG/..."
-          python3 fern/md_to_mdx.py --dir "fern/pages-$TAG"
+          echo "Converting Markdown to Fern MDX in pages-$TAG/ with the tag's md_to_mdx.py..."
+          # Use the tagged commit's converter for fidelity to that release's
+          # pipeline (source is raw markdown, so this converts exactly once).
+          python3 source-checkout/fern/md_to_mdx.py --dir "docs-checkout/fern/pages-$TAG"
           echo "Conversion complete."
 
       - name: Create version config file
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          VERSION="${{ steps.version.outputs.version }}"
-          VERSION_FILE="fern/versions/$TAG.yml"
+          VERSION_FILE="docs-checkout/fern/versions/$TAG.yml"
 
-          echo "Creating version config: $VERSION_FILE"
+          echo "Creating version config from the tag's index.yml: $VERSION_FILE"
 
-          # Copy dev.yml as template
-          cp fern/versions/dev.yml "$VERSION_FILE"
+          # Navigation must come from the tag's index.yml so it references the
+          # pages that actually exist in pages-$TAG.
+          cp source-checkout/docs/index.yml "$VERSION_FILE"
 
-          # Update all page paths from ../pages-dev/ to ../pages-vX.Y.Z/
-          sed -i "s|path: \.\./pages-dev/|path: ../pages-$TAG/|g" "$VERSION_FILE"
+          # Transform paths for the docs-website layout, pinned to this version
+          # (same transform validate-and-publish applies to dev.yml, with the
+          # ../pages-$TAG/ prefix instead of ../pages-dev/).
+          yq -i '(.. | select(has("path")).path) |= sub("^([a-zA-Z])", "../pages-'"$TAG"'/${1}")' "$VERSION_FILE"
 
           echo "Created $VERSION_FILE"
           echo "First 30 lines:"
@@ -636,7 +667,7 @@ jobs:
       - name: Update docs.yml with new version
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          DOCS_FILE="fern/docs.yml"
+          DOCS_FILE="docs-checkout/fern/docs.yml"
 
           echo "Updating $DOCS_FILE to include $TAG..."
 
@@ -670,7 +701,26 @@ jobs:
           echo "Updated docs.yml products/versions section:"
           yq '.products[0].versions' "$DOCS_FILE"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install Fern CLI
+        run: npm install -g fern-api@$(jq -r '.version' docs-checkout/fern/fern.config.json)
+
+      - name: Validate release snapshot (strict)
+        working-directory: docs-checkout
+        run: |
+          # Fail the release before commit/publish if the tag's converter
+          # produced output the site renderer rejects, or any link is broken.
+          # Validates the whole site (all versions); pre-existing broken
+          # snapshots must be clean (fixed manually) or the release is blocked.
+          fern check --warnings --strict-broken-links
+          fern docs broken-links
+
       - name: Commit and push changes
+        working-directory: docs-checkout
         run: |
           TAG="${{ steps.version.outputs.tag }}"
 
@@ -691,16 +741,8 @@ jobs:
 
           echo "Successfully released documentation for $TAG on docs-website branch"
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-
-      - name: Install Fern CLI
-        run: npm install -g fern-api@$(jq -r '.version' fern/fern.config.json)
-
       - name: Publish Docs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        working-directory: ./fern
+        working-directory: docs-checkout/fern
         run: fern generate --docs

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 		add-copyright generate-cli-docs generate-env-vars-docs generate-config-schema \
 		check-config-schema generate-plugin-enums generate-plugin-overloads \
 		check-plugin-overloads generate-plugin-schemas generate-all-plugin-files \
-		generate-all-docs test-stress stress-tests test-fern-docs fern-preview internal-help help \
+		generate-all-docs test-stress stress-tests test-fern-docs fern-preview fern-release-dryrun internal-help help \
 		check-ergonomics regenerate-ergonomics-baseline \
 		check-ruff-baselined regenerate-ruff-baseline \
 		check-agent-files-sync
@@ -323,6 +323,9 @@ fern-preview: #? local Fern docs preview (mirrors the CI md_to_mdx conversion in
 	@python3 fern/md_to_mdx.py --dir fern/.local-preview/docs
 	@printf "$(bold)$(green)Starting fern docs dev (Ctrl-C to stop)...$(reset)\n"
 	@cd fern/.local-preview && fern docs dev $(args)
+
+fern-release-dryrun: #? local dry-run of the Fern release-version job: build a versioned snapshot from a tag and run the strict guard (no publish). Usage: make fern-release-dryrun args="v0.9.0".
+	@./tools/fern_release_dryrun.sh $(args)
 
 generate-cli-docs: #? generate the CLI documentation.
 	$(activate_venv) && ./tools/generate_cli_docs.py

--- a/tools/fern_release_dryrun.sh
+++ b/tools/fern_release_dryrun.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Local dry-run of the `release-version` job in .github/workflows/fern-docs.yml.
+#
+# Reproduces the build + strict-validation half of the job against throwaway
+# git worktrees of the tag and the docs-website branch, then STOPS before the
+# commit/push/publish steps (those need FERN_TOKEN and a bot push and cannot run
+# locally). Use this to confirm a versioned snapshot rebuilt from a tag converts
+# cleanly and passes the strict link guard.
+#
+# Usage:
+#   tools/fern_release_dryrun.sh [TAG]        # default TAG: v0.9.0
+#   tools/fern_release_dryrun.sh v0.9.0
+#   KEEP=1 tools/fern_release_dryrun.sh v0.9.0  # keep worktrees for inspection
+#
+# Requires: git, fern, yq, jq, rsync, python3 (all but yq are usually present;
+# install yq with `brew install yq`).
+
+set -euo pipefail
+
+TAG="${1:-v0.9.0}"
+DOCS_WEBSITE_REF="${DOCS_WEBSITE_REF:-origin/docs-website}"
+
+# --- preconditions ----------------------------------------------------------
+
+if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "error: invalid tag '$TAG' (must be vX.Y.Z, e.g. v0.9.0)" >&2
+  exit 2
+fi
+
+for tool in git fern yq jq rsync python3; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    hint=""
+    [ "$tool" = "yq" ] && hint="  (install: brew install yq)"
+    echo "error: required tool '$tool' not found$hint" >&2
+    exit 2
+  fi
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  echo "error: tag '$TAG' not found locally. Try: git fetch --tags" >&2
+  exit 2
+fi
+
+echo "Fetching $DOCS_WEBSITE_REF ..."
+git fetch origin docs-website >/dev/null 2>&1 || \
+  echo "  warning: could not fetch docs-website; using the local ref if present"
+git rev-parse -q --verify "$DOCS_WEBSITE_REF" >/dev/null || {
+  echo "error: ref '$DOCS_WEBSITE_REF' not found" >&2
+  exit 2
+}
+
+# --- isolated worktrees (mirrors the job's two checkouts) -------------------
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/fern-release-dryrun.XXXXXX")"
+SOURCE_CHECKOUT="$WORK/source-checkout"
+DOCS_CHECKOUT="$WORK/docs-checkout"
+
+cleanup() {
+  if [ "${KEEP:-0}" = "1" ]; then
+    echo "KEEP=1 set; leaving worktrees at $WORK"
+    return
+  fi
+  git worktree remove --force "$SOURCE_CHECKOUT" 2>/dev/null || true
+  git worktree remove --force "$DOCS_CHECKOUT" 2>/dev/null || true
+  rm -rf "$WORK" 2>/dev/null || true
+  git worktree prune 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Creating worktrees under $WORK ..."
+git worktree add --detach "$SOURCE_CHECKOUT" "$TAG" >/dev/null
+git worktree add --detach "$DOCS_CHECKOUT" "$DOCS_WEBSITE_REF" >/dev/null
+
+# --- existing-version guard (informational only in a dry-run) ---------------
+
+if [ -d "$DOCS_CHECKOUT/fern/pages-$TAG" ] || [ -f "$DOCS_CHECKOUT/fern/versions/$TAG.yml" ]; then
+  echo "note: $TAG already exists on docs-website; the real job's existing-version"
+  echo "      guard would stop here unless dispatched with force_rebuild=true."
+  echo "      Rebuilding it anyway for dry-run validation."
+fi
+
+# --- build versioned pages from the tagged commit ---------------------------
+
+echo "Building fern/pages-$TAG/ from source @ $TAG docs/ ..."
+rm -rf "$DOCS_CHECKOUT/fern/pages-$TAG"
+mkdir -p "$DOCS_CHECKOUT/fern/pages-$TAG"
+rsync -a --exclude='index.yml' \
+  "$SOURCE_CHECKOUT/docs/" "$DOCS_CHECKOUT/fern/pages-$TAG/"
+
+# --- pin GitHub links main -> tag (raw markdown, before conversion) ---------
+
+echo "Pinning tree/main and blob/main links to $TAG ..."
+find "$DOCS_CHECKOUT/fern/pages-$TAG" -name "*.md" -o -name "*.mdx" | while read -r file; do
+  if grep -q "github.com/ai-dynamo/aiperf/tree/main" "$file"; then
+    sed -i.bak "s|github.com/ai-dynamo/aiperf/tree/main|github.com/ai-dynamo/aiperf/tree/$TAG|g" "$file"
+  fi
+done
+find "$DOCS_CHECKOUT/fern/pages-$TAG" -name "*.md" -o -name "*.mdx" | while read -r file; do
+  if grep -q "github.com/ai-dynamo/aiperf/blob/main" "$file"; then
+    sed -i.bak "s|github.com/ai-dynamo/aiperf/blob/main|github.com/ai-dynamo/aiperf/blob/$TAG|g" "$file"
+  fi
+done
+find "$DOCS_CHECKOUT/fern/pages-$TAG" -name "*.bak" -delete
+
+# --- convert with the tag's own md_to_mdx.py --------------------------------
+
+echo "Converting Markdown to Fern MDX with the tag's md_to_mdx.py ..."
+python3 "$SOURCE_CHECKOUT/fern/md_to_mdx.py" --dir "$DOCS_CHECKOUT/fern/pages-$TAG"
+
+# --- build versions/<tag>.yml from the tag's index.yml ----------------------
+
+echo "Building fern/versions/$TAG.yml from the tag's index.yml ..."
+VERSION_FILE="$DOCS_CHECKOUT/fern/versions/$TAG.yml"
+cp "$SOURCE_CHECKOUT/docs/index.yml" "$VERSION_FILE"
+yq -i '(.. | select(has("path")).path) |= sub("^([a-zA-Z])", "../pages-'"$TAG"'/${1}")' "$VERSION_FILE"
+
+# --- update docs.yml (skips if the version is already present) --------------
+
+DOCS_FILE="$DOCS_CHECKOUT/fern/docs.yml"
+if yq -e ".products[0].versions[] | select(.\"display-name\" == \"$TAG\")" "$DOCS_FILE" >/dev/null 2>&1; then
+  echo "docs.yml already lists $TAG; leaving version list unchanged."
+else
+  echo "Inserting $TAG into docs.yml ..."
+  DEV_IDX=$(yq '.products[0].versions | to_entries | map(select(.value."display-name" == "dev")) | .[0].key' "$DOCS_FILE")
+  INSERT_IDX=$((DEV_IDX + 1))
+  yq -i "
+    .products[0].versions |= (
+      .[:$INSERT_IDX] +
+      [{\"display-name\": \"$TAG\", \"path\": \"./versions/$TAG.yml\", \"slug\": \"$TAG\", \"availability\": \"stable\"}] +
+      .[$INSERT_IDX:]
+    )
+  " "$DOCS_FILE"
+  yq -i ".products[0].path = \"./versions/$TAG.yml\"" "$DOCS_FILE"
+  yq -i ".products[0].versions[0].path = \"./versions/$TAG.yml\"" "$DOCS_FILE"
+  yq -i ".products[0].versions[0].display-name = \"Latest ($TAG)\"" "$DOCS_FILE"
+  yq -i ".products[0].versions[0].slug = \"latest\"" "$DOCS_FILE"
+  yq -i ".products[0].versions[0].availability = \"stable\"" "$DOCS_FILE"
+fi
+
+# --- strict validation guard ------------------------------------------------
+
+WANT_FERN="$(jq -r '.version' "$DOCS_CHECKOUT/fern/fern.config.json")"
+HAVE_FERN="$(fern --version 2>/dev/null | tr -d '[:space:]')"
+if [ "$WANT_FERN" != "$HAVE_FERN" ]; then
+  echo "note: local fern is $HAVE_FERN but docs-website pins $WANT_FERN."
+  echo "      Pin locally with: npm install -g fern-api@$WANT_FERN"
+fi
+
+echo
+echo "Running strict validation guard in $DOCS_CHECKOUT ..."
+cd "$DOCS_CHECKOUT"
+fern check --warnings --strict-broken-links
+fern docs broken-links
+
+echo
+echo "DRY RUN OK: $TAG snapshot built and passed the strict guard."
+echo "Skipped (cannot run locally): git push origin docs-website; fern generate --docs."


### PR DESCRIPTION
Cherry-picks #1031 that fixes the release documentation publishing for Fern docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dry-run capability for documentation releases via the `fern-release-dryrun` make target.

* **Bug Fixes**
  * Improved error handling for malformed API responses—now gracefully degrades and returns null instead of raising exceptions.
  * Dashboard plots now skip gracefully when required data is unavailable instead of failing.

* **Tests**
  * Added comprehensive test coverage for error handling with malformed/missing data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->