### PR TITLE
feat: add Anthropic Messages API (/v1/messages) endpoint

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -285,7 +285,7 @@ Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default,
 #### `--endpoint-type` `<str>`
 
 The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
-<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
+<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `messages`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
 <br/>_Default: `chat`_
 
 #### `--streaming`
@@ -1692,7 +1692,7 @@ Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default,
 #### `--endpoint-type` `<str>`
 
 The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
-<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
+<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `messages`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
 <br/>_Default: `chat`_
 
 #### `--streaming`

--- a/docs/reference/vendor-usage-fields.md
+++ b/docs/reference/vendor-usage-fields.md
@@ -136,6 +136,8 @@ class ServerToolUsage(BaseModel):
 
 Streaming chunks use `MessageDeltaUsage`, which carries the same fields as `Usage` for cache and tokens (a non-streaming chunk + `MessageDeltaUsage` contain the same shape for our purposes).
 
+**Native endpoint:** AIPerf benchmarks the Messages API directly via `--endpoint-type messages` (`/v1/messages`, [`src/aiperf/endpoints/anthropic_messages.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/endpoints/anthropic_messages.py)). The shared system prompt is emitted in the top-level `system` field (not as a `system`-role message), `max_tokens` is always sent (the API requires it; absent turns fall back to a 16384 default), and streaming splits usage across `message_start` (`input_tokens`) and `message_delta` (`output_tokens`). The usage-field parsing below is shared by this endpoint and by any chat-shaped server that happens to report Anthropic-style fields.
+
 **Modelled:** `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`.
 
 **Not modelled (preserved on dict):**

--- a/src/aiperf/endpoints/anthropic_messages.py
+++ b/src/aiperf/endpoints/anthropic_messages.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import orjson
+
+from aiperf.common.enums import MediaType
+from aiperf.common.models import (
+    ExtractedPayload,
+    InferenceServerResponse,
+    ParsedResponse,
+    ReasoningResponseData,
+    RequestInfo,
+    TextResponseData,
+    ToolCallResponseData,
+)
+from aiperf.common.types import JsonObject
+from aiperf.endpoints.base_endpoint import BaseEndpoint
+
+
+class MessagesEndpoint(BaseEndpoint):
+    """Anthropic Messages API endpoint (``/v1/messages``).
+
+    The role/content message array reuses the generic
+    ``BaseEndpoint.build_messages`` flow - Anthropic messages share the
+    ``{"role": ..., "content": ...}`` shape with OpenAI chat. Only the
+    image content-part shape differs (Anthropic nests a ``source`` object
+    keyed by ``base64``/``url`` rather than OpenAI's ``image_url``), so we
+    override that hook and leave the iteration skeleton alone.
+
+    Two contract differences from chat drive the rest of this class:
+
+    - The shared system prompt lives in the top-level ``system`` field,
+      never as a ``system``-role message inside ``messages``.
+    - ``max_tokens`` is required by the API; absence falls back to
+      ``DEFAULT_MAX_TOKENS`` rather than being omitted.
+
+    Audio and video inputs are not supported by the Messages API; those
+    content parts raise at format time instead of letting the server 4xx.
+    """
+
+    DEFAULT_MAX_TOKENS: ClassVar[int] = 16384
+    """Fallback when a turn carries no ``max_tokens``. The Messages API
+    rejects requests without ``max_tokens``, so unlike chat we always emit
+    a value."""
+
+    # Anthropic content-part type names. ``text`` matches the chat default;
+    # ``image`` replaces chat's ``image_url``. Audio/video are unsupported,
+    # so their sets are empty and ISL accounting never expects them.
+    PART_TYPES: ClassVar[dict[MediaType, set[str]]] = {
+        MediaType.TEXT: {"text"},
+        MediaType.IMAGE: {"image"},
+        MediaType.AUDIO: set(),
+        MediaType.VIDEO: set(),
+    }
+
+    def extract_payload_inputs(self, payload: dict[str, Any]) -> ExtractedPayload:
+        """Messages-API single-pass extraction.
+
+        Inherits the base-class walk (content parts dispatched via
+        ``PART_TYPES``) and additionally prepends the top-level ``system``
+        prompt - the Messages-API equivalent of a system message that lives
+        outside ``messages`` and would otherwise be missed by ISL
+        tokenisation. Accepts both the string and list-of-blocks shapes the
+        API permits for ``system``.
+        """
+        result = super().extract_payload_inputs(payload)
+        system = payload.get("system")
+        if isinstance(system, str):
+            result.texts.insert(0, system)
+        elif isinstance(system, list):
+            collected: list[str] = []
+            for block in system:
+                if isinstance(block, dict):
+                    text = block.get("text")
+                    if isinstance(text, str) and text:
+                        collected.append(text)
+                elif isinstance(block, str) and block:
+                    collected.append(block)
+            for text in reversed(collected):
+                result.texts.insert(0, text)
+        return result
+
+    # --- Content-part hooks ---------------------------------------------------
+
+    def _render_image_part(self, url_or_data_uri: str) -> dict[str, Any]:
+        """Render one image as an Anthropic content block.
+
+        Data URIs (``data:image/png;base64,<b64>``) become a ``base64``
+        source with the parsed ``media_type``; everything else is treated
+        as a remote ``url`` source.
+        """
+        if url_or_data_uri.startswith("data:"):
+            header, _, b64 = url_or_data_uri.partition(",")
+            media_type = header[len("data:") :].split(";", 1)[0] or "image/png"
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": b64,
+                },
+            }
+        return {"type": "image", "source": {"type": "url", "url": url_or_data_uri}}
+
+    def _render_audio_part(self, format_and_b64: str) -> dict[str, Any]:
+        raise NotImplementedError(
+            "Anthropic Messages API does not support audio input. "
+            "Use endpoint=chat for audio turns, or remove the audio content."
+        )
+
+    def _render_video_part(self, url_or_data_uri: str) -> dict[str, Any]:
+        raise NotImplementedError(
+            "Anthropic Messages API does not support video input. "
+            "Use endpoint=chat for video turns, or remove the video content."
+        )
+
+    def format_payload(self, request_info: RequestInfo) -> dict[str, Any]:
+        """Format an Anthropic Messages API request payload from RequestInfo."""
+        if not request_info.turns:
+            raise ValueError("Messages endpoint requires at least one turn.")
+
+        turns = request_info.turns
+        model_endpoint = request_info.model_endpoint
+
+        # The per-conversation user context is prepended as a leading user
+        # message; the shared system prompt is top-level, not a message.
+        messages: list[dict[str, Any]] = []
+        if request_info.user_context_message:
+            messages.append(
+                {
+                    "role": self.DEFAULT_TURN_ROLE,
+                    "content": request_info.user_context_message,
+                }
+            )
+        messages.extend(self.build_messages(turns))
+
+        # Conversation-level fields walk turns from the end so FORK-mode
+        # children whose final turn lacks model/tools still inherit the
+        # parent's intent. Per-request overrides stay scoped to the turn.
+        model_name = turns[-1].model
+        max_tokens = turns[-1].max_tokens
+        extra_body = turns[-1].extra_body
+        raw_tools = self._latest_turn_attr(turns, "raw_tools")
+
+        payload: dict[str, Any] = {
+            "messages": messages,
+            "model": model_name or model_endpoint.primary_model_name,
+            "max_tokens": max_tokens
+            if max_tokens is not None
+            else self.DEFAULT_MAX_TOKENS,
+            "stream": model_endpoint.endpoint.streaming,
+        }
+        if request_info.system_message:
+            payload["system"] = request_info.system_message
+        if raw_tools is not None:
+            payload["tools"] = raw_tools
+
+        if model_endpoint.endpoint.extra:
+            payload.update(model_endpoint.endpoint.extra)
+        if extra_body:
+            payload.update(extra_body)
+
+        self.trace(lambda: f"Formatted payload: {payload}")
+        return payload
+
+    def parse_response(
+        self, response: InferenceServerResponse
+    ) -> ParsedResponse | None:
+        """Parse an Anthropic Messages API response.
+
+        Handles both the non-streaming full message (``type: message``) and
+        the streaming SSE events (``message_start``, ``content_block_delta``,
+        ``message_delta``, etc.). Streaming splits usage across two events:
+        ``message_start`` carries ``input_tokens`` and ``message_delta``
+        carries the final ``output_tokens``; both are surfaced as
+        usage-only ``ParsedResponse`` objects.
+
+        Args:
+            response: Raw response from inference server
+
+        Returns:
+            Parsed response with extracted content and/or usage, or None.
+        """
+        json_obj = response.get_json()
+        if not json_obj:
+            return None
+
+        if json_obj.get("type") == "message":
+            return self._parse_full_response(json_obj, response.perf_ns)
+
+        return self._parse_streaming_event(json_obj, response.perf_ns)
+
+    def _parse_full_response(
+        self, json_obj: JsonObject, perf_ns: int
+    ) -> ParsedResponse | None:
+        """Parse a non-streaming ``type: message`` response object."""
+        data = self._extract_content_blocks(json_obj.get("content"))
+        usage = json_obj.get("usage") or None
+
+        if data is None and not usage:
+            return None
+
+        return ParsedResponse(perf_ns=perf_ns, data=data, usage=usage)
+
+    @staticmethod
+    def _extract_content_blocks(
+        content: Any,
+    ) -> TextResponseData | ReasoningResponseData | ToolCallResponseData | None:
+        """Extract model-generated tokens from a ``content[]`` block list.
+
+        ``text`` blocks contribute prose, ``thinking`` blocks contribute
+        reasoning, and ``tool_use`` blocks contribute their ``name`` plus
+        serialised ``input`` (tokens the model generated and the server's
+        ``usage.output_tokens`` already counts). Precedence mirrors the
+        chat and Responses endpoints: ``reasoning > text > tool``.
+        """
+        if not isinstance(content, list):
+            return None
+
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        tool_call_parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                MessagesEndpoint._collect_content_block(
+                    block, text_parts, reasoning_parts, tool_call_parts
+                )
+
+        if reasoning_parts:
+            return ReasoningResponseData(
+                content="".join(text_parts) or None,
+                reasoning="".join(reasoning_parts),
+            )
+        if text_parts:
+            return TextResponseData(text="".join(text_parts))
+        if tool_call_parts:
+            return ToolCallResponseData(tool_call_text="".join(tool_call_parts))
+        return None
+
+    @staticmethod
+    def _collect_content_block(
+        block: dict[str, Any],
+        text_parts: list[str],
+        reasoning_parts: list[str],
+        tool_call_parts: list[str],
+    ) -> None:
+        """Append one ``content[]`` block's tokens to the matching accumulator."""
+        block_type = block.get("type")
+        if block_type == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                text_parts.append(text)
+        elif block_type == "thinking":
+            thinking = block.get("thinking")
+            if isinstance(thinking, str) and thinking:
+                reasoning_parts.append(thinking)
+        elif block_type == "tool_use":
+            name = block.get("name")
+            if isinstance(name, str) and name:
+                tool_call_parts.append(name)
+            tool_input = block.get("input")
+            if tool_input:
+                tool_call_parts.append(orjson.dumps(tool_input).decode())
+
+    def _parse_streaming_event(
+        self, json_obj: JsonObject, perf_ns: int
+    ) -> ParsedResponse | None:
+        """Parse a single Anthropic streaming SSE event."""
+        event_type = json_obj.get("type")
+
+        if event_type == "content_block_delta":
+            data = self._streaming_delta_data(json_obj.get("delta") or {})
+            return ParsedResponse(perf_ns=perf_ns, data=data) if data else None
+
+        if event_type == "message_start":
+            usage = (json_obj.get("message") or {}).get("usage") or None
+            return (
+                ParsedResponse(perf_ns=perf_ns, data=None, usage=usage)
+                if usage
+                else None
+            )
+
+        if event_type == "message_delta":
+            usage = json_obj.get("usage") or None
+            return (
+                ParsedResponse(perf_ns=perf_ns, data=None, usage=usage)
+                if usage
+                else None
+            )
+
+        # content_block_start/stop, message_stop, ping: structural envelopes
+        # with no replayable token content.
+        return None
+
+    @staticmethod
+    def _streaming_delta_data(
+        delta: dict[str, Any],
+    ) -> TextResponseData | ReasoningResponseData | ToolCallResponseData | None:
+        """Map a ``content_block_delta`` ``delta`` to its response-data shape."""
+        delta_type = delta.get("type")
+        if delta_type == "text_delta":
+            text = delta.get("text")
+            return TextResponseData(text=text) if text else None
+        if delta_type == "thinking_delta":
+            thinking = delta.get("thinking")
+            return ReasoningResponseData(reasoning=thinking) if thinking else None
+        if delta_type == "input_json_delta":
+            partial = delta.get("partial_json")
+            return ToolCallResponseData(tool_call_text=partial) if partial else None
+        return None

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -67,7 +67,7 @@ PublicDatasetType = plugins.create_enum(PluginType.PUBLIC_DATASET_LOADER, "Publi
 
 EndpointTypeStr: TypeAlias = str
 EndpointType = plugins.create_enum(PluginType.ENDPOINT, "EndpointType", module=__name__)
-"""Dynamic enum for endpoint. Example: EndpointType.CHAT, EndpointType.IMAGE_GENERATION, EndpointType.VIDEO_GENERATION"""
+"""Dynamic enum for endpoint. Example: EndpointType.CHAT, EndpointType.IMAGE_RETRIEVAL, EndpointType.VIDEO_GENERATION"""
 
 TransportTypeStr: TypeAlias = str
 TransportType = plugins.create_enum(PluginType.TRANSPORT, "TransportType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -237,6 +237,21 @@ endpoint:
       supports_audio: true
       metrics_title: LLM Metrics
 
+  messages:
+    class: aiperf.endpoints.anthropic_messages:MessagesEndpoint
+    description: |
+      Anthropic Messages API endpoint. Supports text and image inputs and both
+      streaming and non-streaming responses. The shared system prompt lives in
+      the top-level system field and per-request max_tokens is required. Uses
+      /v1/messages path.
+    metadata:
+      endpoint_path: /v1/messages
+      supports_streaming: true
+      produces_tokens: true
+      tokenizes_input: true
+      supports_images: true
+      metrics_title: LLM Metrics
+
   chat_embeddings:
     class: aiperf.endpoints.chat_embeddings:ChatEmbeddingsEndpoint
     description: |

--- a/tests/unit/endpoints/test_messages_endpoint.py
+++ b/tests/unit/endpoints/test_messages_endpoint.py
@@ -1,0 +1,543 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Anthropic Messages API endpoint (``/v1/messages``)."""
+
+import pytest
+
+from aiperf.common.models import (
+    Audio,
+    Image,
+    ReasoningResponseData,
+    Text,
+    TextResponseData,
+    ToolCallResponseData,
+    Turn,
+    Video,
+)
+from aiperf.endpoints.anthropic_messages import MessagesEndpoint
+from aiperf.plugin.enums import EndpointType
+from tests.unit.endpoints.conftest import (
+    create_endpoint_with_mock_transport,
+    create_mock_response,
+    create_model_endpoint,
+    create_request_info,
+)
+
+_PERF_NS = 123456789
+
+
+@pytest.fixture
+def model_endpoint():
+    return create_model_endpoint(EndpointType.MESSAGES)
+
+
+@pytest.fixture
+def streaming_model_endpoint():
+    return create_model_endpoint(EndpointType.MESSAGES, streaming=True)
+
+
+@pytest.fixture
+def endpoint(model_endpoint):
+    return create_endpoint_with_mock_transport(MessagesEndpoint, model_endpoint)
+
+
+class TestMessagesEndpointFormatPayload:
+    """Tests for MessagesEndpoint.format_payload."""
+
+    def test_simple_text(self, endpoint, model_endpoint):
+        turn = Turn(texts=[Text(contents=["Hello, world!"])], model="test-model")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["model"] == "test-model"
+        assert payload["stream"] is False
+        assert payload["messages"] == [{"role": "user", "content": "Hello, world!"}]
+
+    def test_max_tokens_defaulted_when_absent(self, endpoint, model_endpoint):
+        """Anthropic requires max_tokens; absence falls back to the default."""
+        turn = Turn(texts=[Text(contents=["Hello"])], model="test-model")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["max_tokens"] == MessagesEndpoint.DEFAULT_MAX_TOKENS
+
+    def test_max_tokens_from_turn(self, endpoint, model_endpoint):
+        turn = Turn(
+            texts=[Text(contents=["Hello"])], model="test-model", max_tokens=500
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["max_tokens"] == 500
+
+    def test_system_message_is_top_level_not_a_message(self, endpoint, model_endpoint):
+        turn = Turn(texts=[Text(contents=["Hello"])], model="test-model")
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[turn],
+            system_message="You are a helpful assistant.",
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["system"] == "You are a helpful assistant."
+        # System must NOT leak into the messages array (Anthropic contract).
+        assert all(m["role"] != "system" for m in payload["messages"])
+
+    def test_no_system_message_omits_field(self, endpoint, model_endpoint):
+        turn = Turn(texts=[Text(contents=["Hello"])], model="test-model")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert "system" not in payload
+
+    def test_user_context_message_prepended(self, endpoint, model_endpoint):
+        turn = Turn(texts=[Text(contents=["Actual prompt"])], model="test-model")
+        request_info = create_request_info(
+            model_endpoint=model_endpoint,
+            turns=[turn],
+            user_context_message="Context preamble",
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert len(payload["messages"]) == 2
+        assert payload["messages"][0] == {
+            "role": "user",
+            "content": "Context preamble",
+        }
+        assert payload["messages"][1]["content"] == "Actual prompt"
+
+    def test_streaming_enabled(self, streaming_model_endpoint):
+        endpoint = create_endpoint_with_mock_transport(
+            MessagesEndpoint, streaming_model_endpoint
+        )
+        turn = Turn(texts=[Text(contents=["Hello"])], model="test-model")
+        request_info = create_request_info(
+            model_endpoint=streaming_model_endpoint, turns=[turn]
+        )
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["stream"] is True
+
+    def test_model_fallback_to_primary(self, endpoint, model_endpoint):
+        turn = Turn(texts=[Text(contents=["Hello"])])
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["model"] == model_endpoint.primary_model_name
+
+    def test_extra_body_merged(self, endpoint, model_endpoint):
+        turn = Turn(
+            texts=[Text(contents=["Hello"])],
+            model="test-model",
+            extra_body={"temperature": 0.5, "top_p": 0.9},
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["temperature"] == 0.5
+        assert payload["top_p"] == 0.9
+
+    def test_endpoint_extra_merged(self):
+        model_endpoint = create_model_endpoint(
+            EndpointType.MESSAGES, extra=[("anthropic_version", "2023-06-01")]
+        )
+        endpoint = create_endpoint_with_mock_transport(MessagesEndpoint, model_endpoint)
+        turn = Turn(texts=[Text(contents=["Hello"])], model="test-model")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["anthropic_version"] == "2023-06-01"
+
+    def test_raw_tools_forwarded(self, endpoint, model_endpoint):
+        tools = [
+            {
+                "name": "get_weather",
+                "description": "Get the weather",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ]
+        turn = Turn(
+            texts=[Text(contents=["Weather?"])], model="test-model", raw_tools=tools
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["tools"] == tools
+
+    def test_no_raw_tools_omits_tools_key(self, endpoint, model_endpoint):
+        turn = Turn(texts=[Text(contents=["Hello"])], model="test-model")
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        assert "tools" not in payload
+
+    def test_image_data_uri_renders_base64_source(self, endpoint, model_endpoint):
+        turn = Turn(
+            texts=[Text(contents=["Describe"])],
+            images=[Image(contents=["data:image/png;base64,QUJD"])],
+            model="test-model",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        content = payload["messages"][0]["content"]
+        assert isinstance(content, list)
+        image_part = next(p for p in content if p["type"] == "image")
+        assert image_part["source"] == {
+            "type": "base64",
+            "media_type": "image/png",
+            "data": "QUJD",
+        }
+
+    def test_image_url_renders_url_source(self, endpoint, model_endpoint):
+        turn = Turn(
+            texts=[Text(contents=["Describe"])],
+            images=[Image(contents=["https://example.com/cat.png"])],
+            model="test-model",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        payload = endpoint.format_payload(request_info)
+
+        content = payload["messages"][0]["content"]
+        image_part = next(p for p in content if p["type"] == "image")
+        assert image_part["source"] == {
+            "type": "url",
+            "url": "https://example.com/cat.png",
+        }
+
+    def test_audio_input_rejected(self, endpoint, model_endpoint):
+        turn = Turn(
+            texts=[Text(contents=["Listen"])],
+            audios=[Audio(contents=["wav,QUJD"])],
+            model="test-model",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        with pytest.raises(NotImplementedError, match="does not support audio"):
+            endpoint.format_payload(request_info)
+
+    def test_video_input_rejected(self, endpoint, model_endpoint):
+        turn = Turn(
+            texts=[Text(contents=["Watch"])],
+            videos=[Video(contents=["https://example.com/clip.mp4"])],
+            model="test-model",
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+
+        with pytest.raises(NotImplementedError, match="does not support video"):
+            endpoint.format_payload(request_info)
+
+    def test_empty_turns_raises(self, endpoint, model_endpoint):
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[])
+
+        with pytest.raises(ValueError, match="at least one turn"):
+            endpoint.format_payload(request_info)
+
+    def test_multiple_turns_build_messages(self, endpoint, model_endpoint):
+        turns = [
+            Turn(texts=[Text(contents=["First"])], role="user", model="test-model"),
+            Turn(texts=[Text(contents=["Reply"])], role="assistant"),
+            Turn(texts=[Text(contents=["Second"])], role="user"),
+        ]
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=turns)
+
+        payload = endpoint.format_payload(request_info)
+
+        assert [m["role"] for m in payload["messages"]] == [
+            "user",
+            "assistant",
+            "user",
+        ]
+
+
+class TestMessagesEndpointParseResponseNonStreaming:
+    """Tests for parsing non-streaming ``type: message`` responses."""
+
+    def test_text_content_block(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hi there"}],
+                "stop_reason": "end_turn",
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert parsed is not None
+        assert parsed.perf_ns == _PERF_NS
+        assert isinstance(parsed.data, TextResponseData)
+        assert parsed.data.text == "Hi there"
+
+    def test_multiple_text_blocks_concatenated(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "message",
+                "content": [
+                    {"type": "text", "text": "Hello "},
+                    {"type": "text", "text": "world"},
+                ],
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert isinstance(parsed.data, TextResponseData)
+        assert parsed.data.text == "Hello world"
+
+    def test_thinking_block_is_reasoning(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "message",
+                "content": [
+                    {"type": "thinking", "thinking": "Let me reason"},
+                    {"type": "text", "text": "The answer is 42"},
+                ],
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert isinstance(parsed.data, ReasoningResponseData)
+        assert parsed.data.reasoning == "Let me reason"
+        assert parsed.data.content == "The answer is 42"
+
+    def test_tool_use_block(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "message",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu_1",
+                        "name": "get_weather",
+                        "input": {"location": "SF"},
+                    }
+                ],
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert isinstance(parsed.data, ToolCallResponseData)
+        assert "get_weather" in parsed.data.tool_call_text
+        assert "SF" in parsed.data.tool_call_text
+
+    def test_usage_extracted(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "message",
+                "content": [{"type": "text", "text": "Hi"}],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 25,
+                    "cache_read_input_tokens": 4,
+                    "cache_creation_input_tokens": 6,
+                },
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert parsed.usage is not None
+        assert parsed.usage.prompt_tokens == 10
+        assert parsed.usage.completion_tokens == 25
+        assert parsed.usage.prompt_cache_read_tokens == 4
+        assert parsed.usage.prompt_cache_write_tokens == 6
+
+    def test_no_json_returns_none(self, endpoint):
+        parsed = endpoint.parse_response(create_mock_response(_PERF_NS, None))
+        assert parsed is None
+
+    def test_message_no_content_no_usage_returns_none(self, endpoint):
+        response = create_mock_response(_PERF_NS, {"type": "message", "content": []})
+        assert endpoint.parse_response(response) is None
+
+    def test_non_list_content_with_usage_returns_usage_only(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {"type": "message", "content": None, "usage": {"input_tokens": 7}},
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert parsed is not None
+        assert parsed.data is None
+        assert parsed.usage.prompt_tokens == 7
+
+
+class TestMessagesEndpointParseResponseStreaming:
+    """Tests for parsing Anthropic streaming SSE events."""
+
+    def test_message_start_yields_prompt_usage(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "usage": {"input_tokens": 25, "output_tokens": 1},
+                },
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert parsed is not None
+        assert parsed.data is None
+        assert parsed.usage.prompt_tokens == 25
+
+    def test_content_block_delta_text(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hello"},
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert isinstance(parsed.data, TextResponseData)
+        assert parsed.data.text == "Hello"
+
+    def test_content_block_delta_thinking(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "Hmm"},
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert isinstance(parsed.data, ReasoningResponseData)
+        assert parsed.data.reasoning == "Hmm"
+
+    def test_content_block_delta_tool_input(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": '{"loc":'},
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert isinstance(parsed.data, ToolCallResponseData)
+        assert parsed.data.tool_call_text == '{"loc":'
+
+    def test_message_delta_yields_completion_usage(self, endpoint):
+        response = create_mock_response(
+            _PERF_NS,
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 15},
+            },
+        )
+
+        parsed = endpoint.parse_response(response)
+
+        assert parsed is not None
+        assert parsed.data is None
+        assert parsed.usage.completion_tokens == 15
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            {"type": "content_block_start", "index": 0, "content_block": {}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop"},
+            {"type": "ping"},
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": ""},
+            },
+        ],
+    )
+    def test_structural_events_return_none(self, endpoint, event):
+        assert endpoint.parse_response(create_mock_response(_PERF_NS, event)) is None
+
+
+class TestMessagesEndpointExtractPayloadInputs:
+    """The top-level ``system`` prompt must count toward ISL tokenisation."""
+
+    def test_system_and_message_text_collected(self, endpoint):
+        payload = {
+            "system": "System preamble",
+            "messages": [{"role": "user", "content": "User text"}],
+        }
+
+        result = endpoint.extract_payload_inputs(payload)
+
+        assert "System preamble" in result.texts
+        assert "User text" in result.texts
+
+    def test_system_as_list_of_blocks_collected(self, endpoint):
+        payload = {
+            "system": [
+                {"type": "text", "text": "Block one"},
+                {"type": "text", "text": "Block two"},
+            ],
+            "messages": [{"role": "user", "content": "User text"}],
+        }
+
+        result = endpoint.extract_payload_inputs(payload)
+
+        assert result.texts[:2] == ["Block one", "Block two"]
+        assert "User text" in result.texts
+
+    def test_image_counted(self, endpoint):
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hi"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "QUJD",
+                            },
+                        },
+                    ],
+                }
+            ]
+        }
+
+        result = endpoint.extract_payload_inputs(payload)
+
+        assert result.image_count == 1


### PR DESCRIPTION
## Summary

Adds a native **Anthropic Messages API** endpoint (`/v1/messages`) so AIPerf can
benchmark Anthropic and any Messages-compatible server (e.g. Dynamo's
`/v1/messages` surface) directly, instead of forcing users onto `--endpoint-type raw`.

Select it with `--endpoint-type messages`:

```bash
aiperf profile \
    --endpoint-type messages \
    --url <host> \
    --model claude-... \
    --streaming
```

## Motivation

Before this PR the endpoint registry covered OpenAI Chat/Completions/Responses,
Cohere, NIM, HuggingFace, etc., but had **no Messages API endpoint**. The
`Usage` model already understood Anthropic's usage shape (`input_tokens`,
`cache_read_input_tokens`, ...), but nothing knew how to *build* a Messages
request body or *parse* its response/stream. This closes that gap.

## What's included

- `MessagesEndpoint(BaseEndpoint)` in `src/aiperf/endpoints/anthropic_messages.py`
- Registration in `src/aiperf/plugin/plugins.yaml` -> `EndpointType.MESSAGES`
- Regenerated plugin artifacts (`enums.py` / `enums.pyi`)
- Docs: `docs/cli-options.md` (auto-gen, adds `messages` to `--endpoint-type`
  choices) and a "Native endpoint" note in `docs/reference/vendor-usage-fields.md`
- 39 unit tests, 98% coverage of the new module

## Design / contract differences from OpenAI chat

The role/content message array reuses the generic `BaseEndpoint.build_messages`
skeleton (Anthropic shares the `{"role", "content"}` shape), so only the
genuinely different bits are overridden:

| Concern | Anthropic Messages behaviour |
|---|---|
| **System prompt** | Emitted in the top-level `system` field, **never** as a `system`-role message inside `messages`. |
| **`max_tokens`** | Required by the API. Taken from the turn; falls back to `DEFAULT_MAX_TOKENS = 16384` when absent (chat omits it). |
| **Images** | Content block `{"type":"image","source":{...}}`: data URIs -> `base64` source with parsed `media_type`; plain URLs -> `url` source. |
| **Audio / video** | Not supported by the API - rejected at format time with a clear `NotImplementedError` rather than letting the server 4xx. |
| **System in ISL** | `extract_payload_inputs` prepends the top-level `system` (string or block list) so it counts toward input-token accounting. |
| **`user_context_message`** | Prepended as a leading `user` message. |
| **`raw_tools` / `extra_body` / endpoint `extra`** | Forwarded the same way as other endpoints. |

### Response parsing

- **Non-streaming** (`type: message`): walks `content[]` - `text` -> prose,
  `thinking` -> reasoning, `tool_use` -> name + serialised `input`. Precedence
  mirrors the chat/Responses endpoints: `reasoning > text > tool`.
- **Streaming SSE**: usage is split across two events and both are surfaced as
  usage-only `ParsedResponse`s -
  - `message_start` -> `input_tokens`
  - `message_delta` -> final `output_tokens`
  - `content_block_delta` -> `text_delta` / `thinking_delta` / `input_json_delta`
  - `content_block_start/stop`, `message_stop`, `ping` -> no data (structural).

Usage parsing itself is unchanged - it reuses the existing Anthropic synonyms in
the `Usage` model, so `input_tokens`, `output_tokens`,
`cache_read_input_tokens`, and `cache_creation_input_tokens` map to
`prompt_tokens` / `completion_tokens` / `prompt_cache_read_tokens` /
`prompt_cache_write_tokens` out of the box.

## Testing

- New `tests/unit/endpoints/test_messages_endpoint.py` - 39 tests across
  `format_payload`, non-streaming parse, streaming parse, and
  `extract_payload_inputs`. 98% line coverage of the new module.
- `uv run pytest tests/unit/endpoints/ tests/unit/property/ -n auto` -> all green,
  no regressions.
- `make validate-plugin-schemas` passes (class loads, 222 plugins).
- `pre-commit run` clean (ruff, ruff-baselined, ergonomics, generated-docs,
  plugin artifacts).

## Out of scope / follow-ups

- No custom `build_assistant_turn` override yet - multi-turn FORK-mode replay
  uses the base text-only capture. Capturing structured `tool_use` blocks for
  agentic conversation replay can be a follow-up (mirroring
  `ChatEndpoint` / `ResponsesEndpoint`).
- The Messages API doesn't use OpenAI's `stream_options.include_usage`; usage is
  always streamed, so no usage opt-in flag is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmarking support for Anthropic’s Messages API via `--endpoint-type messages` (including `/v1/messages`) with streaming, token/usage tracking, tool support, and image handling (base64/URL). Audio/video inputs are not supported.
* **Documentation**
  * Updated CLI option docs to include `messages`.
  * Clarified Anthropic Messages API usage parsing and system prompt placement.
* **Tests**
  * Added unit tests covering request payload formatting, streaming/non-streaming response parsing, multimodal serialization, and usage extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->