### PR TITLE
feat(exporters): add Weights & Biases data exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ pip install aiperf
 Optional integrations:
 - `pip install "aiperf[mlflow]"` enables MLflow uploads and live telemetry streaming
 - `pip install "aiperf[otel]"` enables OpenTelemetry metric streaming
-- `pip install "aiperf[mlflow,otel]"` installs both extras
+- `pip install "aiperf[wandb]"` enables Weights & Biases result uploads
+- `pip install "aiperf[mlflow,otel,wandb]"` installs all telemetry extras
 
 To run a simple benchmark against your Ollama server:
 
@@ -205,6 +206,7 @@ Log File: /home/user/Code/aiperf/artifacts/granite4:350m-openai-chat-concurrency
 - [Auto-Plot After Profile](docs/tutorials/auto-plot.md) - Run `aiperf plot` automatically after `aiperf profile`
 - [GPU Telemetry](docs/tutorials/gpu-telemetry.md) - DCGM metrics collection
 - [OTel + MLflow Live Telemetry](docs/tutorials/otel-mlflow.md) - Stream metrics to OTel and MLflow in real time
+- [Weights & Biases Export](docs/tutorials/wandb.md) - Upload results tables and artifacts to wandb
 - [Server Metrics](docs/server-metrics/server-metrics.md) - Prometheus-compatible metrics
 
 ## Documentation

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -1002,6 +1002,22 @@ Optional MLflow parent run ID.
 
 Artifact glob overrides for MLflow upload. Can be specified multiple times or as a comma-separated list.
 
+#### `--wandb-project` `<str>`
+
+Weights & Biases project name. Setting this enables wandb export.
+
+#### `--wandb-entity` `<str>`
+
+Weights & Biases entity (team or user). Defaults to the API key's default entity.
+
+#### `--wandb-run-name` `<str>`
+
+Weights & Biases run name.
+
+#### `--wandb-tag` `<list>`
+
+Additional Weights & Biases run tags to attach on upload. Can be specified multiple times or as a comma-separated list.
+
 ### HTTP Trace
 
 #### `--export-http-trace`
@@ -2330,6 +2346,22 @@ Optional MLflow parent run ID.
 #### `--mlflow-artifact-glob` `<list>`
 
 Artifact glob overrides for MLflow upload. Can be specified multiple times or as a comma-separated list.
+
+#### `--wandb-project` `<str>`
+
+Weights & Biases project name. Setting this enables wandb export.
+
+#### `--wandb-entity` `<str>`
+
+Weights & Biases entity (team or user). Defaults to the API key's default entity.
+
+#### `--wandb-run-name` `<str>`
+
+Weights & Biases run name.
+
+#### `--wandb-tag` `<list>`
+
+Additional Weights & Biases run tags to attach on upload. Can be specified multiple times or as a comma-separated list.
 
 ### HTTP Trace
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -258,6 +258,14 @@ User interface and dashboard configuration. Controls refresh rates, update thres
 | `AIPERF_UI_REALTIME_METRICS_ENABLED` | `False` | — | Enable real-time metrics collection and reporting despite UI type |
 | `AIPERF_UI_SPINNER_REFRESH_RATE` | `0.1` | ≥ 0.1, ≤ 100.0 | Progress spinner refresh rate in seconds (default: 10 FPS) |
 
+## WANDB
+
+Weights & Biases export configuration. Controls timeout behavior for the post-run W&B upload.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_WANDB_EXPORT_TIMEOUT_SECONDS` | `30.0` | ≥ 1.0, ≤ 600.0 | Timeout in seconds for the post-run Weights & Biases export operation. If the W&B backend is unreachable, the export will be abandoned after this duration rather than blocking indefinitely. |
+
 ## WORKER
 
 Worker management and auto-scaling configuration. Controls worker pool sizing, health monitoring, load detection, and recovery behavior. The CPU_UTILIZATION_FACTOR is used in the auto-scaling formula: max_workers = max(1, min(int(cpu_count * factor) - 1, MAX_WORKERS_CAP))

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -146,6 +146,8 @@ navigation:
       path: tutorials/gpu-telemetry.md
     - page: OpenTelemetry MLflow Integration
       path: tutorials/otel-mlflow.md
+    - page: Weights & Biases Export
+      path: tutorials/wandb.md
   - section: Configuration
     collapsed: true
     contents:

--- a/docs/tutorials/wandb.md
+++ b/docs/tutorials/wandb.md
@@ -1,0 +1,143 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Weights & Biases Export
+---
+
+# Weights & Biases Export
+
+## What You Will Learn
+
+This tutorial walks through AIPerf's Weights & Biases (wandb) integration:
+
+- **Post-run results table** — upload the final benchmark results as a
+  wandb Table that mirrors the console metrics view, one row per metric
+  with `avg`/`min`/`max`/`p99`/`p90`/`p50`/`std` columns.
+- **Artifact upload** — attach the generated output files (`inputs.json`,
+  `profile_export.jsonl`, CSV/JSON summaries) to the run so it is fully
+  reproducible from the wandb UI.
+- **Cross-run comparison** — use the run config (model, concurrency,
+  request rate) to filter and group benchmark runs in a wandb workspace.
+
+## Prerequisites
+
+Install AIPerf with the optional wandb extra:
+
+```bash
+pip install "aiperf[wandb]"
+```
+
+Authenticate with wandb if you have not already:
+
+```bash
+wandb login   # or export WANDB_API_KEY=...
+```
+
+## Run a Profile with wandb Export Enabled
+
+```bash
+aiperf profile \
+    --url http://localhost:8000 \
+    --model my-model \
+    --endpoint-type chat \
+    --endpoint /v1/chat/completions \
+    --streaming \
+    --synthetic-input-tokens-mean 128 \
+    --output-tokens-mean 128 \
+    --concurrency 4 \
+    --request-count 64 \
+    --wandb-project my-benchmarks \
+    --wandb-entity my-team \
+    --wandb-run-name baseline-c4 \
+    --wandb-tag experiment:baseline
+```
+
+### Flag breakdown
+
+| Flag | Effect |
+|------|--------|
+| `--wandb-project my-benchmarks` | Enables wandb export and selects the project. This is the only required flag. |
+| `--wandb-entity my-team` | Team or username owning the project. Defaults to your API key's default entity. |
+| `--wandb-run-name baseline-c4` | Run name shown in the wandb UI. Defaults to `aiperf-<benchmark-id>`. |
+| `--wandb-tag experiment:baseline` | Additional run tag. Repeat the flag for multiple tags. |
+
+The equivalent config-v2 YAML:
+
+```yaml
+benchmark:
+  wandb:
+    project: my-benchmarks
+    entity: my-team
+    run_name: baseline-c4
+    tags:
+      - "experiment:baseline"
+```
+
+The exporter runs after profiling completes, once the local exporters
+have written their files. The wandb client's local state is written
+under the run's artifact directory, not your working directory.
+
+## What Gets Uploaded
+
+### Results table
+
+The run's workspace contains a `summary_metrics` table with the same
+metrics, ordering, and labels as the console results table:
+
+| Metric | avg | min | max | p99 | p90 | p50 | std |
+|---|---|---|---|---|---|---|---|
+| TTFT (ms) | 369.03 | 312.13 | 765.81 | 727.41 | 381.85 | 327.52 | 132.54 |
+| Req Latency (ms) | 4,381.82 | 3,936.46 | 4,615.45 | 4,614.24 | 4,603.33 | 4,425.42 | 205.00 |
+| Output TPS/User | 249.53 | 232.87 | 277.71 | 276.07 | 261.33 | 246.04 | 12.99 |
+| ... | | | | | | | |
+
+Stats a metric does not produce (for example percentiles on count-style
+metrics) appear as empty cells, matching the console's `N/A`.
+
+> [!TIP]
+> Table panels paginate by default. Use the page-size selector in the
+> panel footer (10/25/50/100) to fit the whole table on one page.
+
+### Artifact bundle
+
+Each run logs one `aiperf-run` artifact containing the files from the
+run's artifact directory: `inputs.json`, `profile_export.jsonl` (when
+record-level export is enabled), `profile_export_aiperf.csv`,
+`profile_export_aiperf.json`, plus any parquet, timeslice, or plot
+files. Download them from the run's **Artifacts** tab to reproduce or
+re-analyze the benchmark.
+
+### Run config and tags
+
+The run config records the endpoint type, model names, redacted URLs,
+load generator settings (concurrency, request rate, request count,
+duration), and the redacted CLI command. Tags include the AIPerf
+version and a `benchmark-<id>` tag. In a project workspace you can
+group or filter runs by any config key — for example, group a
+concurrency sweep by `phases.0.concurrency`.
+
+## Comparing Runs
+
+Run the same benchmark at several settings, giving each run a
+distinguishing name:
+
+```bash
+for c in 1 2 4 8; do
+  aiperf profile ... \
+      --concurrency "$c" \
+      --wandb-project my-benchmarks \
+      --wandb-run-name "sweep-c${c}"
+done
+```
+
+In the wandb project, open each run to read its full results table, or
+use the runs table to compare the same metric across runs side by side.
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+|---------|-------------|
+| `Weights & Biases export is enabled but the optional ... dependency is not installed` | Install the extra: `pip install "aiperf[wandb]"`. |
+| `--wandb-entity ... require --wandb-project to be set` | Secondary wandb flags are rejected without `--wandb-project`. |
+| Run hangs at exit waiting on wandb | Check network reachability to `api.wandb.ai` and that `WANDB_API_KEY` is valid. |
+| No run appears | The exporter only runs when profiling produced results; a benchmark that failed before any request completes skips the upload. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ aiperf = "aiperf.plugin:plugins.yaml"
 mlflow = [
   "mlflow>=3.10.0,<4.0.0",
 ]
+wandb = [
+  "wandb>=0.19.0,<1.0.0",
+]
 otel = [
   "opentelemetry-exporter-otlp-proto-http>=1.24.0,<2.0.0",
   "opentelemetry-sdk>=1.24.0,<2.0.0",
@@ -97,7 +100,7 @@ test = [
   "trustme>=1.0.0",
 ]
 dev = [
-  "aiperf[mlflow,otel,test]",
+  "aiperf[mlflow,otel,test,wandb]",
   "black>=25.1.0",
   "pre-commit>=4.2.0",
   "ruff>=0.14.0,<0.15.0",

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -25,6 +25,7 @@ Structure:
     Environment.TIMING.*         - Timing manager settings
     Environment.TOKENIZER.*      - Tokenizer pre-warm and loading
     Environment.UI.*             - User interface settings
+    Environment.WANDB.*          - Weights & Biases export settings
     Environment.WORKER.*         - Worker management and scaling
     Environment.ZMQ.*            - ZMQ communication settings
 
@@ -1034,6 +1035,26 @@ class _TokenizerSettings(BaseSettings):
     )
 
 
+class _WandbSettings(BaseSettings):
+    """Weights & Biases export configuration.
+
+    Controls timeout behavior for the post-run W&B upload.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="AIPERF_WANDB_",
+    )
+
+    EXPORT_TIMEOUT_SECONDS: float = Field(
+        ge=1.0,
+        le=600.0,
+        default=30.0,
+        description="Timeout in seconds for the post-run Weights & Biases export operation. "
+        "If the W&B backend is unreachable, the export will be abandoned "
+        "after this duration rather than blocking indefinitely.",
+    )
+
+
 class _UISettings(BaseSettings):
     """User interface and dashboard configuration.
 
@@ -1379,6 +1400,10 @@ class _Environment(BaseSettings):
     UI: _UISettings = Field(
         default_factory=_UISettings,
         description="User interface and dashboard settings",
+    )
+    WANDB: _WandbSettings = Field(
+        default_factory=_WandbSettings,
+        description="Weights & Biases export settings",
     )
     WORKER: _WorkerSettings = Field(
         default_factory=_WorkerSettings,

--- a/src/aiperf/common/optional_dependencies.py
+++ b/src/aiperf/common/optional_dependencies.py
@@ -3,6 +3,7 @@
 """Helpers for optional runtime dependency messaging."""
 
 MLFLOW_EXTRA = "aiperf[mlflow]"
+WANDB_EXTRA = "aiperf[wandb]"
 OTEL_EXTRA = "aiperf[otel]"
 OTEL_METRICS_STREAMING_FEATURE = "OpenTelemetry metrics streaming is enabled"
 
@@ -15,6 +16,14 @@ def mlflow_dependency_message(feature: str) -> str:
     return (
         f"{feature} but the optional MLflow dependency is not installed. "
         f"{install_optional_dependency_hint(MLFLOW_EXTRA)}"
+    )
+
+
+def wandb_dependency_message(feature: str) -> str:
+    """Error message for a missing optional wandb dependency."""
+    return (
+        f"{feature} but the optional Weights & Biases dependency is not installed. "
+        f"{install_optional_dependency_hint(WANDB_EXTRA)}"
     )
 
 

--- a/src/aiperf/config/__init__.py
+++ b/src/aiperf/config/__init__.py
@@ -199,6 +199,9 @@ from aiperf.config.types import (
     SequenceDistributionEntry,
     validate_probability_distribution,
 )
+from aiperf.config.wandb import (
+    WandbConfig,
+)
 
 __all__ = [
     "AIPerfConfig",
@@ -287,6 +290,7 @@ __all__ = [
     "VIDEO_AUDIO_CODEC_MAP",
     "VideoAudioConfig",
     "VideoConfig",
+    "WandbConfig",
     "ZMQDualBindConfig",
     "ZMQDualBindProxyConfig",
     "ZMQIPCConfig",

--- a/src/aiperf/config/config.py
+++ b/src/aiperf/config/config.py
@@ -92,6 +92,9 @@ from aiperf.config.sweep.multi_run import (
 from aiperf.config.tokenizer import (
     TokenizerConfig,
 )
+from aiperf.config.wandb import (
+    WandbConfig,
+)
 
 _logger = AIPerfLogger(__name__)
 
@@ -328,6 +331,14 @@ class BenchmarkConfig(BaseConfig, BenchmarkHelpersMixin):
         Field(
             default_factory=MLflowConfig,
             description="MLflow tracking and artifact-upload configuration.",
+        ),
+    ]
+
+    wandb: Annotated[
+        WandbConfig,
+        Field(
+            default_factory=WandbConfig,
+            description="Weights & Biases run-upload configuration.",
         ),
     ]
 

--- a/src/aiperf/config/flags/_converter_telemetry.py
+++ b/src/aiperf/config/flags/_converter_telemetry.py
@@ -411,3 +411,46 @@ def build_mlflow(cli: CLIConfig) -> dict[str, Any]:
     if artifact_globs is not None:
         out["artifact_globs"] = artifact_globs
     return out
+
+
+_WANDB_SECONDARY_FIELDS = (
+    "wandb_entity",
+    "wandb_run_name",
+    "wandb_tags",
+)
+
+
+def build_wandb(cli: CLIConfig, *, base_enabled: bool = False) -> dict[str, Any]:
+    """Translate Weights & Biases CLI flags into the wandb config dict.
+
+    Refuses secondary wandb flags without ``--wandb-project`` and rejects an
+    empty project name. ``base_enabled`` relaxes the project requirement for
+    the YAML+CLI overlay path: when the base config already enables wandb,
+    secondary flags alone emit a partial override dict (e.g.
+    ``-f base.yaml --wandb-run-name rerun``).
+    """
+    cli_set = cli.model_fields_set
+    out: dict[str, Any] = {}
+    if "wandb_project" in cli_set and cli.wandb_project is not None:
+        project = cli.wandb_project.strip()
+        if not project:
+            raise ValueError("--wandb-project cannot be empty.")
+        out["project"] = project
+    elif not base_enabled:
+        if any(key in cli_set for key in _WANDB_SECONDARY_FIELDS):
+            raise ValueError(
+                "--wandb-entity, --wandb-run-name, and --wandb-tag require "
+                "--wandb-project to be set."
+            )
+        return {}
+
+    if "wandb_entity" in cli_set and cli.wandb_entity is not None:
+        entity = cli.wandb_entity.strip()
+        if not entity:
+            raise ValueError("--wandb-entity cannot be empty when set.")
+        out["entity"] = entity
+    if "wandb_run_name" in cli_set and cli.wandb_run_name is not None:
+        out["run_name"] = cli.wandb_run_name.strip() or None
+    if "wandb_tags" in cli_set:
+        out["tags"] = cli.wandb_tags
+    return out

--- a/src/aiperf/config/flags/cli_config.py
+++ b/src/aiperf/config/flags/cli_config.py
@@ -2206,6 +2206,47 @@ class CLIConfig(BaseConfig):
         ),
     ] = None
 
+    wandb_project: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Weights & Biases project name. Setting this enables wandb export.",
+        ),
+        CLIParameter(name=("--wandb-project",), group=Groups.OUTPUT),
+    ] = None
+
+    wandb_entity: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Weights & Biases entity (team or user). Defaults to the API key's default entity.",
+        ),
+        CLIParameter(name=("--wandb-entity",), group=Groups.OUTPUT),
+    ] = None
+
+    wandb_run_name: Annotated[
+        str | None,
+        Field(default=None, description="Weights & Biases run name."),
+        CLIParameter(name=("--wandb-run-name",), group=Groups.OUTPUT),
+    ] = None
+
+    wandb_tags: Annotated[
+        list[str] | None,
+        Field(
+            default=None,
+            description=(
+                "Additional Weights & Biases run tags to attach on upload. "
+                "Can be specified multiple times or as a comma-separated list."
+            ),
+        ),
+        BeforeValidator(parse_str_or_list),
+        CLIParameter(
+            name=("--wandb-tag",),
+            consume_multiple=True,
+            group=Groups.OUTPUT,
+        ),
+    ] = None
+
     ##############################################################################
     # HTTP Trace
     ##############################################################################

--- a/src/aiperf/config/flags/converter.py
+++ b/src/aiperf/config/flags/converter.py
@@ -39,6 +39,7 @@ from aiperf.config.flags._converter_telemetry import (
     build_mlflow,
     build_otel,
     build_server_metrics,
+    build_wandb,
 )
 from aiperf.config.flags._converter_warmup import build_warmup
 from aiperf.config.sweep import MAGIC_LIST_FIELDS
@@ -521,6 +522,7 @@ def _assemble_envelope_dict(cli: CLIConfig) -> dict[str, Any]:
     server_metrics = build_server_metrics(cli)
     otel = build_otel(cli)
     mlflow = build_mlflow(cli)
+    wandb = build_wandb(cli)
     logging_dict, runtime_dict = build_logging_runtime(cli)
 
     nested: dict[str, Any] = {
@@ -538,6 +540,7 @@ def _assemble_envelope_dict(cli: CLIConfig) -> dict[str, Any]:
         "server_metrics": server_metrics,
         "otel": otel,
         "mlflow": mlflow,
+        "wandb": wandb,
     }
     if logging_dict:
         nested["logging"] = logging_dict

--- a/src/aiperf/config/flags/resolver.py
+++ b/src/aiperf/config/flags/resolver.py
@@ -152,6 +152,7 @@ def build_cli_overrides(
         build_tokenizer,
     )
     from aiperf.config.flags._converter_runtime import build_logging_runtime
+    from aiperf.config.flags._converter_telemetry import build_wandb
 
     out: dict[str, Any] = {}
     _apply_endpoint_overrides(out, cli)
@@ -160,6 +161,10 @@ def build_cli_overrides(
     _apply_artifacts_overrides(out, cli)
     _apply_optional_section(out, "tokenizer", build_tokenizer(cli))
     _apply_optional_section(out, "accuracy", build_accuracy(cli))
+    wandb_base_enabled = benchmark_config is not None and benchmark_config.wandb.enabled
+    _apply_optional_section(
+        out, "wandb", build_wandb(cli, base_enabled=wandb_base_enabled)
+    )
 
     if "no_sweep_table" in cli.model_fields_set:
         out["no_sweep_table"] = cli.no_sweep_table

--- a/src/aiperf/config/schema/aiperf-config.schema.json
+++ b/src/aiperf/config/schema/aiperf-config.schema.json
@@ -2102,6 +2102,9 @@
         "mlflow": {
           "$ref": "#/$defs/MLflowConfig"
         },
+        "wandb": {
+          "$ref": "#/$defs/WandbConfig"
+        },
         "runtime": {
           "$ref": "#/$defs/RuntimeConfig",
           "description": "Runtime configuration for worker processes and inter-process communication."
@@ -12148,6 +12151,80 @@
       ],
       "title": "VideoSynthType",
       "type": "string"
+    },
+    "WandbConfig": {
+      "additionalProperties": false,
+      "dependentRequired": {
+        "entity": [
+          "project"
+        ],
+        "runName": [
+          "project"
+        ],
+        "tags": [
+          "project"
+        ]
+      },
+      "description": "Weights & Biases run-upload configuration.",
+      "properties": {
+        "project": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Weights & Biases project name. Setting this enables wandb export.",
+          "title": "Project"
+        },
+        "entity": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Weights & Biases entity (team or user). Defaults to the API key's default entity.",
+          "title": "Entity"
+        },
+        "runName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Weights & Biases run name.",
+          "title": "Runname"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Additional Weights & Biases run tags to attach on upload.",
+          "title": "Tags"
+        }
+      },
+      "title": "WandbConfig",
+      "type": "object"
     },
     "ZipSweep": {
       "additionalProperties": false,

--- a/src/aiperf/config/wandb.py
+++ b/src/aiperf/config/wandb.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+AIPerf Configuration v2.0 - Pydantic Models
+
+Weights & Biases - run-upload configuration.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from pydantic import BeforeValidator, ConfigDict, Field, model_validator
+
+from aiperf.config.base import BaseConfig
+
+__all__ = [
+    "WandbConfig",
+]
+
+
+def _parse_wandb_tags(value: Any | None) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = [value]
+    tags = [str(tag).strip() for tag in value]
+    return [tag for tag in tags if tag] or None
+
+
+def _normalize_optional_str(value: Any | None) -> str | None:
+    if value is None:
+        return None
+    stripped = str(value).strip()
+    return stripped or None
+
+
+class WandbConfig(BaseConfig):
+    """Weights & Biases run-upload configuration."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_default=True,
+        # Mirror _require_project_for_secondary_fields in the generated JSON
+        # schema so editors flag secondary keys authored without `project`.
+        json_schema_extra={
+            "dependentRequired": {
+                "entity": ["project"],
+                "runName": ["project"],
+                "tags": ["project"],
+            }
+        },
+    )
+
+    project: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Weights & Biases project name. Setting this enables wandb export.",
+        ),
+        BeforeValidator(_normalize_optional_str),
+    ]
+    entity: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Weights & Biases entity (team or user). Defaults to the API key's default entity.",
+        ),
+        BeforeValidator(_normalize_optional_str),
+    ]
+    run_name: Annotated[
+        str | None,
+        Field(default=None, description="Weights & Biases run name."),
+        BeforeValidator(_normalize_optional_str),
+    ]
+    tags: Annotated[
+        list[str] | None,
+        Field(
+            default=None,
+            description="Additional Weights & Biases run tags to attach on upload.",
+        ),
+        BeforeValidator(_parse_wandb_tags),
+    ]
+
+    @model_validator(mode="after")
+    def _require_project_for_secondary_fields(self) -> WandbConfig:
+        """Reject secondary wandb settings authored without a project, matching
+        the CLI converter's contract for --wandb-entity/--wandb-run-name/--wandb-tag."""
+        if self.project is None:
+            set_secondary = [
+                name
+                for name in ("entity", "run_name", "tags")
+                if getattr(self, name) is not None
+            ]
+            if set_secondary:
+                raise ValueError(
+                    f"wandb.{', wandb.'.join(set_secondary)} require "
+                    "wandb.project to be set."
+                )
+        return self
+
+    @property
+    def enabled(self) -> bool:
+        """Whether Weights & Biases export is enabled."""
+        return self.project is not None

--- a/src/aiperf/exporters/wandb_data_exporter.py
+++ b/src/aiperf/exporters/wandb_data_exporter.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Any, ClassVar
+
+from aiperf.common.exceptions import DataExporterDisabled
+from aiperf.common.finite import is_finite_value
+from aiperf.common.mixins import AIPerfLoggerMixin
+from aiperf.common.optional_dependencies import wandb_dependency_message
+from aiperf.common.redact import redact_cli_command
+from aiperf.exporters.console_metrics_exporter import ConsoleMetricsExporter
+from aiperf.exporters.exporter_config import ExporterConfig, FileExportInfo
+from aiperf.metrics.metric_registry import MetricRegistry
+
+
+class WandbDataExporter(AIPerfLoggerMixin):
+    """Uploads the final benchmark results table to Weights & Biases."""
+
+    is_deferred = True  # runs after all local exporters write their files
+
+    _ARTIFACT_GLOBS: ClassVar[tuple[str, ...]] = (
+        "*.json",
+        "*.csv",
+        "*.jsonl",
+        "*.parquet",
+        "*_timeslices.*",
+        "**/*.png",
+        "**/*.jpg",
+        "**/*.jpeg",
+        "**/*.svg",
+        "**/*.html",
+    )
+
+    def __init__(self, exporter_config: ExporterConfig, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        # Keep the whole config so we can ship it to the export subprocess
+        self._exporter_config = exporter_config
+        self._results = exporter_config.results
+        self._cfg = exporter_config.cfg
+        run = exporter_config.run
+        self._benchmark_id = run.benchmark_id if run is not None else None
+        self._cli_command = run.cli_command if run is not None else None
+
+        if not self._cfg.wandb.enabled:
+            raise DataExporterDisabled(
+                "Weights & Biases export is disabled (set --wandb-project to enable)."
+            )
+        if self._results is None:
+            raise DataExporterDisabled(
+                "Weights & Biases export is disabled (no profile results available)."
+            )
+
+        self._artifact_directory = self._cfg.artifacts.artifact_directory
+
+    def get_export_info(self) -> FileExportInfo:
+        return FileExportInfo(
+            export_type="Weights & Biases Run Upload",
+            file_path=self._artifact_directory,
+        )
+
+    async def export(self) -> None:
+        """Run blocking wandb client operations in a terminable subprocess."""
+        from aiperf.common.environment import Environment
+        from aiperf.exporters.wandb_export_subprocess import export_with_timeout
+
+        await export_with_timeout(
+            exporter_config=self._exporter_config,
+            export_timeout=Environment.WANDB.EXPORT_TIMEOUT_SECONDS,
+            warn=self.warning,
+        )
+
+    def _export_sync(self) -> None:
+        try:
+            import wandb
+        except ImportError as exc:
+            raise RuntimeError(
+                wandb_dependency_message("Weights & Biases export is enabled")
+            ) from exc
+
+        run_name = self._cfg.wandb.run_name or self._derive_default_run_name()
+        run = wandb.init(
+            entity=self._cfg.wandb.entity,
+            project=self._cfg.wandb.project,
+            name=run_name,
+            dir=str(self._artifact_directory),
+            config=self._build_config_payload(),
+            tags=self._build_tags(),
+        )
+        artifact_files: list[Path] = []
+        try:
+            run.log(
+                {
+                    "summary_metrics": wandb.Table(
+                        columns=["Metric", *ConsoleMetricsExporter.STAT_COLUMN_KEYS],
+                        data=self._build_metric_table_rows(),
+                    )
+                }
+            )
+            artifact_files = self._collect_artifact_files()
+            if artifact_files:
+                artifact = wandb.Artifact(name=f"aiperf-{run.id}", type="aiperf-run")
+                for artifact_file in artifact_files:
+                    artifact.add_file(
+                        str(artifact_file),
+                        name=artifact_file.relative_to(
+                            self._artifact_directory
+                        ).as_posix(),
+                    )
+                run.log_artifact(artifact)
+        finally:
+            run.finish()
+        self.info(
+            f"Uploaded Weights & Biases run '{run_name}' ({run.url}) with "
+            f"{len(artifact_files)} artifact files."
+        )
+
+    def _derive_default_run_name(self) -> str:
+        if self._benchmark_id:
+            return f"aiperf-{self._benchmark_id[:8]}"
+        return f"aiperf-{int(time.time())}"
+
+    def _build_metric_table_rows(self) -> list[list[Any]]:
+        """One row per metric, mirroring the console Real-Time Metrics table:
+        same visibility rules, display order, short labels, and stat columns.
+        """
+
+        def label(record: Any, cls: Any) -> str:
+            name = cls.short_header or record.header
+            if cls.short_header and cls.short_header_hide_unit:
+                return name
+            return f"{name} ({record.unit})"
+
+        visible = [
+            (record, cls)
+            for record in self._results.records or []
+            if (cls := MetricRegistry.get_class_or_none(record.tag)) is not None
+            and cls.missing_flags(ConsoleMetricsExporter.exclude_flags)
+            and cls.console_group in (ConsoleMetricsExporter.console_groups or ())
+        ]
+        visible.sort(key=lambda rc: rc[1].display_order or sys.maxsize)
+
+        rows: list[list[Any]] = []
+        for record, cls in visible:
+            row: list[Any] = [label(record, cls)]
+            for stat in ConsoleMetricsExporter.STAT_COLUMN_KEYS:
+                value = getattr(record, stat, None)
+                row.append(round(float(value), 2) if is_finite_value(value) else None)
+            rows.append(row)
+        return rows
+
+    def _build_config_payload(self) -> dict[str, Any]:
+        # The full resolved benchmark config; JSON-mode serializers redact
+        # secrets (api_key, auth headers, URL userinfo) at the model layer.
+        config: dict[str, Any] = self._cfg.model_dump(mode="json", exclude_none=True)
+        if self._cli_command:
+            config["aiperf.cli_command"] = redact_cli_command(self._cli_command)
+        return config
+
+    def _build_tags(self) -> list[str]:
+        from aiperf import __version__ as aiperf_version
+
+        tags = [f"aiperf-{aiperf_version}"]
+        if self._benchmark_id:
+            tags.append(f"benchmark-{self._benchmark_id[:8]}")
+        tags.extend(self._cfg.wandb.tags or [])
+        return tags
+
+    def _collect_artifact_files(self) -> list[Path]:
+        files: list[Path] = []
+        seen: set[str] = set()
+        # wandb.init(dir=...) writes its own state under <artifact_dir>/wandb/
+        # before collection runs; the recursive globs must not re-upload it.
+        wandb_state_dir = (self._artifact_directory / "wandb").resolve()
+        for pattern in self._ARTIFACT_GLOBS:
+            for candidate in sorted(self._artifact_directory.glob(pattern)):
+                if not candidate.is_file():
+                    continue
+                resolved_path = candidate.resolve()
+                if resolved_path.is_relative_to(wandb_state_dir):
+                    continue
+                resolved = str(resolved_path)
+                if resolved in seen:
+                    continue
+                seen.add(resolved)
+                files.append(candidate)
+        return files

--- a/src/aiperf/exporters/wandb_export_subprocess.py
+++ b/src/aiperf/exporters/wandb_export_subprocess.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Subprocess entrypoint for the Weights & Biases post-run export.
+
+Kept in its own module so ``multiprocessing.get_context("spawn")`` can import
+the target function by fully-qualified name without pulling in the rest of
+``wandb_data_exporter``'s imports at interpreter startup time in the child.
+Mirrors ``mlflow_export_subprocess`` — third backend with this shape should
+extract a shared helper.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+from collections.abc import Callable
+from contextlib import suppress
+from typing import Any
+
+from aiperf.exporters.exporter_config import ExporterConfig
+
+
+def run_export_in_subprocess(
+    exporter_config: ExporterConfig,
+    result_queue: Any,
+) -> None:
+    """Subprocess entrypoint for ``WandbDataExporter._export_sync``.
+
+    Reports success as ``None`` and failure as a ``repr(exc)`` string on
+    ``result_queue`` so the parent can log without requiring pickled
+    exceptions.
+    """
+    # Import lazily so the module-level cost stays minimal for callers that
+    # only read ``run_export_in_subprocess`` as a spawn target.
+    from aiperf.exporters.wandb_data_exporter import WandbDataExporter
+
+    try:
+        exporter = WandbDataExporter(exporter_config=exporter_config)
+        exporter._export_sync()
+        result_queue.put(None)
+    except Exception as exc:  # noqa: BLE001 - all errors must travel back to parent
+        result_queue.put(repr(exc))
+
+
+async def export_with_timeout(
+    exporter_config: ExporterConfig,
+    export_timeout: float,
+    warn: Callable[[str], None],
+) -> None:
+    """Run the W&B export in a terminable subprocess.
+
+    An ``asyncio.to_thread`` wrapper only releases the awaiter — the thread
+    keeps running inside the wandb SDK (holding TCP connections and the run
+    open) until the socket unblocks, which can take minutes against an
+    unreachable backend. Running the export in a ``spawn`` subprocess and
+    calling ``terminate()`` on timeout gives us a real upper bound.
+
+    Uses the ``spawn`` context so the child gets a fresh interpreter — wandb
+    keeps module-level state (active run, settings singletons) that must not
+    be inherited from the parent via fork.
+    """
+    ctx = mp.get_context("spawn")
+    result_queue: mp.Queue[str | None] = ctx.Queue(maxsize=1)
+    # Re-lookup the spawn target by attribute so tests that monkeypatch
+    # ``run_export_in_subprocess`` on this module reach the subprocess.
+    spawn_target = globals()["run_export_in_subprocess"]
+    process = ctx.Process(
+        target=spawn_target,
+        args=(exporter_config, result_queue),
+        name="aiperf-wandb-export",
+        daemon=True,
+    )
+    process.start()
+    try:
+        await asyncio.to_thread(process.join, export_timeout)
+        if process.is_alive():
+            warn(
+                f"Weights & Biases export timed out after {export_timeout}s. "
+                "The W&B backend may be unreachable. Terminating subprocess."
+            )
+            process.terminate()
+            await asyncio.to_thread(process.join, 5.0)
+            if process.is_alive():
+                process.kill()
+                await asyncio.to_thread(process.join, 1.0)
+            return
+        # Subprocess returned; read status from the queue if present. Track
+        # whether the queue yielded any status so silent crashes (spawn
+        # bootstrap failure, SIGKILL/OOM, native crash) surface via exitcode.
+        queue_reported_status = False
+        with suppress(Exception):
+            error_msg = result_queue.get_nowait()
+            queue_reported_status = True
+            if error_msg is not None:
+                warn(f"Weights & Biases export subprocess reported: {error_msg}")
+        exitcode = process.exitcode
+        if not queue_reported_status and exitcode is not None and exitcode != 0:
+            warn(
+                "Weights & Biases export subprocess exited with non-zero status "
+                f"and left no status on the result queue. exitcode={exitcode}. "
+                "Likely a spawn bootstrap failure, SIGKILL/OOM, or native crash."
+            )
+    finally:
+        with suppress(Exception):
+            result_queue.close()
+            result_queue.cancel_join_thread()

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -99,7 +99,7 @@ AccuracyBenchmarkType = plugins.create_enum(PluginType.ACCURACY_BENCHMARK, "Accu
 
 DataExporterTypeStr: TypeAlias = str
 DataExporterType = plugins.create_enum(PluginType.DATA_EXPORTER, "DataExporterType", module=__name__)
-"""Dynamic enum for data exporter. Example: DataExporterType.ACCURACY_CSV, DataExporterType.RAW_RECORD_AGGREGATOR, DataExporterType.TIMESLICE_JSON"""
+"""Dynamic enum for data exporter. Example: DataExporterType.ACCURACY_CSV, DataExporterType.SERVER_METRICS_CSV, DataExporterType.WANDB"""
 
 ConsoleExporterTypeStr: TypeAlias = str
 ConsoleExporterType = plugins.create_enum(PluginType.CONSOLE_EXPORTER, "ConsoleExporterType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1098,6 +1098,13 @@ data_exporter:
       and generated artifacts (including plots) to an MLflow Tracking server.
       Enabled when --mlflow-tracking-uri is configured.
 
+  wandb:
+    class: aiperf.exporters.wandb_data_exporter:WandbDataExporter
+    description: |
+      Weights & Biases post-run exporter that uploads benchmark config, metrics,
+      tags, and generated artifacts to a wandb project.
+      Enabled when --wandb-project is configured.
+
   raw_record_aggregator:
     class: aiperf.post_processors.raw_record_writer_processor:RawRecordAggregator
     description: |

--- a/tests/unit/config/test_converter_telemetry_wandb.py
+++ b/tests/unit/config/test_converter_telemetry_wandb.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Weights & Biases CLI conversion and config validation.
+
+1. Secondary wandb flags (--wandb-entity / --wandb-run-name / --wandb-tag)
+   require --wandb-project to be set.
+2. --wandb-project / --wandb-entity empty-string rejection.
+3. Whitespace normalization on project / entity / run_name.
+4. YAML+CLI overlay: secondary flags alone are valid when the YAML base
+   already enables wandb (``base_enabled`` / resolver path).
+5. WandbConfig model-level normalization and secondary-requires-project rule.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from pytest import param
+
+from aiperf.config import WandbConfig
+from aiperf.config.flags._converter_telemetry import build_wandb
+from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.config.flags.resolver import resolve_config
+
+
+def _make_cli(**overrides: Any) -> CLIConfig:
+    base = {
+        "url": "http://localhost:8000/test",
+        "model_names": ["test-model"],
+    }
+    base.update(overrides)
+    return CLIConfig(**base)
+
+
+class TestSecondaryFlagsRequireProject:
+    def test_no_flags_returns_empty(self) -> None:
+        assert build_wandb(_make_cli()) == {}
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            param("wandb_entity", "my-team", id="entity"),
+            param("wandb_run_name", "my-run", id="run_name"),
+            param("wandb_tags", ["a"], id="tags"),
+        ],
+    )  # fmt: skip
+    def test_secondary_alone_raises(self, field: str, value: object) -> None:
+        cli = _make_cli(**{field: value})
+        with pytest.raises(ValueError, match="require"):
+            build_wandb(cli)
+
+
+class TestEmptyStringRejection:
+    @pytest.mark.parametrize(
+        "field,match",
+        [
+            param("wandb_project", "--wandb-project cannot be empty", id="project"),
+            param("wandb_entity", "--wandb-entity cannot be empty", id="entity"),
+        ],
+    )  # fmt: skip
+    def test_blank_value_raises(self, field: str, match: str) -> None:
+        overrides = {"wandb_project": "proj", field: "  "}
+        with pytest.raises(ValueError, match=match):
+            build_wandb(_make_cli(**overrides))
+
+
+class TestSuccessPaths:
+    def test_project_only(self) -> None:
+        assert build_wandb(_make_cli(wandb_project="proj")) == {"project": "proj"}
+
+    def test_full_flags_normalize_whitespace(self) -> None:
+        cli = _make_cli(
+            wandb_project=" proj ",
+            wandb_entity=" team ",
+            wandb_run_name="  ",
+            wandb_tags=["a", "b"],
+        )
+        assert build_wandb(cli) == {
+            "project": "proj",
+            "entity": "team",
+            "run_name": None,
+            "tags": ["a", "b"],
+        }
+
+
+_YAML_WANDB_BASE = textwrap.dedent("""\
+benchmark:
+  models:
+    - test-model
+  endpoint:
+    urls:
+      - http://localhost:8000/v1/chat/completions
+  datasets:
+    - name: default
+      type: synthetic
+      entries: 100
+      prompts:
+        isl: 128
+        osl: 64
+  phases:
+    - name: profiling
+      type: concurrency
+      requests: 10
+      concurrency: 1
+  wandb:
+    project: yaml-project
+    entity: yaml-team
+""")
+
+
+class TestBaseEnabledOverlay:
+    def test_secondary_alone_with_base_enabled_emits_partial(self) -> None:
+        cli = _make_cli(wandb_run_name="rerun", wandb_tags=["t"])
+        assert build_wandb(cli, base_enabled=True) == {
+            "run_name": "rerun",
+            "tags": ["t"],
+        }
+
+    def test_no_flags_with_base_enabled_returns_empty(self) -> None:
+        assert build_wandb(_make_cli(), base_enabled=True) == {}
+
+    def test_resolver_overlays_secondary_flags_on_yaml_project(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: ``-f base.yaml --wandb-run-name rerun`` must succeed
+        when the YAML already sets ``benchmark.wandb.project``."""
+        cfg_file = tmp_path / "base.yaml"
+        cfg_file.write_text(_YAML_WANDB_BASE)
+        user = CLIConfig(wandb_run_name="rerun", wandb_tags=["overlay-tag"])
+
+        config = resolve_config(user, cfg_file)
+
+        assert config.benchmark.wandb.project == "yaml-project"
+        assert config.benchmark.wandb.entity == "yaml-team"
+        assert config.benchmark.wandb.run_name == "rerun"
+        assert config.benchmark.wandb.tags == ["overlay-tag"]
+
+    def test_resolver_still_rejects_secondary_without_yaml_project(
+        self, tmp_path: Path
+    ) -> None:
+        cfg_file = tmp_path / "base.yaml"
+        cfg_file.write_text(_YAML_WANDB_BASE[: _YAML_WANDB_BASE.index("  wandb:")])
+        user = CLIConfig(wandb_run_name="rerun")
+
+        with pytest.raises(ValueError, match="require"):
+            resolve_config(user, cfg_file)
+
+
+class TestWandbConfigModel:
+    def test_whitespace_project_normalizes_to_disabled(self) -> None:
+        cfg = WandbConfig(project="   ")
+        assert cfg.project is None
+        assert cfg.enabled is False
+
+    def test_project_whitespace_is_stripped(self) -> None:
+        cfg = WandbConfig(project=" proj ", entity=" team ", run_name=" run ")
+        assert cfg.project == "proj"
+        assert cfg.entity == "team"
+        assert cfg.run_name == "run"
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            param("entity", "team", id="entity"),
+            param("run_name", "run", id="run_name"),
+            param("tags", ["a"], id="tags"),
+        ],
+    )  # fmt: skip
+    def test_secondary_without_project_raises(self, field: str, value: object) -> None:
+        with pytest.raises(ValidationError, match=r"wandb\.project"):
+            WandbConfig(**{field: value})

--- a/tests/unit/exporters/test_wandb_data_exporter.py
+++ b/tests/unit/exporters/test_wandb_data_exporter.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Weights & Biases post-run data exporter."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aiperf.common.exceptions import DataExporterDisabled
+from aiperf.common.models import MetricResult, ProfileResults
+from aiperf.common.redact import REDACTED_VALUE
+from aiperf.config import (
+    ArtifactsConfig,
+    BenchmarkConfig,
+    EndpointConfig,
+    WandbConfig,
+)
+from aiperf.exporters.exporter_config import ExporterConfig
+from aiperf.exporters.wandb_data_exporter import WandbDataExporter
+from aiperf.plugin.enums import EndpointType
+
+
+def _make_cfg(
+    tmp_path: Path,
+    *,
+    project: str | None = "aiperf-dev",
+    entity: str | None = "coreweave1",
+    run_name: str | None = None,
+    tags: list[str] | None = None,
+) -> BenchmarkConfig:
+    return BenchmarkConfig(
+        model="test-model",
+        endpoint=EndpointConfig(
+            urls=["http://localhost:8000"],
+            type=EndpointType.CHAT,
+        ),
+        dataset={"type": "synthetic"},
+        profiling={"type": "concurrency", "requests": 1, "concurrency": 1},
+        artifacts=ArtifactsConfig(dir=tmp_path),
+        wandb=WandbConfig(
+            project=project,
+            entity=entity,
+            run_name=run_name,
+            tags=tags,
+        ),
+    )
+
+
+@pytest.fixture
+def sample_results() -> ProfileResults:
+    return ProfileResults(
+        records=[
+            MetricResult(
+                tag="request_throughput",
+                header="Request Throughput",
+                unit="req/s",
+                avg=42.5,
+                count=10,
+                sum=425.0,
+            ),
+            MetricResult(
+                tag="time_to_first_token",
+                header="Time to First Token",
+                unit="ms",
+                avg=None,
+            ),
+        ],
+        total_expected=12,
+        completed=10,
+        start_ns=0,
+        end_ns=1,
+        was_cancelled=False,
+        error_summary=[],
+    )
+
+
+@pytest.fixture
+def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Install a fake wandb module into sys.modules and return call state."""
+    state: dict[str, Any] = {
+        "init_kwargs": None,
+        "logged": [],
+        "artifact_files": [],
+        "logged_artifacts": [],
+        "finished": False,
+    }
+
+    class FakeArtifact:
+        # `type` shadows the builtin on purpose: the exporter calls
+        # wandb.Artifact(name=..., type=...) by keyword, mirroring wandb's API.
+        def __init__(self, name: str, type: str) -> None:
+            self.name = name
+            self.type = type
+
+        def add_file(self, path: str, name: str | None = None) -> None:
+            state["artifact_files"].append((path, name))
+
+    class FakeRun:
+        id = "run-123"
+        url = "https://wandb.ai/fake/run-123"
+
+        def log(self, payload: dict[str, Any]) -> None:
+            state["logged"].append(payload)
+
+        def log_artifact(self, artifact: FakeArtifact) -> None:
+            state["logged_artifacts"].append(artifact)
+
+        def finish(self) -> None:
+            state["finished"] = True
+
+    class FakeTable:
+        def __init__(self, columns: list[str], data: list[list[Any]]) -> None:
+            self.columns = columns
+            self.data = data
+
+    def fake_init(**kwargs: Any) -> FakeRun:
+        state["init_kwargs"] = kwargs
+        return FakeRun()
+
+    fake_module = types.ModuleType("wandb")
+    fake_module.init = fake_init  # type: ignore[attr-defined]
+    fake_module.Table = FakeTable  # type: ignore[attr-defined]
+    fake_module.Artifact = FakeArtifact  # type: ignore[attr-defined]
+    state["table_cls"] = FakeTable
+    monkeypatch.setitem(sys.modules, "wandb", fake_module)
+    return state
+
+
+def _make_exporter(
+    cfg: BenchmarkConfig,
+    results: ProfileResults | None,
+    run: Any | None = None,
+) -> WandbDataExporter:
+    return WandbDataExporter(
+        ExporterConfig(
+            results=results,
+            cfg=cfg,
+            telemetry_results=None,
+            run=run,
+        )
+    )
+
+
+class TestWandbDataExporter:
+    def test_disabled_without_project(
+        self, tmp_path: Path, sample_results: ProfileResults
+    ) -> None:
+        cfg = _make_cfg(tmp_path, project=None, entity=None)
+        with pytest.raises(DataExporterDisabled):
+            _make_exporter(cfg, sample_results)
+
+    def test_disabled_without_results(self, tmp_path: Path) -> None:
+        cfg = _make_cfg(tmp_path)
+        with pytest.raises(DataExporterDisabled):
+            _make_exporter(cfg, results=None)
+
+    @pytest.mark.asyncio
+    async def test_export_logs_console_style_table_and_artifacts(
+        self,
+        tmp_path: Path,
+        sample_results: ProfileResults,
+        fake_wandb: dict[str, Any],
+    ) -> None:
+        """The run carries the full resolved config, tags, exactly one logged
+        payload (the console-style table), and the artifact-dir file bundle.
+        """
+        (tmp_path / "profile_export_aiperf.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "profile_export_aiperf.csv").write_text("a,b", encoding="utf-8")
+
+        cfg = _make_cfg(tmp_path, run_name="my-run", tags=["aa-repro"])
+        exporter = _make_exporter(cfg, sample_results)
+        await asyncio.to_thread(exporter._export_sync)
+
+        init_kwargs = fake_wandb["init_kwargs"]
+        assert init_kwargs["entity"] == "coreweave1"
+        assert init_kwargs["project"] == "aiperf-dev"
+        assert init_kwargs["name"] == "my-run"
+        assert "aa-repro" in init_kwargs["tags"]
+        config = init_kwargs["config"]
+        assert config["models"]["items"][0]["name"] == "test-model"
+        assert config["phases"][0]["concurrency"] == 1
+        assert config["endpoint"]["type"] == "chat"
+        assert config["wandb"]["project"] == "aiperf-dev"
+
+        [logged] = fake_wandb["logged"]
+        assert set(logged) == {"summary_metrics"}  # the table is the only payload
+        table = logged["summary_metrics"]
+        assert isinstance(table, fake_wandb["table_cls"])
+        assert table.columns == ["Metric", "avg", "min", "max", "p99", "p90", "p50", "std"]  # fmt: skip
+        by_label = {row[0]: row for row in table.data}
+        throughput_row = next(
+            row for label, row in by_label.items() if "req/s" in label.lower()
+        )
+        assert throughput_row[1] == 42.5  # avg column
+        ttft_row = next(
+            row for label, row in by_label.items() if "ttft" in label.lower()
+        )
+        assert ttft_row[1] is None  # missing stats stay None
+
+        uploaded = {name for _, name in fake_wandb["artifact_files"]}
+        assert uploaded == {"profile_export_aiperf.json", "profile_export_aiperf.csv"}
+        [artifact] = fake_wandb["logged_artifacts"]
+        assert artifact.type == "aiperf-run"
+        assert fake_wandb["finished"] is True
+
+    @pytest.mark.asyncio
+    async def test_export_finishes_run_on_failure(
+        self,
+        tmp_path: Path,
+        sample_results: ProfileResults,
+        fake_wandb: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failure after wandb.init must still finish the run so it does
+        not linger in the 'running' state in the wandb UI.
+        """
+        exporter = _make_exporter(_make_cfg(tmp_path), sample_results)
+        monkeypatch.setattr(exporter, "_build_metric_table_rows", lambda: 1 / 0)
+        with pytest.raises(ZeroDivisionError):
+            await asyncio.to_thread(exporter._export_sync)
+        assert fake_wandb["finished"] is True
+        assert fake_wandb["logged_artifacts"] == []
+
+    @pytest.mark.asyncio
+    async def test_export_non_finite_stats_become_none(
+        self, tmp_path: Path, fake_wandb: dict[str, Any]
+    ) -> None:
+        """NaN/Inf stats are scrubbed to None per the repo's NaN/Inf
+        discipline for values crossing a serialization boundary.
+        """
+        results = ProfileResults(
+            records=[
+                MetricResult(
+                    tag="request_throughput",
+                    header="Request Throughput",
+                    unit="req/s",
+                    avg=float("nan"),
+                    max=float("inf"),
+                    min=1.0,
+                ),
+            ],
+            total_expected=1,
+            completed=1,
+            start_ns=0,
+            end_ns=1,
+            was_cancelled=False,
+            error_summary=[],
+        )
+        exporter = _make_exporter(_make_cfg(tmp_path), results)
+        await asyncio.to_thread(exporter._export_sync)
+
+        [logged] = fake_wandb["logged"]
+        [row] = logged["summary_metrics"].data
+        by_col = dict(zip(logged["summary_metrics"].columns, row, strict=True))
+        assert by_col["avg"] is None  # nan scrubbed
+        assert by_col["max"] is None  # inf scrubbed
+        assert by_col["min"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_export_includes_redacted_cli_command(
+        self,
+        tmp_path: Path,
+        sample_results: ProfileResults,
+        fake_wandb: dict[str, Any],
+    ) -> None:
+        run = types.SimpleNamespace(
+            benchmark_id="abc123def456",
+            cli_command="aiperf profile --api-key secret --model m",
+        )
+        exporter = _make_exporter(_make_cfg(tmp_path), sample_results, run=run)
+        await asyncio.to_thread(exporter._export_sync)
+
+        cli_command = fake_wandb["init_kwargs"]["config"]["aiperf.cli_command"]
+        assert "secret" not in cli_command
+        assert cli_command.startswith("aiperf profile")
+
+    @pytest.mark.asyncio
+    async def test_export_config_payload_redacts_api_key(
+        self,
+        tmp_path: Path,
+        sample_results: ProfileResults,
+        fake_wandb: dict[str, Any],
+    ) -> None:
+        """The uploaded config relies on the model-layer json serializers for
+        secret redaction; lock that in so a future change can't silently leak.
+        """
+        cfg = _make_cfg(tmp_path)
+        cfg.endpoint.api_key = "super-secret-key"
+        exporter = _make_exporter(cfg, sample_results)
+        await asyncio.to_thread(exporter._export_sync)
+
+        config = fake_wandb["init_kwargs"]["config"]
+        assert "super-secret-key" not in str(config)
+        assert config["endpoint"]["api_key"] == REDACTED_VALUE
+
+    def test_collect_artifact_files_skips_wandb_state_dir(
+        self, tmp_path: Path, sample_results: ProfileResults
+    ) -> None:
+        """wandb.init(dir=...) writes its own run dir under <artifact_dir>/wandb/
+        before collection runs; the recursive globs must not re-upload it.
+        """
+        (tmp_path / "plots").mkdir()
+        (tmp_path / "plots" / "ttft.png").write_bytes(b"png")
+        wandb_media = tmp_path / "wandb" / "run-20260612_010101-abc" / "files" / "media"
+        wandb_media.mkdir(parents=True)
+        (wandb_media / "table.png").write_bytes(b"png")
+        (wandb_media.parent / "config.json").write_text("{}", encoding="utf-8")
+
+        exporter = _make_exporter(_make_cfg(tmp_path), sample_results)
+        collected = exporter._collect_artifact_files()
+
+        names = {f.relative_to(tmp_path).as_posix() for f in collected}
+        assert names == {"plots/ttft.png"}
+
+    def test_default_run_name_uses_benchmark_id(
+        self, tmp_path: Path, sample_results: ProfileResults
+    ) -> None:
+        run = types.SimpleNamespace(benchmark_id="abcdef1234567890", cli_command=None)
+        exporter = _make_exporter(_make_cfg(tmp_path), sample_results, run=run)
+        assert exporter._derive_default_run_name() == "aiperf-abcdef12"
+
+    @pytest.mark.asyncio
+    async def test_export_subprocess_terminates_on_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        sample_results: ProfileResults,
+    ) -> None:
+        """``export()`` must terminate a hung subprocess on timeout.
+
+        Simulates a wedged W&B upload by stubbing the subprocess entrypoint
+        with a sleeper at module scope (spawn can't pickle local closures).
+        With a 1s timeout the outer ``export()`` returns quickly (not 30s
+        default) and the worker subprocess is no longer alive.
+        """
+        import time as time_module
+
+        from aiperf.common import environment as env_module
+
+        monkeypatch.setattr(
+            "aiperf.exporters.wandb_export_subprocess.run_export_in_subprocess",
+            _hang_forever_subprocess_entry,
+        )
+        monkeypatch.setattr(env_module.Environment.WANDB, "EXPORT_TIMEOUT_SECONDS", 1.0)
+
+        exporter = _make_exporter(_make_cfg(tmp_path), sample_results)
+
+        start = time_module.monotonic()
+        await exporter.export()
+        elapsed = time_module.monotonic() - start
+
+        # Must return within a small multiple of the 1s timeout, not 30s.
+        assert elapsed < 10.0, f"export() did not honor timeout: elapsed={elapsed:.1f}s"
+
+
+def _hang_forever_subprocess_entry(exporter_config: Any, result_queue: Any) -> None:
+    """Module-level subprocess stub (must be picklable for spawn context)."""
+    import time as _time
+
+    _time.sleep(30)
+    result_queue.put(None)


### PR DESCRIPTION
Add a post-run data exporter that uploads benchmark results to a
Weights & Biases project, enabled via --wandb-project (with optional
--wandb-entity, --wandb-run-name, and repeatable --wandb-tag), or the
equivalent benchmark.wandb YAML section. CLI flags also overlay onto
YAML configs through the resolver path.

The exporter logs:
- A summary_metrics wandb.Table mirroring the console Real-Time
  Metrics view: same visibility rules (excludes internal/experimental/
  error-only metrics and non-console groups), display order, short
  metric labels, and avg/min/max/p99/p90/p50/std stat columns.
  Non-finite stats are scrubbed to None per the NaN/Inf discipline.
- An aiperf-run artifact bundle containing the generated output files
  (inputs.json, profile_export.jsonl, CSV/JSON summaries, parquet,
  timeslices, plots) with relative paths preserved.
- The full resolved benchmark config (JSON-mode serializers redact
  api_key, auth headers, and URL userinfo at the model layer), the
  redacted CLI command, and identifying tags for cross-run filtering.

wandb is an optional dependency (aiperf[wandb]); the exporter raises
DataExporterDisabled when no project is configured and a clear install
hint when the package is missing. Blocking wandb client calls run off
the event loop via asyncio.to_thread, and the run is always finished
even if the upload fails partway.

Signed-off-by: Aaron Batilo <AaronBatilo@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weights & Biases export: upload benchmark config, metrics, tags, and artifacts; new CLI flags (--wandb-project, --wandb-entity, --wandb-run-name, --wandb-tag); optional dependency extra.

* **Behavior**
  * Exports run in a timed subprocess with sensible default run names, secret redaction, and non-finite metric values serialized as null; exporter tolerates backend timeouts.

* **Documentation**
  * Added W&B tutorial, CLI reference entries, install instructions, and env var docs.

* **Tests**
  * Added unit tests for CLI/config conversion, model validation, and exporter flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->