### PR TITLE
fix: gate phase credit issuance on first-worker readiness (startup race)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -207,7 +207,7 @@ Service lifecycle and inter-service communication configuration. Controls timeou
 | `AIPERF_SERVICE_REGISTRATION_INTERVAL` | `1.0` | ≥ 1.0, ≤ 100000.0 | Interval in seconds between registration attempts for component services |
 | `AIPERF_SERVICE_REGISTRATION_MAX_ATTEMPTS` | `10` | ≥ 1, ≤ 100000 | Maximum number of registration attempts before giving up |
 | `AIPERF_SERVICE_REGISTRATION_TIMEOUT` | `30.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for service registration |
-| `AIPERF_SERVICE_START_TIMEOUT` | `30.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for service start operations |
+| `AIPERF_SERVICE_START_TIMEOUT` | `30.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for service start operations. Also bounds the per-phase wait for the first worker to register with the credit router before credit issuance begins; exceeding it fails the phase. |
 | `AIPERF_SERVICE_TASK_CANCEL_TIMEOUT_SHORT` | `2.0` | ≥ 1.0, ≤ 100000.0 | Maximum time in seconds to wait for simple tasks to complete when cancelling |
 | `AIPERF_SERVICE_EVENT_LOOP_HEALTH_ENABLED` | `True` | — | Enable event loop health monitoring to detect blocked event loops. When enabled, TimingManager and Worker services periodically check if the event loop is responsive and log warnings when latency exceeds the threshold. |
 | `AIPERF_SERVICE_EVENT_LOOP_HEALTH_INTERVAL` | `0.25` | ≥ 0.05, ≤ 10.0 | Interval in seconds between event loop health checks (default: 250ms). The monitor sleeps for this duration and measures actual elapsed time to detect blocking. |

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -847,7 +847,7 @@ class _ServiceSettings(BaseSettings):
         ge=1.0,
         le=100000.0,
         default=30.0,
-        description="Timeout in seconds for service start operations",
+        description="Timeout in seconds for service start operations. Also bounds the per-phase wait for the first worker to register with the credit router before credit issuance begins; exceeding it fails the phase.",
     )
     TASK_CANCEL_TIMEOUT_SHORT: float = Field(
         ge=1.0,

--- a/src/aiperf/credit/sticky_router.py
+++ b/src/aiperf/credit/sticky_router.py
@@ -15,6 +15,7 @@ Includes:
 - StickyCreditRouter: Main router class
 """
 
+import asyncio
 import time
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
@@ -94,6 +95,17 @@ class CreditRouterProtocol(Protocol):
 
         Args:
             credit: Credit to send to worker
+        """
+        ...
+
+    async def wait_for_workers(self, timeout: float) -> None:
+        """Wait for the router to observe at least one registered worker.
+
+        Best-effort startup gate, not an absolute guarantee: a worker can
+        unregister again after this returns. Raises on timeout.
+
+        Args:
+            timeout: Seconds to wait for the first worker before giving up.
         """
         ...
 
@@ -242,6 +254,10 @@ class StickyCreditRouter(CommunicationMixin):
         # Keep track of the minimum load to avoid recalculating it on every credit sent O(1) vs O(n)
         self._min_load: int = 0
 
+        # Set while >=1 worker is registered; lets wait_for_workers() gate a
+        # phase on worker readiness (see that method for the race it closes).
+        self._worker_available_event: asyncio.Event = asyncio.Event()
+
     # =============================================================================
     # Public Methods
     # =============================================================================
@@ -257,6 +273,31 @@ class StickyCreditRouter(CommunicationMixin):
     ) -> None:
         """Set callback for first token events (enables prefill concurrency release)."""
         self._on_first_token_callback = callback
+
+    async def wait_for_workers(self, timeout: float) -> None:
+        """Close the startup race where a phase issues its first credit before
+        any worker has sent ``WorkerReady`` (which makes ``send_credit`` raise
+        on empty workers). Called once per phase before the first credit.
+
+        Best-effort startup gate, not an absolute postcondition: the last worker
+        can unregister between this returning and the first ``send_credit``, so
+        callers must not treat a non-empty pool as guaranteed afterwards.
+
+        Args:
+            timeout: Seconds to wait for the first worker before giving up.
+
+        Raises:
+            RuntimeError: If no worker registers within ``timeout`` seconds.
+        """
+        if self._workers:
+            return
+        try:
+            await asyncio.wait_for(self._worker_available_event.wait(), timeout)
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError(
+                f"No workers registered with the credit router within {timeout}s "
+                "(tunable via AIPERF_SERVICE_START_TIMEOUT); cannot start credit issuance"
+            ) from exc
 
     async def send_credit(self, credit: Credit) -> None:
         """Determine the worker based on sticky sessions or least-loaded and send the credit to the worker.
@@ -433,6 +474,7 @@ class StickyCreditRouter(CommunicationMixin):
             # so we can cheat and just set minimum load to 0 without recalculating.
             self._min_load = 0
             self._workers_by_load[0].add(worker_id)
+            self._worker_available_event.set()
 
     def _unregister_worker(self, worker_id: str) -> None:
         """Unregister worker. Sticky sessions are cleared and reassigned on next access."""
@@ -446,6 +488,8 @@ class StickyCreditRouter(CommunicationMixin):
                     f"Worker unregistered: {worker_id} (remaining={len(self._workers)})"
                 )
             self._workers_by_load[worker_load.in_flight_credits].discard(worker_id)
+            if not self._workers:
+                self._worker_available_event.clear()
 
             # Remove all orphaned sticky sessions now and warn once up front
             orphaned_session_ids = worker_load.active_session_ids

--- a/src/aiperf/timing/phase/runner.py
+++ b/src/aiperf/timing/phase/runner.py
@@ -362,6 +362,13 @@ class PhaseRunner(TaskManagerMixin):
 
         await strategy.setup_phase()
 
+        # Gate credit issuance on worker readiness: on fast startup the first
+        # credit can otherwise be issued before any worker registers, which
+        # deadlocks the phase (see StickyCreditRouter.wait_for_workers).
+        await self._credit_router.wait_for_workers(
+            timeout=Environment.SERVICE.START_TIMEOUT
+        )
+
         self._create_rampers(strategy)
 
         self._lifecycle.start()

--- a/tests/unit/credit/test_sticky_router.py
+++ b/tests/unit/credit/test_sticky_router.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -856,3 +857,54 @@ class TestStickyCreditRouterStickySessionReassignment:
 
         # New sticky session should be created
         assert router._sticky_sessions["session-X"] == "worker-2"
+
+
+class TestStickyCreditRouterWorkerReadiness:
+    """Tests for the worker-readiness barrier that prevents the startup race
+    where the first credit is issued before any worker has registered."""
+
+    async def test_wait_for_workers_returns_when_worker_already_present(
+        self, benchmark_run
+    ) -> None:
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._register_worker("worker-1")
+
+        # Worker already present -> the fast-path returns synchronously. timeout=0
+        # also guards the fast-path itself: without it, asyncio.wait_for(..., 0)
+        # would raise even though the event is set.
+        await router.wait_for_workers(timeout=0)
+
+    async def test_wait_for_workers_blocks_until_first_worker_registers(
+        self, benchmark_run
+    ) -> None:
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+
+        wait_task = asyncio.create_task(router.wait_for_workers(timeout=5.0))
+        await asyncio.sleep(0)
+        assert not wait_task.done(), "wait_for_workers must block when no workers"
+
+        router._register_worker("worker-1")
+        await wait_task
+
+    async def test_wait_for_workers_raises_when_no_worker_before_timeout(
+        self, benchmark_run
+    ) -> None:
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+
+        with pytest.raises(RuntimeError, match="No workers registered"):
+            await router.wait_for_workers(timeout=0)
+
+    async def test_wait_for_workers_blocks_again_after_last_worker_leaves(
+        self, benchmark_run
+    ) -> None:
+        router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        router._register_worker("worker-1")
+        await router.wait_for_workers(timeout=5.0)
+
+        router._unregister_worker("worker-1")
+        wait_task = asyncio.create_task(router.wait_for_workers(timeout=5.0))
+        await asyncio.sleep(0)
+        assert not wait_task.done(), "barrier must re-arm after last worker leaves"
+
+        router._register_worker("worker-2")
+        await wait_task

--- a/tests/unit/timing/conftest.py
+++ b/tests/unit/timing/conftest.py
@@ -61,6 +61,9 @@ class MockCreditRouter:
             self._pending.append(asyncio.create_task(self._do_return(credit)))
             await yield_to_event_loop()
 
+    async def wait_for_workers(self, timeout: float) -> None:
+        pass
+
     async def _do_return(self, credit: Credit) -> None:
         await asyncio.sleep(0.001)
         if self._return_cb:

--- a/tests/unit/timing/phase/test_runner.py
+++ b/tests/unit/timing/phase/test_runner.py
@@ -7,12 +7,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aiperf.common.enums import CreditPhase
+from aiperf.common.environment import Environment
 from aiperf.common.models import (
     ConversationMetadata,
     CreditPhaseStats,
     DatasetMetadata,
     TurnMetadata,
 )
+from aiperf.credit.sticky_router import StickyCreditRouter
 from aiperf.credit.structs import Credit
 from aiperf.plugin.enums import ArrivalPattern, DatasetSamplingStrategy, TimingMode
 from aiperf.timing.config import CreditPhaseConfig
@@ -157,6 +159,7 @@ def pub() -> MagicMock:
 def router() -> MagicMock:
     m = MagicMock()
     m.send_credit = m.cancel_all_credits = AsyncMock()
+    m.wait_for_workers = AsyncMock()
     m.mark_credits_complete = MagicMock()
     return m
 
@@ -758,3 +761,72 @@ class TestFixedScheduleConfigCorrection:
         # Config should reflect the filtered dataset, not the original
         assert r._config.total_expected_requests == 2
         assert r._config.expected_num_sessions == 2
+
+
+class TestPhaseRunnerWorkerReadiness:
+    """The phase must gate credit issuance on worker readiness. Regression
+    coverage for the startup-race deadlock (see PhaseRunner._run_strategy)."""
+
+    async def test_run_strategy_awaits_wait_for_workers_with_start_timeout(
+        self,
+        conv_src: MagicMock,
+        pub: MagicMock,
+        router: MagicMock,
+        conc: MagicMock,
+        cancel: MagicMock,
+        cb: MagicMock,
+    ) -> None:
+        # Pins the barrier's timeout to START_TIMEOUT. Gating is proven by the
+        # real-router test below; the mock barrier here never blocks.
+        r = make_runner(cfg(), conv_src, pub, router, conc, cancel, cb)
+        r._progress.all_credits_sent_event.set()
+        r._progress.all_credits_returned_event.set()
+
+        await r._run_strategy(MockStrategy(), is_final_phase=True)
+
+        router.wait_for_workers.assert_awaited_once_with(
+            timeout=Environment.SERVICE.START_TIMEOUT
+        )
+
+    async def test_run_strategy_blocks_execution_until_worker_registers(
+        self,
+        benchmark_run,
+        conv_src: MagicMock,
+        pub: MagicMock,
+        conc: MagicMock,
+        cancel: MagicMock,
+        cb: MagicMock,
+    ) -> None:
+        # Regression guard for the startup-race deadlock. Uses the REAL
+        # StickyCreditRouter barrier (not a mock), so it actually gates
+        # execution: with no workers, _run_strategy must block before running
+        # execute_phase. A barrier placed after execute_async (the original
+        # bug) would let execute_phase run here and fail the first assert.
+        real_router = StickyCreditRouter(run=benchmark_run, service_id="test-router")
+        r = make_runner(cfg(), conv_src, pub, real_router, conc, cancel, cb)
+
+        class GatedStrategy(MockStrategy):
+            async def execute_phase(self) -> None:
+                self.execute_called = True
+                r._progress.all_credits_sent_event.set()
+                r._progress.all_credits_returned_event.set()
+
+        strategy = GatedStrategy()
+        run_task = asyncio.create_task(r._run_strategy(strategy, is_final_phase=True))
+
+        # Advance to the barrier. With no worker registered the phase must block
+        # there, before kicking off the issuance task. ``_execution_task`` stays
+        # None iff the barrier precedes issuance; if it has been created here the
+        # barrier was placed after ``execute_async`` (the original deadlock).
+        await asyncio.sleep(0.1)
+        assert r._execution_task is None, (
+            "issuance task was created before the worker-readiness barrier "
+            "released: the barrier is not gating execution (startup-race "
+            "regression)"
+        )
+        assert not run_task.done()
+
+        # First worker registers -> barrier releases -> phase runs to completion.
+        real_router._register_worker("worker-1")
+        await asyncio.wait_for(run_task, timeout=5.0)
+        assert strategy.execute_called


### PR DESCRIPTION
With a fast tokenizer (tiktoken o200k_base / cl100k_base / builtin), a
profiling run could hang right after "Phase profiling started"; slow
HuggingFace tokenizers masked the race. PhaseRunner issued the first
credit before any worker had registered, so send_credit() raised "No
workers available for routing" inside the fire-and-forget
execute_async(strategy.execute_phase()) task. That exception is never
retrieved, so it was swallowed: all_credits_sent_event never got set and
_wait_for_sending_complete() awaited forever.

Add a per-phase barrier. StickyCreditRouter.wait_for_workers(timeout) is
backed by an asyncio.Event set on the first worker registration and
cleared when the last one leaves; PhaseRunner awaits it after
setup_phase, before issuing credits. On timeout (START_TIMEOUT) it
raises a clear RuntimeError via the phase-failure path. send_credit
stays fail-fast for the real no-workers-mid-run case.

This closes the startup case only, where no worker has registered yet.
It is best-effort: a worker can still leave before the first
send_credit, and a later issuance-task exception is still swallowed.
Making execute_async observe that exception is a separate follow-up.

Signed-off-by: Aaron Batilo <abatilo@coreweave.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase startup now waits for worker registration before beginning credit issuance to avoid startup deadlocks.

* **Documentation**
  * Clarified timeout description to note it bounds the per-phase wait for the first worker to register before credit issuance; behavior and defaults unchanged.

* **Tests**
  * Added tests covering worker-readiness gating and phase execution blocking/unblocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->