### PR TITLE
docs: fix broken SGLang documentation links

### DIFF
--- a/docs/tutorials/image-generation.md
+++ b/docs/tutorials/image-generation.md
@@ -16,8 +16,8 @@ This guide shows how to benchmark image generation APIs using a Docker-based ser
 ## References
 For the most up-to-date information, please refer to the following resources:
 - [OpenAI Image Generation API](https://platform.openai.com/docs/api-reference/images/create)
-- [SGLang Image Generation Installation Guide](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/install.md)
-- [SGLang Image Generation CLI](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/cli.md)
+- [SGLang Diffusion Installation Guide](https://github.com/sgl-project/sglang/blob/main/docs/diffusion/installation.md)
+- [SGLang Diffusion CLI Reference](https://github.com/sgl-project/sglang/blob/main/docs/diffusion/api/cli.md)
 
 ## Setting up the server
 
@@ -53,7 +53,7 @@ pip install yunchang remote_pdb imageio diffusers diffusion
 > [!WARNING]
 > > The following arguments will setup the server to use the FLUX.1-dev model on a single GPU, on port 30000.
 > > You can modify these arguments to use a different model, different number of GPUs, different port, etc.
-> > See the [SGLang Image Generation CLI](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/cli.md) for more details.
+> > See the [SGLang Diffusion CLI Reference](https://github.com/sgl-project/sglang/blob/main/docs/diffusion/api/cli.md) for more details.
 ```bash
 SERVER_ARGS=(   --model-path black-forest-labs/FLUX.1-dev   --text-encoder-cpu-offload   --pin-cpu-memory   --num-gpus 1   --port 30000 --host 0.0.0.0 )
 ```

--- a/docs/tutorials/sglang-image-edit.md
+++ b/docs/tutorials/sglang-image-edit.md
@@ -50,7 +50,7 @@ docker run --gpus all \
 > [!WARNING]
 > These arguments set up FLUX.2-Klein-4B on a single GPU at port 30000.
 > Adjust the model path, GPU count, or port to match your environment.
-> The flags below come from upstream SGLang multimodal_gen and may change over time — treat the [SGLang Multimodal Gen CLI](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/cli.md) as the source of truth if any flag here is rejected.
+> The flags below come from upstream SGLang diffusion and may change over time — treat the [SGLang Diffusion CLI Reference](https://github.com/sgl-project/sglang/blob/main/docs/diffusion/api/cli.md) as the source of truth if any flag here is rejected.
 ```bash
 SERVER_ARGS=( --model-path black-forest-labs/FLUX.2-klein-4B --num-gpus 1 --port 30000 --host 0.0.0.0 --warmup --enable-torch-compile )
 ```

--- a/docs/tutorials/sglang-video-generation.md
+++ b/docs/tutorials/sglang-video-generation.md
@@ -20,9 +20,9 @@ AIPerf handles this polling workflow automatically.
 ## References
 
 For the most up-to-date information, please refer to the following resources:
-- [SGLang Video Generation API](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/openai_api.md)
-- [SGLang Diffusion Installation Guide](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/install.md)
-- [SGLang CLI Reference](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/docs/cli.md)
+- [SGLang Diffusion OpenAI API Reference](https://github.com/sgl-project/sglang/blob/main/docs/diffusion/api/openai_api.md)
+- [SGLang Diffusion Installation Guide](https://github.com/sgl-project/sglang/blob/main/docs/diffusion/installation.md)
+- [SGLang Diffusion CLI Reference](https://github.com/sgl-project/sglang/blob/main/docs/diffusion/api/cli.md)
 - [OpenAI Videos API](https://platform.openai.com/docs/api-reference/videos)
 
 ## Supported Models


### PR DESCRIPTION
## Summary
- Fix 6 broken external links to SGLang documentation
- The SGLang project reorganized their docs, moving `multimodal_gen` to `diffusion`

## Changes
| Old Path | New Path |
|----------|----------|
| `python/sglang/multimodal_gen/docs/cli.md` | `docs/diffusion/api/cli.md` |
| `python/sglang/multimodal_gen/docs/install.md` | `docs/diffusion/installation.md` |
| `python/sglang/multimodal_gen/docs/openai_api.md` | `docs/diffusion/api/openai_api.md` |

## Files Changed
- `docs/tutorials/image-generation.md` (3 links)
- `docs/tutorials/sglang-image-edit.md` (1 link)
- `docs/tutorials/sglang-video-generation.md` (3 links)

## Test plan
- [x] Verified all new URLs return HTTP 200

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial documentation reference links to point to SGLang Diffusion resources (CLI reference, installation guide, and API reference) instead of previous Image Generation and multimodal_gen CLI references.
  * Added clarification that diffusion-related flags in tutorials originate from upstream SGLang Diffusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->