### PR TITLE
perf(zmq): drive ZMQ off the raw FD + split credit returns onto a PUSH/PULL channel

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -88,6 +88,13 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         uv run pytest tests/unit -n auto --tb=short -m 'not performance and not stress and not slow'
+    - name: Run zmq real-transport tests (Windows)
+      # Real-socket libzmq tests (no looptime). ``!cancelled()`` lets them run
+      # even if the unit step failed, matching the POSIX ``make test-ci``
+      # exit-code aggregation across tiers.
+      if: ${{ !cancelled() && runner.os == 'Windows' }}
+      run: |
+        uv run pytest tests/zmq --tb=short --no-looptime -m 'not performance and not stress and not slow'
     - name: Run component integration tests (Windows)
       # ``!cancelled()`` overrides the implicit ``success()`` so component
       # integration still runs even if the unit-test step failed — matching

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ check-format check-fmt: #? check the formatting of the project using ruff.
 test: #? run the tests using pytest-xdist.
 	$(activate_venv) && pytest tests/unit -n auto -m 'not integration and not performance and not component_integration and not slow' $(args)
 
+test-zmq: #? run the real-socket zmq transport tests (real libzmq, no looptime).
+	$(activate_venv) && pytest tests/zmq --no-looptime $(args)
+
 test-verbose: #? run the tests using pytest-xdist with DEBUG logging.
 	$(activate_venv) && pytest tests/unit -n auto -v -s --log-cli-level=DEBUG -m 'not integration and not performance and not component_integration and not slow'
 
@@ -245,6 +248,9 @@ test-ci: #? run the tests using pytest-xdist for CI.
 	@# Run unit tests first with coverage
 	@printf "$(bold)$(blue)Running unit tests...$(reset)\n"
 	@$(activate_venv) && pytest tests/unit -n auto --cov=src/aiperf --cov-branch --cov-report= -m 'not performance and not stress and not slow' --tb=short $(args) || exit_code=$$?; \
+	# Run real-socket zmq transport tests (real time + real sockets, no looptime) regardless of unit result \
+	printf "$(bold)$(blue)Running zmq real-transport tests...$(reset)\n"; \
+	$(activate_venv) && pytest tests/zmq --cov=src/aiperf --cov-branch --cov-append --cov-report= -m 'not performance and not stress and not slow' --no-looptime --tb=short $(args) || exit_code=$$((exit_code + $$?)); \
 	# Run component integration tests with coverage append regardless of unit test result \
 	printf "$(bold)$(blue)Running component integration tests...$(reset)\n"; \
 	$(activate_venv) && MALLOC_ARENA_MAX=2 pytest tests/component_integration -n auto --cov=src/aiperf --cov-branch --cov-append --cov-report=html --cov-report=xml --cov-report=term -m 'not performance and not stress and not slow' -v --tb=short $(args) || exit_code=$$((exit_code + $$?)); \

--- a/dev/benchmarks/zmq_credit_bench.py
+++ b/dev/benchmarks/zmq_credit_bench.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Open-loop ZMQ credit microbenchmark: throughput + round-trip latency.
+
+Blasts COUNT credits **open-loop** (fire all of them as fast as possible, no
+closed-loop in-flight window) across three ZMQ patterns, comparing the
+production zmq.asyncio await drive against the FdEdgeReader / sync-NOBLOCK
+drive, with NOTHING else in the loop (no HTTP, no aiperf services, no mock):
+
+  await : zmq.asyncio await-recv / await-send, yielding every YIELD_INTERVAL.
+  fd    : FdEdgeReader (loop.add_reader + sync NOBLOCK batch-drain) for recv,
+          sync NOBLOCK send.
+
+Each credit carries a send timestamp (perf_counter_ns, CLOCK_MONOTONIC =
+cross-process comparable on Linux); the worker echoes it back, so the producer
+records the true per-credit round-trip latency on return. Reports throughput
+(credits/sec over the blast) AND latency percentiles (p50/p99/p99.9).
+
+Methodology:
+  * Open-loop blast of N credits, not a closed in-flight loop.
+  * MULTI-PROCESS rig (single-process inflates 20-40x via uncontested sockets).
+  * GC disabled in every process.
+  * Latency clock is perf_counter_ns (CLOCK_MONOTONIC, cross-process on Linux).
+
+Usage:
+  python dev/benchmarks/zmq_credit_bench.py --mode fd --pattern dealer_router --count 250000 --workers 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import gc
+import multiprocessing as mp
+import time
+from collections import deque
+
+import msgspec
+import zmq
+import zmq.asyncio
+
+from aiperf.zmq.fd_reader import FdEdgeReader
+
+YIELD_INTERVAL = 10
+_now = time.perf_counter_ns
+
+
+class Credit(msgspec.Struct, tag_field="t", tag="c"):
+    id: int
+    ts: int = 0  # producer send time (perf_counter_ns)
+    phase: str = "profiling"
+
+
+class CreditReturn(msgspec.Struct, tag_field="t", tag="cr"):
+    id: int
+    ts: int = 0  # echoed producer send time
+
+
+_WireMsg = Credit | CreditReturn
+_ENC = msgspec.msgpack.Encoder()
+_DEC = msgspec.msgpack.Decoder(_WireMsg)
+_READY = -2
+
+
+def _pcts(samples_ns: list[int]) -> dict:
+    if not samples_ns:
+        return {}
+    s = sorted(samples_ns)
+    n = len(s)
+
+    def p(q: float) -> float:
+        # Nearest-rank on (n-1) so p50 etc. aren't biased toward higher indices.
+        return s[min(n - 1, int(q * (n - 1)))] / 1e6  # -> ms
+
+    return {
+        "p50": p(0.50),
+        "p90": p(0.90),
+        "p99": p(0.99),
+        "p999": p(0.999),
+        "max": s[-1] / 1e6,
+        "min": s[0] / 1e6,
+    }
+
+
+def _run(coro) -> None:
+    try:
+        import uvloop
+
+        uvloop.run(coro)
+    except ImportError:
+        asyncio.run(coro)
+
+
+def _recv_mp(sock):
+    """Sync NOBLOCK multipart recv (recv_multipart delegates to the async recv)."""
+    first = zmq.Socket.recv(sock, flags=zmq.NOBLOCK)
+    last = first
+    while sock.getsockopt(zmq.RCVMORE):
+        last = zmq.Socket.recv(sock, flags=zmq.NOBLOCK)
+    return first, last
+
+
+# =============================================================================
+# Worker: echo each credit straight back (id + ts), zero work.
+# =============================================================================
+async def _worker(mode, pattern, addrs, identity, count):
+    ctx = zmq.asyncio.Context.instance()
+    if pattern == "dealer_router":
+        rx = ctx.socket(zmq.DEALER)
+        rx.setsockopt(zmq.IDENTITY, identity.encode())
+        rx.setsockopt(zmq.SNDHWM, 0)
+        rx.setsockopt(zmq.RCVHWM, 0)
+        rx.connect(addrs[0])
+        tx = rx
+        await rx.send(_ENC.encode(CreditReturn(id=_READY)))
+    else:  # push_pull
+        rx = ctx.socket(zmq.PULL)
+        rx.setsockopt(zmq.RCVHWM, 0)
+        rx.connect(addrs[0])
+        tx = ctx.socket(zmq.PUSH)
+        tx.setsockopt(zmq.SNDHWM, 0)
+        tx.connect(addrs[1])
+        zmq.Socket.send(tx, _ENC.encode(CreditReturn(id=_READY)), copy=False)
+
+    done = asyncio.Event()
+    seen = {"n": 0}
+
+    def make_return(c: Credit) -> bytes:
+        return _ENC.encode(CreditReturn(id=c.id, ts=c.ts))
+
+    if mode == "fd":
+
+        def recv_one():
+            return _DEC.decode(zmq.Socket.recv(rx, flags=zmq.NOBLOCK))
+
+        def dispatch(c):
+            zmq.Socket.send(tx, make_return(c), flags=zmq.NOBLOCK, copy=False)
+            seen["n"] += 1
+            if seen["n"] >= count:
+                done.set()
+
+        reader = FdEdgeReader(
+            socket=rx, recv_one=recv_one, dispatch=dispatch, batch_limit=YIELD_INTERVAL
+        )
+        reader.start()
+        await done.wait()
+        reader.stop()
+    else:
+        n = 0
+        while seen["n"] < count:
+            c = _DEC.decode(await rx.recv())
+            await tx.send(make_return(c))
+            seen["n"] += 1
+            n += 1
+            if n % YIELD_INTERVAL == 0:
+                await asyncio.sleep(0)
+    with contextlib.suppress(Exception):
+        rx.close(0)
+        if tx is not rx:
+            tx.close(0)
+
+
+def _worker_main(mode, pattern, addrs, identity, count):
+    gc.disable()
+    _run(_worker(mode, pattern, addrs, identity, count))
+
+
+# =============================================================================
+# Producer: blast COUNT credits open-loop, collect returns, record RTT latency.
+# =============================================================================
+async def _producer(mode, pattern, addrs, n_workers, count, result):
+    ctx = zmq.asyncio.Context.instance()
+    if pattern == "dealer_router":
+        sock = ctx.socket(zmq.ROUTER)
+        sock.setsockopt(zmq.SNDHWM, 0)
+        sock.setsockopt(zmq.RCVHWM, 0)
+        sock.bind(addrs[0])
+        rx = tx = sock
+        idents: list[bytes] = []
+        while len(idents) < n_workers:
+            idents.append((await sock.recv_multipart())[0])
+        targets = deque(idents)
+    else:  # push_pull
+        tx = ctx.socket(zmq.PUSH)
+        tx.setsockopt(zmq.SNDHWM, 0)
+        tx.bind(addrs[0])
+        rx = ctx.socket(zmq.PULL)
+        rx.setsockopt(zmq.RCVHWM, 0)
+        rx.bind(addrs[1])
+        ready = 0
+        while ready < n_workers:
+            await rx.recv()
+            ready += 1
+        targets = None
+
+    lat: list[int] = []
+    done = asyncio.Event()
+    times = {"first_send": 0, "last_recv": 0}
+
+    def on_return(cr: CreditReturn) -> None:
+        now = _now()
+        lat.append(now - cr.ts)
+        times["last_recv"] = now
+        if len(lat) >= count:
+            done.set()
+
+    # ---- recv side ----
+    recv_task = None
+    reader = None
+    if mode == "fd":
+        if pattern == "dealer_router":
+
+            def recv_one():
+                _ident, payload = _recv_mp(rx)
+                return _DEC.decode(payload)
+        else:
+
+            def recv_one():
+                return _DEC.decode(zmq.Socket.recv(rx, flags=zmq.NOBLOCK))
+
+        reader = FdEdgeReader(
+            socket=rx, recv_one=recv_one, dispatch=on_return, batch_limit=YIELD_INTERVAL
+        )
+        reader.start()
+    else:
+
+        async def recv_loop():
+            n = 0
+            while not done.is_set():
+                if pattern == "dealer_router":
+                    cr = _DEC.decode((await rx.recv_multipart())[-1])
+                else:
+                    cr = _DEC.decode(await rx.recv())
+                on_return(cr)
+                n += 1
+                if n % YIELD_INTERVAL == 0:
+                    await asyncio.sleep(0)
+
+        recv_task = asyncio.create_task(recv_loop())
+
+    # ---- open-loop blast ----
+    def send_credit(i: int) -> None:
+        payload = _ENC.encode(Credit(id=i, ts=_now()))
+        if pattern == "dealer_router":
+            ident = targets[0]
+            targets.rotate(-1)
+            if mode == "fd":
+                zmq.Socket.send(tx, ident, flags=zmq.NOBLOCK | zmq.SNDMORE, copy=False)
+                zmq.Socket.send(tx, payload, flags=zmq.NOBLOCK, copy=False)
+            else:
+                return ident, payload
+        else:
+            if mode == "fd":
+                zmq.Socket.send(tx, payload, flags=zmq.NOBLOCK, copy=False)
+            else:
+                return None, payload
+        return None
+
+    times["first_send"] = _now()
+    for i in range(count):
+        if mode == "fd":
+            send_credit(i)
+        else:
+            framed = send_credit(i)
+            if pattern == "dealer_router":
+                await tx.send_multipart([framed[0], framed[1]])
+            else:
+                await tx.send(framed[1])
+        if i % YIELD_INTERVAL == 0:
+            await asyncio.sleep(0)  # let returns drain concurrently (open-loop)
+
+    await done.wait()
+    if reader is not None:
+        reader.stop()
+    if recv_task is not None:
+        recv_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await recv_task
+
+    elapsed = (times["last_recv"] - times["first_send"]) / 1e9
+    result["count"] = len(lat)
+    result["elapsed"] = elapsed
+    result["cps"] = len(lat) / elapsed if elapsed else 0.0
+    result["lat"] = _pcts(lat)
+    with contextlib.suppress(Exception):
+        rx.close(0)
+        if tx is not rx:
+            tx.close(0)
+
+
+def _producer_main(mode, pattern, addrs, n_workers, count, q):
+    gc.disable()
+    result: dict = {}
+    _run(_producer(mode, pattern, addrs, n_workers, count, result))
+    q.put(result)
+
+
+def run_roundtrip(mode, pattern, workers, count) -> dict:
+    ctx = mp.get_context("spawn")
+    stamp = int(time.time() * 1000)
+    if pattern == "dealer_router":
+        addrs = (f"ipc:///tmp/cb_dr_{mode}_{stamp}.ipc",)
+    else:
+        addrs = (
+            f"ipc:///tmp/cb_pp_d_{mode}_{stamp}.ipc",
+            f"ipc:///tmp/cb_pp_u_{mode}_{stamp}.ipc",
+        )
+    q = ctx.Queue()
+    # split the blast across workers so each echoes ~count/workers
+    per = count // workers
+    pp = ctx.Process(
+        target=_producer_main, args=(mode, pattern, addrs, workers, per * workers, q)
+    )
+    pp.start()
+    time.sleep(0.3)
+    wps = [
+        ctx.Process(
+            target=_worker_main, args=(mode, pattern, addrs, f"w{i}", count)
+        )  # worker tolerates >= its share
+        for i in range(workers)
+    ]
+    for w in wps:
+        w.start()
+    result = q.get(timeout=300)
+    pp.join(timeout=10)
+    for w in wps:
+        w.terminate()
+    for w in wps:
+        w.join(timeout=5)
+    return result
+
+
+# =============================================================================
+# PUB/SUB: one PUB blasts COUNT timestamped msgs; SUBs measure one-way latency.
+# =============================================================================
+_TOPIC = b"x\xff"
+
+
+async def _pub(mode, addr, count):
+    ctx = zmq.asyncio.Context.instance()
+    pub = ctx.socket(zmq.PUB)
+    pub.setsockopt(zmq.SNDHWM, 0)
+    pub.bind(addr)
+    await asyncio.sleep(1.0)  # slow-joiner
+    for i in range(count):
+        payload = _ENC.encode(Credit(id=i, ts=_now()))
+        if mode == "fd":
+            zmq.Socket.send(pub, _TOPIC, flags=zmq.NOBLOCK | zmq.SNDMORE, copy=False)
+            zmq.Socket.send(pub, payload, flags=zmq.NOBLOCK, copy=False)
+        else:
+            await pub.send_multipart([_TOPIC, payload])
+        if i % YIELD_INTERVAL == 0:
+            await asyncio.sleep(0)
+    await asyncio.sleep(2.0)  # let subs drain
+    pub.close(0)
+
+
+def _pub_main(mode, addr, count):
+    gc.disable()
+    _run(_pub(mode, addr, count))
+
+
+async def _sub(mode, addr, count, result):
+    ctx = zmq.asyncio.Context.instance()
+    sub = ctx.socket(zmq.SUB)
+    sub.setsockopt(zmq.RCVHWM, 0)
+    sub.setsockopt(zmq.SUBSCRIBE, b"")
+    sub.connect(addr)
+    lat: list[int] = []
+    done = asyncio.Event()
+    times = {"first": 0, "last": 0}
+
+    def on_msg(c: Credit) -> None:
+        now = _now()
+        if not times["first"]:
+            times["first"] = now
+        lat.append(now - c.ts)
+        times["last"] = now
+        if len(lat) >= count:
+            done.set()
+
+    if mode == "fd":
+
+        def recv_one():
+            _t, payload = _recv_mp(sub)
+            return _DEC.decode(payload)
+
+        reader = FdEdgeReader(
+            socket=sub, recv_one=recv_one, dispatch=on_msg, batch_limit=YIELD_INTERVAL
+        )
+        reader.start()
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(done.wait(), timeout=60)
+        reader.stop()
+    else:
+        n = 0
+        try:
+            while not done.is_set():
+                c = _DEC.decode((await asyncio.wait_for(sub.recv_multipart(), 60))[-1])
+                on_msg(c)
+                n += 1
+                if n % YIELD_INTERVAL == 0:
+                    await asyncio.sleep(0)
+        except asyncio.TimeoutError:
+            pass
+    elapsed = (times["last"] - times["first"]) / 1e9
+    result["count"] = len(lat)
+    result["elapsed"] = elapsed
+    result["cps"] = len(lat) / elapsed if elapsed else 0.0
+    result["lat"] = _pcts(lat)
+    sub.close(0)
+
+
+def _sub_main(mode, addr, count, q):
+    gc.disable()
+    result: dict = {}
+    _run(_sub(mode, addr, count, result))
+    q.put(result)
+
+
+def run_pubsub(mode, workers, count) -> dict:
+    ctx = mp.get_context("spawn")
+    addr = f"ipc:///tmp/cb_ps_{mode}_{int(time.time() * 1000)}.ipc"
+    q = ctx.Queue()
+    subs = [
+        ctx.Process(target=_sub_main, args=(mode, addr, count, q))
+        for _ in range(workers)
+    ]
+    pub = ctx.Process(target=_pub_main, args=(mode, addr, count))
+    pub.start()
+    for s in subs:
+        s.start()
+    results = [q.get(timeout=120) for _ in range(workers)]
+    pub.join(timeout=10)
+    for s in subs:
+        s.terminate()
+    for s in subs:
+        s.join(timeout=5)
+    agg = sum(r["cps"] for r in results)
+    # report aggregate throughput, and the worst (max) per-sub latency percentiles
+    best = max(results, key=lambda r: r["count"])
+    return {
+        "count": sum(r["count"] for r in results),
+        "elapsed": best["elapsed"],
+        "cps": agg,
+        "lat": best["lat"],
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["await", "fd"], required=True)
+    ap.add_argument(
+        "--pattern",
+        choices=["dealer_router", "push_pull", "pubsub"],
+        default="dealer_router",
+    )
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--count", type=int, default=250_000)
+    args = ap.parse_args()
+    if args.pattern == "pubsub":
+        r = run_pubsub(args.mode, args.workers, args.count)
+    else:
+        r = run_roundtrip(args.mode, args.pattern, args.workers, args.count)
+    lat = r.get("lat", {})
+    unit = "msgs/s (agg recv, 1-way lat)" if args.pattern == "pubsub" else "credit RT/s"
+    print(
+        f"pattern={args.pattern} mode={args.mode} workers={args.workers} "
+        f"count={args.count} => {r['cps']:,.0f} {unit} | "
+        f"lat ms p50={lat.get('p50', 0):.3f} p99={lat.get('p99', 0):.3f} "
+        f"p999={lat.get('p999', 0):.3f} max={lat.get('max', 0):.1f} "
+        f"(got {r['count']:,} in {r['elapsed']:.2f}s)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,8 +159,10 @@ The Timing Manager uses a **credit-based flow control system** to control when r
 - Allows accurate measurement without artificial delays
 
 **Credit Distribution:**
-- Credits are routed to workers via ROUTER/DEALER pattern
+- Credits are dispatched to workers via a ROUTER/DEALER pattern (the Timing Manager's sticky ROUTER to each worker's DEALER)
 - Router selects workers based on sticky sessions (multi-turn conversations) or least-loaded worker selection
+- Credit returns travel back on a dedicated PUSH/PULL fan-in channel: each worker PUSHes its `CreditReturn`/`FirstToken` to the Timing Manager's single PULL, separating the high-volume return path from credit dispatch
+- The return channel carries no ZMQ envelope identity, so the returning worker id travels inside the message
 - No coordination required between workers
 - Scales to large numbers of workers without bottlenecks
 - Efficient message routing minimizes overhead
@@ -179,12 +181,13 @@ This section describes the end-to-end message flow during a benchmark run, showi
 - **Aggregated Results**: Final performance summary and per-request details
 
 **Message Flow:**
-1. Credit Router routes credits to workers via ROUTER/DEALER pattern
+1. Credit Router dispatches credits to workers via ROUTER/DEALER pattern
 2. Workers access dataset entries via memory-mapped files
 3. Workers send requests to Inference Server (external HTTP)
-4. Workers push raw results to Record Processors
-5. Record Processors push metric records to Records Manager
-6. Records Manager aggregates and exports final results
+4. Workers return completed credits to the Timing Manager over a dedicated PUSH/PULL fan-in channel
+5. Workers push raw results to Record Processors
+6. Record Processors push metric records to Records Manager
+7. Records Manager aggregates and exports final results
 
 ## Communication Architecture
 
@@ -205,8 +208,11 @@ AIPerf uses **ZMQ proxies** for message routing between services and workers:
 
 - Services publish strongly-typed messages to specific topics (Pub/Sub pattern)
 - Services subscribe to relevant message types
-- Router/Dealer patterns for credit distribution to workers
+- Router/Dealer pattern for credit dispatch to workers
+- PUSH/PULL fan-in for credit returns from workers back to the Timing Manager
 - Request/Reply patterns for synchronous operations
+
+For low event-loop overhead, the streaming credit sockets (the dispatch DEALER/ROUTER and the return PUSH/PULL) are driven directly off the raw ZMQ file descriptor with an edge-triggered, non-blocking batch drain rather than per-message `await` wrappers.
 
 ### State Management
 

--- a/src/aiperf/common/base_comms.py
+++ b/src/aiperf/common/base_comms.py
@@ -14,6 +14,8 @@ from aiperf.common.protocols import (
     ReplyClientProtocol,
     RequestClientProtocol,
     StreamingDealerClientProtocol,
+    StreamingPullClientProtocol,
+    StreamingPushClientProtocol,
     StreamingRouterClientProtocol,
     SubClientProtocol,
 )
@@ -169,5 +171,39 @@ class BaseCommunication(AIPerfLifecycleMixin, ABC):
                 bind,
                 socket_ops,
                 identity=identity,
+            ),
+        )
+
+    def create_streaming_push_client(
+        self,
+        address: CommAddressType,
+        bind: bool = False,
+        socket_ops: dict | None = None,
+    ) -> StreamingPushClientProtocol:
+        return cast(
+            StreamingPushClientProtocol,
+            self.create_client(
+                CommClientType.STREAMING_PUSH,
+                address,
+                bind,
+                socket_ops,
+            ),
+        )
+
+    def create_streaming_pull_client(
+        self,
+        address: CommAddressType,
+        bind: bool = True,
+        socket_ops: dict | None = None,
+        additional_bind_address: str | None = None,
+    ) -> StreamingPullClientProtocol:
+        return cast(
+            StreamingPullClientProtocol,
+            self.create_client(
+                CommClientType.STREAMING_PULL,
+                address,
+                bind,
+                socket_ops,
+                additional_bind_address=additional_bind_address,
             ),
         )

--- a/src/aiperf/common/enums/enums.py
+++ b/src/aiperf/common/enums/enums.py
@@ -78,6 +78,11 @@ class CommAddress(CaseInsensitiveStrEnum):
     CREDIT_RETURN_ROUTER = "credit_return_router"
     """Address for credit-return ROUTER-DEALER traffic (separate from CREDIT_ROUTER for high-throughput modes)."""
 
+    CREDIT_RETURN = "credit_return"
+    """Address for the credit-return PUSH/PULL fan-in channel (worker PUSH -> timing-manager PULL).
+    CreditReturn/FirstToken ride this dedicated channel so the dispatch CREDIT_ROUTER stays
+    send-only; returns are unaddressed fan-in (worker_id travels in CreditReturn)."""
+
     CONTROL = "control"
     """Control-plane address for service-manager commands."""
 

--- a/src/aiperf/common/protocols.py
+++ b/src/aiperf/common/protocols.py
@@ -217,6 +217,27 @@ class StreamingDealerClientProtocol(CommunicationClientProtocol, Protocol):
 
 
 @runtime_checkable
+class StreamingPushClientProtocol(CommunicationClientProtocol, Protocol):
+    """Protocol for a PUSH client that sends typed structs (credit-channel wire)."""
+
+    async def send(self, message: MessageT) -> None:
+        """Encode and send a typed struct to the PULL peer."""
+        ...
+
+
+@runtime_checkable
+class StreamingPullClientProtocol(CommunicationClientProtocol, Protocol):
+    """Protocol for a PULL client that decodes typed WorkerToRouterMessage structs."""
+
+    def register_receiver(
+        self,
+        handler: Callable[[MessageT], Coroutine[Any, Any, None]],
+    ) -> None:
+        """Register the handler invoked for each decoded message (no peer identity)."""
+        ...
+
+
+@runtime_checkable
 class SubClientProtocol(CommunicationClientProtocol, Protocol):
     async def subscribe(
         self,
@@ -342,6 +363,27 @@ class CommunicationProtocol(AIPerfLifecycleProtocol, Protocol):
     ) -> StreamingDealerClientProtocol:
         """Create a STREAMING_DEALER client for the given address and identity, which will be automatically
         started and stopped with the CommunicationProtocol instance."""
+        ...
+
+    def create_streaming_push_client(
+        self,
+        address: CommAddressType,
+        bind: bool = False,
+        socket_ops: dict | None = None,
+    ) -> StreamingPushClientProtocol:
+        """Create a STREAMING_PUSH client (typed struct fan-out) for the given address,
+        which will be automatically started and stopped with the CommunicationProtocol instance."""
+        ...
+
+    def create_streaming_pull_client(
+        self,
+        address: CommAddressType,
+        bind: bool = True,
+        socket_ops: dict | None = None,
+        additional_bind_address: str | None = None,
+    ) -> StreamingPullClientProtocol:
+        """Create a STREAMING_PULL client (typed struct fan-in) for the given address,
+        which will be automatically started and stopped with the CommunicationProtocol instance."""
         ...
 
 

--- a/src/aiperf/config/comm/base.py
+++ b/src/aiperf/config/comm/base.py
@@ -143,6 +143,7 @@ _ADDRESS_RESOLVERS: dict[CommAddress, Callable[[BaseZMQCommunicationConfig], str
     ),
     CommAddress.CREDIT_ROUTER: lambda c: c.credit_router_address,
     CommAddress.CREDIT_RETURN_ROUTER: lambda c: c.credit_return_router_address,
+    CommAddress.CREDIT_RETURN: lambda c: c.credit_return_push_pull_address,
     CommAddress.RECORDS: lambda c: c.records_push_pull_address,
     CommAddress.CONTROL: lambda c: c.control_address,
     CommAddress.GROUP_LIFECYCLE: lambda c: c.group_lifecycle_address,

--- a/src/aiperf/config/comm/dual_bind.py
+++ b/src/aiperf/config/comm/dual_bind.py
@@ -201,6 +201,7 @@ class ZMQDualBindConfig(BaseZMQCommunicationConfig):
             ("records_push_pull", ipc_filename("records_push_pull.ipc")),
             ("credit_router", ipc_filename("credit_router.ipc")),
             ("credit_return_router", ipc_filename("credit_return_router.ipc")),
+            ("credit_return_push_pull", ipc_filename("credit_return_push_pull.ipc")),
             ("control", ipc_filename("control.ipc")),
             ("group_lifecycle", ipc_filename("group_lifecycle.ipc")),
         ]
@@ -255,6 +256,12 @@ class ZMQDualBindConfig(BaseZMQCommunicationConfig):
         ge=1,
         le=65535,
         description="TCP port for credit return router communication with remote workers.",
+    )
+    credit_return_push_pull_tcp_port: int = Field(
+        default=5669,
+        ge=1,
+        le=65535,
+        description="TCP port for the credit-return PUSH/PULL fan-in channel.",
     )
     control_tcp_port: int = Field(
         default=5667,
@@ -322,6 +329,15 @@ class ZMQDualBindConfig(BaseZMQCommunicationConfig):
         return self._socket_addr("credit_return_router")
 
     @property
+    def credit_return_push_pull_address(self) -> str:
+        """Get credit-return PUSH/PULL address based on deployment mode."""
+        if self.controller_host:
+            return (
+                f"tcp://{self.controller_host}:{self.credit_return_push_pull_tcp_port}"
+            )
+        return self._socket_addr("credit_return_push_pull")
+
+    @property
     def control_address(self) -> str:
         """Get control channel address based on deployment mode."""
         if self.controller_host:
@@ -356,6 +372,11 @@ class ZMQDualBindConfig(BaseZMQCommunicationConfig):
     def records_push_pull_tcp_bind_address(self) -> str:
         """Get TCP bind address for records push/pull dual binding (controller-side)."""
         return f"tcp://{self.tcp_host}:{self.records_push_pull_tcp_port}"
+
+    @property
+    def credit_return_push_pull_tcp_bind_address(self) -> str:
+        """Get TCP bind address for credit-return push/pull dual binding (controller-side)."""
+        return f"tcp://{self.tcp_host}:{self.credit_return_push_pull_tcp_port}"
 
     @property
     def _remote_host(self) -> str | None:

--- a/src/aiperf/config/comm/ipc.py
+++ b/src/aiperf/config/comm/ipc.py
@@ -283,6 +283,7 @@ class ZMQIPCConfig(BaseZMQCommunicationConfig):
             ("records_push_pull", ipc_filename("records_push_pull.ipc")),
             ("credit_router", ipc_filename("credit_router.ipc")),
             ("credit_return_router", ipc_filename("credit_return_router.ipc")),
+            ("credit_return_push_pull", ipc_filename("credit_return_push_pull.ipc")),
             ("control", ipc_filename("control.ipc")),
             ("group_lifecycle", ipc_filename("group_lifecycle.ipc")),
         ]
@@ -331,6 +332,13 @@ class ZMQIPCConfig(BaseZMQCommunicationConfig):
         """Get the records push/pull address (ipc:// on POSIX, tcp:// on Windows)."""
         return build_socket_address(
             self.path, "records_push_pull.ipc", self._collision_salt
+        )
+
+    @property
+    def credit_return_push_pull_address(self) -> str:
+        """Get the credit-return push/pull address (ipc:// on POSIX, tcp:// on Windows)."""
+        return build_socket_address(
+            self.path, "credit_return_push_pull.ipc", self._collision_salt
         )
 
     @property

--- a/src/aiperf/config/comm/tcp.py
+++ b/src/aiperf/config/comm/tcp.py
@@ -133,6 +133,15 @@ class ZMQTCPConfig(BaseZMQCommunicationConfig):
             description="Port for credit return router (ROUTER-DEALER credit returns)",
         ),
     ] = 5668
+    credit_return_push_pull_port: Annotated[
+        int,
+        Field(
+            default=5669,
+            ge=1,
+            le=65535,
+            description="Port for credit return PUSH/PULL fan-in channel",
+        ),
+    ] = 5669
     control_port: Annotated[
         int,
         Field(
@@ -182,6 +191,11 @@ class ZMQTCPConfig(BaseZMQCommunicationConfig):
     def credit_return_router_address(self) -> str:
         """Get the credit return router address for dedicated return channel."""
         return f"tcp://{self.host}:{self.credit_return_router_port}"
+
+    @property
+    def credit_return_push_pull_address(self) -> str:
+        """Get the credit-return PUSH/PULL fan-in address."""
+        return f"tcp://{self.host}:{self.credit_return_push_pull_port}"
 
     @property
     def control_address(self) -> str:

--- a/src/aiperf/credit/messages.py
+++ b/src/aiperf/credit/messages.py
@@ -109,12 +109,17 @@ class CreditReturn(
         first_token_sent: True if FirstToken was sent before this return.
             Used by orchestrator to release prefill slot if not already released.
         error: Error message if the request failed (None on success).
+        worker_id: Returning worker's id. Only stamped on the PUSH/PULL return
+            channel (CommAddress.CREDIT_RETURN), where there is no ZMQ envelope
+            identity; None on the ROUTER/DEALER path (identity comes from the
+            envelope). Lets the router attribute the return to the right worker.
     """
 
     credit: Credit
     cancelled: bool = False
     first_token_sent: bool = False
     error: str | None = None
+    worker_id: str | None = None
 
 
 class FirstToken(Struct, frozen=True, kw_only=True, tag_field="t", tag="ft"):

--- a/src/aiperf/credit/sticky_router.py
+++ b/src/aiperf/credit/sticky_router.py
@@ -24,7 +24,10 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from aiperf.common.enums import CommAddress
 from aiperf.common.mixins import CommunicationMixin
-from aiperf.common.protocols import StreamingRouterClientProtocol
+from aiperf.common.protocols import (
+    StreamingPullClientProtocol,
+    StreamingRouterClientProtocol,
+)
 from aiperf.config.comm import ZMQDualBindConfig
 from aiperf.credit.messages import (
     CancelCredits,
@@ -198,6 +201,52 @@ class StickyCreditRouter(CommunicationMixin):
         - credit cancellation is O(n × k) where n = number of workers, k = average in-flight credits per worker
     """
 
+    def _init_credit_channels(self, comm_config) -> None:
+        """Bind the credit dispatch ROUTER and the dedicated credit-return PULL.
+
+        Dispatch (Credit/CancelCredits) goes router->worker over CREDIT_ROUTER;
+        CreditReturn/FirstToken fan in worker->router over a separate PUSH/PULL
+        channel (CREDIT_RETURN), so neither socket is bidirectional. In dual-bind
+        (k8s controller) mode each also binds its TCP address so remote worker
+        pods can connect; controller-side services otherwise use IPC.
+        """
+        dual_bind = (
+            isinstance(comm_config, ZMQDualBindConfig)
+            and not comm_config.controller_host
+        )
+
+        dispatch_bind = (
+            comm_config.credit_router_tcp_bind_address if dual_bind else None
+        )
+        if dispatch_bind:
+            self.info(
+                f"Dual-bind mode: credit router will also bind to {dispatch_bind}"
+            )
+        self._router_client: StreamingRouterClientProtocol = (
+            self.comms.create_streaming_router_client(
+                address=CommAddress.CREDIT_ROUTER,
+                bind=True,
+                additional_bind_address=dispatch_bind,
+            )
+        )
+        self._router_client.register_receiver(self._handle_router_message)
+
+        return_bind = (
+            comm_config.credit_return_push_pull_tcp_bind_address if dual_bind else None
+        )
+        if return_bind:
+            self.info(
+                f"Dual-bind mode: credit return PULL will also bind to {return_bind}"
+            )
+        self._return_pull_client: StreamingPullClientProtocol = (
+            self.comms.create_streaming_pull_client(
+                CommAddress.CREDIT_RETURN,
+                bind=True,
+                additional_bind_address=return_bind,
+            )
+        )
+        self._return_pull_client.register_receiver(self._handle_return_pull_message)
+
     def __init__(
         self,
         run: "BenchmarkRun",
@@ -206,28 +255,7 @@ class StickyCreditRouter(CommunicationMixin):
     ) -> None:
         super().__init__(run=run, service_id=service_id, **kwargs)
 
-        # For dual-bind mode (Kubernetes), also bind to TCP for remote workers.
-        # Controller services use IPC (fast, same-pod) but workers connect via TCP.
-        # Only bind to TCP if we're in controller mode (controller_host not set).
-        additional_bind_address: str | None = None
-        comm_config = run.cfg.comm_config
-        if (
-            isinstance(comm_config, ZMQDualBindConfig)
-            and not comm_config.controller_host
-        ):
-            additional_bind_address = comm_config.credit_router_tcp_bind_address
-            self.info(
-                f"Dual-bind mode: credit router will also bind to {additional_bind_address}"
-            )
-
-        self._router_client: StreamingRouterClientProtocol = (
-            self.comms.create_streaming_router_client(
-                address=CommAddress.CREDIT_ROUTER,
-                bind=True,
-                additional_bind_address=additional_bind_address,
-            )
-        )
-        self._router_client.register_receiver(self._handle_router_message)
+        self._init_credit_channels(run.cfg.comm_config)
 
         self._on_return_callback: (
             Callable[[str, CreditReturn], Awaitable[None]] | None
@@ -416,6 +444,26 @@ class StickyCreditRouter(CommunicationMixin):
     # =============================================================================
     # Private Methods
     # =============================================================================
+
+    async def _handle_return_pull_message(self, message: WorkerToRouterMessage) -> None:
+        """Adapt the identity-less PULL fan-in to the shared handler.
+
+        The PUSH/PULL return channel has no ZMQ envelope identity, so the worker
+        id rides inside CreditReturn (FirstToken does not need it). Unpack it and
+        delegate to the common handler.
+
+        Ordering note: CreditReturn/FirstToken now arrive on this PULL channel while
+        WorkerReady/WorkerShutdown stay on the DEALER, so a worker's returns and its
+        lifecycle messages are no longer mutually ordered (on the single bidirectional
+        DEALER they were). That is safe because a worker only emits WorkerShutdown
+        after all its returns have been sent, and the timing manager's phase /
+        cancellation barrier drains outstanding returns before workers are torn down;
+        a return therefore cannot legitimately land after its worker's unregister
+        outside the teardown window, where ``_cancellation_pending`` /
+        ``_credits_complete`` already suppress the ``_warn_missing_worker`` path.
+        """
+        worker_id = getattr(message, "worker_id", None) or ""
+        await self._handle_router_message(worker_id, message)
 
     async def _handle_router_message(
         self, worker_id: str, message: WorkerToRouterMessage

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -127,7 +127,7 @@ CommunicationBackend = plugins.create_enum(PluginType.COMMUNICATION, "Communicat
 
 CommClientTypeStr: TypeAlias = str
 CommClientType = plugins.create_enum(PluginType.COMMUNICATION_CLIENT, "CommClientType", module=__name__)
-"""Dynamic enum for communication client. Example: CommClientType.PUB, CommClientType.REQUEST, CommClientType.SUB"""
+"""Dynamic enum for communication client. Example: CommClientType.PUB, CommClientType.STREAMING_DEALER, CommClientType.SUB"""
 
 ZMQProxyTypeStr: TypeAlias = str
 ZMQProxyType = plugins.create_enum(PluginType.ZMQ_PROXY, "ZMQProxyType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1645,6 +1645,19 @@ communication_client:
       ZMQ ROUTER client for streaming messaging pattern. Receives high-throughput
       streams with identity-based routing and connection management.
 
+  streaming_push:
+    class: aiperf.zmq.streaming_push_client:ZMQStreamingPushClient
+    description: |
+      ZMQ PUSH client that sends typed msgpack structs (the credit-channel wire,
+      no Message-bus envelope). Send-only fan-out leg of the typed PUSH/PULL
+      credit-return channel.
+
+  streaming_pull:
+    class: aiperf.zmq.streaming_pull_client:ZMQStreamingPullClient
+    description: |
+      ZMQ PULL client that decodes typed WorkerToRouterMessage structs. Recv-only
+      fan-in leg of the typed PUSH/PULL credit-return channel.
+
   sub:
     class: aiperf.zmq.sub_client:ZMQSubClient
     description: |

--- a/src/aiperf/workers/worker.py
+++ b/src/aiperf/workers/worker.py
@@ -52,6 +52,7 @@ from aiperf.common.protocols import (
     PushClientProtocol,
     RequestClientProtocol,
     StreamingDealerClientProtocol,
+    StreamingPushClientProtocol,
 )
 from aiperf.credit.messages import (
     CancelCredits,
@@ -185,6 +186,19 @@ class Worker(BaseComponentService, ProcessHealthMixin):
             )
         )
         self.credit_dealer_client.register_receiver(self._on_credit_message)
+
+        # Dual-channel returns: CreditReturn/FirstToken go out a dedicated typed
+        # PUSH -> router PULL fan-in instead of back on the bidirectional credit
+        # DEALER, so the dispatch DEALER is receive-only (no shared-FD send/recv
+        # contention). WorkerReady/WorkerShutdown still go on the DEALER so the
+        # ROUTER registers/tracks identity. Returns carry worker_id in-message
+        # since PUSH/PULL has no ZMQ envelope identity.
+        self.credit_return_push_client: StreamingPushClientProtocol = (
+            self.comms.create_streaming_push_client(
+                CommAddress.CREDIT_RETURN,
+                bind=False,
+            )
+        )
 
         self.memory_usage_before_profiling: float | None = None
 
@@ -348,8 +362,9 @@ class Worker(BaseComponentService, ProcessHealthMixin):
             cancelled=credit_context.cancelled,
             first_token_sent=credit_context.first_token_sent,
             error=str(credit_context.error) if credit_context.error else None,
+            worker_id=self.service_id,
         )
-        self.execute_async(self.credit_dealer_client.send(credit_return))
+        self.execute_async(self.credit_return_push_client.send(credit_return))
         credit_context.returned = True
 
         # Explicitly clear references to help refcounting (GC is disabled on workers)
@@ -403,8 +418,9 @@ class Worker(BaseComponentService, ProcessHealthMixin):
                 cancelled=credit_context.cancelled,
                 first_token_sent=credit_context.first_token_sent,
                 error=str(credit_context.error) if credit_context.error else None,
+                worker_id=self.service_id,
             )
-            await self.credit_dealer_client.send(credit_return)
+            await self.credit_return_push_client.send(credit_return)
             # Mark as returned AFTER send succeeds
             # If send fails/cancelled, done callback will retry
             # Router idempotency guard handles duplicates
@@ -447,7 +463,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
                     return False  # Keep looking for meaningful content
 
                 # Meaningful content found - send FirstToken to router
-                await self.credit_dealer_client.send(
+                await self.credit_return_push_client.send(
                     FirstToken(
                         credit_id=credit.id,
                         phase=credit.phase,

--- a/src/aiperf/zmq/fd_reader.py
+++ b/src/aiperf/zmq/fd_reader.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Edge-triggered ZMQ FD driver for streaming PULL/DEALER/ROUTER sockets.
+
+Drives a ZMQ socket entirely off its raw FD via ``loop.add_reader``, bypassing
+``zmq.asyncio``'s await-recv/await-send wrappers so message bursts clear in fewer
+event-loop round-trips. Generalizes the single-socket PUSH/PULL FD-drain
+technique to the bidirectional DEALER/ROUTER credit channel.
+
+A ZMQ socket exposes ONE fd (``ZMQ_FD``) that becomes OS-readable when *either*
+recv-ready (``POLLIN``) or send-ready (``POLLOUT``) and is edge-triggered: it only
+re-signals on a 0->nonzero ``ZMQ_EVENTS`` transition, and ``ZMQ_EVENTS`` must be
+re-read after every send/recv to re-arm it. Therefore a single ``add_reader``
+owns BOTH directions — recv drains on ``POLLIN``, the (rarely-used) send backlog
+drains on ``POLLOUT`` — and the same socket must never also be driven by
+``zmq.asyncio`` (its async send/recv read ``ZMQ_EVENTS`` too and corrupt the
+shared edge-trigger). Callers route sends through :meth:`send`.
+
+With the default ``SNDHWM=0`` (unbounded send queue) the NOBLOCK send never
+blocks, so the send buffer / ``POLLOUT`` path stays empty; it exists only to stay
+correct under a finite send HWM.
+
+Per-readable drain cycle (``_pump``):
+
+    ZMQ_FD readable   (libzmq queue went 0 -> nonzero: a ZMQ_EVENTS edge)
+        |
+        v
+    +- _pump() --------------------------------------------------
+    |  recv NOBLOCK in a batch loop (up to batch_limit):
+    |      dispatch each item; re-read ZMQ_EVENTS after each recv
+    |      stop on Again, on POLLIN clearing, or at the batch cap
+    |  then flush any buffered sends while POLLOUT is set
+    +------------------------------------------------------------
+        |
+        v
+    POLLIN still set after the pass?
+        |- yes -> call_soon(_pump)   (re-arm: the edge will NOT
+        |                             re-fire for mid-drain arrivals)
+        '- no  -> idle until the next 0 -> nonzero ZMQ_EVENTS edge
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections import deque
+from collections.abc import Callable
+from typing import Any
+
+import zmq
+
+
+class FdEdgeReader:
+    """Drive a ZMQ socket's recv (and optionally send) via an asyncio FD reader.
+
+    Args:
+        socket: The ZMQ socket to drive (``zmq.asyncio`` socket is fine; this uses
+            the synchronous NOBLOCK ops supplied by ``recv_one``/``send_one``).
+        recv_one: One synchronous NOBLOCK recv returning the decoded item, or
+            raising ``zmq.Again`` when drained.
+        dispatch: Called with each received item (must not block).
+        batch_limit: Max recvs drained per pass so the drain cannot monopolize the
+            loop; <=0 falls back to 256.
+        send_one: One synchronous NOBLOCK send of a buffered item, or raising
+            ``zmq.Again`` if the send HWM is hit. Required to use :meth:`send`.
+        on_error: Optional callback for unexpected exceptions during a pass.
+    """
+
+    def __init__(
+        self,
+        *,
+        socket: Any,
+        recv_one: Callable[[], Any],
+        dispatch: Callable[[Any], None],
+        batch_limit: int,
+        send_one: Callable[[Any], None] | None = None,
+        on_error: Callable[[Exception], None] | None = None,
+    ) -> None:
+        self._socket = socket
+        self._recv_one = recv_one
+        self._dispatch = dispatch
+        self._batch_limit = batch_limit if batch_limit and batch_limit > 0 else 256
+        self._send_one = send_one
+        self._on_error = on_error
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._fd: int | None = None
+        self._send_buf: deque[Any] = deque()
+        self._rearm_pending = False
+        self._stopped = False
+
+    def start(self) -> None:
+        """Register the FD reader and drain anything already queued."""
+        self._loop = asyncio.get_running_loop()
+        self._fd = self._socket.getsockopt(zmq.FD)
+        self._loop.add_reader(self._fd, self._pump)
+        self._pump()
+
+    def stop(self) -> None:
+        """Unregister the FD reader."""
+        self._stopped = True
+        if self._fd is not None and self._loop is not None:
+            with contextlib.suppress(ValueError, OSError):
+                self._loop.remove_reader(self._fd)
+            self._fd = None
+
+    def send(self, item: Any) -> None:
+        """Send an item synchronously (NOBLOCK), buffering only if the HWM blocks.
+
+        Reading ``ZMQ_EVENTS`` after the send (via the trailing re-arm) keeps the
+        recv edge-trigger consistent on this shared FD.
+        """
+        if self._send_one is None:
+            raise RuntimeError("FdEdgeReader.send called without a send_one callable")
+        if self._send_buf:
+            # Preserve ordering: something is already queued behind a full HWM.
+            self._send_buf.append(item)
+        else:
+            try:
+                self._send_one(item)
+            except zmq.Again:
+                self._send_buf.append(item)
+        # Keep the FD armed for recv and schedule a drain if work remains.
+        self._rearm()
+
+    def _pump(self) -> None:
+        if self._stopped:
+            return
+        try:
+            events = self._socket.getsockopt(zmq.EVENTS)
+            drained = 0
+            while (events & zmq.POLLIN) and drained < self._batch_limit:
+                try:
+                    item = self._recv_one()
+                except zmq.Again:
+                    break
+                self._dispatch(item)
+                drained += 1
+                events = self._socket.getsockopt(zmq.EVENTS)
+            while self._send_buf and (events & zmq.POLLOUT):
+                try:
+                    self._send_one(self._send_buf[0])  # type: ignore[misc]
+                except zmq.Again:
+                    break
+                self._send_buf.popleft()
+                events = self._socket.getsockopt(zmq.EVENTS)
+        except (zmq.ContextTerminated, zmq.ZMQError):
+            return
+        except Exception as e:  # noqa: BLE001 - drain boundary; report this pass
+            # A non-ZMQ failure (e.g. a malformed frame that fails to decode) has
+            # already consumed its frame. Re-arm before returning: the FD is
+            # edge-triggered and POLLIN may still be set, so without re-checking
+            # ZMQ_EVENTS here the remaining queued messages would be stranded
+            # until the next 0->nonzero edge (which a backlog will never produce).
+            if self._on_error is not None:
+                self._on_error(e)
+            self._rearm()
+            return
+        self._rearm(events)
+
+    def _rearm(self, events: int | None = None) -> None:
+        """Reschedule a pass if recv is still pending (the edge-trigger won't
+        re-fire for messages that arrived mid-drain). A send backlog is left to
+        the FD's own POLLOUT signal to avoid busy-looping against a full HWM."""
+        if self._stopped or self._rearm_pending or self._loop is None:
+            return
+        try:
+            if events is None:
+                events = self._socket.getsockopt(zmq.EVENTS)
+        except zmq.ZMQError:
+            return
+        if events & zmq.POLLIN:
+            self._rearm_pending = True
+            self._loop.call_soon(self._run)
+
+    def _run(self) -> None:
+        self._rearm_pending = False
+        self._pump()

--- a/src/aiperf/zmq/pub_client.py
+++ b/src/aiperf/zmq/pub_client.py
@@ -78,7 +78,19 @@ class ZMQPubClient(BaseZMQClient):
 
             # Publish message
             self.trace(lambda: f"Publishing message {topic=} {message_json_bytes=}")
-            await self.socket.send_multipart([topic.encode(), message_json_bytes])
+            # Sync NOBLOCK multipart send skips zmq.asyncio's await/Future
+            # machinery. PUB is send-only (no recv driver) so there is no FD
+            # edge-trigger to contend with; framed manually since send_multipart
+            # delegates to the async self.send. SNDHWM=0 means it never blocks.
+            zmq.Socket.send(
+                self.socket,
+                topic.encode(),
+                flags=zmq.NOBLOCK | zmq.SNDMORE,
+                copy=False,
+            )
+            zmq.Socket.send(
+                self.socket, message_json_bytes, flags=zmq.NOBLOCK, copy=False
+            )
 
         except (asyncio.CancelledError, zmq.ContextTerminated):
             self.debug(

--- a/src/aiperf/zmq/pull_client.py
+++ b/src/aiperf/zmq/pull_client.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
+import contextlib
 from collections.abc import Callable, Coroutine
 from typing import Any
 
@@ -10,8 +11,6 @@ from aiperf.common.environment import Environment
 from aiperf.common.hooks import background_task, on_stop
 from aiperf.common.messages import Message
 from aiperf.common.types import MessageTypeT
-from aiperf.common.utils import yield_to_event_loop
-from aiperf.timing.concurrency import DynamicConcurrencyLimit
 from aiperf.zmq.zmq_base_client import BaseZMQClient
 
 
@@ -80,11 +79,22 @@ class ZMQPullClient(BaseZMQClient):
             MessageTypeT, Callable[[Message], Coroutine[Any, Any, None]]
         ] = {}
 
-        self.semaphore = DynamicConcurrencyLimit(
+        # `or` (not `is not None`): 0 is not a valid bound here — it would halt
+        # the FD drain entirely (`while self._inflight < self._max_inflight`), so
+        # coalesce a falsy value to the configured default.
+        self._max_inflight: int = (
             max_pull_concurrency or Environment.ZMQ.PULL_MAX_CONCURRENCY
         )
         self._msg_count: int = 0
         self._yield_interval: int = Environment.ZMQ.PULL_YIELD_INTERVAL
+
+        # FD-reader state. Edge-triggered drive over the raw socket FD; flow
+        # control via _inflight (the reader stops draining at _max_inflight,
+        # leaving messages in the ZMQ buffer so the HWM backpressures the pusher).
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._fd: int | None = None
+        self._inflight: int = 0
+        self._rearm_pending: bool = False
 
     @background_task(immediate=True, interval=None)
     async def _pull_receiver(self) -> None:
@@ -93,61 +103,73 @@ class ZMQPullClient(BaseZMQClient):
         This method is a coroutine that will run indefinitely until the client is
         shutdown. It will wait for messages from the socket and handle them.
         """
-        while not self.stop_requested:
-            try:
-                # acquire the semaphore to limit the number of concurrent requests
-                # NOTE: This MUST be done BEFORE calling recv() to allow the zmq push/pull
-                # logic to properly load balance the requests.
-                await self.semaphore.acquire()
+        # Always drive the PULL socket off its raw FD with an edge-triggered
+        # NOBLOCK drain.
+        self._start_fd_reader()
 
-                message_json_bytes = await self.socket.recv()
-                if self.is_trace_enabled:
-                    self.trace(
-                        f"Received message from pull socket: {message_json_bytes}"
-                    )
-                # Use AUTO-LOOKUP approach (no prefix) - optimal for large messages
-                self.execute_async(self._process_message(message_json_bytes))
-                self._msg_count += 1
-                # Yield periodically to allow scheduled handlers to run
-                # and prevent event loop starvation during message bursts.
-                if (
-                    self._yield_interval > 0
-                    and self._msg_count % self._yield_interval == 0
-                ):
-                    await yield_to_event_loop()
+    def _start_fd_reader(self) -> None:
+        """Register an edge-triggered drain on the raw socket FD.
 
-            except zmq.Again:
-                self.debug("Pull client receiver task timed out")
-                self.semaphore.release()  # release the semaphore as it was not used
-                await yield_to_event_loop()
-            except (asyncio.CancelledError, zmq.ContextTerminated):
-                self.debug("Pull client receiver task cancelled")
-                self.semaphore.release()  # release the semaphore as it was not used
-                break
-            except Exception as e:
-                self.exception(f"Exception receiving data from pull socket: {e}")
-                self.semaphore.release()  # release the semaphore as it was not used
-                await yield_to_event_loop()
-
-    @on_stop
-    async def _stop(self) -> None:
-        """Wait for all tasks to complete."""
-        await self.cancel_all_tasks()
-
-    async def _process_message(self, message_json_bytes: bytes) -> None:
-        """Process a message from the pull socket.
-
-        This method is called by the background task when a message is received from
-        the pull socket. It will deserialize the message and call the appropriate
-        callback function.
+        Bypasses zmq.asyncio's await-recv polling: asyncio watches the ZMQ FD and
+        calls ``_on_pull_readable``, which drains all immediately-available messages
+        with NOBLOCK recv.
         """
-        try:
-            # Use AUTO-LOOKUP: parse JSON to dict, extract type, validate
-            # This is 40-60% faster for large messages (>2KB)
-            message = Message.from_json(message_json_bytes)
-            del message_json_bytes  # free raw bytes before handler runs
+        self._loop = asyncio.get_running_loop()
+        self._fd = self.socket.getsockopt(zmq.FD)
+        self._loop.add_reader(self._fd, self._on_pull_readable)
+        # The FD only fires on a 0->nonzero events transition, so drain anything
+        # already queued before we registered.
+        self._on_pull_readable()
 
-            # Call callbacks with Message object
+    def _on_pull_readable(self) -> None:
+        """Drain ready messages with NOBLOCK recv (bounded per call so the drain
+        itself cannot monopolize the event loop)."""
+        if self.stop_requested:
+            return
+        limit = self._yield_interval if self._yield_interval > 0 else 256
+        drained = 0
+        try:
+            while self._inflight < self._max_inflight and drained < limit:
+                # Re-check EVENTS each iteration: the FD is edge-triggered, so the
+                # only reliable readiness signal is ZMQ_EVENTS, not the FD itself.
+                if not (self.socket.getsockopt(zmq.EVENTS) & zmq.POLLIN):
+                    break
+                try:
+                    data = zmq.Socket.recv(self.socket, flags=zmq.NOBLOCK)
+                except zmq.Again:
+                    break
+                if self.is_trace_enabled:
+                    self.trace(lambda d=data: f"Received message from pull socket: {d}")
+                self._inflight += 1
+                drained += 1
+                self.execute_async(self._process_message_fd(data))
+        except (zmq.ContextTerminated, zmq.ZMQError):
+            return
+        # More may be pending (we hit the batch/inflight cap, or a message raced in
+        # during draining); reschedule rather than rely on the FD re-firing.
+        self._maybe_rearm()
+
+    def _maybe_rearm(self) -> None:
+        """Reschedule a drain if work is pending and we have inflight capacity."""
+        if self.stop_requested or self._rearm_pending or self._loop is None:
+            return
+        try:
+            pending = bool(self.socket.getsockopt(zmq.EVENTS) & zmq.POLLIN)
+        except zmq.ZMQError:
+            return
+        if pending and self._inflight < self._max_inflight:
+            self._rearm_pending = True
+            self._loop.call_soon(self._run_reader)
+
+    def _run_reader(self) -> None:
+        self._rearm_pending = False
+        self._on_pull_readable()
+
+    async def _process_message_fd(self, message_json_bytes: bytes) -> None:
+        """FD-reader variant of ``_process_message`` using the _inflight counter."""
+        try:
+            message = Message.from_json(message_json_bytes)
+            del message_json_bytes
             if message.message_type in self._pull_callbacks:
                 await self._pull_callbacks[message.message_type](message)
             else:
@@ -155,8 +177,18 @@ class ZMQPullClient(BaseZMQClient):
                     f"Pull message received for message type {message.message_type} without callback"
                 )
         finally:
-            # always release the semaphore to allow receiving more messages
-            self.semaphore.release()
+            self._inflight -= 1
+            # A slot freed; resume draining if the reader paused at the cap.
+            self._maybe_rearm()
+
+    @on_stop
+    async def _stop(self) -> None:
+        """Wait for all tasks to complete."""
+        if self._fd is not None and self._loop is not None:
+            with contextlib.suppress(ValueError, OSError):
+                self._loop.remove_reader(self._fd)
+            self._fd = None
+        await self.cancel_all_tasks()
 
     def register_pull_callback(
         self,

--- a/src/aiperf/zmq/push_client.py
+++ b/src/aiperf/zmq/push_client.py
@@ -78,7 +78,17 @@ class ZMQPushClient(BaseZMQClient):
 
         try:
             data_json_bytes = message.to_json_bytes()
-            await self.socket.send(data_json_bytes)
+            # copy=False sends without memcpy'ing the payload into a libzmq frame on
+            # the event loop thread. The PUSH path carries record/result payloads
+            # (e.g. multi-thousand-token inference results) where that copy shows up
+            # as event-loop block time under high concurrency. Safe here: the bytes
+            # are freshly serialized, never mutated, and re-serialized on retry, so
+            # pyzmq can hold the buffer until libzmq finishes the send.
+            # Sync NOBLOCK send skips zmq.asyncio's await/Future machinery.
+            # PUSH is send-only (no recv driver on this socket), so there is no
+            # FD edge-trigger to contend with. With the default SNDHWM=0 it never
+            # blocks; a finite HWM raises zmq.Again and falls to the retry path.
+            zmq.Socket.send(self.socket, data_json_bytes, flags=zmq.NOBLOCK, copy=False)
             if self.is_trace_enabled:
                 self.trace(f"Pushed json data: {data_json_bytes}")
         except (asyncio.CancelledError, zmq.ContextTerminated):

--- a/src/aiperf/zmq/streaming_dealer_client.py
+++ b/src/aiperf/zmq/streaming_dealer_client.py
@@ -3,7 +3,6 @@
 
 """Streaming DEALER client for bidirectional communication with ROUTER."""
 
-import asyncio
 from collections.abc import Awaitable, Callable
 from typing import TypeAlias
 
@@ -13,8 +12,8 @@ from msgspec import Struct
 
 from aiperf.common.environment import Environment
 from aiperf.common.hooks import background_task, on_stop
-from aiperf.common.utils import yield_to_event_loop
 from aiperf.credit.messages import RouterToWorkerMessage
+from aiperf.zmq.fd_reader import FdEdgeReader
 from aiperf.zmq.zmq_base_client import BaseZMQClient
 
 # Pre-created encoder/decoder for performance (caches schema)
@@ -112,6 +111,7 @@ class ZMQStreamingDealerClient(BaseZMQClient):
         self._receiver_handler: RouterToWorkerHandler | None = None
         self._msg_count: int = 0
         self._yield_interval: int = Environment.ZMQ.STREAMING_DEALER_YIELD_INTERVAL
+        self._fd_reader: FdEdgeReader | None = None
 
     def register_receiver(self, handler: RouterToWorkerHandler) -> None:
         """
@@ -132,20 +132,42 @@ class ZMQStreamingDealerClient(BaseZMQClient):
     @on_stop
     async def _clear_receiver(self) -> None:
         """Clear receiver handler on stop."""
+        if self._fd_reader is not None:
+            self._fd_reader.stop()
+            self._fd_reader = None
         self._receiver_handler = None
+
+    def _recv_one_dealer(self) -> RouterToWorkerMessage:
+        """Synchronous NOBLOCK recv + decode for the FD-reader drain."""
+        return _decoder.decode(zmq.Socket.recv(self.socket, flags=zmq.NOBLOCK))
+
+    def _dispatch_dealer(self, message: RouterToWorkerMessage) -> None:
+        if self._receiver_handler is not None:
+            self.execute_async(self._receiver_handler(message))
+        else:
+            self.warning(f"Received {type(message).__name__} but no handler registered")
+
+    def _send_one_dealer(self, data: bytes) -> None:
+        """Synchronous NOBLOCK single-frame send for the FD-driver."""
+        zmq.Socket.send(self.socket, data, flags=zmq.NOBLOCK, copy=False)
 
     async def send(self, struct: Struct) -> None:
         """Send struct to ROUTER."""
         await self._check_initialized()
 
-        try:
-            # DEALER automatically handles framing - use single-frame send
-            await self.socket.send(_encoder.encode(struct))
-            if self.is_trace_enabled:
-                self.trace(f"Sent struct: {struct}")
-        except Exception as e:
-            self.exception(f"Failed to send message: {e}")
-            raise
+        # copy=False avoids memcpy'ing the encoded frame into libzmq on the event
+        # loop thread; the encoded buffer is freshly produced here and never reused.
+        data = _encoder.encode(struct)
+        # FD-driver owns both directions of the socket; never touch zmq.asyncio
+        # send here or it corrupts the shared FD edge-trigger. Before the
+        # receiver task has created the driver (early WorkerReady), send
+        # directly — SNDHWM=0 means the NOBLOCK send will not block.
+        if self._fd_reader is not None:
+            self._fd_reader.send(data)
+        else:
+            self._send_one_dealer(data)
+        if self.is_trace_enabled:
+            self.trace(f"Sent struct: {struct}")
 
     @background_task(immediate=True, interval=None)
     async def _streaming_dealer_receiver(self) -> None:
@@ -159,40 +181,16 @@ class ZMQStreamingDealerClient(BaseZMQClient):
             lambda: f"Streaming DEALER receiver task started for {self.identity}"
         )
 
-        while not self.stop_requested:
-            try:
-                message_bytes = await self.socket.recv()
-                if self.is_trace_enabled:
-                    self.trace(f"Received message: {message_bytes}")
-                message = _decoder.decode(message_bytes)
-
-                if self._receiver_handler:
-                    self.execute_async(self._receiver_handler(message))
-                    self._msg_count += 1
-                    # Yield periodically to allow scheduled handlers to run
-                    # and prevent event loop starvation during message bursts.
-                    if (
-                        self._yield_interval > 0
-                        and self._msg_count % self._yield_interval == 0
-                    ):
-                        await yield_to_event_loop()
-                else:
-                    self.warning(
-                        f"Received {type(message).__name__} but no handler registered"
-                    )
-
-            except zmq.Again:
-                self.debug("No data on dealer socket received, yielding to event loop")
-                await yield_to_event_loop()
-            except asyncio.CancelledError:
-                self.debug("Streaming DEALER receiver task cancelled")
-                raise  # re-raise the cancelled error
-            except Exception as e:
-                self.exception(
-                    f"Exception receiving messages for client {self.client_id}: {e!r}"
-                )
-                await yield_to_event_loop()
-
-        self.debug(
-            lambda: f"Streaming DEALER receiver task stopped for {self.identity}"
+        # Always drive the DEALER off its raw FD: edge-triggered NOBLOCK drain on
+        # recv, sync NOBLOCK on send (the driver owns both directions).
+        self._fd_reader = FdEdgeReader(
+            socket=self.socket,
+            recv_one=self._recv_one_dealer,
+            dispatch=self._dispatch_dealer,
+            batch_limit=self._yield_interval,
+            send_one=self._send_one_dealer,
+            on_error=lambda e: self.exception(
+                f"Exception draining dealer socket for {self.client_id}: {e!r}"
+            ),
         )
+        self._fd_reader.start()

--- a/src/aiperf/zmq/streaming_pull_client.py
+++ b/src/aiperf/zmq/streaming_pull_client.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streaming PULL client for the typed credit-return fan-in channel.
+
+Receive-only counterpart of :class:`ZMQStreamingPushClient`. Decodes the typed
+``WorkerToRouterMessage`` msgpack structs (the same wire as the streaming ROUTER
+credit client) off a PULL socket, so the sticky router collects
+``CreditReturn``/``FirstToken`` over the dedicated credit-return fan-in channel.
+
+Unlike the streaming ROUTER, PULL carries no peer identity, so the receiver
+handler takes only the decoded message (the worker id, when needed, travels
+inside the message). PULL is recv-only, so its FD has no POLLOUT to mask the
+recv edge — the FdEdgeReader is used recv-only (no send path).
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
+
+import msgspec
+import zmq
+
+from aiperf.common.environment import Environment
+from aiperf.common.hooks import background_task, on_stop
+from aiperf.credit.messages import WorkerToRouterMessage
+from aiperf.zmq.fd_reader import FdEdgeReader
+from aiperf.zmq.zmq_base_client import BaseZMQClient
+
+# Pre-created decoder (caches schema); matches the streaming ROUTER wire.
+_decoder = msgspec.msgpack.Decoder(WorkerToRouterMessage)
+
+StreamingPullHandler: TypeAlias = Callable[[WorkerToRouterMessage], Awaitable[None]]
+
+
+class ZMQStreamingPullClient(BaseZMQClient):
+    """ZMQ PULL client that decodes typed ``WorkerToRouterMessage`` structs.
+
+    Mirrors the receive path of :class:`ZMQStreamingDealerClient` (single-frame
+    typed decode, edge-triggered FD drain) on a recv-only PULL socket that fans
+    in credit returns from every worker's PUSH socket.
+
+    ASCII Diagram (credit-return fan-in, manager side):
+    ┌──────────────┐                    ┌──────────────┐
+    │     PUSH     │───── returns ─────►│              │
+    │  (Worker 1)  │                    │              │
+    └──────────────┘                    │              │
+    ┌──────────────┐                    │     PULL     │
+    │     PUSH     │───── returns ─────►│  (Manager)   │
+    │  (Worker 2)  │                    │              │
+    └──────────────┘                    │              │
+    ┌──────────────┐                    │              │
+    │     PUSH     │───── returns ─────►│              │
+    │  (Worker N)  │                    │              │
+    └──────────────┘                    └──────────────┘
+
+    Usage Pattern:
+    - PULL binds and fans in returns from every worker's PUSH socket
+    - PULL decodes typed CreditReturn/FirstToken structs (recv-only, no send)
+    - No peer identity in the envelope - the worker id travels in the message
+    - Edge-triggered FD drain (recv-only, so no POLLOUT to mask the recv edge)
+    """
+
+    def __init__(
+        self,
+        *,
+        address: str,
+        bind: bool = False,
+        socket_ops: dict | None = None,
+        max_pull_concurrency: int | None = None,
+        additional_bind_address: str | None = None,
+        **kwargs,
+    ) -> None:
+        # max_pull_concurrency is accepted for factory-call uniformity; this
+        # client dispatches via execute_async and does not gate concurrency.
+        del max_pull_concurrency
+        super().__init__(
+            zmq.SocketType.PULL,
+            address,
+            bind,
+            socket_ops,
+            additional_bind_address=additional_bind_address,
+            **kwargs,
+        )
+        self._receiver_handler: StreamingPullHandler | None = None
+        self._yield_interval: int = Environment.ZMQ.STREAMING_ROUTER_YIELD_INTERVAL
+        self._msg_count: int = 0
+        self._fd_reader: FdEdgeReader | None = None
+
+    def register_receiver(self, handler: StreamingPullHandler) -> None:
+        """Register the handler invoked for each decoded WorkerToRouterMessage."""
+        if self._receiver_handler is not None:
+            raise ValueError("Receiver handler already registered")
+        self._receiver_handler = handler
+
+    @on_stop
+    async def _clear_receiver(self) -> None:
+        if self._fd_reader is not None:
+            self._fd_reader.stop()
+            self._fd_reader = None
+        self._receiver_handler = None
+
+    def _recv_one(self) -> WorkerToRouterMessage:
+        """Synchronous NOBLOCK recv + typed decode for the FD-reader drain."""
+        return _decoder.decode(zmq.Socket.recv(self.socket, flags=zmq.NOBLOCK))
+
+    def _dispatch(self, message: WorkerToRouterMessage) -> None:
+        if self._receiver_handler is not None:
+            self.execute_async(self._receiver_handler(message))
+        else:
+            self.warning(f"Received {type(message).__name__} but no handler registered")
+
+    @background_task(immediate=True, interval=None)
+    async def _streaming_pull_receiver(self) -> None:
+        """Receive typed structs from the PUSH peers until stop is requested."""
+        # Recv-only: no send_one, so no POLLOUT to coordinate on the FD edge.
+        self._fd_reader = FdEdgeReader(
+            socket=self.socket,
+            recv_one=self._recv_one,
+            dispatch=self._dispatch,
+            batch_limit=self._yield_interval,
+            on_error=lambda e: self.exception(
+                f"Exception draining pull socket for {self.client_id}: {e!r}"
+            ),
+        )
+        self._fd_reader.start()

--- a/src/aiperf/zmq/streaming_push_client.py
+++ b/src/aiperf/zmq/streaming_push_client.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streaming PUSH client for the typed credit-return fan-in channel.
+
+Send-only counterpart of :class:`ZMQStreamingPullClient`. Encodes the same typed
+msgpack structs as the streaming DEALER/ROUTER credit clients (no Message-bus
+JSON envelope), so workers PUSH ``CreditReturn``/``FirstToken`` to the
+timing-manager's PULL fan-in on the dedicated credit-return channel.
+
+PUSH is send-only, so there is no receive path and no FD edge-trigger to share;
+with the default ``SNDHWM=0`` a synchronous NOBLOCK send never blocks, matching
+the PUSH sync-send fast path used elsewhere.
+"""
+
+import asyncio
+
+import msgspec
+import zmq
+from msgspec import Struct
+
+from aiperf.common.environment import Environment
+from aiperf.common.exceptions import CommunicationError
+from aiperf.zmq.zmq_base_client import BaseZMQClient
+
+# Pre-created encoder (caches schema); matches the streaming DEALER/ROUTER wire.
+_encoder = msgspec.msgpack.Encoder()
+
+
+class ZMQStreamingPushClient(BaseZMQClient):
+    """ZMQ PUSH client that sends typed msgpack structs (no Message-bus envelope).
+
+    Mirrors the encode/send fast path of :class:`ZMQStreamingDealerClient` but on
+    a send-only PUSH socket (no identity, no receiver). One of many worker PUSH
+    sockets fanning credit returns in to the manager's single PULL socket.
+
+    ASCII Diagram (credit-return fan-in, worker side):
+    ┌──────────────┐                    ┌──────────────┐
+    │     PUSH     │───── returns ─────►│     PULL     │
+    │   (Worker)   │                    │  (Manager)   │
+    └──────────────┘                    └──────────────┘
+
+    Usage Pattern:
+    - PUSH connects to the manager's PULL on the dedicated credit-return channel
+    - PUSH sends typed CreditReturn/FirstToken structs (send-only, no receiver)
+    - Worker identity travels inside the message, not a ZMQ envelope
+    - SNDHWM=0 so the NOBLOCK send never blocks the event loop
+    """
+
+    def __init__(
+        self,
+        *,
+        address: str,
+        bind: bool = False,
+        socket_ops: dict | None = None,
+        max_pull_concurrency: int | None = None,
+        additional_bind_address: str | None = None,
+        **kwargs,
+    ) -> None:
+        # max_pull_concurrency is accepted for factory-call uniformity and ignored
+        # (PUSH has no receive path).
+        del max_pull_concurrency
+        super().__init__(
+            zmq.SocketType.PUSH,
+            address,
+            bind,
+            socket_ops,
+            additional_bind_address=additional_bind_address,
+            **kwargs,
+        )
+
+    async def send(
+        self,
+        struct: Struct,
+        retry_count: int = 0,
+        max_retries: int | None = None,
+    ) -> None:
+        """Encode and send a typed struct to the PULL peer.
+
+        The fast path is a sync NOBLOCK send straight to libzmq, skipping
+        zmq.asyncio's Future/polling machinery. With ``SNDHWM=0`` the send never
+        blocks on the high-water mark, but ``IMMEDIATE=1`` makes a send to a
+        not-yet-connected peer raise ``zmq.Again`` (e.g. a startup race before the
+        manager's PULL has connected). Retry with backoff so a credit return is
+        never silently dropped, matching :class:`ZMQPushClient`.
+        """
+        await self._check_initialized()
+        if max_retries is None:
+            max_retries = Environment.ZMQ.PUSH_MAX_RETRIES
+        data = _encoder.encode(struct)
+        try:
+            zmq.Socket.send(self.socket, data, flags=zmq.NOBLOCK, copy=False)
+        except (asyncio.CancelledError, zmq.ContextTerminated):
+            return
+        except zmq.Again as e:
+            if retry_count >= max_retries:
+                raise CommunicationError(
+                    f"Failed to send {type(struct).__name__} after {retry_count} retries: {e}"
+                ) from e
+            await asyncio.sleep(Environment.ZMQ.PUSH_RETRY_DELAY)
+            return await self.send(struct, retry_count + 1, max_retries)
+        if self.is_trace_enabled:
+            self.trace(f"Sent struct: {struct}")

--- a/src/aiperf/zmq/streaming_router_client.py
+++ b/src/aiperf/zmq/streaming_router_client.py
@@ -3,7 +3,6 @@
 
 """Streaming ROUTER client for bidirectional communication with DEALER clients."""
 
-import asyncio
 from collections.abc import Awaitable, Callable
 from typing import TypeAlias
 
@@ -13,8 +12,8 @@ from msgspec import Struct
 
 from aiperf.common.environment import Environment
 from aiperf.common.hooks import background_task, on_stop
-from aiperf.common.utils import yield_to_event_loop
 from aiperf.credit.messages import WorkerToRouterMessage
+from aiperf.zmq.fd_reader import FdEdgeReader
 from aiperf.zmq.zmq_base_client import BaseZMQClient
 
 # Pre-created encoder/decoder for performance (caches schema)
@@ -124,6 +123,7 @@ class ZMQStreamingRouterClient(BaseZMQClient):
         self._receiver_handler: WorkerToRouterHandler | None = None
         self._msg_count: int = 0
         self._yield_interval: int = Environment.ZMQ.STREAMING_ROUTER_YIELD_INTERVAL
+        self._fd_reader: FdEdgeReader | None = None
 
     def register_receiver(self, handler: WorkerToRouterHandler) -> None:
         """
@@ -143,7 +143,53 @@ class ZMQStreamingRouterClient(BaseZMQClient):
     @on_stop
     async def _clear_receiver(self) -> None:
         """Clear receiver handler and callbacks on stop."""
+        if self._fd_reader is not None:
+            self._fd_reader.stop()
+            self._fd_reader = None
         self._receiver_handler = None
+
+    def _recv_one_router(self) -> tuple[str, WorkerToRouterMessage]:
+        """Synchronous NOBLOCK multipart recv + decode for the FD-reader drain.
+
+        ROUTER envelope: [identity, ..., message_bytes]. Assembled manually via the
+        direct base-class ``recv`` because ``recv_multipart`` delegates to
+        ``self.recv`` — which on a ``zmq.asyncio`` socket is the async override that
+        returns a Future. The first frame raises ``zmq.Again`` when drained;
+        subsequent frames (RCVMORE) are atomic and always immediately available.
+        """
+        identity = zmq.Socket.recv(self.socket, flags=zmq.NOBLOCK)
+        payload = identity
+        while self.socket.getsockopt(zmq.RCVMORE):
+            payload = zmq.Socket.recv(self.socket, flags=zmq.NOBLOCK)
+        return identity.decode("utf-8"), _decoder.decode(payload)
+
+    def _dispatch_router(self, item: tuple[str, WorkerToRouterMessage]) -> None:
+        identity, message = item
+        if self._receiver_handler is not None:
+            self.execute_async(self._receiver_handler(identity, message))
+        else:
+            self.warning(f"Received {type(message).__name__} but no handler registered")
+
+    def _send_one_router(self, frames: tuple[bytes, bytes]) -> None:
+        """Synchronous NOBLOCK multipart send for the FD-driver.
+
+        Framed manually (identity SNDMORE + payload) because ``send_multipart``
+        delegates to ``self.send`` -> the async override. With SNDHWM=0 neither
+        frame blocks, so the two-frame message stays atomic.
+
+        GUARDRAIL: this socket must keep ``SNDHWM=0``. ``FdEdgeReader.send`` buffers
+        and retries the whole ``(identity, payload)`` tuple as one unit, so if a
+        finite SNDHWM ever split the send (frame 1 sent, frame 2 -> ``zmq.Again``)
+        the retry would re-emit the identity frame and desync the ROUTER framing.
+        A finite SNDHWM here would first require making the send buffer per-frame
+        (track partial-multipart state). The single-frame DEALER/PUSH paths have no
+        such constraint.
+        """
+        identity, payload = frames
+        zmq.Socket.send(
+            self.socket, identity, flags=zmq.NOBLOCK | zmq.SNDMORE, copy=False
+        )
+        zmq.Socket.send(self.socket, payload, flags=zmq.NOBLOCK, copy=False)
 
     async def send_to(self, identity: str, struct: Struct) -> None:
         """
@@ -159,18 +205,16 @@ class ZMQStreamingRouterClient(BaseZMQClient):
         """
         await self._check_initialized()
 
-        try:
-            # Send using routing envelope pattern (identity string → bytes)
-            await self.socket.send_multipart(
-                [identity.encode(), _encoder.encode(struct)]
-            )
-            if self.is_trace_enabled:
-                self.trace(f"Sent {type(struct).__name__} to {identity}: {struct}")
-        except Exception as e:
-            self.exception(
-                f"Failed to send to {identity} for client {self.client_id}: {e!r}"
-            )
-            raise
+        # copy=False avoids memcpy'ing the frames into libzmq on the event loop
+        # thread; both frames are freshly produced here and never reused.
+        frames = (identity.encode(), _encoder.encode(struct))
+        # FD-driver owns both directions; never touch zmq.asyncio send here.
+        if self._fd_reader is not None:
+            self._fd_reader.send(frames)
+        else:
+            self._send_one_router(frames)
+        if self.is_trace_enabled:
+            self.trace(f"Sent {type(struct).__name__} to {identity}: {struct}")
 
     @background_task(immediate=True, interval=None)
     async def _streaming_router_receiver(self) -> None:
@@ -182,48 +226,16 @@ class ZMQStreamingRouterClient(BaseZMQClient):
         """
         self.debug("Streaming ROUTER receiver task started")
 
-        while not self.stop_requested:
-            try:
-                data = await self.socket.recv_multipart()
-                if self.is_trace_enabled:
-                    self.trace(f"Received message: {data}")
-
-                # ROUTER envelope: [identity, message_bytes]
-                identity = data[0].decode("utf-8")
-                message = _decoder.decode(data[-1])
-
-                if self.is_trace_enabled:
-                    self.trace(
-                        f"Received {type(message).__name__} from {identity}: {message}"
-                    )
-
-                if self._receiver_handler:
-                    self.execute_async(self._receiver_handler(identity, message))
-                    self._msg_count += 1
-                    # Yield periodically to allow scheduled handlers to run
-                    # and prevent event loop starvation during message bursts.
-                    if (
-                        self._yield_interval > 0
-                        and self._msg_count % self._yield_interval == 0
-                    ):
-                        await yield_to_event_loop()
-                else:
-                    self.warning(
-                        f"Received {type(message).__name__} but no handler registered"
-                    )
-
-            except zmq.Again:
-                self.debug("Router receiver task timed out")
-                await yield_to_event_loop()
-                continue
-            except (asyncio.CancelledError, zmq.ContextTerminated):
-                self.debug("Streaming ROUTER receiver task cancelled")
-                break
-            except Exception as e:
-                if not self.stop_requested:
-                    self.exception(
-                        f"Error in streaming ROUTER receiver for client {self.client_id}: {e!r}"
-                    )
-                await yield_to_event_loop()
-
-        self.debug("Streaming ROUTER receiver task stopped")
+        # Always drive the ROUTER off its raw FD: edge-triggered NOBLOCK multipart
+        # drain on recv, sync NOBLOCK on send (the driver owns both directions).
+        self._fd_reader = FdEdgeReader(
+            socket=self.socket,
+            recv_one=self._recv_one_router,
+            dispatch=self._dispatch_router,
+            batch_limit=self._yield_interval,
+            send_one=self._send_one_router,
+            on_error=lambda e: self.exception(
+                f"Exception draining router socket for {self.client_id}: {e!r}"
+            ),
+        )
+        self._fd_reader.start()

--- a/src/aiperf/zmq/sub_client.py
+++ b/src/aiperf/zmq/sub_client.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -8,10 +7,11 @@ import zmq.asyncio
 
 from aiperf.common.environment import Environment
 from aiperf.common.exceptions import CommunicationError
-from aiperf.common.hooks import background_task
+from aiperf.common.hooks import background_task, on_stop
 from aiperf.common.messages import Message
 from aiperf.common.types import MessageTypeT
-from aiperf.common.utils import call_all_functions, yield_to_event_loop
+from aiperf.common.utils import call_all_functions
+from aiperf.zmq.fd_reader import FdEdgeReader
 from aiperf.zmq.zmq_base_client import BaseZMQClient
 from aiperf.zmq.zmq_defaults import (
     TOPIC_END_ENCODED,
@@ -78,6 +78,7 @@ class ZMQSubClient(BaseZMQClient):
         self._wildcard_subscriber: Callable[[Message], Awaitable[None]] | None = None
         self._msg_count: int = 0
         self._yield_interval: int = Environment.ZMQ.SUB_YIELD_INTERVAL
+        self._fd_reader: FdEdgeReader | None = None
 
     async def subscribe_all(
         self,
@@ -199,6 +200,30 @@ class ZMQSubClient(BaseZMQClient):
                     f"Error in wildcard subscription handler for topic {topic}"
                 )
 
+    def _recv_one_sub(self) -> tuple[bytes, bytes]:
+        """Synchronous NOBLOCK multipart recv for the FD-reader drain.
+
+        SUB envelope: [topic, message_bytes]. Assembled manually via the direct
+        base-class ``recv`` because ``recv_multipart`` delegates to the async
+        ``self.recv``. First frame raises ``zmq.Again`` when drained.
+        """
+        topic = zmq.Socket.recv(self.socket, flags=zmq.NOBLOCK)
+        payload = b""
+        while self.socket.getsockopt(zmq.RCVMORE):
+            payload = zmq.Socket.recv(self.socket, flags=zmq.NOBLOCK)
+        return topic, payload
+
+    def _dispatch_sub(self, frames: tuple[bytes, bytes]) -> None:
+        topic_bytes, message_bytes = frames
+        # Must be async, otherwise it may deadlock the event loop (see await path).
+        self.execute_async(self._handle_message(topic_bytes, message_bytes))
+
+    @on_stop
+    async def _stop_fd_reader(self) -> None:
+        if self._fd_reader is not None:
+            self._fd_reader.stop()
+            self._fd_reader = None
+
     @background_task(immediate=True, interval=None)
     async def _sub_receiver(self) -> None:
         """Background task for receiving messages from subscribed topics.
@@ -206,32 +231,15 @@ class ZMQSubClient(BaseZMQClient):
         This method is a coroutine that will run indefinitely until the client is
         shutdown. It will wait for messages from the socket and handle them.
         """
-        while not self.stop_requested:
-            try:
-                topic_bytes, message_bytes = await self.socket.recv_multipart()
-                if self.is_trace_enabled:
-                    self.trace(
-                        f"Socket received message: {topic_bytes} {message_bytes}"
-                    )
-                # NOTE: This must be async otherwise it may deadlock the event loop.
-                self.execute_async(self._handle_message(topic_bytes, message_bytes))
-                self._msg_count += 1
-                # Yield periodically to allow scheduled handlers to run
-                # and prevent event loop starvation during message bursts.
-                if (
-                    self._yield_interval > 0
-                    and self._msg_count % self._yield_interval == 0
-                ):
-                    await yield_to_event_loop()
-
-            except zmq.Again:
-                self.debug(f"Sub client {self.client_id} receiver task timed out")
-                await yield_to_event_loop()
-            except (asyncio.CancelledError, zmq.ContextTerminated):
-                self.debug(f"Sub client {self.client_id} receiver task cancelled")
-                break
-            except Exception as e:
-                self.exception(
-                    f"Exception receiving message from subscription: {e}, {type(e)}"
-                )
-                await yield_to_event_loop()
+        # Always drive the SUB socket off its raw FD with an edge-triggered
+        # NOBLOCK multipart drain.
+        self._fd_reader = FdEdgeReader(
+            socket=self.socket,
+            recv_one=self._recv_one_sub,
+            dispatch=self._dispatch_sub,
+            batch_limit=self._yield_interval,
+            on_error=lambda e: self.exception(
+                f"Exception draining sub socket for {self.client_id}: {e!r}"
+            ),
+        )
+        self._fd_reader.start()

--- a/tests/harness/fake_communication.py
+++ b/tests/harness/fake_communication.py
@@ -208,6 +208,48 @@ class FakeStreamingDealerClient(FakeCommunicationClient):
                     await router_client.handler(self.identity, message)
 
 
+class FakeStreamingPullClient(FakeCommunicationClient):
+    """Fake typed PULL - fan-in receiver for streaming_push clients at the address."""
+
+    client_type = CommClientType.STREAMING_PULL
+
+    def __init__(
+        self,
+        address: str,
+        identity: str,
+        bus: FakeCommunicationBus,
+        additional_bind_address: str | None = None,
+    ) -> None:
+        super().__init__(
+            address, identity, bus, additional_bind_address=additional_bind_address
+        )
+        self.handler: Callable[[Any], Awaitable[None]] | None = None
+
+    def register_receiver(
+        self, handler: Callable[[Any], Coroutine[Any, Any, None]]
+    ) -> None:
+        if self.handler is not None:
+            raise ValueError("Receiver handler already registered")
+        self.handler = handler
+
+
+class FakeStreamingPushClient(FakeCommunicationClient):
+    """Fake typed PUSH - sends structs to streaming_pull clients at the address."""
+
+    client_type = CommClientType.STREAMING_PUSH
+
+    async def send(self, message: Any) -> None:
+        """Fan-in to the streaming_pull receivers bound at this address."""
+        self.capture_sent_payload(message)
+        for comm in self.bus.communications:
+            for pull_client in comm.streaming_pull_clients:
+                if pull_client.address == self.address and pull_client.handler:
+                    pull_client.capture_received_payload(
+                        message, sender_identity=self.identity
+                    )
+                    await pull_client.handler(message)
+
+
 class FakePubClient(FakeCommunicationClient):
     """Fake PUB - publishes to all subscribers at same address."""
 
@@ -455,6 +497,8 @@ class FakeCommunication(BaseCommunication):
         self.sub_clients: list[FakeSubClient] = []
         self.push_clients: dict[str, list[FakePushClient]] = defaultdict(list)
         self.pull_clients: list[FakePullClient] = []
+        self.streaming_pull_clients: list[FakeStreamingPullClient] = []
+        self.streaming_push_clients: list[FakeStreamingPushClient] = []
         self.request_clients: list[FakeRequestClient] = []
         self.reply_clients: dict[str, list[FakeReplyClient]] = defaultdict(list)
         # Client cache for deduplication on the same service like the real communication layer
@@ -543,6 +587,16 @@ class FakeCommunication(BaseCommunication):
             case CommClientType.STREAMING_DEALER:
                 client = FakeStreamingDealerClient(addr, identity, self.bus)
                 self.dealer_clients[identity] = client
+
+            case CommClientType.STREAMING_PUSH:
+                client = FakeStreamingPushClient(addr, identity, self.bus)
+                self.streaming_push_clients.append(client)
+
+            case CommClientType.STREAMING_PULL:
+                client = FakeStreamingPullClient(
+                    addr, identity, self.bus, additional_bind_address=additional_bind
+                )
+                self.streaming_pull_clients.append(client)
 
             case CommClientType.PUB:
                 client = FakePubClient(addr, identity, self.bus)

--- a/tests/unit/zmq/conftest.py
+++ b/tests/unit/zmq/conftest.py
@@ -7,13 +7,16 @@ This module provides reusable fixtures, mocks, and helpers for testing ZMQ funct
 """
 
 import asyncio
+import contextlib
 import itertools
+import socket as stdlib_socket
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 import zmq.asyncio
 
+from aiperf.common.constants import IS_WINDOWS
 from aiperf.common.enums import CreditPhase, LifecycleState
 from aiperf.common.messages import HeartbeatMessage
 from aiperf.credit.messages import (
@@ -23,6 +26,22 @@ from aiperf.credit.messages import (
     WorkerShutdown,
 )
 from aiperf.credit.structs import Credit
+from aiperf.zmq.fd_reader import FdEdgeReader as _RealFdEdgeReader
+
+
+@pytest.fixture(scope="session")
+def event_loop_policy():
+    """Force the selector loop on Windows so the FD-driver can register.
+
+    The FD-driver calls ``loop.add_reader(getsockopt(zmq.FD), ...)``, which the
+    default Windows ``ProactorEventLoop`` does not implement (raises
+    ``NotImplementedError``). Production switches to the selector policy in
+    ``bootstrap._configure_event_loop_policy_for_platform``; the test loop never
+    runs bootstrap, so mirror that here. No-op on Linux/macOS.
+    """
+    if IS_WINDOWS:
+        return asyncio.WindowsSelectorEventLoopPolicy()
+    return asyncio.get_event_loop_policy()
 
 
 async def _block_forever():
@@ -56,6 +75,164 @@ def _create_recv_function_with_blocking(side_effect_items):
     return recv_with_blocking
 
 
+def _install_fd_support(socket):
+    """Make a mock socket drivable by the FdEdgeReader / sync-FD path.
+
+    The streaming/push/pub/sub/pull clients now drive the raw socket FD: they
+    register ``loop.add_reader(getsockopt(zmq.FD), ...)`` and drain with the
+    UNBOUND sync ops ``zmq.Socket.send/recv`` + ``recv_into`` (bypassing the
+    asyncio overrides). This wires a mock socket for that path using a frame
+    queue so ``getsockopt(zmq.EVENTS)`` reflects whether data is pending:
+
+    - ``getsockopt(zmq.FD)`` returns a real (idle) socket fd so
+      ``loop.add_reader`` installs cleanly (the socket is never written, so the
+      reader fires only via the bootstrap drain at start()). A socketpair is used
+      rather than ``os.pipe`` because pipe fds are not selectable on Windows; a
+      socket fd is selectable under the selector loop on every platform.
+    - ``getsockopt(zmq.EVENTS)`` reports ``POLLIN`` iff ``_recv_frames`` is
+      non-empty (always ``POLLOUT``). When the queue drains, EVENTS goes to
+      ``POLLOUT`` only, so the edge-triggered drain stops — no busy loop.
+    - ``_sync_recv`` / ``recv_into`` pop one frame; ``RCVMORE`` reflects the
+      last-popped frame's more-flag (multipart). A queued ``Exception`` is
+      raised instead of returned.
+    - ``_sync_send`` records sync sends. The async ``send``/``recv`` mocks are
+      left intact for the unchanged REQ/REP clients.
+
+    Use ``enqueue_recv_frames(socket, [b"a", b"b"])`` for a multipart message or
+    ``enqueue_recv_messages(socket, [m1, m2])`` for N single-frame messages.
+    """
+    import collections
+
+    r_sock, w_sock = stdlib_socket.socketpair()
+    r_sock.setblocking(False)
+    socket._test_socketpair = (r_sock, w_sock)
+    fd = r_sock.fileno()
+    # Each entry: (payload_or_exc, more: bool).
+    socket._recv_frames = collections.deque()
+    socket._last_more = False
+    socket._pollout = True
+
+    def _getsockopt(opt):
+        if opt == zmq.FD:
+            return fd
+        if opt == zmq.EVENTS:
+            events = zmq.POLLOUT if socket._pollout else 0
+            if socket._recv_frames:
+                events |= zmq.POLLIN
+            return events
+        if opt == zmq.RCVMORE:
+            return 1 if socket._last_more else 0
+        return 0
+
+    def _pop_frame():
+        if not socket._recv_frames:
+            raise zmq.Again()
+        payload, more = socket._recv_frames.popleft()
+        socket._last_more = more
+        if isinstance(payload, BaseException):
+            raise payload
+        return payload
+
+    def _recv_into(buf, *args, **kwargs):
+        data = _pop_frame()
+        n = len(data)
+        buf[:n] = data
+        return n
+
+    socket.getsockopt = Mock(side_effect=_getsockopt)
+    socket._sync_recv = MagicMock(side_effect=lambda *a, **k: _pop_frame())
+    socket.recv_into = MagicMock(side_effect=_recv_into)
+    socket._sync_send = MagicMock(name="zmq.Socket.send(sync)")
+    return socket
+
+
+def enqueue_recv_frames(socket, frames):
+    """Queue one multipart message (list of byte frames) for the FD drain."""
+    n = len(frames)
+    for i, frame in enumerate(frames):
+        socket._recv_frames.append((frame, i < n - 1))
+
+
+def enqueue_recv_messages(socket, messages):
+    """Queue N single-frame messages (bytes or Exceptions) for the FD drain."""
+    for msg in messages:
+        socket._recv_frames.append((msg, False))
+
+
+def _close_fd_support(socket):
+    for sock in getattr(socket, "_test_socketpair", ()):
+        with contextlib.suppress(OSError):
+            sock.close()
+
+
+class _TestSafeFdEdgeReader(_RealFdEdgeReader):
+    """FdEdgeReader that refuses to reschedule on a non-int EVENTS value.
+
+    An uninstrumented mock socket returns a truthy ``Mock`` from
+    ``getsockopt(zmq.EVENTS)``; the real ``_rearm`` would then ``call_soon`` the
+    pump forever (busy loop / OOM). Treat a non-int events value as "no work",
+    so such sockets leave the driver idle. Instrumented sockets (EVENTS = int
+    via ``_install_fd_support``) behave exactly as in production.
+    """
+
+    def _rearm(self, events=None):
+        if events is None:
+            try:
+                events = self._socket.getsockopt(zmq.EVENTS)
+            except Exception:  # noqa: BLE001 - mock teardown / closed socket
+                return
+        if not isinstance(events, int):
+            return
+        super()._rearm(events)
+
+
+@pytest.fixture(autouse=True)
+def _safe_fd_edge_reader(monkeypatch):
+    """Swap the FdEdgeReader the clients import for the busy-loop-safe variant."""
+    for module in (
+        "pull_client",
+        "sub_client",
+        "streaming_dealer_client",
+        "streaming_router_client",
+        "streaming_pull_client",
+    ):
+        with contextlib.suppress(AttributeError):
+            monkeypatch.setattr(
+                f"aiperf.zmq.{module}.FdEdgeReader", _TestSafeFdEdgeReader
+            )
+
+
+@pytest.fixture(autouse=True)
+def _patch_sync_zmq_ops(monkeypatch):
+    """Route the unbound sync ZMQ ops to per-socket recorders.
+
+    The FD-driver / sync-send path calls ``zmq.Socket.send/recv(self.socket, ...)``
+    (the base-class ops) which, on a mock socket, would hit the real C functions
+    ("Socket operation on non-socket"). Delegate them to ``socket._sync_send`` /
+    ``socket._sync_recv``. ``zmq.asyncio.Socket`` overrides ``send``/``recv`` with
+    its async versions, so the REQ/REP clients' awaited calls are unaffected.
+    """
+
+    def _send(self, *args, **kwargs):
+        try:
+            rec = self._sync_send
+        except AttributeError:
+            rec = MagicMock(name="zmq.Socket.send(sync)")
+            self._sync_send = rec
+        return rec(*args, **kwargs)
+
+    def _recv(self, *args, **kwargs):
+        try:
+            rec = self._sync_recv
+        except AttributeError:
+            rec = MagicMock(name="zmq.Socket.recv(sync)", side_effect=zmq.Again())
+            self._sync_recv = rec
+        return rec(*args, **kwargs)
+
+    monkeypatch.setattr(zmq.Socket, "send", _send)
+    monkeypatch.setattr(zmq.Socket, "recv", _recv)
+
+
 @pytest.fixture
 def mock_zmq_socket():
     """Create a mock ZMQ socket with common methods.
@@ -66,7 +243,8 @@ def mock_zmq_socket():
 
     By default, recv methods block forever (await on a never-completing Future)
     to avoid busy loops with mocked sleep. Tests should override these when
-    they need specific return values.
+    they need specific return values. FD-driver support (real idle pipe FD,
+    EVENTS=0, sync recorders) is installed via ``_install_fd_support``.
     """
     socket = AsyncMock(spec=zmq.asyncio.Socket)
     socket.bind = Mock()
@@ -79,7 +257,9 @@ def mock_zmq_socket():
     socket.recv = AsyncMock(side_effect=_block_forever)
     socket.recv_multipart = AsyncMock(side_effect=_block_forever)
     socket.closed = False
-    return socket
+    _install_fd_support(socket)
+    yield socket
+    _close_fd_support(socket)
 
 
 @pytest.fixture
@@ -89,6 +269,23 @@ def mock_zmq_context(mock_zmq_socket):
     context.socket = Mock(return_value=mock_zmq_socket)
     context.term = Mock()
     return context
+
+
+@pytest.fixture
+def fd_enqueue():
+    """Queue messages/frames for a mock socket's FD drain.
+
+    ``messages``: list of single-frame payloads (DEALER/PULL).
+    ``frames``: one multipart message as a list of frames (ROUTER/SUB).
+    """
+
+    def _enq(socket, messages=None, frames=None):
+        if messages is not None:
+            enqueue_recv_messages(socket, messages)
+        if frames is not None:
+            enqueue_recv_frames(socket, frames)
+
+    return _enq
 
 
 @pytest.fixture(autouse=True)
@@ -280,6 +477,39 @@ class BaseClientTestHelper:
             # Default to blocking forever to prevent busy loop
             mock_socket.recv_multipart = AsyncMock(side_effect=_block_forever)
 
+        _install_fd_support(mock_socket)
+
+        # Feed the FD-drain queue: the production path reads via the raw FD
+        # (sync recv/recv_into), not the async recv/recv_multipart. Translate the
+        # configured side-effects so existing receiver tests deliver through it.
+        # A bare zmq.Again means "no data" (idle), so it is skipped.
+        def _as_list(items):
+            if items is None:
+                return []
+            return items if isinstance(items, list) else [items]
+
+        _skip = (zmq.Again, asyncio.CancelledError)
+        for item in _as_list(recv_side_effect):
+            if isinstance(item, _skip):
+                continue
+            enqueue_recv_messages(mock_socket, [item])
+        for msg in _as_list(recv_multipart_side_effect):
+            if isinstance(msg, _skip):
+                continue
+            if isinstance(msg, BaseException):
+                enqueue_recv_messages(mock_socket, [msg])
+            else:
+                enqueue_recv_frames(mock_socket, list(msg))
+
+        # The sync FD/send path records on _sync_send, not the async send /
+        # send_multipart. Route any configured send error there so error-path
+        # tests still fire (ROUTER/streaming framing goes frame-by-frame through
+        # the sync send).
+        if send_side_effect is not None:
+            mock_socket._sync_send.side_effect = send_side_effect
+        if send_multipart_side_effect is not None:
+            mock_socket._sync_send.side_effect = send_multipart_side_effect
+
         self.mock_zmq_context.socket = Mock(return_value=mock_socket)
         return mock_socket
 
@@ -322,6 +552,9 @@ class BaseClientTestHelper:
             yield client
         finally:
             await client.stop()
+            socket = getattr(self.mock_zmq_context, "socket", None)
+            if socket is not None and hasattr(socket, "return_value"):
+                _close_fd_support(socket.return_value)
 
 
 @pytest.fixture

--- a/tests/unit/zmq/test_fd_reader.py
+++ b/tests/unit/zmq/test_fd_reader.py
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Direct unit tests for the FdEdgeReader edge-triggered ZMQ FD driver.
+
+The client tests exercise the driver indirectly through the busy-loop-safe
+subclass in ``conftest._TestSafeFdEdgeReader``; these drive the real
+:class:`FdEdgeReader` against a minimal fake socket so the send path, the
+``_pump`` send-drain branch, the error boundary, and the ``_rearm`` reschedule
+are covered without a live ZMQ context.
+"""
+
+import asyncio
+import socket as stdlib_socket
+from collections import deque
+
+import pytest
+import zmq
+
+from aiperf.zmq.fd_reader import FdEdgeReader
+
+
+class _FakeSocket:
+    """Stand-in exposing ``getsockopt(FD/EVENTS)`` for the FD driver.
+
+    ``events`` is the current ``ZMQ_EVENTS`` bitmask (POLLIN/POLLOUT) the driver
+    re-reads each pass. Set ``events_error`` to make ``getsockopt(EVENTS)`` raise.
+    """
+
+    def __init__(self, fd: int = -1, events: int = 0) -> None:
+        self._fd = fd
+        self.events = events
+        self.events_error: BaseException | None = None
+
+    def getsockopt(self, opt: int) -> int:
+        if opt == zmq.FD:
+            return self._fd
+        if opt == zmq.EVENTS:
+            if self.events_error is not None:
+                raise self.events_error
+            return self.events
+        return 0
+
+
+def _make_reader(sock, **kwargs):
+    """Build a reader with no-op defaults so tests override only what they need."""
+    kwargs.setdefault("recv_one", lambda: (_ for _ in ()).throw(zmq.Again()))
+    kwargs.setdefault("dispatch", lambda item: None)
+    kwargs.setdefault("batch_limit", 10)
+    return FdEdgeReader(socket=sock, **kwargs)
+
+
+# =============================================================================
+# start() / stop()
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_start_registers_fd_and_bootstrap_drains():
+    """start() installs the reader and the bootstrap pump drains queued items."""
+    r_sock, w_sock = stdlib_socket.socketpair()
+    r_sock.setblocking(False)
+    sock = _FakeSocket(fd=r_sock.fileno(), events=zmq.POLLIN)
+    received: list[bytes] = []
+    items = iter([b"a", b"b"])
+
+    def recv_one():
+        try:
+            return next(items)
+        except StopIteration:
+            sock.events = 0  # buffer drained -> POLLIN clears, mirrors ZMQ_EVENTS
+            raise zmq.Again() from None
+
+    reader = _make_reader(sock, recv_one=recv_one, dispatch=received.append)
+    try:
+        reader.start()
+        await asyncio.sleep(0)  # let any rearm reschedule run
+        assert received == [b"a", b"b"]
+        assert reader._fd == r_sock.fileno()
+    finally:
+        reader.stop()
+        r_sock.close()
+        w_sock.close()
+
+    assert reader._stopped is True
+    assert reader._fd is None
+
+
+def test_stop_without_start_is_safe():
+    """stop() before start() (no fd/loop) is a no-op that still marks stopped."""
+    reader = _make_reader(_FakeSocket())
+    reader.stop()
+    assert reader._stopped is True
+
+
+def test_batch_limit_nonpositive_falls_back_to_256():
+    """A <=0 batch_limit clamps to the 256 default."""
+    assert _make_reader(_FakeSocket(), batch_limit=0)._batch_limit == 256
+    assert _make_reader(_FakeSocket(), batch_limit=-5)._batch_limit == 256
+
+
+# =============================================================================
+# send()
+# =============================================================================
+
+
+def test_send_without_send_one_raises():
+    """send() with no send_one callable is a programming error."""
+    reader = _make_reader(_FakeSocket())
+    with pytest.raises(RuntimeError, match="without a send_one"):
+        reader.send(b"x")
+
+
+def test_send_immediate_when_buffer_empty():
+    """An empty buffer sends synchronously and does not buffer."""
+    sent: list[bytes] = []
+    reader = _make_reader(_FakeSocket(events=0), send_one=sent.append)
+    reader.send(b"x")
+    assert sent == [b"x"]
+    assert not reader._send_buf
+
+
+def test_send_buffers_on_hwm_again():
+    """A NOBLOCK send hitting the HWM (zmq.Again) buffers the item instead."""
+
+    def send_one(_item):
+        raise zmq.Again()
+
+    reader = _make_reader(_FakeSocket(events=0), send_one=send_one)
+    reader.send(b"x")
+    assert list(reader._send_buf) == [b"x"]
+
+
+def test_send_preserves_order_when_already_buffered():
+    """Once something is queued behind a full HWM, later sends append in order."""
+    sent: list[bytes] = []
+    reader = _make_reader(_FakeSocket(events=0), send_one=sent.append)
+    reader._send_buf.append(b"first")
+    reader.send(b"second")
+    # send_one must not be called while a backlog exists; ordering preserved.
+    assert sent == []
+    assert list(reader._send_buf) == [b"first", b"second"]
+
+
+# =============================================================================
+# _pump()
+# =============================================================================
+
+
+def test_pump_noop_when_stopped():
+    """A stopped reader pumps nothing."""
+    dispatched: list = []
+    reader = _make_reader(
+        _FakeSocket(events=zmq.POLLIN),
+        recv_one=lambda: b"x",
+        dispatch=dispatched.append,
+    )
+    reader._stopped = True
+    reader._pump()
+    assert dispatched == []
+
+
+def test_pump_breaks_on_recv_again():
+    """POLLIN set but recv immediately Again -> no dispatch, clean exit."""
+    dispatched: list = []
+    reader = _make_reader(
+        _FakeSocket(events=zmq.POLLIN),
+        recv_one=lambda: (_ for _ in ()).throw(zmq.Again()),
+        dispatch=dispatched.append,
+    )
+    reader._pump()
+    assert dispatched == []
+
+
+def test_pump_drains_send_backlog_on_pollout():
+    """With POLLOUT and a backlog, _pump flushes buffered sends until Again."""
+    sock = _FakeSocket(events=zmq.POLLOUT)
+    sent: list[bytes] = []
+    calls = {"n": 0}
+
+    def send_one(item):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            sent.append(item)
+            return
+        raise zmq.Again()  # HWM hit again on the second buffered item
+
+    reader = _make_reader(sock, send_one=send_one)
+    reader._send_buf.extend([b"a", b"b"])
+    reader._pump()
+
+    assert sent == [b"a"]
+    # b"a" popped, b"b" stayed buffered after the HWM Again.
+    assert list(reader._send_buf) == [b"b"]
+
+
+def test_pump_swallows_zmq_error():
+    """ContextTerminated / ZMQError during a pass ends the pass without on_error."""
+    errors: list[Exception] = []
+    reader = _make_reader(
+        _FakeSocket(events=zmq.POLLIN),
+        recv_one=lambda: (_ for _ in ()).throw(zmq.ContextTerminated()),
+        on_error=errors.append,
+    )
+    reader._pump()
+    assert errors == []
+
+
+def test_pump_reports_unexpected_exception_to_on_error():
+    """A non-ZMQ exception is reported via on_error and ends the pass."""
+    errors: list[Exception] = []
+    boom = RuntimeError("boom")
+    reader = _make_reader(
+        _FakeSocket(events=zmq.POLLIN),
+        recv_one=lambda: (_ for _ in ()).throw(boom),
+        on_error=errors.append,
+    )
+    reader._pump()
+    assert errors == [boom]
+
+
+def test_pump_unexpected_exception_without_on_error_is_swallowed():
+    """Without an on_error callback the exception is still contained."""
+    reader = _make_reader(
+        _FakeSocket(events=zmq.POLLIN),
+        recv_one=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    reader._pump()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_pump_rearms_after_error_so_drain_continues():
+    """After a non-ZMQ error mid-drain, _pump re-arms (POLLIN still set) and the
+    rescheduled pass drains the messages queued behind the poisoned one.
+
+    Without the re-arm, the edge-triggered FD would never re-fire for the already
+    queued backlog and those messages would be stranded.
+    """
+    sock = _FakeSocket(events=zmq.POLLIN)
+    errors: list[Exception] = []
+    dispatched: list[int] = []
+    calls = {"n": 0}
+
+    def recv_one():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("poison")  # decode-style failure; frame consumed
+        if calls["n"] <= 3:
+            return calls["n"]  # two good messages queued behind the poison
+        sock.events = 0  # buffer drained
+        raise zmq.Again()
+
+    reader = _make_reader(
+        sock, recv_one=recv_one, dispatch=dispatched.append, on_error=errors.append
+    )
+    reader._loop = asyncio.get_running_loop()
+
+    reader._pump()
+    # error reported AND a continuation scheduled (not stranded)
+    assert len(errors) == 1 and isinstance(errors[0], RuntimeError)
+    assert reader._rearm_pending is True
+
+    for _ in range(5):
+        await asyncio.sleep(0)
+        if not reader._rearm_pending and sock.events == 0:
+            break
+
+    assert dispatched == [2, 3]
+
+
+# =============================================================================
+# _rearm() / _run()
+# =============================================================================
+
+
+def test_rearm_noop_without_loop():
+    """No loop -> nothing scheduled."""
+    reader = _make_reader(_FakeSocket(events=zmq.POLLIN))
+    reader._rearm(zmq.POLLIN)
+    assert reader._rearm_pending is False
+
+
+@pytest.mark.asyncio
+async def test_rearm_noop_when_already_pending():
+    """An in-flight rearm is not double-scheduled."""
+    reader = _make_reader(_FakeSocket(events=zmq.POLLIN))
+    reader._loop = asyncio.get_running_loop()
+    reader._rearm_pending = True
+    reader._rearm(zmq.POLLIN)
+    # Still exactly one pending flag, no extra callback churn.
+    assert reader._rearm_pending is True
+
+
+@pytest.mark.asyncio
+async def test_rearm_swallows_getsockopt_error():
+    """A ZMQError while re-reading EVENTS ends the rearm quietly."""
+    sock = _FakeSocket(events=zmq.POLLIN)
+    sock.events_error = zmq.ZMQError()
+    reader = _make_reader(sock)
+    reader._loop = asyncio.get_running_loop()
+    reader._rearm()  # events=None -> getsockopt raises -> swallowed
+    assert reader._rearm_pending is False
+
+
+@pytest.mark.asyncio
+async def test_rearm_schedules_run_on_pollin():
+    """POLLIN pending schedules exactly one _run, which pumps and clears pending."""
+    sock = _FakeSocket(events=zmq.POLLIN)
+    dispatched: list = []
+    buf = deque([b"only"])
+
+    def recv_one():
+        if not buf:
+            raise zmq.Again()
+        item = buf.popleft()
+        if not buf:
+            sock.events = 0  # buffer now empty: ZMQ_EVENTS clears POLLIN at once
+        return item
+
+    reader = _make_reader(sock, recv_one=recv_one, dispatch=dispatched.append)
+    reader._loop = asyncio.get_running_loop()
+
+    reader._rearm(zmq.POLLIN)
+    assert reader._rearm_pending is True
+
+    await asyncio.sleep(0)  # _run executes
+
+    assert reader._rearm_pending is False
+    assert dispatched == [b"only"]

--- a/tests/unit/zmq/test_pub_client.py
+++ b/tests/unit/zmq/test_pub_client.py
@@ -38,8 +38,9 @@ class TestZMQPubClientPublish:
 
         await client.publish(sample_message)
 
-        mock_zmq_socket.send_multipart.assert_called_once()
-        sent_parts = mock_zmq_socket.send_multipart.call_args[0][0]
+        # PUB FD path frames the message as two sync sends: topic + payload.
+        sent_parts = [c.args[0] for c in mock_zmq_socket._sync_send.call_args_list]
+        assert len(sent_parts) == 2
 
         # First part is topic
         topic = sent_parts[0].decode()
@@ -61,7 +62,7 @@ class TestZMQPubClientPublish:
 
         await client.publish(message)
 
-        sent_parts = mock_zmq_socket.send_multipart.call_args[0][0]
+        sent_parts = [c.args[0] for c in mock_zmq_socket._sync_send.call_args_list]
         topic = sent_parts[0].decode()
 
         assert topic == f"{MessageType.HEARTBEAT}{TOPIC_END}"
@@ -82,7 +83,7 @@ class TestZMQPubClientPublish:
 
         await client.publish(message)
 
-        sent_parts = mock_zmq_socket.send_multipart.call_args[0][0]
+        sent_parts = [c.args[0] for c in mock_zmq_socket._sync_send.call_args_list]
         topic = sent_parts[0].decode()
 
         expected_topic = f"{MessageType.COMMAND}{TOPIC_DELIMITER}service-123{TOPIC_END}"
@@ -104,7 +105,7 @@ class TestZMQPubClientPublish:
 
         await client.publish(message)
 
-        sent_parts = mock_zmq_socket.send_multipart.call_args[0][0]
+        sent_parts = [c.args[0] for c in mock_zmq_socket._sync_send.call_args_list]
         topic = sent_parts[0].decode()
 
         expected_topic = f"{MessageType.COMMAND}{TOPIC_DELIMITER}WORKER{TOPIC_END}"
@@ -127,7 +128,7 @@ class TestZMQPubClientPublish:
 
         await client.publish(message)
 
-        sent_parts = mock_zmq_socket.send_multipart.call_args[0][0]
+        sent_parts = [c.args[0] for c in mock_zmq_socket._sync_send.call_args_list]
         topic = sent_parts[0].decode()
 
         # Should use service_id in topic
@@ -238,4 +239,5 @@ class TestZMQPubClientEdgeCases:
         for msg in messages:
             await client.publish(msg)
 
-        assert mock_zmq_socket.send_multipart.call_count == 5
+        # Two sync sends (topic + payload) per publish.
+        assert mock_zmq_socket._sync_send.call_count == 5 * 2

--- a/tests/unit/zmq/test_pull_client.py
+++ b/tests/unit/zmq/test_pull_client.py
@@ -34,7 +34,7 @@ class TestZMQPullClientInitialization:
         ):
             client = ZMQPullClient(address="tcp://127.0.0.1:5555", bind=False)
 
-            assert client.semaphore.effective_slots == 10
+            assert client._max_inflight == 10
 
     def test_init_with_custom_concurrency(self, mock_zmq_context):
         """Test initialization with custom max_pull_concurrency."""
@@ -42,7 +42,7 @@ class TestZMQPullClientInitialization:
             address="tcp://127.0.0.1:5555", bind=False, max_pull_concurrency=5
         )
 
-        assert client.semaphore.effective_slots == 5
+        assert client._max_inflight == 5
 
 
 class TestZMQPullClientCallbackRegistration:
@@ -133,11 +133,10 @@ class TestZMQPullClientBackgroundTask:
             await wait_for_background_task()
 
     @pytest.mark.asyncio
-    async def test_background_task_releases_semaphore_on_timeout(
+    async def test_background_task_idle_on_no_data(
         self, pull_test_helper, wait_for_background_task
     ):
-        """Test that background task releases semaphore on timeout."""
-        # Explicitly raise zmq.Again to simulate timeout for this test
+        """FD drain stays idle (no in-flight) when recv yields no data."""
         async with pull_test_helper.create_client(
             auto_start=True,
             max_pull_concurrency=5,
@@ -145,8 +144,8 @@ class TestZMQPullClientBackgroundTask:
         ) as client:
             await wait_for_background_task()
 
-            # Semaphore should still have its original value (releases after timeout)
-            assert client.semaphore.stats.release_count == 1
+            # Nothing was delivered, so no credits are in flight.
+            assert client._inflight == 0
 
     @pytest.mark.asyncio
     async def test_background_task_handles_exception_gracefully(
@@ -177,11 +176,13 @@ class TestZMQPullClientBackgroundTask:
 
 
 class TestZMQPullClientConcurrency:
-    """Test concurrency control with semaphore."""
+    """Test FD-drain flow control via the _inflight counter."""
 
     @pytest.mark.asyncio
-    async def test_semaphore_limits_concurrent_processing(self, mock_zmq):
-        """Test that semaphore limits concurrent message processing."""
+    async def test_inflight_processes_multiple_messages(
+        self, mock_zmq_socket, mock_zmq_context, fd_enqueue
+    ):
+        """The FD drain delivers all queued messages (bounded by _max_inflight)."""
         messages = [
             HeartbeatMessage(
                 service_id="test-service",
@@ -191,9 +192,7 @@ class TestZMQPullClientConcurrency:
             )
             for i in range(10)
         ]
-
-        for message in messages:
-            await mock_zmq.recv_queue.put(message.to_json_bytes())
+        fd_enqueue(mock_zmq_socket, messages=[m.to_json_bytes() for m in messages])
 
         client = ZMQPullClient(
             address="tcp://127.0.0.1:5555", bind=False, max_pull_concurrency=3
@@ -204,9 +203,8 @@ class TestZMQPullClientConcurrency:
 
         async def slow_callback(msg: Message) -> None:
             processing.append(msg.request_id)
-            if len(processing) >= 3:  # At least 3 messages processed
+            if len(processing) >= 3:
                 done_event.set()
-            # Simulate slow processing (mocked to instant yield)
             await asyncio.sleep(0.1)
 
         client.register_pull_callback(MessageType.HEARTBEAT, slow_callback)
@@ -214,18 +212,20 @@ class TestZMQPullClientConcurrency:
         await client.initialize()
         await client.start()
 
-        # Wait for at least some messages to be processed
         await asyncio.wait_for(done_event.wait(), timeout=1.0)
 
         await client.stop()
 
-        # At least some messages should have been processed
-        assert len(processing) > 0
+        # max_pull_concurrency=3 bounds the drain, and done_event fires once the
+        # third callback starts, so at least the inflight cap's worth is delivered.
+        assert len(processing) >= 3
 
     @pytest.mark.asyncio
-    async def test_semaphore_released_after_processing(self, sample_message, mock_zmq):
-        """Test that semaphore is released after message processing."""
-        await mock_zmq.recv_queue.put(sample_message.to_json_bytes())
+    async def test_inflight_released_after_processing(
+        self, mock_zmq_socket, mock_zmq_context, sample_message, fd_enqueue
+    ):
+        """_inflight returns to 0 once a delivered message finishes processing."""
+        fd_enqueue(mock_zmq_socket, messages=[sample_message.to_json_bytes()])
 
         client = ZMQPullClient(
             address="tcp://127.0.0.1:5555", bind=False, max_pull_concurrency=5
@@ -234,7 +234,6 @@ class TestZMQPullClientConcurrency:
         done_event = asyncio.Event()
 
         async def callback(msg: Message) -> None:
-            # Simulate processing with mocked time
             await asyncio.sleep(0.01)
             done_event.set()
 
@@ -243,8 +242,9 @@ class TestZMQPullClientConcurrency:
         await client.initialize()
         await client.start()
 
-        # Wait for processing to complete (using mocked time)
-        await done_event.wait()
+        await asyncio.wait_for(done_event.wait(), timeout=1.0)
+        # Let the _process_message_fd finally-block run (_inflight -= 1).
+        await asyncio.sleep(0)
 
-        assert client.semaphore.stats.release_count == 1
-        assert client.semaphore.stats.wait_count == 0
+        assert client._inflight == 0
+        await client.stop()

--- a/tests/unit/zmq/test_push_client.py
+++ b/tests/unit/zmq/test_push_client.py
@@ -48,8 +48,8 @@ class TestZMQPushClientPush:
 
         await client.push(sample_message)
 
-        mock_zmq_socket.send.assert_called_once()
-        sent_data = mock_zmq_socket.send.call_args[0][0]
+        mock_zmq_socket._sync_send.assert_called_once()
+        sent_data = mock_zmq_socket._sync_send.call_args[0][0]
         # sent_data is bytes, so decode to string for comparison
         assert sample_message.message_type.value.encode() in sent_data
 
@@ -65,7 +65,7 @@ class TestZMQPushClientPush:
 
         await client.push(message)
 
-        sent_data = mock_zmq_socket.send.call_args[0][0]
+        sent_data = mock_zmq_socket._sync_send.call_args[0][0]
         # Verify it's valid JSON containing our data (sent_data is bytes)
         sent_str = sent_data.decode()
         assert (
@@ -80,8 +80,8 @@ class TestZMQPushClientPush:
         mock_socket = AsyncMock(spec=zmq.asyncio.Socket)
         mock_socket.bind = Mock()
         mock_socket.setsockopt = Mock()
-        # First call fails, second succeeds
-        mock_socket.send = AsyncMock(side_effect=[zmq.Again(), None])
+        # Sync FD-send path: first call fails (zmq.Again), second succeeds.
+        mock_socket._sync_send = Mock(side_effect=[zmq.Again(), None])
         mock_zmq_context.socket = Mock(return_value=mock_socket)
 
         with (
@@ -97,7 +97,7 @@ class TestZMQPushClientPush:
             await client.push(message)
 
             # Verify it was called twice (once failed, once succeeded)
-            assert mock_socket.send.call_count == 2
+            assert mock_socket._sync_send.call_count == 2
 
     @pytest.mark.asyncio
     async def test_push_raises_communication_error_after_max_retries(
@@ -107,7 +107,7 @@ class TestZMQPushClientPush:
         mock_socket = AsyncMock(spec=zmq.asyncio.Socket)
         mock_socket.bind = Mock()
         mock_socket.setsockopt = Mock()
-        mock_socket.send = AsyncMock(side_effect=zmq.Again())
+        mock_socket._sync_send = Mock(side_effect=zmq.Again())
         mock_zmq_context.socket = Mock(return_value=mock_socket)
 
         with (
@@ -177,4 +177,4 @@ class TestZMQPushClientEdgeCases:
         for msg in messages:
             await client.push(msg)
 
-        assert mock_zmq_socket.send.call_count == 5
+        assert mock_zmq_socket._sync_send.call_count == 5

--- a/tests/unit/zmq/test_streaming_clients.py
+++ b/tests/unit/zmq/test_streaming_clients.py
@@ -68,12 +68,11 @@ class TestStreamingRouterClientSendTo:
 
         await client.send_to("worker-42", sample_credit)
 
-        # Verify multipart message with correct envelope
-        mock_zmq_socket.send_multipart.assert_called_once()
-        call_args = mock_zmq_socket.send_multipart.call_args[0][0]
-
-        assert call_args[0] == b"worker-42"  # Identity
-        decoded = msgspec.msgpack.decode(call_args[1], type=Credit)
+        # FD path frames the message as two sync sends: identity + payload.
+        assert mock_zmq_socket._sync_send.call_count == 2
+        calls = mock_zmq_socket._sync_send.call_args_list
+        assert calls[0][0][0] == b"worker-42"  # Identity
+        decoded = msgspec.msgpack.decode(calls[1][0][0], type=Credit)
         assert decoded.id == sample_credit.id
 
     @pytest.mark.asyncio
@@ -90,7 +89,7 @@ class TestStreamingRouterClientReceiver:
 
     @pytest.mark.asyncio
     async def test_receives_worker_ready_and_calls_handler(
-        self, mock_zmq_context, sample_worker_ready, wait_for_background_task
+        self, mock_zmq_socket, mock_zmq_context, sample_worker_ready, fd_enqueue
     ):
         """Should receive messages from DEALERs and call registered handler."""
         handler_called = asyncio.Event()
@@ -103,27 +102,11 @@ class TestStreamingRouterClientReceiver:
             received_message = message
             handler_called.set()
 
-        # Setup mock socket to return one message
-        mock_socket = AsyncMock(spec=zmq.asyncio.Socket)
-        mock_socket.bind = Mock()
-        mock_socket.setsockopt = Mock()
-        mock_socket.send_multipart = AsyncMock()
-
-        # Return message in ROUTER format: [identity, message_bytes]
-        call_count = 0
-
-        async def recv_multipart_handler():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                await asyncio.sleep(0.01)  # Small delay
-                return [b"worker-1", msgspec.msgpack.encode(sample_worker_ready)]
-            else:
-                # Block forever on subsequent calls
-                await asyncio.Future()
-
-        mock_socket.recv_multipart = recv_multipart_handler
-        mock_zmq_context.socket = Mock(return_value=mock_socket)
+        # Queue one ROUTER message [identity, payload] for the FD drain.
+        fd_enqueue(
+            mock_zmq_socket,
+            frames=[b"worker-1", msgspec.msgpack.encode(sample_worker_ready)],
+        )
 
         client = ZMQStreamingRouterClient(address="tcp://*:5555", bind=True)
         client.register_receiver(handler)
@@ -211,9 +194,9 @@ class TestStreamingDealerClientSend:
 
         await client.send(sample_worker_ready)
 
-        # Verify message was sent (DEALER uses send, not send_multipart)
-        mock_zmq_socket.send.assert_called_once()
-        call_args = mock_zmq_socket.send.call_args[0][0]
+        # DEALER FD path uses a single sync send (no async send_multipart).
+        mock_zmq_socket._sync_send.assert_called_once()
+        call_args = mock_zmq_socket._sync_send.call_args[0][0]
 
         decoded = msgspec.msgpack.decode(call_args, type=WorkerReady)
         assert decoded.worker_id == sample_worker_ready.worker_id
@@ -236,7 +219,7 @@ class TestStreamingDealerClientReceiver:
 
     @pytest.mark.asyncio
     async def test_receives_credits_and_calls_handler(
-        self, mock_zmq_context, sample_credit, wait_for_background_task
+        self, mock_zmq_socket, mock_zmq_context, sample_credit, fd_enqueue
     ):
         """Should receive credits from ROUTER and call registered handler."""
         handler_called = asyncio.Event()
@@ -247,27 +230,8 @@ class TestStreamingDealerClientReceiver:
             received_message = message
             handler_called.set()
 
-        # Setup mock socket to return one message
-        mock_socket = AsyncMock(spec=zmq.asyncio.Socket)
-        mock_socket.bind = Mock()
-        mock_socket.connect = Mock()
-        mock_socket.setsockopt = Mock()
-        mock_socket.send = AsyncMock()
-
-        # DEALER receives using recv() not recv_multipart()
-        call_count = 0
-
-        async def recv_handler():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                await asyncio.sleep(0.01)
-                return msgspec.msgpack.encode(sample_credit)
-            else:
-                await asyncio.Future()
-
-        mock_socket.recv = recv_handler
-        mock_zmq_context.socket = Mock(return_value=mock_socket)
+        # Queue one DEALER frame (the credit) for the FD drain.
+        fd_enqueue(mock_zmq_socket, messages=[msgspec.msgpack.encode(sample_credit)])
 
         client = ZMQStreamingDealerClient(
             address="tcp://localhost:5555", identity="worker-1"
@@ -285,7 +249,7 @@ class TestStreamingDealerClientReceiver:
 
     @pytest.mark.asyncio
     async def test_receives_credit_with_msgpack_framing(
-        self, mock_zmq_context, sample_credit, wait_for_background_task
+        self, mock_zmq_socket, mock_zmq_context, sample_credit, fd_enqueue
     ):
         """Should handle msgpack encoded credits (DEALER uses recv, framing handled by ZMQ)."""
         handler_called = asyncio.Event()
@@ -296,26 +260,7 @@ class TestStreamingDealerClientReceiver:
             received_message = message
             handler_called.set()
 
-        mock_socket = AsyncMock(spec=zmq.asyncio.Socket)
-        mock_socket.bind = Mock()
-        mock_socket.connect = Mock()
-        mock_socket.setsockopt = Mock()
-        mock_socket.send = AsyncMock()
-
-        # DEALER uses recv() - ZMQ handles framing automatically
-        call_count = 0
-
-        async def recv_handler():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                await asyncio.sleep(0.01)
-                return msgspec.msgpack.encode(sample_credit)
-            else:
-                await asyncio.Future()
-
-        mock_socket.recv = recv_handler
-        mock_zmq_context.socket = Mock(return_value=mock_socket)
+        fd_enqueue(mock_zmq_socket, messages=[msgspec.msgpack.encode(sample_credit)])
 
         client = ZMQStreamingDealerClient(
             address="tcp://localhost:5555", identity="worker-1"

--- a/tests/unit/zmq/test_streaming_dealer_client.py
+++ b/tests/unit/zmq/test_streaming_dealer_client.py
@@ -151,8 +151,8 @@ class TestZMQStreamingDealerClientSend:
 
             await client.send(sample_worker_ready)
 
-            mock_socket.send.assert_called_once()
-            sent_data = mock_socket.send.call_args[0][0]
+            mock_socket._sync_send.assert_called_once()
+            sent_data = mock_socket._sync_send.call_args[0][0]
             decoded = msgspec.msgpack.decode(sent_data, type=WorkerReady)
             assert decoded.worker_id == sample_worker_ready.worker_id
 
@@ -168,7 +168,7 @@ class TestZMQStreamingDealerClientSend:
             for struct in structs:
                 await client.send(struct)
 
-            assert mock_socket.send.call_count == len(structs)
+            assert mock_socket._sync_send.call_count == len(structs)
 
     @pytest.mark.asyncio
     async def test_send_raises_when_not_initialized(
@@ -218,16 +218,10 @@ class TestZMQStreamingDealerClientReceiver:
         async def test_handler(message: RouterToWorkerMessage) -> None:
             await callback(message)
 
-        call_count = 0
-
-        async def mock_recv():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return msgspec.msgpack.encode(sample_credit)
-            await asyncio.Future()  # Block forever after first call
-
-        streaming_dealer_test_helper.setup_mock_socket(recv_side_effect=mock_recv)
+        # FD path reads via the raw FD: enqueue the encoded credit as a frame.
+        streaming_dealer_test_helper.setup_mock_socket(
+            recv_side_effect=[msgspec.msgpack.encode(sample_credit)]
+        )
 
         async with streaming_dealer_test_helper.create_client() as client:
             # Register handler BEFORE starting to avoid race condition
@@ -246,16 +240,9 @@ class TestZMQStreamingDealerClientReceiver:
         self, streaming_dealer_test_helper, sample_credit, wait_for_background_task
     ):
         """Test that receiver logs warning when no handler is registered."""
-        call_count = 0
-
-        async def mock_recv():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return msgspec.msgpack.encode(sample_credit)
-            await asyncio.Future()  # Block forever after first call
-
-        streaming_dealer_test_helper.setup_mock_socket(recv_side_effect=mock_recv)
+        streaming_dealer_test_helper.setup_mock_socket(
+            recv_side_effect=[msgspec.msgpack.encode(sample_credit)]
+        )
 
         async with streaming_dealer_test_helper.create_client(auto_start=True):
             # Don't register handler
@@ -275,25 +262,20 @@ class TestZMQStreamingDealerClientReceiver:
         streaming_dealer_test_helper,
         exception,
         iterations,
-        time_traveler,
     ):
-        """Test that receiver handles exceptions gracefully."""
-        call_count = 0
-        done_event = asyncio.Event()
+        """Test that the FD-driver surfaces a recv error without crashing.
 
-        async def mock_recv():
-            nonlocal call_count
-            call_count += 1
-            if call_count < iterations:
-                raise exception
-            done_event.set()
-            await asyncio.Future()  # Block forever after
+        Under the FD path a raising recv is reported via the driver's on_error
+        callback (generic error) or yields no data (zmq.Again); either way the
+        client stays RUNNING.
+        """
+        streaming_dealer_test_helper.setup_mock_socket(recv_side_effect=[exception])
 
-        streaming_dealer_test_helper.setup_mock_socket(recv_side_effect=mock_recv)
-
-        async with streaming_dealer_test_helper.create_client(auto_start=True):
-            await asyncio.wait_for(done_event.wait(), timeout=1.0)
-            assert call_count >= iterations
+        async with streaming_dealer_test_helper.create_client(
+            auto_start=True
+        ) as client:
+            await asyncio.sleep(0)
+            assert client.state == LifecycleState.RUNNING
 
     @pytest.mark.asyncio
     async def test_receiver_stops_on_cancelled_error(
@@ -380,7 +362,7 @@ class TestZMQStreamingDealerClientEdgeCases:
                 *[client.send(sample_worker_ready) for _ in range(num_structs)]
             )
 
-            assert mock_socket.send.call_count == num_structs
+            assert mock_socket._sync_send.call_count == num_structs
 
     @pytest.mark.asyncio
     async def test_different_struct_types(
@@ -394,7 +376,7 @@ class TestZMQStreamingDealerClientEdgeCases:
             for struct in structs:
                 await client.send(struct)
 
-            assert mock_socket.send.call_count == len(structs)
+            assert mock_socket._sync_send.call_count == len(structs)
 
     @pytest.mark.asyncio
     async def test_receiver_with_multiple_credits(
@@ -414,19 +396,12 @@ class TestZMQStreamingDealerClientEdgeCases:
             for i in range(3)
         ]
 
-        credit_index = 0
         received = []
         received_event = asyncio.Event()
 
-        async def mock_recv():
-            nonlocal credit_index
-            if credit_index < len(credits):
-                result = msgspec.msgpack.encode(credits[credit_index])
-                credit_index += 1
-                return result
-            await asyncio.Future()  # Block forever after all credits
-
-        streaming_dealer_test_helper.setup_mock_socket(recv_side_effect=mock_recv)
+        streaming_dealer_test_helper.setup_mock_socket(
+            recv_side_effect=[msgspec.msgpack.encode(c) for c in credits]
+        )
 
         async def test_handler(message: RouterToWorkerMessage) -> None:
             received.append(message)

--- a/tests/unit/zmq/test_streaming_fanin_clients.py
+++ b/tests/unit/zmq/test_streaming_fanin_clients.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the typed credit-return fan-in clients.
+
+``ZMQStreamingPushClient`` (worker side, send-only) and
+``ZMQStreamingPullClient`` (timing-manager side, recv-only) carry typed msgpack
+structs over the dedicated credit-return PUSH/PULL channel. These cover the
+send encode path, the FD-drain receive path, handler registration, and stop.
+"""
+
+import asyncio
+from unittest.mock import PropertyMock, patch
+
+import msgspec.msgpack
+import pytest
+import zmq.asyncio
+
+from aiperf.common.exceptions import CommunicationError, NotInitializedError
+from aiperf.credit.messages import CreditReturn, WorkerToRouterMessage
+from aiperf.zmq.streaming_pull_client import ZMQStreamingPullClient
+from aiperf.zmq.streaming_push_client import ZMQStreamingPushClient
+
+# ============================================================================
+# ZMQStreamingPushClient
+# ============================================================================
+
+
+class TestStreamingPushClient:
+    """Send-only typed PUSH client."""
+
+    def test_creates_push_socket(self, mock_zmq_context):
+        """Should create a PUSH socket."""
+        client = ZMQStreamingPushClient(address="tcp://localhost:5555", bind=False)
+        assert client.socket_type == zmq.SocketType.PUSH
+
+    def test_ignores_max_pull_concurrency(self, mock_zmq_context):
+        """max_pull_concurrency is accepted for factory uniformity and ignored."""
+        client = ZMQStreamingPushClient(
+            address="tcp://localhost:5555", bind=False, max_pull_concurrency=7
+        )
+        assert client.socket_type == zmq.SocketType.PUSH
+
+    @pytest.mark.asyncio
+    async def test_send_encodes_and_sync_sends(
+        self, mock_zmq_socket, mock_zmq_context, sample_credit_return
+    ):
+        """send() msgpack-encodes the struct and issues one NOBLOCK sync send."""
+        client = ZMQStreamingPushClient(address="tcp://localhost:5555", bind=False)
+        await client.initialize()
+
+        await client.send(sample_credit_return)
+
+        mock_zmq_socket._sync_send.assert_called_once()
+        call = mock_zmq_socket._sync_send.call_args
+        decoded = msgspec.msgpack.decode(call.args[0], type=WorkerToRouterMessage)
+        assert isinstance(decoded, CreditReturn)
+        assert decoded.credit.id == sample_credit_return.credit.id
+        assert call.kwargs["flags"] == zmq.NOBLOCK
+        assert call.kwargs["copy"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_traces_when_enabled(
+        self, mock_zmq_socket, mock_zmq_context, sample_worker_ready
+    ):
+        """With trace logging on, send() emits a trace without altering the send."""
+        client = ZMQStreamingPushClient(address="tcp://localhost:5555", bind=False)
+        await client.initialize()
+
+        with patch.object(
+            type(client), "is_trace_enabled", new_callable=PropertyMock
+        ) as trace_on:
+            trace_on.return_value = True
+            with patch.object(client, "trace") as trace:
+                await client.send(sample_worker_ready)
+
+        trace.assert_called_once()
+        mock_zmq_socket._sync_send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_if_not_initialized(
+        self, mock_zmq_context, sample_worker_ready
+    ):
+        """send() before initialize() raises NotInitializedError."""
+        client = ZMQStreamingPushClient(address="tcp://localhost:5555", bind=False)
+        with pytest.raises(NotInitializedError):
+            await client.send(sample_worker_ready)
+
+    @pytest.mark.asyncio
+    async def test_send_retries_on_zmq_again(
+        self, mock_zmq_socket, mock_zmq_context, sample_credit_return
+    ):
+        """A transient zmq.Again (IMMEDIATE=1 no-peer race) is retried, not dropped."""
+        client = ZMQStreamingPushClient(address="tcp://localhost:5555", bind=False)
+        await client.initialize()
+
+        # First sync send hits Again (no connected peer yet), second succeeds.
+        mock_zmq_socket._sync_send.side_effect = [zmq.Again(), None]
+
+        await client.send(sample_credit_return)
+
+        assert mock_zmq_socket._sync_send.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_raises_after_max_retries(
+        self, mock_zmq_socket, mock_zmq_context, sample_credit_return
+    ):
+        """A persistently-Again send raises CommunicationError after exhausting retries."""
+        client = ZMQStreamingPushClient(address="tcp://localhost:5555", bind=False)
+        await client.initialize()
+
+        mock_zmq_socket._sync_send.side_effect = zmq.Again()
+
+        with pytest.raises(CommunicationError, match="after 2 retries"):
+            await client.send(sample_credit_return, max_retries=2)
+
+        # 1 initial attempt + 2 retries = 3 sync sends.
+        assert mock_zmq_socket._sync_send.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_send_swallows_context_terminated(
+        self, mock_zmq_socket, mock_zmq_context, sample_credit_return
+    ):
+        """A send racing socket/context teardown returns quietly (no raise, no retry)."""
+        client = ZMQStreamingPushClient(address="tcp://localhost:5555", bind=False)
+        await client.initialize()
+
+        mock_zmq_socket._sync_send.side_effect = zmq.ContextTerminated()
+
+        await client.send(sample_credit_return)  # must not raise
+
+        assert mock_zmq_socket._sync_send.call_count == 1
+
+
+# ============================================================================
+# ZMQStreamingPullClient
+# ============================================================================
+
+
+class TestStreamingPullClientRegistration:
+    """Handler registration on the recv-only PULL client."""
+
+    def test_creates_pull_socket(self, mock_zmq_context):
+        """Should create a PULL socket."""
+        client = ZMQStreamingPullClient(address="tcp://localhost:5555", bind=True)
+        assert client.socket_type == zmq.SocketType.PULL
+
+    def test_register_receiver(self, mock_zmq_context):
+        """Registering a handler stores it."""
+        client = ZMQStreamingPullClient(address="tcp://localhost:5555", bind=True)
+
+        async def handler(message: WorkerToRouterMessage) -> None:
+            pass
+
+        client.register_receiver(handler)
+        assert client._receiver_handler is handler
+
+    def test_register_duplicate_receiver_raises(self, mock_zmq_context):
+        """A second register_receiver is a programming error."""
+        client = ZMQStreamingPullClient(address="tcp://localhost:5555", bind=True)
+
+        async def handler(message: WorkerToRouterMessage) -> None:
+            pass
+
+        client.register_receiver(handler)
+        with pytest.raises(ValueError, match="already registered"):
+            client.register_receiver(handler)
+
+
+class TestStreamingPullClientReceiver:
+    """FD-drain receive path on the PULL client."""
+
+    @pytest.mark.asyncio
+    async def test_receives_and_calls_handler(
+        self, mock_zmq_socket, mock_zmq_context, sample_credit_return, fd_enqueue
+    ):
+        """A queued typed struct is decoded and delivered to the handler."""
+        handler_called = asyncio.Event()
+        received: WorkerToRouterMessage | None = None
+
+        async def handler(message: WorkerToRouterMessage) -> None:
+            nonlocal received
+            received = message
+            handler_called.set()
+
+        fd_enqueue(
+            mock_zmq_socket, messages=[msgspec.msgpack.encode(sample_credit_return)]
+        )
+
+        client = ZMQStreamingPullClient(address="tcp://localhost:5555", bind=True)
+        client.register_receiver(handler)
+        await client.initialize()
+        await client.start()
+
+        try:
+            await asyncio.wait_for(handler_called.wait(), timeout=1.0)
+            assert isinstance(received, CreditReturn)
+            assert received.credit.id == sample_credit_return.credit.id
+        finally:
+            await client.stop()
+
+    @pytest.mark.asyncio
+    async def test_warns_when_no_handler_registered(
+        self, mock_zmq_socket, mock_zmq_context, sample_worker_ready, fd_enqueue
+    ):
+        """A message with no registered handler logs a warning and does not crash."""
+        fd_enqueue(
+            mock_zmq_socket, messages=[msgspec.msgpack.encode(sample_worker_ready)]
+        )
+
+        client = ZMQStreamingPullClient(address="tcp://localhost:5555", bind=True)
+        await client.initialize()
+
+        warned = asyncio.Event()
+        with patch.object(client, "warning", side_effect=lambda *a, **k: warned.set()):
+            await client.start()
+            await asyncio.wait_for(warned.wait(), timeout=1.0)
+            await client.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_reader_and_handler(
+        self, mock_zmq_socket, mock_zmq_context, sample_credit_return, fd_enqueue
+    ):
+        """stop() tears down the FD reader and clears the handler."""
+        delivered = asyncio.Event()
+
+        async def handler(message: WorkerToRouterMessage) -> None:
+            delivered.set()
+
+        fd_enqueue(
+            mock_zmq_socket, messages=[msgspec.msgpack.encode(sample_credit_return)]
+        )
+
+        client = ZMQStreamingPullClient(address="tcp://localhost:5555", bind=True)
+        client.register_receiver(handler)
+        await client.initialize()
+        await client.start()
+        # Waiting for a delivery guarantees the @background_task has installed
+        # the FD reader, avoiding a race on start() scheduling.
+        await asyncio.wait_for(delivered.wait(), timeout=1.0)
+        assert client._fd_reader is not None
+
+        await client.stop()
+
+        assert client._fd_reader is None
+        assert client._receiver_handler is None

--- a/tests/unit/zmq/test_streaming_router_client.py
+++ b/tests/unit/zmq/test_streaming_router_client.py
@@ -108,10 +108,11 @@ class TestZMQStreamingRouterClientSendTo:
 
             await client.send_to(identity, sample_credit)
 
-            mock_socket.send_multipart.assert_called_once()
-            sent_data = mock_socket.send_multipart.call_args[0][0]
-            assert sent_data[0] == identity.encode()
-            decoded = msgspec.msgpack.decode(sent_data[1], type=Credit)
+            # FD path frames the message as two sync sends: identity + payload.
+            assert mock_socket._sync_send.call_count == 2
+            calls = mock_socket._sync_send.call_args_list
+            assert calls[0][0][0] == identity.encode()
+            decoded = msgspec.msgpack.decode(calls[1][0][0], type=Credit)
             assert decoded.id == sample_credit.id
 
     @pytest.mark.asyncio
@@ -125,7 +126,8 @@ class TestZMQStreamingRouterClientSendTo:
             for identity in multiple_identities:
                 await client.send_to(identity, sample_credit)
 
-            assert mock_socket.send_multipart.call_count == len(multiple_identities)
+            # Two sync sends (identity + payload) per message.
+            assert mock_socket._sync_send.call_count == len(multiple_identities) * 2
 
     @pytest.mark.asyncio
     async def test_send_to_raises_when_not_initialized(
@@ -159,8 +161,9 @@ class TestZMQStreamingRouterClientSendTo:
 
             await client.send_to(special_identity, sample_credit)
 
-            sent_data = mock_socket.send_multipart.call_args[0][0]
-            assert sent_data[0] == special_identity.encode()
+            assert mock_socket._sync_send.call_args_list[0][0][0] == (
+                special_identity.encode()
+            )
 
 
 class TestZMQStreamingRouterClientReceiver:
@@ -187,18 +190,11 @@ class TestZMQStreamingRouterClientReceiver:
         ) -> None:
             await callback((recv_identity, message))
 
-        # Setup mock to return message once then block forever
-        call_count = 0
-
-        async def mock_recv():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return [identity.encode(), msgspec.msgpack.encode(sample_worker_ready)]
-            await asyncio.Future()  # Block forever after first call
-
+        # FD path drains the [identity, payload] frames off the raw socket.
         streaming_router_test_helper.setup_mock_socket(
-            recv_multipart_side_effect=mock_recv
+            recv_multipart_side_effect=[
+                [identity.encode(), msgspec.msgpack.encode(sample_worker_ready)]
+            ]
         )
 
         async with streaming_router_test_helper.create_client() as client:
@@ -221,17 +217,10 @@ class TestZMQStreamingRouterClientReceiver:
         wait_for_background_task,
     ):
         """Test that receiver logs warning when no handler is registered."""
-        call_count = 0
-
-        async def mock_recv():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return [b"worker-1", msgspec.msgpack.encode(sample_worker_ready)]
-            await asyncio.Future()  # Block forever after first call
-
         streaming_router_test_helper.setup_mock_socket(
-            recv_multipart_side_effect=mock_recv
+            recv_multipart_side_effect=[
+                [b"worker-1", msgspec.msgpack.encode(sample_worker_ready)]
+            ]
         )
 
         async with streaming_router_test_helper.create_client(auto_start=True):
@@ -252,27 +241,21 @@ class TestZMQStreamingRouterClientReceiver:
         streaming_router_test_helper,
         exception,
         iterations,
-        time_traveler,
     ):
-        """Test that receiver handles exceptions gracefully."""
-        call_count = 0
-        done_event = asyncio.Event()
+        """Test that the FD-driver surfaces a recv error without crashing.
 
-        async def mock_recv():
-            nonlocal call_count
-            call_count += 1
-            if call_count < iterations:
-                raise exception
-            done_event.set()
-            await asyncio.Future()  # Block forever after
-
+        A raising recv is reported via the driver's on_error callback (generic
+        error) or yields no data (zmq.Again); the client stays RUNNING.
+        """
         streaming_router_test_helper.setup_mock_socket(
-            recv_multipart_side_effect=mock_recv
+            recv_multipart_side_effect=[exception]
         )
 
-        async with streaming_router_test_helper.create_client(auto_start=True):
-            await asyncio.wait_for(done_event.wait(), timeout=1.0)
-            assert call_count >= iterations
+        async with streaming_router_test_helper.create_client(
+            auto_start=True
+        ) as client:
+            await asyncio.sleep(0)
+            assert client.state == LifecycleState.RUNNING
 
     @pytest.mark.asyncio
     async def test_receiver_stops_on_cancelled_error(
@@ -302,17 +285,10 @@ class TestZMQStreamingRouterClientReceiver:
         async def test_handler(identity: str, message: WorkerToRouterMessage) -> None:
             await callback((identity, message))
 
-        call_count = 0
-
-        async def mock_recv():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return [b"", msgspec.msgpack.encode(sample_worker_ready)]
-            await asyncio.Future()  # Block forever after first call
-
         streaming_router_test_helper.setup_mock_socket(
-            recv_multipart_side_effect=mock_recv
+            recv_multipart_side_effect=[
+                [b"", msgspec.msgpack.encode(sample_worker_ready)]
+            ]
         )
 
         async with streaming_router_test_helper.create_client() as client:
@@ -396,4 +372,4 @@ class TestZMQStreamingRouterClientEdgeCases:
                 ]
             )
 
-            assert mock_socket.send_multipart.call_count == len(multiple_identities)
+            assert mock_socket._sync_send.call_count == len(multiple_identities) * 2

--- a/tests/unit/zmq/test_sub_client.py
+++ b/tests/unit/zmq/test_sub_client.py
@@ -460,19 +460,14 @@ class TestZMQSubClientBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_background_task_receives_and_handles_message(
-        self, mock_zmq_context, sample_message, wait_for_background_task
+        self, mock_zmq_socket, mock_zmq_context, sample_message, fd_enqueue
     ):
         """Test that background task receives and handles messages."""
         topic_bytes = f"{sample_message.message_type}{TOPIC_END}".encode()
         message_bytes = sample_message.model_dump_json().encode()
 
-        mock_socket = AsyncMock(spec=zmq.asyncio.Socket)
-        mock_socket.bind = Mock()
-        mock_socket.setsockopt = Mock()
-        mock_socket.recv_multipart = AsyncMock(
-            side_effect=[[topic_bytes, message_bytes], zmq.Again()]
-        )
-        mock_zmq_context.socket = Mock(return_value=mock_socket)
+        # Queue the [topic, payload] multipart message for the FD drain.
+        fd_enqueue(mock_zmq_socket, frames=[topic_bytes, message_bytes])
 
         client = ZMQSubClient(address="tcp://127.0.0.1:5555", bind=False)
 
@@ -484,7 +479,6 @@ class TestZMQSubClientBackgroundTask:
         await client.initialize()
         await client.subscribe(sample_message.message_type, callback)
         await client.start()
-        await wait_for_background_task()
 
         # Wait for callback to be called
         await asyncio.wait_for(callback_called.wait(), timeout=1.0)
@@ -554,19 +548,20 @@ class TestZMQSubClientBackgroundTask:
         await client.stop()
 
     @pytest.mark.asyncio
-    async def test_sub_receiver_stops_on_context_terminated(self, mock_zmq_context):
-        """Test that _sub_receiver breaks on ContextTerminated."""
-        mock_socket = AsyncMock(spec=zmq.asyncio.Socket)
-        mock_socket.bind = Mock()
-        mock_socket.setsockopt = Mock()
-        mock_socket.recv_multipart = AsyncMock(side_effect=zmq.ContextTerminated())
-        mock_zmq_context.socket = Mock(return_value=mock_socket)
+    async def test_sub_receiver_stops_on_context_terminated(
+        self, mock_zmq_socket, mock_zmq_context, fd_enqueue
+    ):
+        """Test that the FD drain swallows ContextTerminated without crashing."""
+        # Queue a ContextTerminated for the very first recv; the FD-driver pump
+        # must catch it and leave the reader installed (no propagation).
+        fd_enqueue(mock_zmq_socket, messages=[zmq.ContextTerminated()])
 
         client = ZMQSubClient(address="tcp://127.0.0.1:5555", bind=False)
         await client.initialize()
 
-        # Call _sub_receiver directly to exercise the except clause
+        # Installs the FdEdgeReader and runs the bootstrap drain, which hits the
+        # queued ContextTerminated and returns gracefully.
         await client._sub_receiver()
 
-        # Should have tried to recv and hit ContextTerminated
-        mock_socket.recv_multipart.assert_called()
+        assert client._fd_reader is not None
+        await client.stop()

--- a/tests/zmq/__init__.py
+++ b/tests/zmq/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/zmq/conftest.py
+++ b/tests/zmq/conftest.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fixtures for real-socket ZMQ transport tests.
+
+Unlike ``tests/unit/zmq`` (which mocks the socket and the FD via the autouse
+fixtures in its own conftest), these tests drive the REAL ZMQ client classes
+over a live ``libzmq`` transport. They share the process-wide
+``zmq.asyncio.Context.instance()`` and talk over ``inproc://`` endpoints
+(cross-platform, no ports or files), with real time (no looptime) so the
+FD edge-trigger, re-arm, and bootstrap-drain behaviors are exercised against
+the actual event loop and kernel objects.
+"""
+
+import asyncio
+import contextlib
+import itertools
+
+import pytest
+
+from aiperf.common.constants import IS_WINDOWS
+
+
+@pytest.fixture(scope="session")
+def event_loop_policy():
+    """Force the selector loop on Windows so the FD-driver can register.
+
+    The FD-driver calls ``loop.add_reader(getsockopt(zmq.FD), ...)``, which the
+    default Windows ``ProactorEventLoop`` does not implement. Production switches
+    to the selector policy in ``bootstrap``; these tests never run bootstrap, so
+    mirror it here (no-op on Linux/macOS).
+    """
+    if IS_WINDOWS:
+        return asyncio.WindowsSelectorEventLoopPolicy()
+    return asyncio.get_event_loop_policy()
+
+
+# Per-process counter -> unique inproc endpoint names. inproc namespaces are
+# scoped to a Context, and each xdist worker is its own process with its own
+# Context.instance(), so a per-process counter is collision-free.
+_ADDR_COUNTER = itertools.count()
+
+
+@pytest.fixture
+def new_addr():
+    """Return a factory yielding a fresh unique ``inproc://`` endpoint per call."""
+
+    def _make() -> str:
+        return f"inproc://aiperf-zmqtest-{next(_ADDR_COUNTER)}"
+
+    return _make
+
+
+@pytest.fixture
+async def client_factory():
+    """Create real ZMQ clients and tear them all down after the test.
+
+    For ``inproc`` the bind side must exist before the connect side, so create
+    ``bind=True`` clients (PULL/ROUTER) before ``bind=False`` ones (PUSH/DEALER).
+
+    Args to the returned factory:
+        cls: the client class to instantiate.
+        address/bind: endpoint and bind flag.
+        start: if True, ``await client.start()`` after init (installs the FD reader).
+        receiver: optional handler passed to ``register_receiver`` before start.
+        **kwargs: forwarded to the client constructor (e.g. ``identity=...``).
+    """
+    created = []
+
+    async def _make(cls, *, address, bind, start=False, receiver=None, **kwargs):
+        client = cls(address=address, bind=bind, **kwargs)
+        await client.initialize()
+        if receiver is not None:
+            client.register_receiver(receiver)
+        if start:
+            await client.start()
+        created.append(client)
+        return client
+
+    yield _make
+
+    for client in reversed(created):
+        with contextlib.suppress(Exception):  # best-effort teardown
+            await client.stop()

--- a/tests/zmq/test_zmq_real_transport.py
+++ b/tests/zmq/test_zmq_real_transport.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Adversarial real-socket tests for the FD-driven ZMQ credit clients.
+
+These run the actual client classes over a live ``libzmq`` ``inproc`` transport
+(no mocks, real event loop, real FD) to cover edge cases the mocked unit suite
+cannot reproduce:
+
+* the FD edge-trigger re-arm under a tight burst (the kernel FD fires once on the
+  0->nonzero transition; messages that land mid-drain must still be picked up),
+* the bootstrap drain of a backlog queued *before* the reader is installed,
+* true PUSH/PULL fan-in from many real worker sockets into one PULL,
+* the shared-FD bidirectional DEALER/ROUTER drive (recv and send on one FD),
+* graceful stop while messages are still in flight.
+"""
+
+import asyncio
+from collections import Counter
+
+import msgspec
+
+from aiperf.common.enums import CreditPhase
+from aiperf.credit.messages import (
+    CreditReturn,
+    WorkerReady,
+)
+from aiperf.credit.structs import Credit
+from aiperf.zmq.streaming_dealer_client import ZMQStreamingDealerClient
+from aiperf.zmq.streaming_pull_client import ZMQStreamingPullClient
+from aiperf.zmq.streaming_push_client import ZMQStreamingPushClient
+from aiperf.zmq.streaming_router_client import ZMQStreamingRouterClient
+
+# Small real-time settle so inproc connect/subscription completes before the
+# first send (real time here - no looptime in tests/zmq).
+_SETTLE = 0.05
+
+
+class _Bogus(msgspec.Struct, tag_field="t", tag="bogus"):
+    """A tagged struct whose tag is NOT in WorkerToRouterMessage, so the PULL
+    decoder raises a (non-ZMQ) decode error on it."""
+
+    n: int = 0
+
+
+def _credit(i: int) -> Credit:
+    return Credit(
+        id=i,
+        phase=CreditPhase.PROFILING,
+        conversation_id="conv",
+        x_correlation_id="corr",
+        turn_index=0,
+        num_turns=1,
+        issued_at_ns=1,
+    )
+
+
+async def test_push_pull_roundtrip(client_factory, new_addr):
+    """A CreditReturn pushed over the real PUSH/PULL channel decodes intact,
+    including the in-message worker_id (the channel carries no ZMQ identity)."""
+    addr = new_addr()
+    inbox: asyncio.Queue = asyncio.Queue()
+
+    await client_factory(
+        ZMQStreamingPullClient, address=addr, bind=True, start=True, receiver=inbox.put
+    )
+    push = await client_factory(ZMQStreamingPushClient, address=addr, bind=False)
+    await asyncio.sleep(_SETTLE)
+
+    await push.send(CreditReturn(credit=_credit(42), worker_id="worker-7"))
+
+    msg = await asyncio.wait_for(inbox.get(), timeout=2.0)
+    assert isinstance(msg, CreditReturn)
+    assert msg.credit.id == 42
+    assert msg.worker_id == "worker-7"
+
+
+async def test_push_pull_fan_in_no_loss(client_factory, new_addr):
+    """Many real worker PUSH sockets fan in to one PULL with no loss or dup."""
+    addr = new_addr()
+    n_workers, per_worker = 4, 64
+    total = n_workers * per_worker
+    received: list[tuple[str, int]] = []
+    done = asyncio.Event()
+
+    async def handler(msg: CreditReturn) -> None:
+        received.append((msg.worker_id, msg.credit.id))
+        if len(received) >= total:
+            done.set()
+
+    await client_factory(
+        ZMQStreamingPullClient, address=addr, bind=True, start=True, receiver=handler
+    )
+    pushers = [
+        await client_factory(ZMQStreamingPushClient, address=addr, bind=False)
+        for _ in range(n_workers)
+    ]
+    await asyncio.sleep(_SETTLE)
+
+    async def blast(worker_idx: int, push: ZMQStreamingPushClient) -> None:
+        for i in range(per_worker):
+            await push.send(
+                CreditReturn(credit=_credit(i), worker_id=f"worker-{worker_idx}")
+            )
+
+    await asyncio.gather(*(blast(w, p) for w, p in enumerate(pushers)))
+    await asyncio.wait_for(done.wait(), timeout=5.0)
+
+    assert len(received) == total
+    expected = Counter(
+        (f"worker-{w}", i) for w in range(n_workers) for i in range(per_worker)
+    )
+    assert Counter(received) == expected
+
+
+async def test_push_pull_burst_drains_all_in_order(client_factory, new_addr):
+    """A tight burst from one PUSH is fully drained, in order.
+
+    This is the FD re-arm stress: the raw FD only signals on the 0->nonzero
+    ``ZMQ_EVENTS`` edge, so messages enqueued while ``_pump`` is mid-drain would
+    be stranded if the reader did not re-check ``POLLIN`` and ``call_soon`` itself.
+    A single pusher preserves order, so an exact ordered match proves no message
+    was dropped or duplicated.
+    """
+    addr = new_addr()
+    burst = 2000
+    received: list[int] = []
+    done = asyncio.Event()
+
+    async def handler(msg: CreditReturn) -> None:
+        received.append(msg.credit.id)
+        if len(received) >= burst:
+            done.set()
+
+    await client_factory(
+        ZMQStreamingPullClient, address=addr, bind=True, start=True, receiver=handler
+    )
+    push = await client_factory(ZMQStreamingPushClient, address=addr, bind=False)
+    await asyncio.sleep(_SETTLE)
+
+    for i in range(burst):
+        await push.send(CreditReturn(credit=_credit(i)))
+
+    await asyncio.wait_for(done.wait(), timeout=10.0)
+    assert received == list(range(burst))
+
+
+async def test_pull_bootstrap_drains_prestart_backlog(client_factory, new_addr):
+    """Messages queued before the reader is installed are drained on start().
+
+    The edge-triggered FD will not fire for messages already sitting in the recv
+    buffer when ``add_reader`` registers, so ``start()`` must run a bootstrap
+    ``_pump`` to clear the backlog. Here we send before ``pull.start()`` and
+    assert nothing is delivered until start, then the whole backlog arrives.
+    """
+    addr = new_addr()
+    received: list[int] = []
+    got_all = asyncio.Event()
+    backlog = 16
+
+    async def handler(msg: CreditReturn) -> None:
+        received.append(msg.credit.id)
+        if len(received) >= backlog:
+            got_all.set()
+
+    # Initialize + register the handler, but do NOT start the FD reader yet.
+    pull = await client_factory(
+        ZMQStreamingPullClient, address=addr, bind=True, start=False, receiver=handler
+    )
+    push = await client_factory(ZMQStreamingPushClient, address=addr, bind=False)
+    await asyncio.sleep(_SETTLE)
+
+    for i in range(backlog):
+        await push.send(CreditReturn(credit=_credit(i)))
+    await asyncio.sleep(0.1)  # let the backlog settle in the PULL recv buffer
+
+    assert received == []  # reader not started -> nothing drained yet
+
+    await pull.start()  # bootstrap drain must clear the pre-queued backlog
+    await asyncio.wait_for(got_all.wait(), timeout=2.0)
+    assert sorted(received) == list(range(backlog))
+
+
+async def test_dealer_router_bidirectional_roundtrip(client_factory, new_addr):
+    """Real DEALER<->ROUTER round-trip exercises the shared-FD both-direction drive.
+
+    The worker DEALER sends (recv on the router side) and the router replies by
+    identity (recv on the dealer side), all driven off each socket's single raw FD.
+    """
+    addr = new_addr()
+    router_inbox: asyncio.Queue = asyncio.Queue()
+    dealer_inbox: asyncio.Queue = asyncio.Queue()
+
+    async def router_handler(identity: str, msg) -> None:
+        await router_inbox.put((identity, msg))
+
+    router = await client_factory(
+        ZMQStreamingRouterClient,
+        address=addr,
+        bind=True,
+        start=True,
+        receiver=router_handler,
+    )
+    dealer = await client_factory(
+        ZMQStreamingDealerClient,
+        address=addr,
+        bind=False,
+        start=True,
+        receiver=dealer_inbox.put,
+        identity="worker-1",
+    )
+    await asyncio.sleep(_SETTLE)
+
+    # DEALER -> ROUTER
+    await dealer.send(WorkerReady(worker_id="worker-1"))
+    identity, msg = await asyncio.wait_for(router_inbox.get(), timeout=2.0)
+    assert identity == "worker-1"
+    assert isinstance(msg, WorkerReady)
+    assert msg.worker_id == "worker-1"
+
+    # ROUTER -> DEALER (routed back by the captured identity)
+    await router.send_to(identity, _credit(7))
+    reply = await asyncio.wait_for(dealer_inbox.get(), timeout=2.0)
+    assert isinstance(reply, Credit)
+    assert reply.id == 7
+
+
+async def test_stop_is_clean_with_messages_in_flight(client_factory, new_addr):
+    """Stopping the PULL client mid-stream tears down cleanly (no raised error,
+    FD reader removed) even while a sender is still pushing."""
+    addr = new_addr()
+    received: list[int] = []
+
+    async def handler(msg: CreditReturn) -> None:
+        received.append(msg.credit.id)
+
+    pull = await client_factory(
+        ZMQStreamingPullClient, address=addr, bind=True, start=True, receiver=handler
+    )
+    push = await client_factory(ZMQStreamingPushClient, address=addr, bind=False)
+    await asyncio.sleep(_SETTLE)
+
+    for i in range(200):
+        await push.send(CreditReturn(credit=_credit(i)))
+
+    # Stop while the drain may still have work queued; must not raise.
+    await pull.stop()
+    assert pull._fd_reader is None
+
+
+async def test_poison_message_does_not_strand_the_drain(client_factory, new_addr):
+    """A frame that fails to decode is reported but does NOT stall the reader.
+
+    Valid messages queued behind an undecodable one must still be delivered. We
+    pre-queue [v0, v1, bogus, v2, v3] before start(), so the bootstrap drain hits
+    the poison in a single pass: the FD is edge-triggered and POLLIN stays set,
+    so if ``_pump`` returned without re-arming after the decode error, v2/v3 would
+    be stranded forever (this test would time out). The re-arm keeps the drain going.
+    """
+    addr = new_addr()
+    received: list[int] = []
+    done = asyncio.Event()
+
+    async def handler(msg: CreditReturn) -> None:
+        received.append(msg.credit.id)
+        if len(received) >= 4:
+            done.set()
+
+    pull = await client_factory(
+        ZMQStreamingPullClient, address=addr, bind=True, start=False, receiver=handler
+    )
+    push = await client_factory(ZMQStreamingPushClient, address=addr, bind=False)
+    await asyncio.sleep(_SETTLE)
+
+    await push.send(CreditReturn(credit=_credit(0)))
+    await push.send(CreditReturn(credit=_credit(1)))
+    await push.send(_Bogus(n=99))  # undecodable as WorkerToRouterMessage
+    await push.send(CreditReturn(credit=_credit(2)))
+    await push.send(CreditReturn(credit=_credit(3)))
+    await asyncio.sleep(0.1)  # everything queued in the PULL buffer
+
+    await pull.start()  # one bootstrap drain pass hits the poison mid-stream
+    await asyncio.wait_for(done.wait(), timeout=3.0)
+    assert received == [0, 1, 2, 3]


### PR DESCRIPTION
## Summary

Drive every ZMQ socket off its raw FD instead of the `zmq.asyncio` await-recv/await-send loops, and split credit returns onto a dedicated channel.

- **FD-driver everywhere.** PULL/SUB recv and the streaming DEALER/ROUTER (both directions) drain via `loop.add_reader` on the socket FD with an edge-triggered NOBLOCK loop (`FdEdgeReader`). PUSH/PUB send with a synchronous NOBLOCK send. This clears message bursts in fewer event-loop round-trips and avoids the `zmq.asyncio` Future/polling overhead per op.
- **Credit returns split onto their own channel.** The credit plane was a single bidirectional ROUTER/DEALER socket (`CREDIT_ROUTER`) carrying both dispatch (router→worker) and returns (worker→router). `CreditReturn`/`FirstToken` now go out a dedicated typed PUSH (worker) → PULL (timing-manager) fan-in (`CommAddress.CREDIT_RETURN`), so `CREDIT_ROUTER` is send-only and the worker's credit DEALER recv-only — neither pays the shared-FD send/recv `ZMQ_EVENTS` re-arm. `worker_id` rides inside `CreditReturn` since PUSH/PULL carries no envelope identity; `WorkerReady`/`WorkerShutdown` stay on the dispatch DEALER so the ROUTER still learns each worker's identity. New typed streaming PUSH/PULL clients carry the credit msgpack wire; dual-bind (k8s) is wired for the return PULL.

## Benchmarks

Credit-channel lanes (`dev/benchmarks/zmq_bench`, 50 workers × 250k credits, zero-work echo so the transport is the bottleneck):

| lane | throughput |
|---|---|
| python — await ROUTER/DEALER (baseline) | ~70k c/s |
| python — FD ROUTER/DEALER + PUSH/PULL returns (this PR) | **~285k c/s (~4×)** |
| python — FD PUSH/PULL both legs (no addressing) | ~410k c/s |
| rust — async_zmq ROUTER/DEALER | ~640k c/s |
| rust — poll-owner / semaphore-gated | ~1.5M c/s |

Isolated transport ceiling (open-loop 250k blast, 8 workers): the FD-driver lifts ROUTER/DEALER credit round-trips from **51k → 192k RT/s** (p50 17.8ms → 0.64ms), PUSH/PULL 97k → 326k, PUB/SUB ~555k → ~2.0M msg/s. End-to-end against the mock server (isl8/osl1, 50w/250k, credit-bound): **~12k → ~18k req/s (1.5×)** with far tighter run-to-run variance.

## Tests

The zmq client unit tests are migrated to the FD model (FD-safe mock socket whose `getsockopt(EVENTS)` tracks a frame queue), plus `FakeStreamingPush/PullClient` in the component harness. Full `unit`, `zmq`, `credit`, `workers`, and `component_integration` suites pass; `integration` passes except 2 pre-existing MLflow-env failures that reproduce identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a ZMQ credit benchmarking CLI (round-trip and one-way PUB/SUB) with multiple messaging patterns and run modes.
  * Introduced a dedicated credit-return PUSH/PULL channel with optional worker attribution.
  * Added typed streaming PUSH/PULL client support for the credit-return message flow.

* **Performance Improvements**
  * Improved ZMQ send/receive efficiency by moving key client I/O onto FD edge-triggered draining and synchronous non-blocking sends.

* **Other**
  * Removed the W&B data exporter plugin.
  * Updated unit tests to align with FD-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->