### PR TITLE
feat(accuracy): add GSM8K benchmark loader and grader

### DIFF
--- a/docs/accuracy/accuracy-benchmarking.md
+++ b/docs/accuracy/accuracy-benchmarking.md
@@ -79,6 +79,7 @@ system message).
 | `math_500` | `lighteval_latex` | 0 | `HuggingFaceH4/MATH-500` (trt-llm/lighteval reference, gold is full solution containing `\boxed{answer}`, `latex_gold_metric`) |
 | `gpqa_diamond` | `lighteval_gpqa` | 0 | `Idavidrein/gpqa` subset `gpqa_diamond` (trt-llm/lighteval reference, simple-evals template with SHA-256-seeded deterministic A/B/C/D shuffling, `gpqa_metric`) |
 | `lcb_codegeneration` | `code_execution` | 0 | `livecodebench/code_generation_lite` (trt-llm/lighteval reference; LCB test-case payload serialized into `BenchmarkProblem.ground_truth` as an orjson blob; `code_execution` grader runs the generated code against the bundled test cases via lighteval's `codegen_metrics`) |
+| `gsm8k` | `lighteval_gsm8k` | 0 | `gsm8k` subset `main` (trt-llm/lighteval reference, `gsm8k_leaderboard` config; prompt `"Question: {question}\nAnswer:"`, gold is the raw answer ending in `#### <number>`, `quasi_exact_match_gsm8k`) |
 
 ### LiveCodeBench (lcb_codegeneration) version pinning
 

--- a/docs/accuracy/accuracy_stubs.md
+++ b/docs/accuracy/accuracy_stubs.md
@@ -7,7 +7,7 @@
 
 This document catalogs every stubbed method in the accuracy benchmarking scaffolding. The scaffolding is fully integrated into the plugin system, CLI, and config pipeline — the performance benchmarking path is unaffected.
 
-**Status summary:** All accuracy scaffolding is now implemented end-to-end. The seven graders (`MultipleChoiceGrader`, `MathGrader`, `CodeExecutionGrader`, `LightevalExprGrader`, `LightevalLatexGrader`, `LightevalGPQAGrader`, `ExactMatchGrader`) and nine benchmark loaders (`MMLUBenchmark`, `AIMEBenchmark`, `HellaSwagBenchmark`, `BigBenchBenchmark`, `AIME24Benchmark`, `AIME25Benchmark`, `Math500Benchmark`, `GPQADiamondBenchmark`, `LCBCodeGenerationBenchmark`) are all wired into the plugin system, CLI, config pipeline, and processor/exporter chain. There are no remaining stubs.
+**Status summary:** All accuracy scaffolding is now implemented end-to-end. The eight graders (`MultipleChoiceGrader`, `MathGrader`, `CodeExecutionGrader`, `LightevalExprGrader`, `LightevalLatexGrader`, `LightevalGPQAGrader`, `LightevalGSM8KGrader`, `ExactMatchGrader`) and ten benchmark loaders (`MMLUBenchmark`, `AIMEBenchmark`, `HellaSwagBenchmark`, `BigBenchBenchmark`, `AIME24Benchmark`, `AIME25Benchmark`, `Math500Benchmark`, `GPQADiamondBenchmark`, `LCBCodeGenerationBenchmark`, `GSM8KBenchmark`) are all wired into the plugin system, CLI, config pipeline, and processor/exporter chain. There are no remaining stubs.
 
 ## Table of Contents
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -1304,7 +1304,7 @@ Number of log-spaced steps for the decode-itl-curve recipe's OSL grid (default 4
 #### `--accuracy-benchmark` `<str>`
 
 Accuracy benchmark to run (e.g., mmlu, aime, hellaswag). When set, enables accuracy benchmarking mode alongside performance profiling.
-<br/>_Choices: [`mmlu`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gpqa_diamond`, `lcb_codegeneration`]_
+<br/>_Choices: [`mmlu`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
 
 #### `--accuracy-tasks` `<list>`
 
@@ -1323,7 +1323,7 @@ Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instru
 #### `--accuracy-grader` `<str>`
 
 Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
-<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`]_
+<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`]_
 
 #### `--accuracy-system-prompt` `<str>`
 
@@ -2629,7 +2629,7 @@ Number of log-spaced steps for the decode-itl-curve recipe's OSL grid (default 4
 #### `--accuracy-benchmark` `<str>`
 
 Accuracy benchmark to run (e.g., mmlu, aime, hellaswag). When set, enables accuracy benchmarking mode alongside performance profiling.
-<br/>_Choices: [`mmlu`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gpqa_diamond`, `lcb_codegeneration`]_
+<br/>_Choices: [`mmlu`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
 
 #### `--accuracy-tasks` `<list>`
 
@@ -2648,7 +2648,7 @@ Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instru
 #### `--accuracy-grader` `<str>`
 
 Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
-<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`]_
+<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`]_
 
 #### `--accuracy-system-prompt` `<str>`
 

--- a/src/aiperf/accuracy/benchmarks/gsm8k.py
+++ b/src/aiperf/accuracy/benchmarks/gsm8k.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GSM8K benchmark loader, aligned with the lighteval reference.
+
+Mirrors lighteval's ``gsm8k_leaderboard`` task config
+(``trt-llm-benchmark-recipe/lighteval/src/lighteval/tasks/default_tasks.py``):
+
+    gsm8k_leaderboard = LightevalTaskConfig(
+        name="gsm8k",
+        prompt_function=prompt.gsm8k,      # "Question: {question}\\nAnswer:"
+        hf_repo="gsm8k",
+        hf_subset="main",
+        evaluation_splits=["test"],
+        few_shots_split=None,
+        generation_size=256,
+        metric=[Metrics.quasi_exact_match_gsm8k],
+        stop_sequence=["Question=", "Question", "="],
+        trust_dataset=True,
+    )
+
+lighteval's ``prompt.gsm8k`` (``default_prompts.py``) produces::
+
+    Doc(query=f"Question: {line['question']}\\nAnswer:",
+        choices=[f" {line['answer']}"],
+        gold_index=0)
+
+We emit the same prompt and store the raw ``answer`` field (which ends
+with ``#### <number>``) as ``ground_truth``. ``LightevalGSM8KGrader``
+runs ``gsm8k_normalizer`` over the gold at grade time to pull the
+number after ``####`` — matching the recipe's
+``quasi_exact_match_gsm8k`` ``normalize_gold``.
+
+Unlike ``Math500Benchmark`` (subject-per-row task), GSM8K has a single
+task name; there are no subtasks to break down by.
+
+Reference:
+    trt-llm-benchmark-recipe/lighteval/src/lighteval/tasks/default_tasks.py
+        gsm8k_leaderboard task config.
+    trt-llm-benchmark-recipe/lighteval/src/lighteval/tasks/default_prompts.py
+        gsm8k prompt function.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from datasets import Dataset, load_dataset
+
+from aiperf.accuracy.models import AccuracyChatMessage, BenchmarkProblem
+from aiperf.common.mixins import AIPerfLoggerMixin
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
+
+DATASET_NAME = "gsm8k"
+DATASET_CONFIG = "main"
+TASK_NAME = "gsm8k"
+
+# lighteval's gsm8k_leaderboard task config: ``generation_size=256``.
+DEFAULT_GENERATION_SIZE = 256
+
+# Schema field names in the ``gsm8k`` (``main``) dataset.
+QUESTION_FIELD = "question"
+ANSWER_FIELD = "answer"
+
+
+class GSM8KBenchmark(AIPerfLoggerMixin):
+    """GSM8K lighteval-aligned benchmark loader.
+
+    Loads ``gsm8k`` (``main`` subset, test split) and emits one user
+    message per problem formatted as ``"Question: {question}\\nAnswer:"``
+    — matching lighteval's ``prompt.gsm8k``. Gold is the raw ``answer``
+    field (which ends in ``#### <number>``); ``LightevalGSM8KGrader``
+    extracts the number via ``gsm8k_normalizer`` at grade time.
+    """
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.run = run
+
+    async def load_problems(
+        self, tasks: list[str] | None, n_shots: int, enable_cot: bool
+    ) -> list[BenchmarkProblem]:
+        """Load GSM8K problems lighteval-style.
+
+        Args:
+            tasks: Ignored — GSM8K has no subtasks.
+            n_shots: Ignored — the lighteval reference is zero-shot
+                (``few_shots_split=None``).
+            enable_cot: Ignored — lighteval's ``prompt.gsm8k`` does not
+                add a CoT trigger; the model decides whether to reason
+                based on the system prompt the user supplies via
+                ``--accuracy-system-prompt``.
+
+        Returns:
+            One ``BenchmarkProblem`` per dataset row, in dataset order.
+        """
+        ds: Dataset = await asyncio.to_thread(
+            load_dataset, DATASET_NAME, DATASET_CONFIG, split="test"
+        )
+        return await asyncio.to_thread(self._build_problems, ds)
+
+    def _build_problems(self, ds: Dataset) -> list[BenchmarkProblem]:
+        problems: list[BenchmarkProblem] = []
+        for row in ds:
+            question = row[QUESTION_FIELD]
+            prompt = f"Question: {question}\nAnswer:"
+            messages: list[AccuracyChatMessage] = [{"role": "user", "content": prompt}]
+            problems.append(
+                BenchmarkProblem(
+                    prompt=prompt,
+                    # Gold is the raw answer ending in ``#### <number>``;
+                    # LightevalGSM8KGrader's gsm8k_normalizer extracts it.
+                    ground_truth=str(row[ANSWER_FIELD]),
+                    task=TASK_NAME,
+                    metadata={"generation_size": DEFAULT_GENERATION_SIZE},
+                    raw_messages=messages,
+                )
+            )
+        return problems

--- a/src/aiperf/accuracy/graders/gsm8k_grader.py
+++ b/src/aiperf/accuracy/graders/gsm8k_grader.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GSM8K grader implementing lighteval's ``quasi_exact_match_gsm8k``.
+
+The recipe grades GSM8K with lighteval's ``quasi_exact_match_gsm8k``
+(``trt-llm-benchmark-recipe/lighteval/src/lighteval/metrics/metrics.py``):
+
+    quasi_exact_match_gsm8k = SampleLevelMetric(
+        sample_level_fn=ExactMatches(
+            strip_strings=True,
+            normalize_pred=gsm8k_normalizer,
+            normalize_gold=gsm8k_normalizer,
+        ).compute,
+        ...
+    )
+
+``ExactMatches`` with ``type_exact_match="full"`` reduces to::
+
+    1 if gsm8k_normalizer(gold.strip()) == gsm8k_normalizer(pred.strip()) else 0
+
+and ``gsm8k_normalizer`` pulls the number after ``####`` (comma-
+stripped), returning ``"[invalid]"`` when there is none.
+
+**Deliberate deviation for chat models.** Lighteval runs the *same*
+``gsm8k_normalizer`` over the prediction. That only works for a base
+model completing the few-shot ``#### <number>`` format; a chat model
+answering ``"... so the answer is 24."`` produces no ``####`` and would
+normalize to ``"[invalid]"`` — scoring essentially every chat response
+wrong. So this grader keeps lighteval's gold extraction exactly, but
+makes prediction extraction a superset: try ``gsm8k_normalizer`` first
+(byte-for-byte lighteval parity when the model *does* emit ``####``),
+and fall back to the last number in the response otherwise. Predictions
+that need that fallback are flagged ``unparsed=True`` (the model didn't
+follow the expected ``####`` format), mirroring ``MultipleChoiceGrader``
+— but a correct fallback answer is still scored correct, since
+``unparsed`` is a separate diagnostic counter from accuracy.
+
+We also compare numerically rather than by string equality so ``"24"``,
+``"24.0"`` and ``"24.00"`` all match — lighteval's string ``==`` would
+reject those, but a chat model emitting ``"24.0"`` is plainly correct.
+String equality is the final fallback when a side is non-numeric.
+
+This grader is pure-regex and has no ``lighteval`` import, so it runs
+without the ``[accuracy]`` extras.
+
+Reference:
+    trt-llm-benchmark-recipe/lighteval/src/lighteval/metrics/normalizations.py
+        gsm8k_normalizer.
+    trt-llm-benchmark-recipe/lighteval/src/lighteval/metrics/metrics_sample.py
+        ExactMatches.compute_one_item.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import TYPE_CHECKING, Any
+
+from aiperf.accuracy.graders.base import BaseGrader
+from aiperf.accuracy.models import GradingResult
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
+
+# lighteval's gsm8k_normalizer gold pattern: the number after "####".
+_GSM8K_ANS_RE = re.compile(r"#### (\-?[0-9\.\,]+)")
+_INVALID_ANS = "[invalid]"
+
+# Fallback prediction pattern: a number (optionally signed, optional
+# thousands commas, optional decimal part). Anchored on a leading digit
+# so it never matches a bare "." or ",".
+_NUMBER_RE = re.compile(r"-?[0-9][0-9,]*(?:\.[0-9]+)?")
+
+# Numbers within this absolute tolerance are treated as equal, so
+# "24" == "24.0" == "24.00".
+_NUMERIC_ABS_TOL = 1e-6
+
+
+def gsm8k_normalizer(text: str) -> str:
+    """Extract the number after ``####``, comma-stripped.
+
+    Byte-for-byte port of lighteval's ``gsm8k_normalizer``
+    (``normalizations.py``). Returns ``"[invalid]"`` when the text has
+    no ``#### <number>`` marker.
+    """
+    match = _GSM8K_ANS_RE.search(text)
+    if match:
+        return match.group(1).strip().replace(",", "")
+    return _INVALID_ANS
+
+
+def _extract_prediction(response_text: str) -> tuple[str, bool]:
+    """Extract the predicted answer number from a model response.
+
+    Superset of lighteval's prediction normalization: prefer the
+    ``#### <number>`` marker when present (exact lighteval parity), else
+    fall back to the last standalone number in the response.
+
+    Returns ``(answer, used_fallback)``. ``used_fallback`` is True when
+    the response lacked the ``####`` marker and we resorted to the
+    last-number heuristic — i.e. the model did not follow lighteval's
+    expected format. This drives ``GradingResult.unparsed`` the same way
+    ``MultipleChoiceGrader`` flags its regex fallback. ``answer`` is
+    ``"[invalid]"`` when no number can be found at all.
+    """
+    normalized = gsm8k_normalizer(response_text)
+    if normalized != _INVALID_ANS:
+        return normalized, False
+    matches = _NUMBER_RE.findall(response_text)
+    if matches:
+        return matches[-1].replace(",", ""), True
+    return _INVALID_ANS, True
+
+
+def _numbers_match(gold: str, pred: str) -> bool:
+    """Compare two normalized answer strings.
+
+    Numeric comparison with a small absolute tolerance when both parse
+    as floats (so ``"24"`` matches ``"24.0"``); exact string equality
+    otherwise (so non-numeric edge cases still grade deterministically).
+    """
+    try:
+        return math.isclose(
+            float(gold), float(pred), rel_tol=0.0, abs_tol=_NUMERIC_ABS_TOL
+        )
+    except ValueError:
+        return gold == pred
+
+
+class LightevalGSM8KGrader(BaseGrader):
+    """Lighteval ``quasi_exact_match_gsm8k`` grader for GSM8K.
+
+    Extracts the gold number with ``gsm8k_normalizer`` (the number after
+    ``####``) and the predicted number from the model response (``####``
+    marker if present, else the last number). Scores correct when the
+    two match numerically. See the module docstring for why this
+    deviates from lighteval's symmetric ``gsm8k_normalizer`` on the
+    prediction side.
+    """
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(run=run, **kwargs)
+
+    def extract_answer(self, response_text: str, **kwargs: Any) -> str:
+        """Return the predicted answer number, or ``"[invalid]"``."""
+        answer, _ = _extract_prediction(response_text or "")
+        return answer
+
+    async def grade(
+        self, response_text: str, ground_truth: str, **kwargs: Any
+    ) -> GradingResult:
+        gold = gsm8k_normalizer((ground_truth or "").strip())
+        pred, used_fallback = _extract_prediction((response_text or "").strip())
+        parseable = pred != _INVALID_ANS
+        # A correct-but-fallback (no ``####``) response is still correct;
+        # unparsed only flags that the expected format wasn't matched.
+        unparsed = used_fallback or not parseable
+        correct = parseable and gold != _INVALID_ANS and _numbers_match(gold, pred)
+        if not parseable:
+            note = " (no number in response)"
+        elif used_fallback:
+            note = " (no #### marker; used last-number fallback)"
+        else:
+            note = ""
+        return GradingResult(
+            correct=correct,
+            unparsed=unparsed,
+            confidence=1.0 if correct else 0.0,
+            reasoning=(
+                f"gsm8k quasi-exact-match: gold '{gold}' vs pred '{pred}'; "
+                f"match={correct}{note}"
+            ),
+            extracted_answer=pred,
+            ground_truth=gold,
+        )

--- a/src/aiperf/config/schema/aiperf-config.schema.json
+++ b/src/aiperf/config/schema/aiperf-config.schema.json
@@ -26,6 +26,7 @@
         "aime24",
         "aime25",
         "math_500",
+        "gsm8k",
         "gpqa_diamond",
         "lcb_codegeneration"
       ],
@@ -149,7 +150,8 @@
         "code_execution",
         "lighteval_expr",
         "lighteval_latex",
-        "lighteval_gpqa"
+        "lighteval_gpqa",
+        "lighteval_gsm8k"
       ],
       "title": "AccuracyGraderType",
       "type": "string"

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -91,11 +91,11 @@ ServerMetricsProcessorType = plugins.create_enum(PluginType.SERVER_METRICS_PROCE
 
 AccuracyGraderTypeStr: TypeAlias = str
 AccuracyGraderType = plugins.create_enum(PluginType.ACCURACY_GRADER, "AccuracyGraderType", module=__name__)
-"""Dynamic enum for accuracy grader. Example: AccuracyGraderType.CODE_EXECUTION, AccuracyGraderType.LIGHTEVAL_GPQA, AccuracyGraderType.MULTIPLE_CHOICE"""
+"""Dynamic enum for accuracy grader. Example: AccuracyGraderType.CODE_EXECUTION, AccuracyGraderType.LIGHTEVAL_GSM8K, AccuracyGraderType.MULTIPLE_CHOICE"""
 
 AccuracyBenchmarkTypeStr: TypeAlias = str
 AccuracyBenchmarkType = plugins.create_enum(PluginType.ACCURACY_BENCHMARK, "AccuracyBenchmarkType", module=__name__)
-"""Dynamic enum for accuracy benchmark. Example: AccuracyBenchmarkType.AIME, AccuracyBenchmarkType.GPQA_DIAMOND, AccuracyBenchmarkType.MMLU"""
+"""Dynamic enum for accuracy benchmark. Example: AccuracyBenchmarkType.AIME, AccuracyBenchmarkType.GSM8K, AccuracyBenchmarkType.MMLU"""
 
 DataExporterTypeStr: TypeAlias = str
 DataExporterType = plugins.create_enum(PluginType.DATA_EXPORTER, "DataExporterType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1425,6 +1425,15 @@ accuracy_grader:
       ``IndicesExtractionConfig(prefix_for_extraction="NativeLetters")``
       to find the chosen A/B/C/D letter in both gold and prediction.
 
+  lighteval_gsm8k:
+    class: aiperf.accuracy.graders.gsm8k_grader:LightevalGSM8KGrader
+    description: |
+      Lighteval ``quasi_exact_match_gsm8k`` grader — used by GSM8K. Extracts
+      the number after "####" from the gold answer using gsm8k_normalizer,
+      and extracts the last number from the model prediction (preferring a
+      "####" marker when present). Compares numerically so "24" and "24.0"
+      match. Pure-regex; no lighteval install required.
+
 # =============================================================================
 # Accuracy Benchmarks
 # =============================================================================
@@ -1512,6 +1521,19 @@ accuracy_benchmark:
       ``LightevalLatexGrader`` extracts the boxed expression at grade time.
     metadata:
       default_grader: lighteval_latex
+      default_n_shots: 0
+
+  gsm8k:
+    class: aiperf.accuracy.benchmarks.gsm8k:GSM8KBenchmark
+    description: |
+      GSM8K (Grade School Math 8K) benchmark. Grade-school math word
+      problems requiring multi-step reasoning. Aligned with lighteval's
+      ``gsm8k_leaderboard`` task config (gsm8k/main test split, prompt
+      ``"Question: {question}\nAnswer:"``, ``generation_size=256``).
+      Gold is the raw ``answer`` field ending in ``#### <number>``;
+      ``LightevalGSM8KGrader`` extracts the number at grade time.
+    metadata:
+      default_grader: lighteval_gsm8k
       default_n_shots: 0
 
   gpqa_diamond:

--- a/tests/unit/accuracy/test_gsm8k_benchmark.py
+++ b/tests/unit/accuracy/test_gsm8k_benchmark.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``GSM8KBenchmark``.
+
+lighteval's ``gsm8k_leaderboard`` uses ``prompt.gsm8k`` which produces
+``Doc(query="Question: {question}\\nAnswer:", choices=[" {answer}"],
+gold_index=0)``. Aiperf mirrors this: prompt is the
+``"Question: ...\\nAnswer:"`` template; ground_truth is the raw
+``answer`` field (which ends in ``#### <number>``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aiperf.accuracy.benchmarks.gsm8k import (
+    DEFAULT_GENERATION_SIZE,
+    TASK_NAME,
+    GSM8KBenchmark,
+)
+from aiperf.accuracy.models import BenchmarkProblem
+from aiperf.plugin.enums import AccuracyBenchmarkType, EndpointType
+from tests.unit.conftest import make_benchmark_run
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
+
+
+def _make_run() -> BenchmarkRun:
+    return make_benchmark_run(
+        model_names=["test-model"],
+        endpoint_type=EndpointType.COMPLETIONS,
+        streaming=False,
+        accuracy={"benchmark": AccuracyBenchmarkType.GSM8K},
+    )
+
+
+def _make_row(
+    question: str = "Natalia sold clips. How many?",
+    answer: str = "She sold 48/2 = <<48/2=24>>24 in May.\n#### 24",
+) -> dict[str, Any]:
+    return {"question": question, "answer": answer}
+
+
+def _make_fake_dataset(rows: list[dict[str, Any]]) -> MagicMock:
+    ds = MagicMock()
+    ds.__iter__ = MagicMock(side_effect=lambda: iter(rows))
+    ds.__len__ = MagicMock(return_value=len(rows))
+    ds.__getitem__ = MagicMock(side_effect=lambda i: rows[i])
+    return ds
+
+
+async def _load(rows: list[dict[str, Any]], **kwargs: Any) -> list[BenchmarkProblem]:
+    with patch(
+        "aiperf.accuracy.benchmarks.gsm8k.load_dataset",
+        return_value=_make_fake_dataset(rows),
+    ) as mock_load:
+        bench = GSM8KBenchmark(run=_make_run())
+        problems = await bench.load_problems(
+            tasks=kwargs.get("tasks"),
+            n_shots=kwargs.get("n_shots", 0),
+            enable_cot=kwargs.get("enable_cot", False),
+        )
+    return problems, mock_load
+
+
+class TestPromptFormat:
+    @pytest.mark.asyncio
+    async def test_prompt_uses_question_answer_template(self) -> None:
+        problems, _ = await _load([_make_row(question="What is 1+1?")])
+        assert problems[0].prompt == "Question: What is 1+1?\nAnswer:"
+
+    @pytest.mark.asyncio
+    async def test_chat_message_is_single_user_message(self) -> None:
+        problems, _ = await _load([_make_row()])
+        msgs = problems[0].raw_messages
+        assert msgs is not None
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == problems[0].prompt
+
+
+class TestGroundTruthIsRawAnswer:
+    @pytest.mark.asyncio
+    async def test_ground_truth_keeps_full_answer_with_marker(self) -> None:
+        answer = "Steps... <<48/2=24>>24.\n#### 24"
+        problems, _ = await _load([_make_row(answer=answer)])
+        # Gold is stored raw, NOT pre-extracted — the grader normalizes it.
+        assert problems[0].ground_truth == answer
+        assert "####" in problems[0].ground_truth
+
+
+class TestDatasetLoading:
+    @pytest.mark.asyncio
+    async def test_loads_main_subset_test_split(self) -> None:
+        _, mock_load = await _load([_make_row()])
+        mock_load.assert_called_once_with("gsm8k", "main", split="test")
+
+    @pytest.mark.asyncio
+    async def test_returns_one_problem_per_row(self) -> None:
+        rows = [_make_row(question=f"q{i}") for i in range(5)]
+        problems, _ = await _load(rows)
+        assert len(problems) == 5
+        assert all(isinstance(p, BenchmarkProblem) for p in problems)
+
+    @pytest.mark.asyncio
+    async def test_task_is_constant_gsm8k(self) -> None:
+        problems, _ = await _load([_make_row(), _make_row(question="q2")])
+        assert {p.task for p in problems} == {TASK_NAME}
+
+    @pytest.mark.asyncio
+    async def test_metadata_carries_generation_size(self) -> None:
+        problems, _ = await _load([_make_row()])
+        assert problems[0].metadata["generation_size"] == DEFAULT_GENERATION_SIZE
+        assert DEFAULT_GENERATION_SIZE == 256
+
+
+class TestNShotsAndCoTIgnored:
+    @pytest.mark.asyncio
+    async def test_n_shots_does_not_affect_prompt(self) -> None:
+        zero_shot, _ = await _load([_make_row()], n_shots=0)
+        eight_shot, _ = await _load([_make_row()], n_shots=8)
+        assert zero_shot[0].prompt == eight_shot[0].prompt
+
+    @pytest.mark.asyncio
+    async def test_enable_cot_does_not_affect_prompt(self) -> None:
+        no_cot, _ = await _load([_make_row()], enable_cot=False)
+        with_cot, _ = await _load([_make_row()], enable_cot=True)
+        assert no_cot[0].prompt == with_cot[0].prompt
+
+
+class TestPathologicalRows:
+    @pytest.mark.asyncio
+    async def test_empty_dataset_returns_empty_list(self) -> None:
+        problems, _ = await _load([])
+        assert problems == []
+
+    @pytest.mark.asyncio
+    async def test_unicode_in_question_preserved(self) -> None:
+        problems, _ = await _load([_make_row(question="½ of 8 is what?")])
+        assert "½" in problems[0].prompt

--- a/tests/unit/accuracy/test_gsm8k_grader.py
+++ b/tests/unit/accuracy/test_gsm8k_grader.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``LightevalGSM8KGrader``.
+
+Covers the gold-side ``gsm8k_normalizer`` (the number after ``####``)
+and the prediction-side extraction that deviates from lighteval to
+handle chat-model outputs that lack the ``####`` marker.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest import param
+
+from aiperf.accuracy.graders.gsm8k_grader import (
+    LightevalGSM8KGrader,
+    _numbers_match,
+    gsm8k_normalizer,
+)
+from tests.unit.conftest import make_benchmark_run
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
+
+_RAW_GOLD = "Natalia sold 48/2 = <<48/2=24>>24 clips in May.\n#### 24"
+
+
+def _make_run() -> BenchmarkRun:
+    return make_benchmark_run(model_names=["test-model"])
+
+
+def _grader() -> LightevalGSM8KGrader:
+    return LightevalGSM8KGrader(run=_make_run())
+
+
+class TestGsm8kNormalizer:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            param("Solution.\n#### 24", "24", id="simple"),
+            param("#### -5", "-5", id="negative"),
+            param("#### 1,234", "1234", id="strips-commas"),
+            param("#### 18.5", "18.5", id="decimal"),
+            param("no marker here", "[invalid]", id="no-marker"),
+            param("", "[invalid]", id="empty"),
+        ],
+    )  # fmt: skip
+    def test_extracts_number_after_marker(self, text: str, expected: str) -> None:
+        assert gsm8k_normalizer(text) == expected
+
+
+class TestGradingCorrect:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "response,extracted,unparsed",
+        [
+            # Only a response carrying the #### marker matches the expected
+            # format; everything else is a correct-but-fallback extraction
+            # and is flagged unparsed (still scored correct).
+            param("#### 24", "24", False, id="model-emits-marker"),
+            param("The answer is 24.", "24", True, id="trailing-sentence"),
+            param("... so 48/2 = 24", "24", True, id="last-number"),
+            param("24", "24", True, id="bare-number"),
+            param("The total is 24.0", "24.0", True, id="decimal-equiv"),
+            param("That gives 1,024 - 1000 = 24 clips", "24", True, id="commas-and-last"),
+        ],
+    )  # fmt: skip
+    async def test_correct_predictions_match_gold(
+        self, response: str, extracted: str, unparsed: bool
+    ) -> None:
+        result = await _grader().grade(response, _RAW_GOLD)
+        assert result.correct is True
+        assert result.unparsed is unparsed
+        assert result.extracted_answer == extracted
+        assert result.ground_truth == "24"
+
+    @pytest.mark.asyncio
+    async def test_marker_prediction_matches_lighteval_exactly(self) -> None:
+        # When the model emits ####, prediction extraction is byte-for-byte
+        # lighteval (gsm8k_normalizer on both sides) and not flagged unparsed.
+        result = await _grader().grade("Work...\n#### 1,024", "gold\n#### 1024")
+        assert result.correct is True
+        assert result.unparsed is False
+
+
+class TestGradingIncorrect:
+    @pytest.mark.asyncio
+    async def test_wrong_number_is_incorrect(self) -> None:
+        result = await _grader().grade("The answer is 25.", _RAW_GOLD)
+        assert result.correct is False
+        # No #### marker -> last-number fallback -> flagged unparsed.
+        assert result.unparsed is True
+        assert result.extracted_answer == "25"
+
+    @pytest.mark.asyncio
+    async def test_wrong_number_with_marker_is_not_unparsed(self) -> None:
+        # A wrong answer that still follows the #### format is parseable.
+        result = await _grader().grade("Work...\n#### 25", _RAW_GOLD)
+        assert result.correct is False
+        assert result.unparsed is False
+        assert result.extracted_answer == "25"
+
+    @pytest.mark.asyncio
+    async def test_no_number_in_response_is_unparsed(self) -> None:
+        result = await _grader().grade("I am not sure.", _RAW_GOLD)
+        assert result.correct is False
+        assert result.unparsed is True
+        assert result.extracted_answer == "[invalid]"
+
+    @pytest.mark.asyncio
+    async def test_empty_response_is_unparsed(self) -> None:
+        result = await _grader().grade("", _RAW_GOLD)
+        assert result.correct is False
+        assert result.unparsed is True
+
+    @pytest.mark.asyncio
+    async def test_invalid_gold_never_matches(self) -> None:
+        # Gold without a #### marker normalizes to "[invalid]"; a valid
+        # prediction must not be scored correct against it.
+        result = await _grader().grade("The answer is 24.", "no marker")
+        assert result.correct is False
+        assert result.ground_truth == "[invalid]"
+
+
+class TestNumbersMatch:
+    @pytest.mark.parametrize(
+        "gold,pred,expected",
+        [
+            param("24", "24", True, id="int-equal"),
+            param("24", "24.0", True, id="int-vs-decimal"),
+            param("24", "24.00", True, id="trailing-zeros"),
+            param("24", "25", False, id="int-unequal"),
+            param("-7", "-7.0", True, id="negative-equal"),
+            # Non-numeric inputs fall back to exact string equality.
+            param("[invalid]", "[invalid]", True, id="nonnumeric-equal"),
+            param("[invalid]", "24", False, id="nonnumeric-vs-number"),
+        ],
+    )  # fmt: skip
+    def test_numeric_then_string_fallback(
+        self, gold: str, pred: str, expected: bool
+    ) -> None:
+        assert _numbers_match(gold, pred) is expected
+
+
+class TestExtractAnswer:
+    def test_prefers_marker_over_last_number(self) -> None:
+        # Even with a later number, the #### marker wins (lighteval parity).
+        assert _grader().extract_answer("foo 99 bar\n#### 24 then 7") == "24"
+
+    def test_falls_back_to_last_number(self) -> None:
+        assert _grader().extract_answer("steps 3, 4, then 12") == "12"
+
+    def test_strips_commas(self) -> None:
+        assert _grader().extract_answer("the result is 1,234,567") == "1234567"
+
+    def test_no_number_returns_invalid(self) -> None:
+        assert _grader().extract_answer("none") == "[invalid]"

--- a/tests/unit/accuracy/test_gsm8k_lighteval_parity.py
+++ b/tests/unit/accuracy/test_gsm8k_lighteval_parity.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parity tests: our GSM8K port vs the real lighteval implementation.
+
+``LightevalGSM8KGrader`` is a hand port of lighteval's
+``quasi_exact_match_gsm8k`` (``gsm8k_normalizer`` gold extraction +
+``ExactMatches`` full-string comparison). These tests lock that port to
+the *real* lighteval so it can never silently drift:
+
+- the gold ``gsm8k_normalizer`` must be byte-for-byte identical, and
+- in the regime our port claims parity for — a prediction containing the
+  ``#### <number>`` marker — our correct/incorrect decision must match
+  lighteval's ``ExactMatches.compute_one_item`` exactly.
+
+We also pin the one *intentional* divergence: a chat-style prediction
+with no ``####`` marker (lighteval scores 0; we rescue the last number).
+
+Unlike the rest of the accuracy unit tests, this file uses the real
+lighteval dependency on purpose — a fake harness cannot serve as a
+reference oracle. It is skipped when lighteval (the ``[accuracy]``
+extra) is not installed.
+
+Reference:
+    lighteval.metrics.normalizations.gsm8k_normalizer
+    lighteval.metrics.metrics_sample.ExactMatches.compute_one_item
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest import param
+
+# This file is a parity oracle against the real dependency; skip cleanly
+# when lighteval isn't installed rather than faking it.
+pytest.importorskip("lighteval")
+
+from lighteval.metrics.metrics_sample import ExactMatches  # noqa: E402
+from lighteval.metrics.normalizations import (  # noqa: E402
+    gsm8k_normalizer as lighteval_gsm8k_normalizer,
+)
+
+from aiperf.accuracy.graders.gsm8k_grader import (  # noqa: E402
+    _extract_prediction,
+    _numbers_match,
+    gsm8k_normalizer,
+)
+
+# Exactly the metric the recipe builds: quasi_exact_match_gsm8k.
+_LIGHTEVAL_QEM = ExactMatches(
+    strip_strings=True,
+    normalize_pred=lighteval_gsm8k_normalizer,
+    normalize_gold=lighteval_gsm8k_normalizer,
+)
+
+
+def _our_decision(gold_raw: str, pred_raw: str) -> bool:
+    """Reproduce ``LightevalGSM8KGrader.grade``'s correctness decision."""
+    gold = gsm8k_normalizer(gold_raw.strip())
+    pred, _ = _extract_prediction(pred_raw.strip())
+    return pred != "[invalid]" and gold != "[invalid]" and _numbers_match(gold, pred)
+
+
+class TestGoldNormalizerParity:
+    """Our ``gsm8k_normalizer`` must match lighteval's byte-for-byte."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            param("Natalia sold clips.\n#### 24", id="simple"),
+            param("#### -5", id="negative"),
+            param("#### 1,234", id="thousands-comma"),
+            param("#### 1,000,000", id="millions"),
+            param("#### 18.5", id="decimal"),
+            param("long text ending #### 0", id="zero"),
+            param("no marker present", id="no-marker"),
+            param("", id="empty"),
+            param("#### 24\nbut also #### 99", id="first-marker-wins"),
+        ],
+    )  # fmt: skip
+    def test_matches_lighteval(self, text: str) -> None:
+        assert gsm8k_normalizer(text) == lighteval_gsm8k_normalizer(text)
+
+
+class TestMarkerRegimeFullParity:
+    """When the prediction carries ``####``, our extraction equals
+    lighteval's, so the whole decision must match
+    ``ExactMatches.compute_one_item``."""
+
+    @pytest.mark.parametrize(
+        "gold,pred",
+        [
+            param("gold\n#### 24", "work\n#### 24", id="correct"),
+            param("gold\n#### 24", "work\n#### 25", id="wrong"),
+            param("gold\n#### 1,024", "steps\n#### 1024", id="comma-vs-bare"),
+            param("gold\n#### -7", "steps\n#### -7", id="negative"),
+            param("gold\n#### 18", "steps\n#### 0", id="off-by-a-lot"),
+        ],
+    )  # fmt: skip
+    def test_decision_matches_lighteval(self, gold: str, pred: str) -> None:
+        ours = _our_decision(gold, pred)
+        theirs = bool(_LIGHTEVAL_QEM.compute_one_item(gold=gold, pred=pred))
+        assert ours == theirs
+
+
+class TestIntentionalDivergence:
+    """Chat predictions without ``####``: lighteval scores 0, we rescue
+    the last number. This divergence is deliberate and pinned here."""
+
+    @pytest.mark.parametrize(
+        "pred",
+        [
+            param("The answer is 24.", id="trailing-sentence"),
+            param("... so 48/2 = 24", id="last-number"),
+            param("I get 24.0", id="decimal-equiv"),
+        ],
+    )  # fmt: skip
+    def test_we_rescue_chat_answers_lighteval_rejects(self, pred: str) -> None:
+        gold = "gold\n#### 24"
+        assert _our_decision(gold, pred) is True
+        assert bool(_LIGHTEVAL_QEM.compute_one_item(gold=gold, pred=pred)) is False


### PR DESCRIPTION
Add GSM8KBenchmark (gsm8k/main test split, lighteval gsm8k_leaderboard prompt "Question: {q}\nAnswer:", raw answer as ground_truth, generation_size=256) and LightevalGSM8KGrader implementing quasi_exact_match_gsm8k: gsm8k_normalizer gold extraction, last-number prediction fallback for chat-model outputs that lack the "####" marker, and numeric comparison so "24"/"24.0" match.

Register both in plugins.yaml (default_grader=lighteval_gsm8k, default_n_shots=0); regenerate plugin enums and CLI docs; update docs/accuracy. Unit tests plus a lighteval parity test (gated on the [accuracy] extra) give 100% coverage on both new modules.

AIP-934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GSM8K accuracy benchmark with a lighteval-compatible GSM8K grader and default zero-shot configuration.

* **Documentation**
  * Updated accuracy docs, CLI options, and scaffolding status to include GSM8K and the new grader (now eight graders, ten loaders).

* **Tests**
  * Added unit and parity tests for benchmark loading, prompt formatting, grading/extraction, numeric matching, and lighteval parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->