### PR TITLE
fix(sweep): handle nested-dict variation values in aggregation grouping

### DIFF
--- a/src/aiperf/cli_runner/_multi_run.py
+++ b/src/aiperf/cli_runner/_multi_run.py
@@ -26,6 +26,7 @@ from aiperf.cli_runner._strategy import (
     validate_convergence_config,
 )
 from aiperf.cli_runner._sweep_aggregate import (
+    _variation_key,
     aggregate_per_variation_and_export,
     aggregate_sweep_and_export,
 )
@@ -316,10 +317,7 @@ def _log_failed_sweep_variations(
     """
     by_variation: dict[tuple, list[RunResult]] = {}
     for r in failed_runs:
-        key = (
-            r.variation_label or "",
-            tuple(sorted((r.variation_values or {}).items())),
-        )
+        key = _variation_key(r.variation_label or "", r.variation_values or {})
         by_variation.setdefault(key, []).append(r)
 
     def _format_key(label: str, params: tuple) -> str:

--- a/src/aiperf/cli_runner/_sweep_aggregate.py
+++ b/src/aiperf/cli_runner/_sweep_aggregate.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import orjson
+
 from aiperf.cli_runner._pareto import _resolve_pareto_axes
 
 if TYPE_CHECKING:
@@ -101,6 +103,20 @@ def _plan_post_process(plan: BenchmarkPlan) -> Any:
     return plan.sweep.post_process
 
 
+def _hashable_value(value: Any) -> Any:
+    """Return ``value``, or its sorted-key JSON string when it is unhashable.
+
+    Scenario sweeps put nested override dicts in ``variation_values``, and
+    those can't go in a dict key directly. Sorted keys keep equal overrides
+    grouping together.
+    """
+    try:
+        hash(value)
+    except TypeError:
+        return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode()
+    return value
+
+
 def _variation_key(label: str, values: dict[str, Any]) -> VariationKey:
     """Hashable, order-stable key for a variation cell.
 
@@ -114,7 +130,7 @@ def _variation_key(label: str, values: dict[str, Any]) -> VariationKey:
         >>> _variation_key("sobol_0006", {"concurrency": 3})
         ('sobol_0006', (('concurrency', 3),))
     """
-    return (label, tuple(sorted(values.items())))
+    return (label, tuple(sorted((k, _hashable_value(v)) for k, v in values.items())))
 
 
 def _key_values(key: VariationKey) -> tuple[tuple[str, Any], ...]:

--- a/tests/unit/cli_runner/test_aggregation_round3.py
+++ b/tests/unit/cli_runner/test_aggregation_round3.py
@@ -328,3 +328,22 @@ def test_strict_zip_in_aggregator_raises_on_length_mismatch() -> None:
         "strict=False zip(plan.configs, plan.variations) reintroduced; "
         "see round-2 R2-L7."
     )
+
+
+def test_scenario_sweep_nested_dict_values_group_without_typeerror() -> None:
+    """Scenario sweeps put nested override dicts in variation_values;
+    grouping used to crash with ``TypeError: unhashable type: 'dict'``.
+    """
+    override_a = {"benchmark": {"dataset": {"prompts": {"isl": {"mean": 1000}}}}}
+    override_b = {"benchmark": {"dataset": {"prompts": {"isl": {"mean": 10000}}}}}
+    results = [
+        _result("r1", variation_label="aa-1k", variation_values=override_a),
+        _result("r2", variation_label="aa-1k", variation_values=override_a),
+        _result("r3", variation_label="aa-10k", variation_values=override_b),
+    ]
+
+    groups = _group_results_by_variation(results)
+
+    assert len(groups) == 2
+    sizes = sorted(len(g) for g in groups.values())
+    assert sizes == [1, 2]


### PR DESCRIPTION
Scenario sweeps carry the nested deep-merge override dict (e.g.
{"benchmark": {...}}) as variation values. _variation_key built dict
keys via tuple(sorted(values.items())), which raises
TypeError: unhashable type: 'dict' during post-run sweep aggregation,
crashing aiperf profile after all benchmarks completed successfully.

Repro: any config with sweep: {type: scenarios} whose runs override a
nested benchmark section, e.g.

  sweep:
    type: scenarios
    runs:
      - name: aa-1k
        benchmark:
          dataset:
            prompts:
              isl: {type: normal, mean: 1000, stddev: 0}

Canonicalize non-hashable values to a stable sorted-key JSON string so
equal overrides still pool while distinct overrides stay separate, and
reuse _variation_key in _log_failed_sweep_variations which had the
same latent bug.

The regression test fails on main with the exact TypeError and passes
with this change.

Signed-off-by: Aaron Batilo <AaronBatilo@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed crashes when processing sweep variations containing nested dictionary values during result grouping and aggregation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->