### PR TITLE
Add output token replay annotations

### DIFF
--- a/docs/benchmark-modes/trace-replay.md
+++ b/docs/benchmark-modes/trace-replay.md
@@ -144,6 +144,22 @@ Use the `extra` field to inject arbitrary key-value pairs into the HTTP payload 
 
 **Merge semantics:** Merging is shallow — a per-entry `{"nvext": {...}}` replaces the entire global `nvext` key. Deep merge is not performed.
 
+## Output Token Replay
+
+When replaying against a backend configured for output token replay, a trace row can carry exact output token IDs:
+
+```json
+{"request_id": "req-1", "messages": [{"role": "user", "content": "Call the weather tool"}], "output_length": 5, "output_token_ids": [123, 456, 789, 321, 654]}
+```
+
+`output_token_ids` is optional. When present, `output_length` must equal the number of token IDs. AIPerf does not send `output_token_ids` to the server. Instead, it derives a replay key and adds a request annotation under `nvext.annotations`:
+
+- `request_id` when the row provides one
+- `<session_id>:<turn_index>` for rows with `session_id`
+- `line:<zero_based_line_index>` otherwise
+
+For the example above, AIPerf sends `nvext.annotations: ["output_replay_id:req-1"]`. A backend that supports output token replay can use that key to look up and emit the planned output token sequence.
+
 ## Profile using real Mooncake Trace
 
 For real-world benchmarking, use the FAST25 production trace data from the Mooncake research paper:

--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Literal, TypeVar
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, PrivateAttr, model_validator
 
 from aiperf.common.models import AIPerfBaseModel, Audio, Image, Text, Video
 from aiperf.plugin.enums import CustomDatasetType
@@ -227,7 +227,10 @@ class MooncakeTrace(AIPerfBaseModel):
     - With messages: {"messages": [{"role": "user", "content": "Hello"}], "output_length": 4}
     - With payload: {"payload": {"prompt": "Hello", "max_tokens": 50}, "timestamp": 1000}
     - With timestamp and hash ID: {"timestamp": 1000, "input_length": 10, "hash_ids": [123]}
+    - With planned output token replay: {"text_input": "Hello", "output_length": 3, "output_token_ids": [1, 2, 3]}
     """
+
+    _output_replay_key: str | None = PrivateAttr(default=None)
 
     type: Literal[CustomDatasetType.MOONCAKE_TRACE] = CustomDatasetType.MOONCAKE_TRACE
     input_length: int | None = Field(
@@ -256,6 +259,15 @@ class MooncakeTrace(AIPerfBaseModel):
     # Optional fields
     output_length: int | None = Field(
         None, description="The output sequence length of a request"
+    )
+    output_token_ids: list[int] | None = Field(
+        None,
+        description="Exact output token IDs for output token replay. "
+        "When provided, output_length must match the number of token IDs.",
+    )
+    request_id: str | None = Field(
+        None,
+        description="Optional stable request identifier used as the output replay key.",
     )
     hash_ids: list[int] | None = Field(None, description="The hash ids of a request")
     timestamp: int | float | None = Field(
@@ -298,6 +310,23 @@ class MooncakeTrace(AIPerfBaseModel):
                 "'hash_ids' is only allowed when 'input_length' is provided, not when 'text_input', 'messages', or 'payload' are provided"
             )
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_output_token_ids(self) -> "MooncakeTrace":
+        """Validate planned output token replay fields."""
+        if self.output_token_ids is None:
+            return self
+        if any(token_id < 0 for token_id in self.output_token_ids):
+            raise ValueError("'output_token_ids' must contain non-negative token IDs")
+        if self.output_length is None:
+            raise ValueError(
+                "'output_length' is required when 'output_token_ids' is provided"
+            )
+        if self.output_length != len(self.output_token_ids):
+            raise ValueError(
+                "'output_length' must equal len('output_token_ids') when planned output tokens are provided"
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/aiperf/dataset/loader/mooncake_trace.py
+++ b/src/aiperf/dataset/loader/mooncake_trace.py
@@ -2,16 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+import orjson
 from pydantic import ValidationError
 
 from aiperf.common.enums import ConversationContextMode
 from aiperf.common.models import Turn
 from aiperf.dataset.loader.base_loader import LoaderProbeData
-from aiperf.dataset.loader.base_trace_loader import BaseTraceDatasetLoader
+from aiperf.dataset.loader.base_trace_loader import (
+    BaseTraceDatasetLoader,
+    _has_meaningful_synthesis,
+)
 from aiperf.dataset.loader.models import MooncakeTrace
+from aiperf.dataset.loader.output_replay import (
+    effective_replay_key,
+    merge_output_replay_annotation,
+)
 from aiperf.dataset.loader.speed_bench import is_speed_bench_row
 
 
@@ -63,6 +72,79 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
 
     def _parse_trace(self, record: dict) -> MooncakeTrace:
         return MooncakeTrace.model_validate(record)
+
+    def _iter_records_with_line_index(self) -> Iterator[tuple[int, dict[str, Any]]]:
+        if self.inline_records is not None:
+            if isinstance(self.inline_records, dict):
+                raise ValueError(
+                    "Mooncake trace inline records must be a list of records, not a dict of pools."
+                )
+            yield from enumerate(self.inline_records)
+            return
+
+        with open(self.filename, encoding="utf-8") as f:
+            for line_index, line in enumerate(f):
+                if line := line.strip():
+                    try:
+                        yield line_index, orjson.loads(line)
+                    except orjson.JSONDecodeError as e:
+                        raise ValueError(
+                            f"Invalid JSON in dataset file {self.filename} at line {line_index + 1}: {e}"
+                        ) from None
+
+    def load_dataset(self) -> dict[str, list[MooncakeTrace]]:
+        self._skipped_traces = 0
+        self._skipped_max_isl = 0
+        self._capped_max_osl = 0
+        items: list[MooncakeTrace] = []
+        session_turns: dict[str, int] = {}
+
+        for line_index, record_dict in self._iter_records_with_line_index():
+            trace = self._parse_trace(record_dict)
+            turn_index = (
+                session_turns.get(trace.session_id, 0)
+                if trace.session_id is not None
+                else 0
+            )
+            if trace.output_token_ids is not None:
+                if (
+                    self._max_osl is not None
+                    and trace.output_length is not None
+                    and trace.output_length > self._max_osl
+                ):
+                    raise ValueError(
+                        "mooncake trace output_token_ids cannot be combined with max_osl capping"
+                    )
+                trace._output_replay_key = effective_replay_key(
+                    trace.request_id,
+                    trace.session_id,
+                    turn_index,
+                    line_index,
+                )
+            if trace.session_id is not None:
+                session_turns[trace.session_id] = turn_index + 1
+
+            self._preprocess_trace(trace)
+            if not self._filter_and_cap_trace(trace):
+                continue
+            items.append(trace)
+
+        data = self._group_traces(items)
+        self.debug(
+            lambda: (
+                f"Loaded {sum(len(v) for v in data.values()):,} traces "
+                f"across {len(data):,} sessions "
+                f"from {self.filename if self.filename else '<inline records>'}"
+            )
+        )
+
+        if _has_meaningful_synthesis(self._synthesis):
+            data = self._apply_synthesis(data)
+
+        data = self._cap_grouped_traces_max_osl(data)
+        self._log_filtering_summary()
+
+        return data
 
     def _group_traces(
         self, items: list[MooncakeTrace]
@@ -118,9 +200,14 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
                 timestamp=trace.timestamp,
                 delay=trace.delay,
                 max_tokens=trace.output_length,
-                raw_payload=trace.payload,
+                raw_payload=merge_output_replay_annotation(
+                    trace.payload, trace._output_replay_key
+                ),
                 extra_body=trace.extra,
             )
+        extra_body = merge_output_replay_annotation(
+            trace.extra, trace._output_replay_key
+        )
         if trace.messages is not None:
             return Turn(
                 timestamp=trace.timestamp,
@@ -128,11 +215,11 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
                 max_tokens=trace.output_length,
                 raw_messages=trace.messages,
                 raw_tools=trace.tools,
-                extra_body=trace.extra,
+                extra_body=extra_body,
             )
         turn = super()._build_turn(trace, prompt)
-        if trace.extra is not None:
-            turn.extra_body = trace.extra
+        if extra_body is not None:
+            turn.extra_body = extra_body
         return turn
 
     # ------------------------------------------------------------------
@@ -145,4 +232,7 @@ class MooncakeTraceDatasetLoader(BaseTraceDatasetLoader[MooncakeTrace]):
     def _reconstruct_traces(
         self, originals: list[MooncakeTrace], synth_dicts: list[dict[str, Any]]
     ) -> list[MooncakeTrace]:
-        return [MooncakeTrace.model_validate(t) for t in synth_dicts]
+        traces = [MooncakeTrace.model_validate(t) for t in synth_dicts]
+        for trace, original in zip(traces, originals, strict=False):
+            trace._output_replay_key = original._output_replay_key
+        return traces

--- a/src/aiperf/dataset/loader/output_replay.py
+++ b/src/aiperf/dataset/loader/output_replay.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+OUTPUT_REPLAY_ID_ANNOTATION_KEY = "output_replay_id"
+OUTPUT_REPLAY_ID_ANNOTATION_PREFIX = f"{OUTPUT_REPLAY_ID_ANNOTATION_KEY}:"
+
+
+def effective_replay_key(
+    request_id: str | None,
+    session_id: str | None,
+    turn_index: int,
+    line_index: int,
+) -> str:
+    if request_id is not None and request_id.strip():
+        return request_id.strip()
+    if session_id is not None and session_id.strip():
+        return f"{session_id.strip()}:{turn_index}"
+    return f"line:{line_index}"
+
+
+def output_replay_id_annotation(replay_key: str) -> str:
+    return f"{OUTPUT_REPLAY_ID_ANNOTATION_PREFIX}{replay_key}"
+
+
+def merge_output_replay_annotation(
+    body: dict[str, Any] | None, replay_key: str | None
+) -> dict[str, Any] | None:
+    if replay_key is None:
+        return body
+
+    merged: dict[str, Any] = deepcopy(body) if body is not None else {}
+    nvext = merged.get("nvext")
+    if nvext is None:
+        nvext = {}
+        merged["nvext"] = nvext
+    if not isinstance(nvext, dict):
+        raise ValueError("nvext must be a dict to attach output replay annotations")
+
+    annotations = nvext.get("annotations")
+    if annotations is None:
+        annotations = []
+        nvext["annotations"] = annotations
+    if not isinstance(annotations, list):
+        raise ValueError(
+            "nvext.annotations must be a list to attach output replay annotations"
+        )
+
+    annotation = output_replay_id_annotation(replay_key)
+    if annotation not in annotations:
+        annotations.append(annotation)
+
+    return merged

--- a/tests/unit/dataset/loader/test_mooncake_payload_mode.py
+++ b/tests/unit/dataset/loader/test_mooncake_payload_mode.py
@@ -8,12 +8,13 @@ import orjson
 import pytest
 from pydantic import ValidationError
 
+from aiperf.common.models import Turn
 from aiperf.config.flags import CLIConfig
 from aiperf.dataset.loader.models import MooncakeTrace
 from aiperf.dataset.loader.mooncake_trace import MooncakeTraceDatasetLoader
 
 
-def test_mooncake_trace_accepts_extra():
+def test_mooncake_trace_accepts_extra() -> None:
     t = MooncakeTrace(
         text_input="Hello",
         extra={"vendor_top_k": 5, "ignore_eos": True},
@@ -21,9 +22,39 @@ def test_mooncake_trace_accepts_extra():
     assert t.extra == {"vendor_top_k": 5, "ignore_eos": True}
 
 
-def test_mooncake_trace_extra_defaults_to_none():
+def test_mooncake_trace_extra_defaults_to_none() -> None:
     t = MooncakeTrace(text_input="Hello")
     assert t.extra is None
+
+
+def test_mooncake_trace_accepts_replay_fields() -> None:
+    t = MooncakeTrace(
+        text_input="Hello",
+        output_length=3,
+        output_token_ids=[10, 11, 12],
+        request_id="request-a",
+    )
+    assert t.output_token_ids == [10, 11, 12]
+    assert t.request_id == "request-a"
+
+
+def test_mooncake_trace_rejects_replay_length_mismatch() -> None:
+    with pytest.raises(ValidationError, match="output_length.*len"):
+        MooncakeTrace(
+            text_input="Hello",
+            output_length=2,
+            output_token_ids=[10, 11, 12],
+        )
+
+
+def test_mooncake_trace_rejects_replay_tokens_without_output_length() -> None:
+    with pytest.raises(ValidationError, match="output_length.*required"):
+        MooncakeTrace(text_input="Hello", output_token_ids=[10])
+
+
+def test_mooncake_trace_rejects_negative_replay_token_ids() -> None:
+    with pytest.raises(ValidationError, match="non-negative"):
+        MooncakeTrace(text_input="Hello", output_length=1, output_token_ids=[-1])
 
 
 @pytest.fixture
@@ -32,7 +63,7 @@ def default_cfg() -> CLIConfig:
 
 
 @pytest.fixture
-def mock_prompt_generator():
+def mock_prompt_generator() -> Mock:
     generator = Mock()
     generator.generate.return_value = "Generated prompt text"
     generator._decoded_cache = {}
@@ -82,6 +113,31 @@ class TestMooncakeTracePayloadMode:
 
 
 class TestMooncakeTraceLoaderPayload:
+    @staticmethod
+    def _write_jsonl(
+        file: Path, rows: list[dict], *, leading_blank: bool = False
+    ) -> None:
+        with open(file, "wb") as f:
+            if leading_blank:
+                f.write(b"\n")
+            for row in rows:
+                f.write(orjson.dumps(row))
+                f.write(b"\n")
+
+    @staticmethod
+    def _load_turns(
+        file: Path,
+        default_cfg: CLIConfig,
+        mock_prompt_generator: Mock,
+    ) -> list[Turn]:
+        loader = MooncakeTraceDatasetLoader(
+            filename=file,
+            cfg=default_cfg,
+            prompt_generator=mock_prompt_generator,
+        )
+        conversations = loader.convert_to_conversations(loader.load_dataset())
+        return [turn for conv in conversations for turn in conv.turns]
+
     def test_payload_traces_produce_raw_payload_turns(
         self,
         tmp_path: Path,
@@ -179,3 +235,117 @@ class TestMooncakeTraceLoaderPayload:
         conversations = loader.convert_to_conversations(loader.load_dataset())
         turn = conversations[0].turns[0]
         assert turn.extra_body == {"vendor_x": 1, "stream": False}
+
+    def test_replay_request_id_injects_output_replay_annotation(
+        self,
+        tmp_path: Path,
+        default_cfg: CLIConfig,
+        mock_prompt_generator,
+    ):
+        file = tmp_path / "trace.jsonl"
+        self._write_jsonl(
+            file,
+            [
+                {
+                    "request_id": "req-1",
+                    "text_input": "hello",
+                    "output_length": 2,
+                    "output_token_ids": [100, 101],
+                    "extra": {"nvext": {"annotations": ["existing"]}},
+                }
+            ],
+        )
+
+        turns = self._load_turns(file, default_cfg, mock_prompt_generator)
+        assert turns[0].extra_body == {
+            "nvext": {"annotations": ["existing", "output_replay_id:req-1"]}
+        }
+
+    def test_replay_key_uses_session_turn_index_without_request_id(
+        self,
+        tmp_path: Path,
+        default_cfg: CLIConfig,
+        mock_prompt_generator,
+    ):
+        file = tmp_path / "trace.jsonl"
+        self._write_jsonl(
+            file,
+            [
+                {
+                    "session_id": "session-a",
+                    "text_input": "first",
+                    "output_length": 1,
+                    "output_token_ids": [100],
+                },
+                {
+                    "session_id": "session-a",
+                    "text_input": "second",
+                    "output_length": 1,
+                    "output_token_ids": [101],
+                },
+            ],
+        )
+
+        turns = self._load_turns(file, default_cfg, mock_prompt_generator)
+        annotations = [
+            turn.extra_body["nvext"]["annotations"][0]
+            for turn in turns
+            if turn.extra_body is not None
+        ]
+        assert annotations == [
+            "output_replay_id:session-a:0",
+            "output_replay_id:session-a:1",
+        ]
+
+    def test_replay_key_uses_physical_line_index_without_request_or_session(
+        self,
+        tmp_path: Path,
+        default_cfg: CLIConfig,
+        mock_prompt_generator,
+    ):
+        file = tmp_path / "trace.jsonl"
+        self._write_jsonl(
+            file,
+            [
+                {
+                    "text_input": "hello",
+                    "output_length": 1,
+                    "output_token_ids": [100],
+                }
+            ],
+            leading_blank=True,
+        )
+
+        turns = self._load_turns(file, default_cfg, mock_prompt_generator)
+        assert turns[0].extra_body == {
+            "nvext": {"annotations": ["output_replay_id:line:1"]}
+        }
+
+    def test_replay_annotation_is_injected_into_payload_mode_raw_payload(
+        self,
+        tmp_path: Path,
+        default_cfg: CLIConfig,
+        mock_prompt_generator,
+    ):
+        file = tmp_path / "trace.jsonl"
+        self._write_jsonl(
+            file,
+            [
+                {
+                    "request_id": "payload-req",
+                    "payload": {
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "model": "test-model",
+                        "nvext": {"annotations": ["existing"]},
+                    },
+                    "output_length": 1,
+                    "output_token_ids": [100],
+                }
+            ],
+        )
+
+        turns = self._load_turns(file, default_cfg, mock_prompt_generator)
+        assert turns[0].raw_payload["nvext"]["annotations"] == [
+            "existing",
+            "output_replay_id:payload-req",
+        ]


### PR DESCRIPTION
## Summary
- add optional Mooncake trace output_token_ids and request_id fields
- derive generic output_replay_id annotations from request_id, session turn index, or trace line index
- document the output token replay trace contract and validate output_length/token count mismatches

## Validation
- uv run --with ruff ruff format src/aiperf/dataset/loader/output_replay.py src/aiperf/dataset/loader/mooncake_trace.py src/aiperf/dataset/loader/models.py tests/unit/dataset/loader/test_mooncake_payload_mode.py
- uv run --with ruff ruff check src/aiperf/dataset/loader/output_replay.py src/aiperf/dataset/loader/mooncake_trace.py src/aiperf/dataset/loader/models.py tests/unit/dataset/loader/test_mooncake_payload_mode.py
- uv run pytest tests/unit/dataset/loader/test_trace.py tests/unit/dataset/loader/test_mooncake_payload_mode.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "Output Token Replay" in trace-based mode, allowing traces to include output token IDs for request identification and replay validation.
  * Introduced `request_id` field for stable request identification.
  * AIPerf now automatically derives and attaches replay identifiers to requests using request ID, session/turn context, or physical line index.

* **Documentation**
  * Updated trace replay documentation to explain the new Output Token Replay capability and replay key derivation mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->