### PR TITLE
chore: add CODEOWNERS to require team approval for merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# CODEOWNERS for ai-dynamo/aiperf
+#
+# Defines the repository's code owners. With the "Require review from Code
+# Owners" branch-protection rule on `main`, a PR can only merge after one of
+# these owners approves — so a named team member (not an automated reviewer
+# such as the dynamo-ops bot) must sign off before merge. Owners are also
+# auto-requested for review on PRs touching a matching path.
+#
+# Each line is a file pattern followed by one or more owners (GitHub @usernames);
+# the LAST matching pattern takes precedence.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owners for everything in the repository — the core NVIDIA AIPerf team.
+*   @ajcasagrande @debermudez @matthewkotila @ilana-n @lkomali @ganeshku1 @FrankD412


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` (none existed before) defining the core NVIDIA AIPerf team as the repository's code owners.

The goal is **merge-gating, not review-requesting**: with the "Require review from Code Owners" branch-protection rule on `main`, a PR can only merge once one of these team members approves. That prevents an automated reviewer (e.g. the `dynamo-ops` bot) from being the sole approval that unblocks a merge — a human owner must sign off.

Code owners for `*`:

| Handle | Name |
|---|---|
| @ajcasagrande | Anthony |
| @debermudez | Elias |
| @matthewkotila | Matthew |
| @ilana-n | Ilana |
| @lkomali | Harshini |
| @ganeshku1 | Ganesh |
| @FrankD412 | Frank |

## Notes

- CODEOWNERS is necessary but not sufficient on its own — the **"Require review from Code Owners"** branch-protection rule on `main` must be enabled for the merge-gating effect.
- The file carries the standard SPDX header so the `add-license` pre-commit hook passes.
- CODEOWNERS resolves by *last matching pattern*, so more specific per-directory ownership rules can be layered on top of this global default later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for development workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->