### PR TITLE
fix(converter): reject synthetic-only flags on --public-dataset

### DIFF
--- a/src/aiperf/config/flags/_converter_dataset.py
+++ b/src/aiperf/config/flags/_converter_dataset.py
@@ -493,21 +493,24 @@ _FILE_DATASET_INCOMPATIBLE_TRIGGERS: tuple[tuple[str, str], ...] = (
 )
 
 
-def _reject_file_dataset_incompatible(cli: CLIConfig) -> None:
-    """Reject synthetic-only flags when --input-file is set.
+def _reject_non_synthetic_incompatible(cli: CLIConfig) -> None:
+    """Reject synthetic-only flags when --input-file or --public-dataset is set.
 
     Flags rejected: prefix prompts, ISL shaping (--isl/--isl-stddev/
     --isl-block-size), --prompt-batch-size, --seq-dist, multimodal
-    batch_size. These are only meaningful for synthetic datasets; on file
-    datasets they were previously silently dropped by the strip in
-    ``_apply_dataset_type`` (or worse, leaked through and crashed
-    AIPerfConfig validation with ``extra_forbidden`` on the
-    FileDataset). Surface a clear message instead.
+    batch_size. These are only meaningful for synthetic datasets. On file
+    datasets they previously leaked through ``_apply_dataset_type``'s strip
+    (or crashed AIPerfConfig validation with ``extra_forbidden`` on the
+    FileDataset). Public datasets strip the same subtables in
+    ``_apply_dataset_type`` and so silently dropped these flags too — the
+    benchmark ran as if they were never passed, with no error or warning.
+    Surface a clear message for both instead.
 
-    --osl / --osl-stddev are NOT rejected — they're routed onto
-    ``FileDataset.osl`` by ``_apply_file_osl`` as a per-record fallback.
+    --osl / --osl-stddev are NOT rejected — for file datasets they're routed
+    onto ``FileDataset.osl`` by ``_apply_file_osl`` as a per-record fallback,
+    so leaving them out preserves the existing file-dataset contract.
     """
-    if not cli.input_file:
+    if not (cli.input_file or cli.public_dataset):
         return
     s = cli.model_fields_set
     violations = [
@@ -516,7 +519,7 @@ def _reject_file_dataset_incompatible(cli: CLIConfig) -> None:
     if violations:
         raise ValueError(
             f"{', '.join(violations)} is only supported with synthetic datasets; "
-            "use a synthetic dataset (no --input-file) to apply synthetic-only "
+            "remove --input-file/--public-dataset to apply synthetic-only "
             "prompt shaping (ISL, prefix prompts, multimodal generation, etc)."
         )
 
@@ -643,13 +646,13 @@ def build_dataset(cli: CLIConfig) -> dict[str, Any]:
     flat input fields and sub-config holders on ``cli``, then assembles the
     sub-fields into the correct dataset shape. Rejects synthetic-only
     flags (prefix, ISL shaping, batch_size, seq-dist, multimodal batch_size)
-    when --input-file is set.
+    when --input-file or --public-dataset is set.
 
     Returns:
         A dict suitable for ``DatasetConfig.model_validate({"name": "main", **out})``.
     """
     needs_text = _determine_needs_text(cli)
-    _reject_file_dataset_incompatible(cli)
+    _reject_non_synthetic_incompatible(cli)
 
     d = _flat_dataset_fields(cli)
     _attach_subtables(d, cli)

--- a/tests/unit/config/test_v1_public_dataset_rejections.py
+++ b/tests/unit/config/test_v1_public_dataset_rejections.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for v1 -> v2 converter rejecting synthetic-only flags
+on public (--public-dataset) datasets.
+
+Public datasets source their prompts from the downloaded dataset, so the
+synthetic-only shaping flags (ISL, prefix prompts, batch_size, seq-dist,
+multimodal batch_size) do not apply. ``_apply_dataset_type`` strips the
+``prompts``/``prefix_prompts``/``rankings``/``audio``/``images``/``video``
+subtables for PUBLIC datasets, so these flags were previously dropped
+*silently* — the benchmark ran as if the user never passed them, with no
+error or warning. This was inconsistent with the ``--input-file`` path,
+which already raised a clear ValueError naming the offending flag. Reject at
+convert-time for public datasets too so the user sees the same flag-level
+error instead of a silently-ignored flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest import param
+
+from aiperf.config.flags._converter_dataset import build_dataset
+from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.config.flags.converter import convert_cli_to_aiperf
+
+
+def _public_user(*, prompt_kwargs: dict | None = None) -> CLIConfig:
+    """Build a v1 CLIConfig with ``--public-dataset sharegpt`` + a
+    synthetic-only prompt field set. ``prompt_kwargs`` keys must be the
+    flat ``prompt_*`` attribute names on CLIConfig."""
+    prompt_kwargs = prompt_kwargs or {}
+    return CLIConfig(
+        model_names=["test-model"],
+        endpoint_type="chat",
+        **CLIConfig(request_count=5, concurrency=1).model_dump(exclude_unset=True),
+        public_dataset="sharegpt",
+        **prompt_kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "prompt_kwargs, expected_flag_fragment",
+    [
+        param(
+            {"prompt_input_tokens_block_size": 20},
+            "--isl-block-size",
+            id="isl-block-size",
+        ),
+        param(
+            {"prompt_input_tokens_mean": 128},
+            "--isl",
+            id="isl-mean",
+        ),
+        param(
+            {"prompt_input_tokens_stddev": 10},
+            "--isl-stddev",
+            id="isl-stddev",
+        ),
+        param(
+            {"prompt_batch_size": 4},
+            "--prompt-batch-size",
+            id="prompt-batch-size",
+        ),
+        param(
+            {"prompt_sequence_distribution": "256,256:100.0"},
+            "--seq-dist",
+            id="seq-dist",
+        ),
+        param(
+            {"prompt_prefix_length": 20},
+            "--prompt-prefix-length",
+            id="prefix-prompt-length",
+        ),
+    ],
+)  # fmt: skip
+def test_synthetic_only_flag_rejected_on_public_dataset(
+    prompt_kwargs: dict, expected_flag_fragment: str
+) -> None:
+    """Each synthetic-only flag must raise ValueError naming the flag when
+    paired with --public-dataset, instead of silently dropping it."""
+    user = _public_user(prompt_kwargs=prompt_kwargs)
+    with pytest.raises(ValueError, match=expected_flag_fragment):
+        build_dataset(user)
+
+
+def test_public_dataset_without_synthetic_flags_validates_cleanly() -> None:
+    """The fix must not regress the happy path: a public dataset with only
+    public-compatible flags must build a valid AIPerfConfig with no
+    synthetic-only subtables leaking onto the public-typed dict."""
+    user = CLIConfig(
+        model_names=["test-model"],
+        endpoint_type="chat",
+        **CLIConfig(request_count=5, concurrency=1).model_dump(exclude_unset=True),
+        public_dataset="sharegpt",
+    )
+
+    out = build_dataset(user)
+    assert out["type"] == "public"
+    assert out["dataset"] == "sharegpt"
+    # Synthetic-only subtables must be absent on the public-typed dict.
+    for forbidden_key in (
+        "prompts",
+        "prefix_prompts",
+        "rankings",
+        "audio",
+        "images",
+        "video",
+    ):
+        assert forbidden_key not in out, (
+            f"PublicDataset must not carry {forbidden_key!r}"
+        )
+
+    # Full envelope must validate against AIPerfConfig without extra_forbidden.
+    aiperf_cfg = convert_cli_to_aiperf(user)
+    datasets = aiperf_cfg.benchmark.datasets
+    assert len(datasets) == 1
+    assert datasets[0].type == "public"

--- a/tests/unit/config/test_v1_public_dataset_rejections.py
+++ b/tests/unit/config/test_v1_public_dataset_rejections.py
@@ -73,6 +73,41 @@ def _public_user(*, prompt_kwargs: dict | None = None) -> CLIConfig:
             "--prompt-prefix-length",
             id="prefix-prompt-length",
         ),
+        param(
+            {"prompt_prefix_pool_size": 5},
+            "--prompt-prefix-pool-size",
+            id="prefix-prompt-pool-size",
+        ),
+        param(
+            {"prompt_prefix_shared_system_length": 10},
+            "--shared-system-prompt-length",
+            id="shared-system-prompt-length",
+        ),
+        param(
+            {"prompt_prefix_user_context_length": 10},
+            "--user-context-prompt-length",
+            id="user-context-prompt-length",
+        ),
+        param(
+            {"image_batch_size": 2},
+            "--image-batch-size",
+            id="image-batch-size",
+        ),
+        param(
+            {"image_source": "https://example.com/x.png"},
+            "--image-source",
+            id="image-source",
+        ),
+        param(
+            {"audio_batch_size": 2},
+            "--audio-batch-size",
+            id="audio-batch-size",
+        ),
+        param(
+            {"video_batch_size": 2},
+            "--video-batch-size",
+            id="video-batch-size",
+        ),
     ],
 )  # fmt: skip
 def test_synthetic_only_flag_rejected_on_public_dataset(


### PR DESCRIPTION
## Summary

--public-dataset drops synthetic-only flags (--isl, --isl-stddev, --prompt-batch-size, --seq-dist, prefix/multimodal flags) with no error or warning, so the run ignores them without telling you. The --input-file path already rejects these with a clear error. This makes --public-dataset do the same.

Fixes #996

## Root cause

The rejection guard returns early unless --input-file is set, so --public-dataset skips it. `_apply_dataset_type()` then strips the prompt subtables for public datasets and the flags are lost.

## Change

- The guard now also fires for --public-dataset:
  ```python
  if not (cli.input_file or cli.public_dataset):
      return
  ```
- Renamed `_reject_file_dataset_incompatible` to `_reject_non_synthetic_incompatible`.
- --osl is left out, matching the file-dataset behavior (file datasets route --osl onto `FileDataset.osl`).

The YAML path already rejects the same thing via `PublicDataset(extra="forbid")`, covered by `test_isl_osl_not_hoisted_on_public_dataset`. This brings the CLI path in line.

## Tests

New `tests/unit/config/test_v1_public_dataset_rejections.py`: each flag is rejected with --public-dataset sharegpt, plus a happy path that still builds type=public and validates. `pytest tests/unit/config/` passes (1631); ruff check/format clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened dataset validation to reject synthetic-only configuration flags when a dataset is sourced from a file or a public dataset, with clearer error messages.

* **Tests**
  * Added regression tests covering rejection of synthetic-only flags for public datasets and a happy-path test ensuring clean validation when only public-compatible flags are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->