### PR TITLE
feat: network-RTT-adjusted latency metrics (network_adjusted_*)

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -32,7 +32,7 @@ Validate an AIPerf config file.
 
 Run the Profile subcommand.
 
-[Endpoint](#endpoint) • [Tokenizer](#tokenizer) • [Input](#input) • [Fixed Schedule](#fixed-schedule) • [Goodput](#goodput) • [Conversation Input](#conversation-input) • [Prompt](#prompt) • [Prefix Prompt](#prefix-prompt) • [Input Sequence Length (ISL)](#input-sequence-length-isl) • [Output Sequence Length (OSL)](#output-sequence-length-osl) • [Audio Input](#audio-input) • [Image Input](#image-input) • [Video Input](#video-input) • [Rankings](#rankings) • [Synthesis](#synthesis) • [Load Generator](#load-generator) • [Warmup](#warmup) • [User-Centric Rate](#user-centric-rate) • [Request Cancellation](#request-cancellation) • [Output](#output) • [HTTP Trace](#http-trace) • [Server Metrics](#server-metrics) • [GPU Telemetry](#gpu-telemetry) • [UI](#ui) • [Multi-Run](#multi-run) • [Accuracy](#accuracy) • [Service](#service) • [Workers](#workers) • [ZMQ Communication](#zmq-communication)
+[Endpoint](#endpoint) • [Tokenizer](#tokenizer) • [Input](#input) • [Fixed Schedule](#fixed-schedule) • [Goodput](#goodput) • [Conversation Input](#conversation-input) • [Prompt](#prompt) • [Prefix Prompt](#prefix-prompt) • [Input Sequence Length (ISL)](#input-sequence-length-isl) • [Output Sequence Length (OSL)](#output-sequence-length-osl) • [Audio Input](#audio-input) • [Image Input](#image-input) • [Video Input](#video-input) • [Rankings](#rankings) • [Synthesis](#synthesis) • [Load Generator](#load-generator) • [Warmup](#warmup) • [User-Centric Rate](#user-centric-rate) • [Request Cancellation](#request-cancellation) • [Output](#output) • [HTTP Trace](#http-trace) • [Server Metrics](#server-metrics) • [Network Latency](#network-latency) • [GPU Telemetry](#gpu-telemetry) • [UI](#ui) • [Multi-Run](#multi-run) • [Accuracy](#accuracy) • [Service](#service) • [Workers](#workers) • [ZMQ Communication](#zmq-communication)
 
 ### [`plot`](#aiperf-plot)
 
@@ -46,7 +46,7 @@ Explore AIPerf plugins: aiperf plugins [category] [type]
 
 Run an AIPerf service in a single process.
 
-[Parameters](#parameters) • [Endpoint](#endpoint) • [Tokenizer](#tokenizer) • [Input](#input) • [Fixed Schedule](#fixed-schedule) • [Goodput](#goodput) • [Conversation Input](#conversation-input) • [Prompt](#prompt) • [Prefix Prompt](#prefix-prompt) • [Input Sequence Length (ISL)](#input-sequence-length-isl) • [Output Sequence Length (OSL)](#output-sequence-length-osl) • [Audio Input](#audio-input) • [Image Input](#image-input) • [Video Input](#video-input) • [Rankings](#rankings) • [Synthesis](#synthesis) • [Load Generator](#load-generator) • [Warmup](#warmup) • [User-Centric Rate](#user-centric-rate) • [Request Cancellation](#request-cancellation) • [Output](#output) • [HTTP Trace](#http-trace) • [Server Metrics](#server-metrics) • [GPU Telemetry](#gpu-telemetry) • [UI](#ui) • [Multi-Run](#multi-run) • [Accuracy](#accuracy) • [Service](#service) • [Workers](#workers) • [ZMQ Communication](#zmq-communication)
+[Parameters](#parameters) • [Endpoint](#endpoint) • [Tokenizer](#tokenizer) • [Input](#input) • [Fixed Schedule](#fixed-schedule) • [Goodput](#goodput) • [Conversation Input](#conversation-input) • [Prompt](#prompt) • [Prefix Prompt](#prefix-prompt) • [Input Sequence Length (ISL)](#input-sequence-length-isl) • [Output Sequence Length (OSL)](#output-sequence-length-osl) • [Audio Input](#audio-input) • [Image Input](#image-input) • [Video Input](#video-input) • [Rankings](#rankings) • [Synthesis](#synthesis) • [Load Generator](#load-generator) • [Warmup](#warmup) • [User-Centric Rate](#user-centric-rate) • [Request Cancellation](#request-cancellation) • [Output](#output) • [HTTP Trace](#http-trace) • [Server Metrics](#server-metrics) • [Network Latency](#network-latency) • [GPU Telemetry](#gpu-telemetry) • [UI](#ui) • [Multi-Run](#multi-run) • [Accuracy](#accuracy) • [Service](#service) • [Workers](#workers) • [ZMQ Communication](#zmq-communication)
 
 ### [`speed-bench-report`](#aiperf-speed-bench-report)
 
@@ -1053,6 +1053,23 @@ Specify which output formats to generate for server metrics. Multiple formats ca
 | `jsonl` |  | Export raw time-series records in line-delimited JSON format. Best for: Time-series analysis, debugging, visualizing metric evolution. Warning: Can generate very large files for long-running benchmarks. |
 | `parquet` |  | Export raw time-series data with delta calculations in Parquet columnar format. Best for: Analytics with DuckDB/pandas/Polars, efficient storage, SQL queries. Includes cumulative deltas from reference point for counters and histograms. |
 
+### Network Latency
+
+#### `--network-latency-automatic`
+
+Automatically measure network latency (DISABLED BY DEFAULT). Opens a fresh TCP connection to the endpoint throughout the run, measures the handshake RTT, and subtracts the mean from request-start-anchored latency metrics (request_latency, time_to_first_token, time_to_first_output_token). Raw metrics are preserved; adjusted values are emitted as separate network_adjusted_* metrics plus a network_rtt summary. Mutually exclusive with --network-latency-mean.
+<br/>_Flag (no value required)_
+
+#### `--network-latency-mean` `<float>`
+
+Set a fixed mean network RTT in milliseconds to subtract, bypassing active probing. Implicitly enables network latency adjustment. Mutually exclusive with --network-latency-automatic.
+<br/>_Constraints: ≥ 0.0_
+
+#### `--network-latency-ping-interval` `<float>`
+
+Seconds between TCP-handshake RTT probes during profiling (default: 1.0s). Only applies with --network-latency-automatic.
+<br/>_Constraints: > 0.0_
+
 ### GPU Telemetry
 
 #### `--gpu-telemetry` `<list>`
@@ -1536,7 +1553,7 @@ For standard single-node benchmarking, use the `aiperf profile` command instead.
 #### `--type` `<str>` _(Required)_
 
 Service type to run.
-<br/>_Choices: [`api`, `dataset_manager`, `gpu_telemetry_manager`, `record_processor`, `records_manager`, `server_metrics_manager`, `system_controller`, `timing_manager`, `worker`, `worker_manager`]_
+<br/>_Choices: [`api`, `dataset_manager`, `gpu_telemetry_manager`, `network_latency_manager`, `record_processor`, `records_manager`, `server_metrics_manager`, `system_controller`, `timing_manager`, `worker`, `worker_manager`]_
 
 #### `--service-id` `<str>`
 
@@ -2397,6 +2414,23 @@ Specify which output formats to generate for server metrics. Multiple formats ca
 | `csv` | _default_ | Export aggregated statistics in CSV tabular format organized by metric type. Best for: Spreadsheet analysis, Excel/Google Sheets, pandas DataFrames. |
 | `jsonl` |  | Export raw time-series records in line-delimited JSON format. Best for: Time-series analysis, debugging, visualizing metric evolution. Warning: Can generate very large files for long-running benchmarks. |
 | `parquet` |  | Export raw time-series data with delta calculations in Parquet columnar format. Best for: Analytics with DuckDB/pandas/Polars, efficient storage, SQL queries. Includes cumulative deltas from reference point for counters and histograms. |
+
+### Network Latency
+
+#### `--network-latency-automatic`
+
+Automatically measure network latency (DISABLED BY DEFAULT). Opens a fresh TCP connection to the endpoint throughout the run, measures the handshake RTT, and subtracts the mean from request-start-anchored latency metrics (request_latency, time_to_first_token, time_to_first_output_token). Raw metrics are preserved; adjusted values are emitted as separate network_adjusted_* metrics plus a network_rtt summary. Mutually exclusive with --network-latency-mean.
+<br/>_Flag (no value required)_
+
+#### `--network-latency-mean` `<float>`
+
+Set a fixed mean network RTT in milliseconds to subtract, bypassing active probing. Implicitly enables network latency adjustment. Mutually exclusive with --network-latency-automatic.
+<br/>_Constraints: ≥ 0.0_
+
+#### `--network-latency-ping-interval` `<float>`
+
+Seconds between TCP-handshake RTT probes during profiling (default: 1.0s). Only applies with --network-latency-automatic.
+<br/>_Constraints: > 0.0_
 
 ### GPU Telemetry
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -149,6 +149,18 @@ MLflow export configuration. Controls timeout behavior for post-run MLflow artif
 |----------------------|---------|-------------|-------------|
 | `AIPERF_MLFLOW_EXPORT_TIMEOUT_SECONDS` | `30.0` | ≥ 1.0, ≤ 600.0 | Timeout in seconds for the post-run MLflow export operation. If the MLflow tracking server is unreachable, the export will be abandoned after this duration rather than blocking indefinitely. |
 
+## NETWORKLATENCY
+
+Network latency calibration configuration. Controls the TCP-handshake RTT probes used to estimate the client-to-endpoint network round-trip time so it can be subtracted from latency metrics. Probes run throughout the profiling phase. Enable with `--network-latency-automatic`.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_NETWORK_LATENCY_DEFAULT_PROBE_INTERVAL` | `1.0` | ≥ 0.001, ≤ 300.0 | Default seconds between RTT probes when --network-latency-ping-interval is unset (default: 1.0s, ~1Hz) |
+| `AIPERF_NETWORK_LATENCY_MIN_SAMPLES` | `5` | ≥ 1, ≤ 100000 | Minimum number of successful RTT samples to collect; extra probes are issued at profile completion if a short run did not reach this floor |
+| `AIPERF_NETWORK_LATENCY_CONNECT_TIMEOUT` | `5.0` | ≥ 0.001, ≤ 300.0 | Timeout in seconds for a single TCP-handshake RTT probe |
+| `AIPERF_NETWORK_LATENCY_COMPLETE_TOPUP_TIMEOUT` | `3.0` | ≥ 0.0, ≤ 30.0 | Wall-clock budget in seconds for the final MIN_SAMPLES top-up probes at PROFILE_COMPLETE, kept well under the command-response budget so a slow endpoint cannot stall completion |
+| `AIPERF_NETWORK_LATENCY_EXPORT_BATCH_SIZE` | `100` | ≥ 1, ≤ 1000000 | Batch size for the network latency jsonl writer export results processor |
+
 ## OTEL
 
 OpenTelemetry metrics streaming configuration. Controls buffering and flush behavior for OTLP metric streaming.

--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -97,6 +97,9 @@ This document provides a comprehensive reference of all metrics available in AIP
     - [Minimum Request Timestamp](#minimum-request-timestamp)
     - [Maximum Response Timestamp](#maximum-response-timestamp)
     - [Benchmark Duration](#benchmark-duration)
+  - [Network Latency Calibration Metrics](#network-latency-calibration-metrics)
+    - [Network RTT](#network-rtt)
+    - [Network-Adjusted Latency Metrics](#network-adjusted-latency-metrics)
   - [HTTP Trace Metrics](#http-trace-metrics)
     - [HTTP Blocked](#http-blocked)
     - [HTTP DNS Lookup](#http-dns-lookup)
@@ -1481,6 +1484,67 @@ benchmark_duration = max_response_timestamp - min_request_timestamp
 **Notes:**
 - Uses wall-clock timestamps representing real calendar time.
 - Used as the denominator for throughput calculations; represents the effective measurement window.
+
+---
+
+## Network Latency Calibration Metrics
+
+These metrics appear only when network latency calibration is enabled (with
+`--network-latency-automatic` or `--network-latency-mean`). They make benchmark runs
+taken from different client network locations comparable by removing the client-to-endpoint
+network round-trip from the reported latencies.
+
+With `--network-latency-automatic`, AIPerf opens a fresh TCP connection to the endpoint
+host:port on an interval throughout profiling (`--network-latency-ping-interval`, default 1s)
+and records the handshake RTT. The handshake is one network round-trip with no server compute,
+so it isolates the network leg and is immune to server load. Each probe is written to
+`profile_export_network_latency.jsonl`. The **mean** RTT over successful probes is then
+subtracted from the request-start-anchored latency metrics. Alternatively, a fixed mean RTT
+can be supplied with `--network-latency-mean <ms>` to skip probing (the two flags are
+mutually exclusive). The chosen RTT is logged at run completion.
+
+Subtracting a constant from a distribution shifts the mean and every percentile by that
+constant and leaves the standard deviation unchanged, so the adjustment is applied to the
+aggregated results (clamped at 0). The raw metrics are always preserved.
+
+### Network RTT
+
+**Type:** [Derived Metric](#derived-metrics)
+
+The mean network RTT that was subtracted from the adjusted latency metrics (single value).
+
+**Notes:**
+- Measured via TCP handshakes throughout the run, or supplied directly via `--network-latency-mean`.
+- Full per-probe samples and per-target statistics are written to `profile_export_network_latency.jsonl`.
+
+---
+
+### Network-Adjusted Latency Metrics
+
+**Type:** [Derived Metric](#derived-metrics)
+
+Non-destructive, RTT-corrected variants of the request-start-anchored latency metrics:
+
+| Metric | Tag | Source metric |
+|---|---|---|
+| Network-Adjusted Request Latency | `network_adjusted_request_latency` | Request Latency |
+| Network-Adjusted Time to First Token | `network_adjusted_time_to_first_token` | Time to First Token (TTFT) |
+| Network-Adjusted Time to First Output Token | `network_adjusted_time_to_first_output_token` | Time to First Output Token (TTFO) |
+
+**Formula:**
+```python
+# nanoseconds, applied to every aggregated statistic (avg, min, max, p1..p99)
+network_adjusted_ns = max(0, source_metric_ns - mean_network_rtt_ns)
+```
+
+**Notes:**
+- Only metrics whose interval starts at the client request-send timestamp are adjusted.
+  Time to Second Token (second_response - first_response), Inter Token Latency (ITL), and
+  Inter Chunk Latency (ICL) are intentionally **not** adjusted: they are intra-stream gaps
+  that do not include the connection RTT (and for ITL the RTT cancels in
+  `(request_latency - ttft)`), so they are already network-invariant.
+- Values are clamped at 0; if the subtracted RTT exceeds some measured latencies a warning
+  is logged (the RTT may be larger than the true network leg).
 
 ---
 

--- a/src/aiperf/common/enums/enums.py
+++ b/src/aiperf/common/enums/enums.py
@@ -368,6 +368,7 @@ class MessageType(CaseInsensitiveStrEnum):
     TELEMETRY_STATUS = "telemetry_status"
     SERVER_METRICS_RECORD = "server_metrics_record"
     SERVER_METRICS_STATUS = "server_metrics_status"
+    NETWORK_LATENCY_RECORD = "network_latency_record"
     WORKER_HEALTH = "worker_health"
     WORKER_STATUS_SUMMARY = "worker_status_summary"
 

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -760,6 +760,54 @@ class _ServerMetricsSettings(BaseSettings):
     )
 
 
+class _NetworkLatencySettings(BaseSettings):
+    """Network latency calibration configuration.
+
+    Controls the TCP-handshake RTT probes used to estimate the client-to-endpoint
+    network round-trip time so it can be subtracted from latency metrics. Probes run
+    throughout the profiling phase. Enable with `--network-latency-automatic`.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="AIPERF_NETWORK_LATENCY_",
+        env_parse_enums=True,
+    )
+
+    DEFAULT_PROBE_INTERVAL: float = Field(
+        ge=0.001,
+        le=300.0,
+        default=1.0,
+        description="Default seconds between RTT probes when --network-latency-ping-interval is unset (default: 1.0s, ~1Hz)",
+    )
+    MIN_SAMPLES: int = Field(
+        ge=1,
+        le=100000,
+        default=5,
+        description="Minimum number of successful RTT samples to collect; extra probes are issued at "
+        "profile completion if a short run did not reach this floor",
+    )
+    CONNECT_TIMEOUT: float = Field(
+        ge=0.001,
+        le=300.0,
+        default=5.0,
+        description="Timeout in seconds for a single TCP-handshake RTT probe",
+    )
+    COMPLETE_TOPUP_TIMEOUT: float = Field(
+        ge=0.0,
+        le=30.0,
+        default=3.0,
+        description="Wall-clock budget in seconds for the final MIN_SAMPLES top-up probes "
+        "at PROFILE_COMPLETE, kept well under the command-response budget so a slow "
+        "endpoint cannot stall completion",
+    )
+    EXPORT_BATCH_SIZE: int = Field(
+        ge=1,
+        le=1000000,
+        default=100,
+        description="Batch size for the network latency jsonl writer export results processor",
+    )
+
+
 class _TimingSettings(BaseSettings):
     """Timing manager configuration.
 
@@ -1380,6 +1428,10 @@ class _Environment(BaseSettings):
     SEARCH_PLANNER: _SearchPlannerSettings = Field(
         default_factory=_SearchPlannerSettings,
         description="Adaptive-search planner tunables",
+    )
+    NETWORK_LATENCY: _NetworkLatencySettings = Field(
+        default_factory=_NetworkLatencySettings,
+        description="Network latency calibration settings",
     )
     SERVER_METRICS: _ServerMetricsSettings = Field(
         default_factory=_ServerMetricsSettings,

--- a/src/aiperf/common/messages/__init__.py
+++ b/src/aiperf/common/messages/__init__.py
@@ -42,6 +42,9 @@ from aiperf.common.messages.inference_messages import (
     MetricRecordsMessage,
     RealtimeMetricsMessage,
 )
+from aiperf.common.messages.network_latency_messages import (
+    NetworkLatencyRecordMessage,
+)
 from aiperf.common.messages.progress_messages import (
     AllRecordsReceivedMessage,
     ProcessRecordsResultMessage,
@@ -96,6 +99,7 @@ __all__ = [
     "Message",
     "MetricRecordsData",
     "MetricRecordsMessage",
+    "NetworkLatencyRecordMessage",
     "ProcessRecordsCommand",
     "ProcessRecordsResponse",
     "ProcessRecordsResultMessage",

--- a/src/aiperf/common/messages/network_latency_messages.py
+++ b/src/aiperf/common/messages/network_latency_messages.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from pydantic import Field
+
+from aiperf.common.enums import MessageType
+from aiperf.common.messages.service_messages import BaseServiceMessage
+from aiperf.common.models import ErrorDetails, NetworkLatencySample
+from aiperf.common.types import MessageTypeT
+
+
+class NetworkLatencyRecordMessage(BaseServiceMessage):
+    """Message from the network latency probe manager to the records manager.
+
+    Carries a single TCP-handshake RTT probe sample (success or failure) from
+    one probe target. The ``error`` field is populated on a transport-level
+    failure to push the sample (mirrors ServerMetricsRecordMessage); a failed
+    probe itself is conveyed via ``sample.success == False``.
+    """
+
+    message_type: MessageTypeT = MessageType.NETWORK_LATENCY_RECORD
+
+    collector_id: str = Field(
+        description="The ID of the probe collector that produced the sample (typically host:port)"
+    )
+    sample: NetworkLatencySample | None = Field(
+        default=None,
+        description="The network latency probe sample",
+    )
+    error: ErrorDetails | None = Field(
+        default=None,
+        description="Transport error details if the sample could not be delivered.",
+    )
+
+    @property
+    def valid(self) -> bool:
+        """Whether a sample was delivered without a transport-level error."""
+        return self.error is None and self.sample is not None

--- a/src/aiperf/common/models/__init__.py
+++ b/src/aiperf/common/models/__init__.py
@@ -55,6 +55,11 @@ from aiperf.common.models.model_endpoint_info import (
     ModelInfo,
     ModelListInfo,
 )
+from aiperf.common.models.network_latency_models import (
+    NetworkLatencyResults,
+    NetworkLatencySample,
+    NetworkLatencyTargetSummary,
+)
 from aiperf.common.models.prerequisites import TurnPrerequisite
 from aiperf.common.models.progress_models import WorkerProcessingStats, WorkerStats
 from aiperf.common.models.record_models import (
@@ -208,6 +213,9 @@ __all__ = [
     "ModelEndpointInfo",
     "ModelInfo",
     "ModelListInfo",
+    "NetworkLatencyResults",
+    "NetworkLatencySample",
+    "NetworkLatencyTargetSummary",
     "ParsedResponse",
     "ParsedResponseRecord",
     "PhaseRecordsStats",

--- a/src/aiperf/common/models/network_latency_models.py
+++ b/src/aiperf/common/models/network_latency_models.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from aiperf.common.models.base_models import AIPerfBaseModel
+from aiperf.common.models.error_models import ErrorDetails, ErrorDetailsCount
+
+__all__ = [
+    "NetworkLatencyResults",
+    "NetworkLatencySample",
+    "NetworkLatencyTargetSummary",
+]
+
+
+class NetworkLatencySample(AIPerfBaseModel):
+    """Single TCP-handshake RTT probe sample against one endpoint target.
+
+    Emitted once per probe (success or failure) by the probe collector and
+    written verbatim to the per-sample JSONL artifact. A failed probe carries
+    ``success=False``, ``rtt_ns=None`` and the captured ``error``.
+    """
+
+    timestamp_ns: int = Field(
+        ge=0,
+        description="Wall-clock timestamp (time.time_ns) when the probe was issued",
+    )
+    target_url: str = Field(
+        description="Endpoint URL the target was derived from (credential-free)"
+    )
+    target_host: str = Field(description="Resolved/parsed host the probe connected to")
+    target_port: int = Field(
+        ge=1, le=65535, description="TCP port the probe connected to"
+    )
+    probe_type: str = Field(
+        default="tcp_connect",
+        description="Probe mechanism used; always 'tcp_connect' (raw TCP handshake)",
+    )
+    rtt_ns: int | None = Field(
+        default=None,
+        ge=0,
+        description="Measured TCP-handshake round-trip time in nanoseconds, or None on failure",
+    )
+    success: bool = Field(
+        description="Whether the TCP handshake completed within the connect timeout"
+    )
+    error: ErrorDetails | None = Field(
+        default=None,
+        description="Error details when the probe failed (timeout/refused), else None",
+    )
+
+
+class NetworkLatencyTargetSummary(AIPerfBaseModel):
+    """Aggregate RTT statistics for a single probe target over the profiling phase."""
+
+    target_url: str = Field(description="Endpoint URL the target was derived from")
+    target_host: str = Field(description="Host the probes connected to")
+    target_port: int = Field(
+        ge=1, le=65535, description="TCP port the probes connected to"
+    )
+    count: int = Field(
+        ge=0, description="Total number of probes issued for this target"
+    )
+    success_count: int = Field(ge=0, description="Number of successful probes")
+    failure_count: int = Field(ge=0, description="Number of failed probes")
+    min_ns: float | None = Field(
+        default=None, ge=0, description="Minimum successful RTT in nanoseconds"
+    )
+    mean_ns: float | None = Field(
+        default=None, ge=0, description="Mean successful RTT in nanoseconds"
+    )
+    median_ns: float | None = Field(
+        default=None, ge=0, description="Median successful RTT in nanoseconds"
+    )
+    p90_ns: float | None = Field(
+        default=None, ge=0, description="90th-percentile successful RTT in nanoseconds"
+    )
+    p99_ns: float | None = Field(
+        default=None, ge=0, description="99th-percentile successful RTT in nanoseconds"
+    )
+    stddev_ns: float | None = Field(
+        default=None,
+        ge=0,
+        description="Standard deviation of successful RTT in nanoseconds",
+    )
+
+
+class NetworkLatencyResults(AIPerfBaseModel):
+    """Aggregate network-latency calibration results for a profile run.
+
+    The aggregate ``mean_ns`` (mean over all successful samples across all
+    targets) is the value delivered to the metric results processor for the
+    ``network_adjusted_*`` metric injection.
+    """
+
+    benchmark_id: str | None = Field(
+        default=None,
+        description="Unique identifier for this benchmark run (UUID), shared across exports",
+    )
+    target_summaries: dict[str, NetworkLatencyTargetSummary] = Field(
+        default_factory=dict,
+        description="Per-target aggregate RTT statistics keyed by 'host:port'",
+    )
+    count: int = Field(
+        default=0, ge=0, description="Total number of probes issued across all targets"
+    )
+    success_count: int = Field(
+        default=0,
+        ge=0,
+        description="Total number of successful probes across all targets",
+    )
+    failure_count: int = Field(
+        default=0, ge=0, description="Total number of failed probes across all targets"
+    )
+    min_ns: float | None = Field(
+        default=None,
+        ge=0,
+        description="Minimum successful RTT in nanoseconds (all targets)",
+    )
+    mean_ns: float | None = Field(
+        default=None,
+        ge=0,
+        description="Mean successful RTT in nanoseconds (all targets); delivered to the metric processor",
+    )
+    median_ns: float | None = Field(
+        default=None,
+        ge=0,
+        description="Median successful RTT in nanoseconds (all targets)",
+    )
+    p90_ns: float | None = Field(
+        default=None,
+        ge=0,
+        description="90th-percentile successful RTT in nanoseconds (all targets)",
+    )
+    p99_ns: float | None = Field(
+        default=None,
+        ge=0,
+        description="99th-percentile successful RTT in nanoseconds (all targets)",
+    )
+    stddev_ns: float | None = Field(
+        default=None,
+        ge=0,
+        description="Standard deviation of successful RTT in nanoseconds (all targets)",
+    )
+    error_summary: list[ErrorDetailsCount] = Field(
+        default_factory=list,
+        description="Unique probe error details and their counts",
+    )

--- a/src/aiperf/config/artifacts.py
+++ b/src/aiperf/config/artifacts.py
@@ -62,6 +62,7 @@ class OutputDefaults:
     SERVER_METRICS_EXPORT_JSON_FILE = Path("server_metrics_export.json")
     SERVER_METRICS_EXPORT_CSV_FILE = Path("server_metrics_export.csv")
     SERVER_METRICS_EXPORT_PARQUET_FILE = Path("server_metrics_export.parquet")
+    NETWORK_LATENCY_EXPORT_JSONL_FILE = Path("profile_export_network_latency.jsonl")
     EXPORT_LEVEL = ExportLevel.RECORDS
     EXPORT_HTTP_TRACE = False
     SHOW_TRACE_TIMING = False
@@ -234,6 +235,7 @@ class ArtifactsConfig(BaseConfig):
         "_server_metrics.jsonl",
         "_server_metrics.json",
         "_server_metrics.csv",
+        "_network_latency.jsonl",
         "_gpu_telemetry.jsonl",
         "_timeslices.csv",
         "_timeslices.json",
@@ -324,6 +326,17 @@ class ArtifactsConfig(BaseConfig):
         """Path for the server metrics JSONL export file."""
         base = self._base()
         name = f"{base}_server_metrics.jsonl" if base else "server_metrics_export.jsonl"
+        return self.dir / name
+
+    @property
+    def network_latency_export_jsonl_file(self) -> Path:
+        """Path for the per-sample network latency RTT probe JSONL export file."""
+        base = self._base()
+        name = (
+            f"{base}_network_latency.jsonl"
+            if base
+            else "profile_export_network_latency.jsonl"
+        )
         return self.dir / name
 
     @property

--- a/src/aiperf/config/cli_parameter.py
+++ b/src/aiperf/config/cli_parameter.py
@@ -51,6 +51,7 @@ class Groups:
     VIDEO_INPUT = Group.create_ordered("Video Input")
     SERVICE = Group.create_ordered("Service")
     SERVER_METRICS = Group.create_ordered("Server Metrics")
+    NETWORK_LATENCY = Group.create_ordered("Network Latency")
     GPU_TELEMETRY = Group.create_ordered("GPU Telemetry")
     UI = Group.create_ordered("UI")
     WORKERS = Group.create_ordered("Workers")

--- a/src/aiperf/config/config.py
+++ b/src/aiperf/config/config.py
@@ -70,6 +70,9 @@ from aiperf.config.mlflow import (
 from aiperf.config.models import (
     ModelsAdvanced,
 )
+from aiperf.config.network_latency import (
+    NetworkLatencyConfig,
+)
 from aiperf.config.otel import (
     OTelConfig,
 )
@@ -315,6 +318,16 @@ class BenchmarkConfig(BaseConfig, BenchmarkHelpersMixin):
             "Collects operational metrics (queue depth, KV cache, batch sizes) "
             "from inference server Prometheus endpoints. "
             "Enabled by default. Set enabled: false to disable.",
+        ),
+    ]
+
+    network_latency: Annotated[
+        NetworkLatencyConfig,
+        Field(
+            default_factory=NetworkLatencyConfig,
+            description="Network latency calibration configuration. Probes the endpoint "
+            "RTT during profiling and subtracts the mean from latency metrics, emitted as "
+            "separate network_adjusted_* metrics. Disabled by default.",
         ),
     ]
 

--- a/src/aiperf/config/flags/_converter_telemetry.py
+++ b/src/aiperf/config/flags/_converter_telemetry.py
@@ -198,6 +198,50 @@ def build_server_metrics(cli: CLIConfig) -> dict[str, Any]:
     return server_metrics
 
 
+def build_network_latency(cli: CLIConfig) -> dict[str, Any]:
+    """Translate the network-latency CLI flags into the network-latency dict.
+
+    ``--network-latency-automatic`` actively probes the endpoint RTT;
+    ``--network-latency-mean`` supplies a fixed mean RTT and implicitly enables
+    adjustment without probing. The two are mutually exclusive (automatic means
+    measure it, mean means set it). The ``--network-latency-ping-interval`` flag
+    only applies to automatic mode. When neither is requested the section stays
+    disabled and no adjusted metrics are emitted.
+    """
+    cli_set = cli.model_fields_set
+    mean_set = (
+        "network_latency_mean" in cli_set and cli.network_latency_mean is not None
+    )
+    interval_set = "network_latency_ping_interval" in cli_set
+
+    if mean_set and cli.network_latency_automatic:
+        raise ValueError(
+            "Cannot use both --network-latency-automatic and --network-latency-mean together. "
+            "Automatic measures the RTT; mean sets it directly."
+        )
+
+    if mean_set:
+        if interval_set:
+            raise ValueError(
+                "--network-latency-ping-interval only applies with --network-latency-automatic, "
+                "not with --network-latency-mean."
+            )
+        return {"enabled": True, "mean_ms": cli.network_latency_mean}
+
+    if not cli.network_latency_automatic:
+        if interval_set:
+            raise ValueError(
+                "--network-latency-ping-interval only applies when --network-latency-automatic "
+                "is set (or --network-latency-mean is provided)."
+            )
+        return {"enabled": False}
+
+    network_latency: dict[str, Any] = {"enabled": True}
+    if interval_set and cli.network_latency_ping_interval is not None:
+        network_latency["ping_interval"] = cli.network_latency_ping_interval
+    return network_latency
+
+
 def _normalize_otel_metrics_url(url: str) -> str:
     """Normalize OTel collector URL to an OTLP/HTTP metrics endpoint.
 

--- a/src/aiperf/config/flags/cli_config.py
+++ b/src/aiperf/config/flags/cli_config.py
@@ -2327,6 +2327,59 @@ class CLIConfig(BaseConfig):
     ] = _DEFAULT_SERVER_METRICS_FORMATS
 
     ##############################################################################
+    # Network Latency
+    ##############################################################################
+    network_latency_automatic: Annotated[
+        bool,
+        Field(
+            description=(
+                "Automatically measure network latency (DISABLED BY DEFAULT). "
+                "Opens a fresh TCP connection to the endpoint throughout the run, "
+                "measures the handshake RTT, and subtracts the mean from request-start-anchored "
+                "latency metrics (request_latency, time_to_first_token, "
+                "time_to_first_output_token). Raw metrics are preserved; adjusted values are "
+                "emitted as separate network_adjusted_* metrics plus a network_rtt summary. "
+                "Mutually exclusive with --network-latency-mean."
+            ),
+        ),
+        CLIParameter(
+            name=("--network-latency-automatic",),
+            group=Groups.NETWORK_LATENCY,
+        ),
+    ] = False
+
+    network_latency_mean: Annotated[
+        float | None,
+        Field(
+            ge=0.0,
+            description=(
+                "Set a fixed mean network RTT in milliseconds to subtract, bypassing active "
+                "probing. Implicitly enables network latency adjustment. Mutually exclusive "
+                "with --network-latency-automatic."
+            ),
+        ),
+        CLIParameter(
+            name=("--network-latency-mean",),
+            group=Groups.NETWORK_LATENCY,
+        ),
+    ] = None
+
+    network_latency_ping_interval: Annotated[
+        float | None,
+        Field(
+            gt=0.0,
+            description=(
+                "Seconds between TCP-handshake RTT probes during profiling "
+                "(default: 1.0s). Only applies with --network-latency-automatic."
+            ),
+        ),
+        CLIParameter(
+            name=("--network-latency-ping-interval",),
+            group=Groups.NETWORK_LATENCY,
+        ),
+    ] = None
+
+    ##############################################################################
     # GPU Telemetry
     ##############################################################################
     gpu_telemetry: Annotated[

--- a/src/aiperf/config/flags/converter.py
+++ b/src/aiperf/config/flags/converter.py
@@ -37,6 +37,7 @@ from aiperf.config.flags._converter_runtime import (
 from aiperf.config.flags._converter_telemetry import (
     build_gpu_telemetry,
     build_mlflow,
+    build_network_latency,
     build_otel,
     build_server_metrics,
     build_wandb,
@@ -520,6 +521,7 @@ def _assemble_envelope_dict(cli: CLIConfig) -> dict[str, Any]:
     artifacts = build_artifacts(cli)
     gpu_telemetry = build_gpu_telemetry(cli)
     server_metrics = build_server_metrics(cli)
+    network_latency = build_network_latency(cli)
     otel = build_otel(cli)
     mlflow = build_mlflow(cli)
     wandb = build_wandb(cli)
@@ -538,6 +540,7 @@ def _assemble_envelope_dict(cli: CLIConfig) -> dict[str, Any]:
         "artifacts": artifacts,
         "gpu_telemetry": gpu_telemetry,
         "server_metrics": server_metrics,
+        "network_latency": network_latency,
         "otel": otel,
         "mlflow": mlflow,
         "wandb": wandb,

--- a/src/aiperf/config/network_latency.py
+++ b/src/aiperf/config/network_latency.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+AIPerf Configuration - Pydantic Models
+
+Network Latency - TCP-handshake RTT calibration configuration. When enabled, AIPerf
+probes the inference endpoint throughout the profiling phase, measures the network
+round-trip time, and subtracts the mean RTT from request-start-anchored latency
+metrics (emitted as separate ``network_adjusted_*`` metrics; raw metrics are
+preserved). This makes runs taken from different network locations comparable.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import ConfigDict, Field
+
+from aiperf.config.base import BaseConfig
+
+__all__ = [
+    "NetworkLatencyConfig",
+]
+
+
+def _default_ping_interval() -> float:
+    # Imported lazily: aiperf.common.environment imports the config package, so a
+    # module-level import here would create a circular import.
+    from aiperf.common.environment import Environment
+
+    return Environment.NETWORK_LATENCY.DEFAULT_PROBE_INTERVAL
+
+
+class NetworkLatencyConfig(BaseConfig):
+    """Network latency calibration configuration.
+
+    When ``enabled``, AIPerf opens a fresh TCP connection to the endpoint
+    host:port on an interval during profiling and records the handshake RTT.
+    The mean RTT is subtracted from the request-start-anchored latency metrics
+    (request_latency, time_to_first_token, time_to_first_output_token) to produce
+    non-destructive ``network_adjusted_*``
+    variants. ``mean_ms`` supplies a fixed mean RTT and skips active probing.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_default=True,
+        json_schema_extra={"x-kubernetes-preserve-unknown-fields": True},
+    )
+
+    enabled: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Enable network latency calibration. When true, AIPerf measures "
+            "the endpoint RTT (or uses mean_ms) and subtracts it from latency "
+            "metrics, emitted as separate network_adjusted_* metrics.",
+        ),
+    ]
+
+    ping_interval: Annotated[
+        float,
+        Field(
+            default_factory=_default_ping_interval,
+            gt=0.0,
+            description="Seconds between TCP-handshake RTT probes during profiling. "
+            "Ignored when mean_ms is set.",
+        ),
+    ]
+
+    mean_ms: Annotated[
+        float | None,
+        Field(
+            default=None,
+            ge=0.0,
+            description="Fixed mean network RTT in milliseconds to subtract, bypassing "
+            "active probing. When set, no probes are sent and this value is used directly.",
+        ),
+    ]
+
+    @property
+    def should_probe(self) -> bool:
+        """True when active RTT probing should run (enabled and no manual mean)."""
+        return self.enabled and self.mean_ms is None

--- a/src/aiperf/config/schema/aiperf-config.schema.json
+++ b/src/aiperf/config/schema/aiperf-config.schema.json
@@ -2096,6 +2096,10 @@
           "$ref": "#/$defs/ServerMetricsConfig",
           "description": "Server metrics configuration for Prometheus scraping. Collects operational metrics (queue depth, KV cache, batch sizes) from inference server Prometheus endpoints. Enabled by default. Set enabled: false to disable."
         },
+        "networkLatency": {
+          "$ref": "#/$defs/NetworkLatencyConfig",
+          "description": "Network latency calibration configuration. Probes the endpoint RTT during profiling and subtracts the mean from latency metrics, emitted as separate network_adjusted_* metrics. Disabled by default."
+        },
         "otel": {
           "$ref": "#/$defs/OTelConfig"
         },
@@ -8183,6 +8187,69 @@
         "peaks"
       ],
       "title": "MultimodalDistribution",
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "NetworkLatencyConfig": {
+      "additionalProperties": false,
+      "description": "Network latency calibration configuration.\n\nWhen ``enabled``, AIPerf opens a fresh TCP connection to the endpoint\nhost:port on an interval during profiling and records the handshake RTT.\nThe mean RTT is subtracted from the request-start-anchored latency metrics\n(request_latency, time_to_first_token, time_to_first_output_token) to produce\nnon-destructive ``network_adjusted_*``\nvariants. ``mean_ms`` supplies a fixed mean RTT and skips active probing.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable network latency calibration. When true, AIPerf measures the endpoint RTT (or uses mean_ms) and subtracts it from latency metrics, emitted as separate network_adjusted_* metrics.",
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "pingInterval": {
+          "description": "Seconds between TCP-handshake RTT probes during profiling. Ignored when mean_ms is set.",
+          "title": "Pinginterval",
+          "oneOf": [
+            {
+              "description": "Seconds between TCP-handshake RTT probes during profiling. Ignored when mean_ms is set.",
+              "exclusiveMinimum": 0.0,
+              "title": "Pinginterval",
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "pattern": ".*\\{\\{.*\\}\\}.*",
+              "description": "Jinja2 template (e.g., '{{ variable }}')."
+            },
+            {
+              "type": "string",
+              "pattern": ".*\\$\\{[A-Za-z_][A-Za-z0-9_]*(?::[^}]*)?\\}.*",
+              "description": "Environment variable (e.g., '${VAR}' or '${VAR:default}')."
+            }
+          ],
+          "x-jinja2-supported": true
+        },
+        "meanMs": {
+          "anyOf": [
+            {
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "pattern": ".*\\{\\{.*\\}\\}.*",
+              "description": "Jinja2 template (e.g., '{{ variable }}')."
+            },
+            {
+              "type": "string",
+              "pattern": ".*\\$\\{[A-Za-z_][A-Za-z0-9_]*(?::[^}]*)?\\}.*",
+              "description": "Environment variable (e.g., '${VAR}' or '${VAR:default}')."
+            }
+          ],
+          "default": null,
+          "description": "Fixed mean network RTT in milliseconds to subtract, bypassing active probing. When set, no probes are sent and this value is used directly.",
+          "title": "Meanms",
+          "x-jinja2-supported": true
+        }
+      },
+      "title": "NetworkLatencyConfig",
       "type": "object",
       "x-kubernetes-preserve-unknown-fields": true
     },

--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -260,6 +260,10 @@ class SystemController(SignalHandlerMixin, BaseService):
             self.info("Server metrics disabled via --no-server-metrics")
             self._should_wait_for_server_metrics = False
 
+        if self.run.cfg.network_latency.should_probe:
+            self.debug("Starting optional NetworkLatencyManager service")
+            await self.service_manager.run_service(ServiceType.NETWORK_LATENCY_MANAGER)
+
         # Start AIPerf API if enabled
         api_port = self.run.cfg.runtime.api_port or Environment.API_SERVER.PORT
         api_host = self.run.cfg.runtime.api_host or Environment.API_SERVER.HOST

--- a/src/aiperf/metrics/types/network_adjusted_metrics.py
+++ b/src/aiperf/metrics/types/network_adjusted_metrics.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Network-RTT-adjusted latency metrics.
+
+When network latency calibration is enabled, the mean client-to-endpoint RTT is
+subtracted from the request-start-anchored latency metrics to produce these
+``network_adjusted_*`` variants, making runs taken from different network locations
+comparable. The raw metrics are always preserved.
+
+These metrics are NOT computed per-record. The RTT is a run-level scalar that is only
+known at the end of the run, so :class:`aiperf.post_processors.metric_results_processor`
+injects the shifted distributions after aggregation (subtracting a constant shifts every
+percentile and the mean by that constant and leaves the standard deviation unchanged).
+``_derive_value`` therefore always defers.
+
+Inter-token / inter-chunk latencies are intentionally NOT adjusted: the same RTT cancels
+in ``(request_latency - ttft)``, so those metrics are already network-invariant.
+"""
+
+from aiperf.common.enums import MetricFlags, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.types import MetricTagT
+from aiperf.metrics import BaseDerivedMetric
+from aiperf.metrics.metric_dicts import MetricResultsDict
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+from aiperf.metrics.types.time_to_first_output_token_metric import (
+    TimeToFirstOutputTokenMetric,
+)
+from aiperf.metrics.types.ttft_metric import TTFTMetric
+
+
+class _NetworkAdjustedMixin:
+    """Shared metadata and deferred-derivation behavior for injected network metrics.
+
+    Not a metric itself (does not subclass BaseMetric), so it is never registered and
+    does not interfere with the value-type auto-detection that reads the concrete
+    class's parameterized ``BaseDerivedMetric[...]`` base.
+    """
+
+    unit = MetricTimeUnit.NANOSECONDS
+    display_unit = MetricTimeUnit.MILLISECONDS
+
+    def _derive_value(self, metric_results: MetricResultsDict):
+        raise NoMetricValue(
+            f"{self.tag} is injected post-aggregation by the network latency transform"  # type: ignore[attr-defined]
+        )
+
+
+class NetworkAdjustedRequestLatencyMetric(
+    _NetworkAdjustedMixin, BaseDerivedMetric[int]
+):
+    tag = "network_adjusted_request_latency"
+    header = "Network-Adjusted Request Latency"
+    short_header = "Net-Adj Req Latency"
+    display_order = 301
+    flags = MetricFlags.NONE
+
+
+class NetworkAdjustedTTFTMetric(_NetworkAdjustedMixin, BaseDerivedMetric[int]):
+    tag = "network_adjusted_time_to_first_token"
+    header = "Network-Adjusted Time to First Token"
+    short_header = "Net-Adj TTFT"
+    display_order = 101
+    flags = MetricFlags.STREAMING_TOKENS_ONLY
+
+
+class NetworkAdjustedTimeToFirstOutputTokenMetric(
+    _NetworkAdjustedMixin, BaseDerivedMetric[int]
+):
+    tag = "network_adjusted_time_to_first_output_token"
+    header = "Network-Adjusted Time to First Output Token"
+    short_header = "Net-Adj TTFO"
+    display_order = 211
+    flags = MetricFlags.STREAMING_TOKENS_ONLY | MetricFlags.SUPPORTS_REASONING
+
+
+class NetworkRttMetric(_NetworkAdjustedMixin, BaseDerivedMetric[float]):
+    """The mean network RTT that was subtracted from the adjusted latency metrics.
+
+    Single-value summary metric (no per-record distribution).
+    """
+
+    tag = "network_rtt"
+    header = "Network RTT"
+    short_header = "Net RTT"
+    display_order = 305
+    flags = MetricFlags.NO_INDIVIDUAL_RECORDS
+
+
+NETWORK_ADJUSTED_SOURCES: dict[MetricTagT, MetricTagT] = {
+    NetworkAdjustedRequestLatencyMetric.tag: RequestLatencyMetric.tag,
+    NetworkAdjustedTTFTMetric.tag: TTFTMetric.tag,
+    NetworkAdjustedTimeToFirstOutputTokenMetric.tag: TimeToFirstOutputTokenMetric.tag,
+}
+"""Maps each network_adjusted_* tag to the source latency metric it shifts.
+
+Only metrics whose interval STARTS at the client request-send timestamp carry the
+network RTT. Time to Second Token (second_response - first_response) and the
+inter-token / inter-chunk latencies are intra-stream gaps that do not include the RTT,
+so they are intentionally excluded.
+"""

--- a/src/aiperf/network_latency/__init__.py
+++ b/src/aiperf/network_latency/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Network latency calibration package for AIPerf.
+
+Probes the endpoint's TCP-handshake RTT throughout profiling, writes a
+per-sample JSONL artifact, and delivers the mean RTT to the metric results
+processor so it can emit ``network_adjusted_*`` metrics.
+"""

--- a/src/aiperf/network_latency/accumulator.py
+++ b/src/aiperf/network_latency/accumulator.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import numpy as np
+
+from aiperf.common.models import (
+    ErrorDetails,
+    ErrorDetailsCount,
+    NetworkLatencyResults,
+    NetworkLatencySample,
+    NetworkLatencyTargetSummary,
+)
+
+__all__ = ["NetworkLatencyAccumulator"]
+
+
+def _percentile_stats(rtts_ns: list[int]) -> dict[str, float | None]:
+    """Compute min/mean/median/p90/p99/stddev (ns) over successful RTT samples."""
+    if not rtts_ns:
+        return {
+            "min_ns": None,
+            "mean_ns": None,
+            "median_ns": None,
+            "p90_ns": None,
+            "p99_ns": None,
+            "stddev_ns": None,
+        }
+    arr = np.asarray(rtts_ns, dtype=np.float64)
+    return {
+        "min_ns": float(np.min(arr)),
+        "mean_ns": float(np.mean(arr)),
+        "median_ns": float(np.median(arr)),
+        "p90_ns": float(np.percentile(arr, 90)),
+        "p99_ns": float(np.percentile(arr, 99)),
+        "stddev_ns": float(np.std(arr)),
+    }
+
+
+class NetworkLatencyAccumulator:
+    """Accumulates RTT probe samples and computes per-target + aggregate stats.
+
+    Instantiated directly by the RecordsManager (not a plugin results processor)
+    because the aggregate ``mean_ns`` must be delivered to every
+    MetricResultsProcessor via ``set_network_rtt_ns`` before ``summarize()`` is
+    called, rather than flowing through the standard summarize pipeline.
+    """
+
+    def __init__(self, benchmark_id: str | None = None) -> None:
+        self._benchmark_id = benchmark_id
+        self._success_rtts_by_target: dict[str, list[int]] = defaultdict(list)
+        self._counts_by_target: dict[str, int] = defaultdict(int)
+        self._failures_by_target: dict[str, int] = defaultdict(int)
+        self._target_meta: dict[str, tuple[str, str, int]] = {}
+        self._error_counts: dict[ErrorDetails, int] = defaultdict(int)
+
+    def add_sample(self, sample: NetworkLatencySample) -> None:
+        """Accumulate one probe sample (success or failure)."""
+        key = f"{sample.target_host}:{sample.target_port}"
+        self._target_meta[key] = (
+            sample.target_url,
+            sample.target_host,
+            sample.target_port,
+        )
+        self._counts_by_target[key] += 1
+        if sample.success and sample.rtt_ns is not None:
+            self._success_rtts_by_target[key].append(sample.rtt_ns)
+        else:
+            self._failures_by_target[key] += 1
+            if sample.error is not None:
+                self._error_counts[sample.error] += 1
+
+    @property
+    def mean_rtt_ns(self) -> float | None:
+        """Mean RTT (ns) over all successful samples across all targets, or None."""
+        all_rtts = [
+            rtt for rtts in self._success_rtts_by_target.values() for rtt in rtts
+        ]
+        if not all_rtts:
+            return None
+        return float(np.mean(np.asarray(all_rtts, dtype=np.float64)))
+
+    @property
+    def successful_sample_count(self) -> int:
+        """Number of successful RTT samples across all targets."""
+        return sum(len(rtts) for rtts in self._success_rtts_by_target.values())
+
+    def export_results(self) -> NetworkLatencyResults:
+        """Compute the final per-target and aggregate RTT results."""
+        target_summaries: dict[str, NetworkLatencyTargetSummary] = {}
+        for key, (target_url, host, port) in self._target_meta.items():
+            success_rtts = self._success_rtts_by_target.get(key, [])
+            stats = _percentile_stats(success_rtts)
+            target_summaries[key] = NetworkLatencyTargetSummary(
+                target_url=target_url,
+                target_host=host,
+                target_port=port,
+                count=self._counts_by_target.get(key, 0),
+                success_count=len(success_rtts),
+                failure_count=self._failures_by_target.get(key, 0),
+                **stats,
+            )
+
+        all_rtts = [
+            rtt for rtts in self._success_rtts_by_target.values() for rtt in rtts
+        ]
+        aggregate_stats = _percentile_stats(all_rtts)
+        total_count = sum(self._counts_by_target.values())
+        total_failures = sum(self._failures_by_target.values())
+
+        error_summary = [
+            ErrorDetailsCount(error_details=error_details, count=count)
+            for error_details, count in self._error_counts.items()
+        ]
+
+        return NetworkLatencyResults(
+            benchmark_id=self._benchmark_id,
+            target_summaries=target_summaries,
+            count=total_count,
+            success_count=len(all_rtts),
+            failure_count=total_failures,
+            error_summary=error_summary,
+            **aggregate_stats,
+        )

--- a/src/aiperf/network_latency/jsonl_writer.py
+++ b/src/aiperf/network_latency/jsonl_writer.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aiperf.common.environment import Environment
+from aiperf.common.exceptions import PostProcessorDisabled
+from aiperf.common.mixins import BufferedJSONLWriterMixin
+from aiperf.common.models import NetworkLatencySample
+from aiperf.common.models.record_models import MetricResult
+from aiperf.post_processors.base_metrics_processor import BaseMetricsProcessor
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
+
+
+class NetworkLatencyJSONLWriter(
+    BaseMetricsProcessor,
+    BufferedJSONLWriterMixin[NetworkLatencySample],
+):
+    """Exports per-sample TCP-handshake RTT probes to a JSONL artifact.
+
+    Writes one JSON line per probe (success or failure) to
+    ``profile_export_network_latency.jsonl`` (respecting --profile-export-prefix
+    with the ``_network_latency.jsonl`` suffix). Self-disables unless network
+    latency calibration is actively probing (enabled and no mean_ms).
+    """
+
+    def __init__(
+        self,
+        run: BenchmarkRun,
+        **kwargs,
+    ) -> None:
+        if not run.cfg.network_latency.should_probe:
+            raise PostProcessorDisabled(
+                "Network latency JSONL export disabled: probing not enabled "
+                "(requires --network-latency-automatic and no mean_ms)"
+            )
+
+        output_file = run.cfg.artifacts.network_latency_export_jsonl_file
+
+        super().__init__(
+            run=run,
+            output_file=output_file,
+            batch_size=Environment.NETWORK_LATENCY.EXPORT_BATCH_SIZE,
+            **kwargs,
+        )
+
+        self.info(f"Network latency JSONL export enabled: {self.output_file}")
+
+    async def process_network_latency_sample(
+        self, sample: NetworkLatencySample
+    ) -> None:
+        """Write a single probe sample to the JSONL artifact."""
+        await self.buffered_write(sample)
+
+    async def summarize(self) -> list[MetricResult]:
+        """Summarize result. Not used for this processor."""
+        return []

--- a/src/aiperf/network_latency/manager.py
+++ b/src/aiperf/network_latency/manager.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from aiperf.common.base_component_service import BaseComponentService
+from aiperf.common.enums import CommAddress, CommandType
+from aiperf.common.environment import Environment
+from aiperf.common.hooks import on_command, on_stop
+from aiperf.common.messages import (
+    NetworkLatencyRecordMessage,
+    ProfileCancelCommand,
+    ProfileCompleteCommand,
+    ProfileStartCommand,
+)
+from aiperf.common.models import ErrorDetails, NetworkLatencySample
+from aiperf.common.protocols import PushClientProtocol
+from aiperf.common.redact import redact_url
+from aiperf.network_latency.probe import NetworkLatencyProbeCollector
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
+
+# Default ports for schemes when a URL omits an explicit port.
+_DEFAULT_PORTS: dict[str, int] = {"http": 80, "https": 443}
+
+
+class NetworkLatencyManager(BaseComponentService):
+    """Coordinates TCP-handshake RTT probes against the endpoint targets.
+
+    Mirrors ServerMetricsManager: one probe collector per unique (host, port)
+    target derived from the endpoint URLs. Probing spans the PROFILING phase —
+    started on PROFILE_START and stopped on PROFILE_COMPLETE. On completion, if
+    fewer than ``Environment.NETWORK_LATENCY.MIN_SAMPLES`` successful samples
+    were collected, extra back-to-back probes are fired synchronously until the
+    floor is reached (mirrors the server-metrics final-scrape pattern).
+
+    This service is only spawned when ``run.cfg.network_latency.should_probe`` is
+    True (i.e. enabled and no manual mean_ms); the manual-mean path
+    needs no service.
+
+    Args:
+        run: BenchmarkRun carrying the BenchmarkConfig + per-run state.
+        service_id: Optional unique identifier for this service instance.
+    """
+
+    def __init__(
+        self,
+        run: BenchmarkRun,
+        service_id: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            run=run,
+            service_id=service_id,
+            **kwargs,
+        )
+
+        self.records_push_client: PushClientProtocol = self.comms.create_push_client(
+            CommAddress.RECORDS,
+        )
+
+        self._collectors: dict[str, NetworkLatencyProbeCollector] = {}
+        self._ping_interval = self.run.cfg.network_latency.ping_interval
+        self._min_samples = Environment.NETWORK_LATENCY.MIN_SAMPLES
+
+        # One probe target per unique (host, port) derived from the endpoint URLs.
+        self._targets: dict[str, tuple[str, str, int]] = {}
+        for url in self.run.cfg.endpoint.urls:
+            target = self._derive_target(url)
+            if target is None:
+                continue
+            host, port = target
+            key = f"{host}:{port}"
+            if key not in self._targets:
+                self._targets[key] = (redact_url(url), host, port)
+        self.info(
+            f"Network Latency: Discovered {len(self._targets)} probe target(s): "
+            f"{list(self._targets.keys())}"
+        )
+
+        self._shutdown_task: asyncio.Task[None] | None = None
+
+    @staticmethod
+    def _derive_target(url: str) -> tuple[str, int] | None:
+        """Parse host:port from an endpoint URL, applying scheme default ports."""
+        parsed = urlparse(url if "://" in url else f"http://{url}")
+        host = parsed.hostname
+        if not host:
+            return None
+        port = parsed.port or _DEFAULT_PORTS.get(parsed.scheme, 80)
+        return host, port
+
+    @on_command(CommandType.PROFILE_START)
+    async def _on_start_profiling(self, message: ProfileStartCommand) -> None:
+        """Create, resolve, and start a probe collector per unique target.
+
+        Resolves each target host once (so probes time pure TCP connect) and
+        starts the background probe loop. Partial failures are tolerated: the
+        run continues as long as at least one collector starts.
+        """
+        if not self._targets:
+            self.warning("Network Latency: No probe targets discovered; nothing to do")
+            self._shutdown_task = self.execute_async(self._delayed_shutdown())
+            return
+
+        self._collectors.clear()
+        started_count = 0
+        for key, (display_url, host, port) in self._targets.items():
+            collector = NetworkLatencyProbeCollector(
+                target_url=display_url,
+                target_host=host,
+                target_port=port,
+                ping_interval=self._ping_interval,
+                connect_timeout=Environment.NETWORK_LATENCY.CONNECT_TIMEOUT,
+                record_callback=self._on_network_latency_samples,
+                error_callback=self._on_network_latency_error,
+                collector_id=key,
+            )
+            # why: per-collector startup is isolated so one bad target can't
+            # abort the @on_command handler; the run proceeds with the rest.
+            try:
+                await collector.initialize()
+                await collector.resolve()
+                await collector.start()
+                self._collectors[key] = collector
+                started_count += 1
+            except Exception as e:  # noqa: BLE001
+                self.error(f"Failed to start probe collector for {key}: {e!r}")
+
+        if started_count == 0:
+            self.warning("Network Latency: No probe collectors successfully started")
+            self._shutdown_task = self.execute_async(self._delayed_shutdown())
+            return
+        self.info(
+            f"Network Latency: Started {started_count} probe collector(s) at "
+            f"{self._ping_interval}s interval"
+        )
+
+    @on_command(CommandType.PROFILE_COMPLETE)
+    async def _handle_profile_complete_command(
+        self, message: ProfileCompleteCommand
+    ) -> None:
+        """Top up to MIN_SAMPLES with synchronous probes, then stop all collectors.
+
+        Idempotent: a no-op once collectors have been stopped.
+        """
+        if not self._collectors:
+            self.debug("Network Latency: Already stopped, skipping final probes")
+            return
+
+        self.info("Network Latency: Profiling complete, topping up RTT samples...")
+        # why: the top-up runs inside the PROFILE_COMPLETE command handler, which the
+        # caller awaits on a fixed response budget. Bound the whole top-up by a
+        # wall-clock deadline (across all collectors) so a slow/unreachable endpoint
+        # cannot stall completion; whatever samples we have are used as-is.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + Environment.NETWORK_LATENCY.COMPLETE_TOPUP_TIMEOUT
+        for key, collector in list(self._collectors.items()):
+            attempts = 0
+            max_attempts = self._min_samples * 2
+            while (
+                collector.successful_samples < self._min_samples
+                and attempts < max_attempts
+                and loop.time() < deadline
+            ):
+                attempts += 1
+                # why: a top-up probe failure must not crash the completion path,
+                # just stop topping up this collector.
+                try:
+                    await collector.probe_once()
+                except Exception as e:  # noqa: BLE001
+                    self.warning(
+                        f"Network Latency: Final top-up probe failed for {key}: {e!r}"
+                    )
+                    break
+            if loop.time() >= deadline:
+                self.warning(
+                    "Network Latency: top-up budget exhausted; proceeding to stop with "
+                    "the samples collected so far"
+                )
+                break
+
+        await self._stop_all_collectors()
+
+    @on_command(CommandType.PROFILE_CANCEL)
+    async def _handle_profile_cancel_command(
+        self, message: ProfileCancelCommand
+    ) -> None:
+        """Stop all probe collectors when profiling is cancelled."""
+        await self._stop_all_collectors()
+
+    @on_stop
+    async def _network_latency_manager_stop(self) -> None:
+        """Stop all probe collectors during service shutdown."""
+        await self._stop_all_collectors()
+
+    async def _stop_all_collectors(self) -> None:
+        """Stop all probe collectors, tolerating individual shutdown errors."""
+        if not self._collectors:
+            return
+        collectors = list(self._collectors.items())
+        self._collectors.clear()
+        for key, collector in collectors:
+            # why: shutdown isolation — one collector's stop() error must not
+            # leave the remaining collectors running or fail service teardown.
+            try:
+                await collector.stop()
+            except Exception as e:  # noqa: BLE001
+                self.error(f"Failed to stop probe collector for {key}: {e!r}")
+
+    async def _delayed_shutdown(self) -> None:
+        """Shutdown the service after a delay so the command response can be sent."""
+        await asyncio.sleep(Environment.SERVER_METRICS.SHUTDOWN_DELAY)
+        await asyncio.shield(self.stop())
+
+    async def _on_network_latency_samples(
+        self, samples: list[NetworkLatencySample], collector_id: str
+    ) -> None:
+        """Forward probe samples to RecordsManager via the RECORDS push socket."""
+        if not samples:
+            return
+        for sample in samples:
+            # why: sample-forwarding callback is an isolation boundary; a push
+            # failure must be logged, not crash the probe collector's loop.
+            try:
+                message = NetworkLatencyRecordMessage(
+                    service_id=self.service_id,
+                    collector_id=collector_id,
+                    sample=sample,
+                    error=None,
+                )
+                await self.records_push_client.push(message)
+            except Exception as e:  # noqa: BLE001
+                self.error(
+                    f"Failed to send network latency sample from {collector_id}: {e!r}"
+                )
+                # why: error-forwarding fallback is also an isolation boundary.
+                try:
+                    error_message = NetworkLatencyRecordMessage(
+                        service_id=self.service_id,
+                        collector_id=collector_id,
+                        sample=None,
+                        error=ErrorDetails.from_exception(e),
+                    )
+                    await self.records_push_client.push(error_message)
+                except Exception as nested_error:  # noqa: BLE001
+                    self.error(
+                        f"Failed to send error message after sample send failure: {nested_error!r}"
+                    )
+
+    async def _on_network_latency_error(
+        self, error: ErrorDetails, collector_id: str
+    ) -> None:
+        """Forward a transport-level probe error to RecordsManager."""
+        # why: error-forwarding callback is an isolation boundary; a push
+        # failure must be logged, not crash the probe collector's loop.
+        try:
+            error_message = NetworkLatencyRecordMessage(
+                service_id=self.service_id,
+                collector_id=collector_id,
+                sample=None,
+                error=error,
+            )
+            await self.records_push_client.push(error_message)
+        except Exception as e:  # noqa: BLE001
+            self.error(f"Failed to send network latency error message: {e!r}")
+
+
+def main() -> None:
+    """Main entry point for the network latency manager."""
+    from aiperf.common.bootstrap import bootstrap_and_run_service
+    from aiperf.plugin.enums import ServiceType
+
+    bootstrap_and_run_service(ServiceType.NETWORK_LATENCY_MANAGER)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aiperf/network_latency/probe.py
+++ b/src/aiperf/network_latency/probe.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import time
+from collections.abc import Awaitable, Callable
+
+from aiperf.common.environment import Environment
+from aiperf.common.hooks import background_task
+from aiperf.common.mixins import AIPerfLifecycleMixin
+from aiperf.common.models import ErrorDetails, NetworkLatencySample
+
+__all__ = ["NetworkLatencyProbeCollector"]
+
+
+class NetworkLatencyProbeCollector(AIPerfLifecycleMixin):
+    """Probes a single (host, port) target's TCP-handshake RTT on an interval.
+
+    Each probe opens a fresh, unpooled TCP connection via
+    ``asyncio.open_connection`` and times the handshake with
+    ``time.perf_counter_ns``. A pooled HTTP client (aiohttp) would measure ~0 on
+    connection reuse, so raw ``open_connection`` is used to force a real
+    handshake every probe. For ``https://`` targets a plain TCP connect to the
+    port is performed (no TLS) so ``rtt_ns`` is one uniform network round-trip
+    across http/https.
+
+    The host is resolved once at construction time (cached resolved address)
+    so probes time pure TCP connect, not DNS resolution.
+
+    Probe failures (timeout/refused) are recorded as a failed sample
+    (``success=False``, ``rtt_ns=None``, ``error=...``) and never crash the run:
+    the background loop wraps the probe in ``probe_once`` which isolates errors
+    and routes them to ``record_callback`` as a failed sample.
+
+    Args:
+        target_url: Endpoint URL the target was derived from (credential-free).
+        target_host: Host to connect to.
+        target_port: TCP port to connect to.
+        ping_interval: Seconds between probes.
+        connect_timeout: Per-probe TCP-handshake timeout in seconds.
+        record_callback: Async callback receiving probe samples.
+            Signature: async (samples: list[NetworkLatencySample], collector_id: str) -> None
+        error_callback: Async callback receiving transport-level errors.
+            Signature: async (error: ErrorDetails, collector_id: str) -> None
+        collector_id: Unique identifier for this collector (typically host:port).
+    """
+
+    def __init__(
+        self,
+        target_url: str,
+        target_host: str,
+        target_port: int,
+        *,
+        ping_interval: float,
+        connect_timeout: float | None = None,
+        record_callback: Callable[[list[NetworkLatencySample], str], Awaitable[None]] | None = None,
+        error_callback: Callable[[ErrorDetails, str], Awaitable[None]] | None = None,
+        collector_id: str = "network_latency_probe",
+    ) -> None:  # fmt: skip
+        super().__init__(id=collector_id)
+        self._target_url = target_url
+        self._target_host = target_host
+        self._target_port = target_port
+        self._ping_interval = ping_interval
+        self._connect_timeout = (
+            connect_timeout
+            if connect_timeout is not None
+            else Environment.NETWORK_LATENCY.CONNECT_TIMEOUT
+        )
+        self._record_callback = record_callback
+        self._error_callback = error_callback
+        # Resolved connect target cached so probes time pure TCP connect, not DNS.
+        # None until resolve() succeeds; falls back to the parsed host:port.
+        self._resolved_host: str = target_host
+        self._resolved_family: int = socket.AF_UNSPEC
+        self._successful_samples: int = 0
+
+    @property
+    def ping_interval(self) -> float:
+        """Seconds between probes."""
+        return self._ping_interval
+
+    @property
+    def successful_samples(self) -> int:
+        """Number of successful probes recorded by this collector."""
+        return self._successful_samples
+
+    async def resolve(self) -> None:
+        """Resolve the target host once and cache the address for pure-connect probes.
+
+        Resolution failure is non-fatal: the loop falls back to passing the
+        original host to ``open_connection`` (which will resolve per-probe), so
+        a transient DNS hiccup at configure time does not disable probing.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            infos = await loop.getaddrinfo(
+                self._target_host,
+                self._target_port,
+                type=socket.SOCK_STREAM,
+            )
+            if infos:
+                family, _, _, _, sockaddr = infos[0]
+                self._resolved_family = family
+                self._resolved_host = sockaddr[0]
+                self.debug(
+                    lambda: f"Resolved {self._target_host}:{self._target_port} -> {self._resolved_host}"
+                )
+        except OSError as e:
+            self.warning(
+                f"Failed to resolve {self._target_host}:{self._target_port} "
+                f"({e!r}); probes will resolve per-connect."
+            )
+
+    @background_task(immediate=True, interval=lambda self: self.ping_interval)
+    async def _probe_loop(self) -> None:
+        """Background task that fires a probe every ping_interval seconds.
+
+        Uses execute_async (fire-and-forget) so a slow handshake near the
+        connect timeout does not delay the next scheduled probe.
+        """
+        self.execute_async(self.probe_once())
+
+    async def probe_once(self) -> None:
+        """Issue one TCP-handshake RTT probe with full error isolation.
+
+        Always produces exactly one NetworkLatencySample (success or failure)
+        and delivers it via the record callback. Never raises — a probe failure
+        becomes a failed sample so the run is never crashed by a refused/timed-out
+        endpoint (mirrors base_metrics_collector_mixin error isolation).
+        """
+        timestamp_ns = time.time_ns()
+        rtt_ns: int | None = None
+        error: ErrorDetails | None = None
+        success = False
+
+        start_perf_ns = time.perf_counter_ns()
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(self._resolved_host, self._target_port),
+                timeout=self._connect_timeout,
+            )
+            rtt_ns = time.perf_counter_ns() - start_perf_ns
+            success = True
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except OSError as close_error:
+                self.debug(
+                    lambda err=close_error: f"Error closing probe connection to "
+                    f"{self._target_host}:{self._target_port}: {err!r}"
+                )
+        except (OSError, asyncio.TimeoutError) as e:
+            error = ErrorDetails.from_exception(e)
+
+        if success:
+            self._successful_samples += 1
+
+        sample = NetworkLatencySample(
+            timestamp_ns=timestamp_ns,
+            target_url=self._target_url,
+            target_host=self._target_host,
+            target_port=self._target_port,
+            probe_type="tcp_connect",
+            rtt_ns=rtt_ns,
+            success=success,
+            error=error,
+        )
+        await self._send_sample(sample)
+
+    async def _send_sample(self, sample: NetworkLatencySample) -> None:
+        """Deliver a probe sample via the record callback, isolating callback errors."""
+        if self._record_callback is None:
+            return
+        # why: callback dispatch is the probe-loop isolation boundary; any user
+        # callback failure must be logged, not crash the benchmark run.
+        try:
+            await self._record_callback([sample], self.id)
+        except Exception as e:  # noqa: BLE001
+            self.error(f"Failed to send probe sample via callback: {e!r}")
+            if self._error_callback:
+                # why: error-callback dispatch is also an isolation boundary.
+                try:
+                    await self._error_callback(ErrorDetails.from_exception(e), self.id)
+                except Exception as callback_error:  # noqa: BLE001
+                    self.error(f"Failed to send error via callback: {callback_error!r}")

--- a/src/aiperf/network_latency/protocols.py
+++ b/src/aiperf/network_latency/protocols.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from aiperf.common.models import MetricResult, NetworkLatencySample
+
+
+@runtime_checkable
+class NetworkLatencyProcessorProtocol(Protocol):
+    """Protocol for results processors that consume network latency RTT samples.
+
+    Separate from ResultsProcessorProtocol because RTT probe samples are
+    structurally distinct from inference metric records.
+    """
+
+    async def process_network_latency_sample(
+        self, sample: NetworkLatencySample
+    ) -> None:
+        """Process a single TCP-handshake RTT probe sample.
+
+        Args:
+            sample: NetworkLatencySample with the probe result (success or failure)
+        """
+        ...
+
+    async def summarize(self) -> list[MetricResult]: ...

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -115,7 +115,7 @@ URLSelectionStrategy = plugins.create_enum(PluginType.URL_SELECTION_STRATEGY, "U
 
 ServiceTypeStr: TypeAlias = str
 ServiceType = plugins.create_enum(PluginType.SERVICE, "ServiceType", module=__name__)
-"""Dynamic enum for service. Example: ServiceType.API, ServiceType.SERVER_METRICS_MANAGER, ServiceType.WORKER_MANAGER"""
+"""Dynamic enum for service. Example: ServiceType.API, ServiceType.RECORDS_MANAGER, ServiceType.WORKER_MANAGER"""
 
 ServiceRunTypeStr: TypeAlias = str
 ServiceRunType = plugins.create_enum(PluginType.SERVICE_MANAGER, "ServiceRunType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -52,6 +52,17 @@ service:
       required: false
       auto_start: true
 
+  network_latency_manager:
+    class: aiperf.network_latency.manager:NetworkLatencyManager
+    description: |
+      Network latency calibration service. Probes the endpoint's TCP-handshake
+      RTT throughout the profiling phase so the mean network round-trip can be
+      subtracted from latency metrics. Only spawned when network latency
+      calibration is enabled with active probing (no mean_ms).
+    metadata:
+      required: false
+      auto_start: true
+
   record_processor:
     class: aiperf.records.record_processor_service:RecordProcessor
     description: |
@@ -986,6 +997,13 @@ results_processor:
       Results processor that computes metrics from MetricType.DERIVED and
       aggregates results from all record processors. Final stage of metrics
       pipeline. Always loaded.
+
+  network_latency_jsonl_writer:
+    class: aiperf.network_latency.jsonl_writer:NetworkLatencyJSONLWriter
+    description: |
+      Network latency JSONL writer that exports per-sample TCP-handshake RTT
+      probes to a JSONL file. Enabled when network latency calibration is
+      actively probing (no mean_ms).
 
   otel_metrics_streamer:
     class: aiperf.post_processors.otel_metrics_results_processor:OTelMetricsResultsProcessor

--- a/src/aiperf/post_processors/metric_results_processor.py
+++ b/src/aiperf/post_processors/metric_results_processor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
 from aiperf.common.enums import (
     MetricDictValueTypeT,
     MetricFlags,
@@ -22,6 +24,10 @@ from aiperf.metrics.display_units import to_display_unit
 from aiperf.metrics.list_metric_aggregation import TDigestListMetricAggregator
 from aiperf.metrics.metric_dicts import MetricAggregator, MetricArray, MetricResultsDict
 from aiperf.metrics.metric_registry import MetricRegistry
+from aiperf.metrics.types.network_adjusted_metrics import (
+    NETWORK_ADJUSTED_SOURCES,
+    NetworkRttMetric,
+)
 from aiperf.post_processors.base_metrics_processor import BaseMetricsProcessor
 
 if TYPE_CHECKING:
@@ -51,6 +57,11 @@ class MetricResultsProcessor(BaseMetricsProcessor):
         # Create the results dict, which will be used to store the results of non-derived metrics,
         # and then be updated with the derived metrics.
         self._results: MetricResultsDict = MetricResultsDict()
+
+        # Run-level mean network RTT (ns) to subtract from request-start-anchored
+        # latency metrics. Set by the RecordsManager before summarize() when network
+        # latency calibration is enabled; None means no adjustment is applied.
+        self._network_rtt_ns: float | None = None
 
         # Get all of the metric classes.
         _all_metric_classes: list[type[BaseMetric]] = MetricRegistry.all_classes()
@@ -142,6 +153,49 @@ class MetricResultsProcessor(BaseMetricsProcessor):
         """
         return self._results
 
+    def set_network_rtt_ns(self, rtt_ns: float | None) -> None:
+        """Set the run-level mean network RTT (ns) to subtract from latency metrics.
+
+        Called by the RecordsManager before summarize() when network latency
+        calibration is enabled (or a manual override was provided). None disables
+        the adjustment.
+        """
+        self._network_rtt_ns = rtt_ns
+
+    def _inject_network_adjusted_metrics(self) -> None:
+        """Inject network_adjusted_* distributions and the network_rtt summary.
+
+        Subtracting a constant RTT from every record shifts the mean and every
+        percentile by that constant and leaves the standard deviation unchanged, so the
+        adjustment is applied to each source metric's aggregated array (clamped at 0).
+        Values flow through the normal _create_metric_result / to_display_unit path
+        because the network_adjusted_* and network_rtt metrics are registered.
+        """
+        rtt_ns = self._network_rtt_ns
+        if rtt_ns is None:
+            return
+
+        self._results[NetworkRttMetric.tag] = float(rtt_ns)
+
+        clamped_tags: list[str] = []
+        for adjusted_tag, source_tag in NETWORK_ADJUSTED_SOURCES.items():
+            source = self._results.get(source_tag)
+            if not isinstance(source, MetricArray) or len(source) == 0:
+                continue
+            data = source.data
+            if np.any(data < rtt_ns):
+                clamped_tags.append(adjusted_tag)
+            adjusted = MetricArray()
+            adjusted.extend(np.maximum(data - rtt_ns, 0.0))
+            self._results[adjusted_tag] = adjusted
+
+        if clamped_tags:
+            self.warning(
+                lambda tags=clamped_tags: f"Network RTT ({rtt_ns / 1e6:.3f} ms) exceeded "
+                f"some measured latencies; clamped to 0 for: {', '.join(tags)}. "
+                "The subtracted RTT may be larger than the true network leg."
+            )
+
     async def update_derived_metrics(self) -> None:
         """Computes the values for the derived metrics, and stores them in the results dict."""
         for tag, derive_func in self.derive_funcs.items():
@@ -183,6 +237,7 @@ class MetricResultsProcessor(BaseMetricsProcessor):
         but filtered from output unless dev mode flags are enabled.
         """
         await self.update_derived_metrics()
+        self._inject_network_adjusted_metrics()
 
         # Compute metric results, filter internal/experimental, and convert to display units
         results = [

--- a/src/aiperf/records/records_manager.py
+++ b/src/aiperf/records/records_manager.py
@@ -24,6 +24,7 @@ from aiperf.common.messages import (
     DatasetConfiguredNotification,
     MetricRecordsData,
     MetricRecordsMessage,
+    NetworkLatencyRecordMessage,
     ProcessRecordsCommand,
     ProcessRecordsResultMessage,
     ProcessServerMetricsResultMessage,
@@ -44,6 +45,7 @@ from aiperf.common.models import (
     ErrorDetails,
     ErrorDetailsCount,
     MetricResult,
+    NetworkLatencySample,
     PhaseRecordsStats,
     ProcessRecordsResult,
     ProcessServerMetricsResult,
@@ -71,6 +73,8 @@ from aiperf.metrics.cache_reporting_hint import (
     CACHE_REPORTING_HINT,
     usage_without_cache_in_record,
 )
+from aiperf.network_latency.accumulator import NetworkLatencyAccumulator
+from aiperf.network_latency.protocols import NetworkLatencyProcessorProtocol
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import PluginType, ResultsProcessorType, UIType
 from aiperf.post_processors.protocols import (
@@ -87,6 +91,7 @@ from aiperf.server_metrics.protocols import (
 
 if TYPE_CHECKING:
     from aiperf.config.resolution.plan import BenchmarkRun
+    from aiperf.plugin.types import PluginEntry
 
 
 @dataclass
@@ -170,6 +175,17 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         self._server_metrics_processors: list[ServerMetricsProcessorProtocol] = []  # fmt: skip
         self._gpu_telemetry_accumulator: GPUTelemetryAccumulatorProtocol | None = None  # fmt: skip
         self._server_metrics_accumulator: ServerMetricsAccumulatorProtocol | None = None  # fmt: skip
+        self._network_latency_processors: list[NetworkLatencyProcessorProtocol] = []  # fmt: skip
+
+        # In-process accumulator for RTT probe samples. Computes the run-level
+        # mean RTT delivered to each MetricResultsProcessor via set_network_rtt_ns
+        # before summarize(). None unless network latency probing is active.
+        self._network_latency_accumulator: NetworkLatencyAccumulator | None = (
+            NetworkLatencyAccumulator(benchmark_id=self.run.benchmark_id)
+            if self.run.cfg.network_latency.should_probe
+            else None
+        )
+        self._network_latency_state = ErrorTrackingState()
 
         for entry in plugins.iter_entries(PluginType.RESULTS_PROCESSOR):
             try:
@@ -183,27 +199,7 @@ class RecordsManager(PullClientMixin, BaseComponentService):
                 )
                 self.attach_child_lifecycle(results_processor)
 
-                if isinstance(results_processor, GPUTelemetryProcessorProtocol):
-                    self._gpu_telemetry_processors.append(results_processor)
-
-                    # Store the accumulating processor separately for hierarchy access
-                    if entry.name == ResultsProcessorType.GPU_TELEMETRY_ACCUMULATOR:
-                        self._gpu_telemetry_accumulator = results_processor
-
-                elif isinstance(results_processor, ServerMetricsProcessorProtocol):
-                    self._server_metrics_processors.append(results_processor)
-
-                    # Store the accumulating processor separately for hierarchy access
-                    if entry.name == ResultsProcessorType.SERVER_METRICS_ACCUMULATOR:
-                        self._server_metrics_accumulator = results_processor
-
-                else:
-                    self._metric_results_processors.append(results_processor)
-                    if (
-                        entry.name == ResultsProcessorType.OTEL_METRICS_STREAMER
-                        and self.run.cfg.otel.stream_timing_enabled
-                    ):
-                        self._timing_results_processors.append(results_processor)
+                self._classify_results_processor(results_processor, entry)
 
                 self.debug(
                     f"Created results processor: {entry.name}: {results_processor.__class__.__name__}"
@@ -219,6 +215,38 @@ class RecordsManager(PullClientMixin, BaseComponentService):
                     )
             except Exception as e:
                 self.error(f"Failed to create results processor {entry.name}: {e}")
+
+    def _classify_results_processor(
+        self,
+        results_processor: ResultsProcessorProtocol,
+        entry: PluginEntry,
+    ) -> None:
+        """Route a constructed results processor into its subsystem bucket.
+
+        Sorts by protocol into GPU telemetry, server metrics, network latency,
+        or the generic metric processors list, and captures the GPU/server
+        accumulator singletons and any timing-capable processor.
+        """
+        if isinstance(results_processor, GPUTelemetryProcessorProtocol):
+            self._gpu_telemetry_processors.append(results_processor)
+            if entry.name == ResultsProcessorType.GPU_TELEMETRY_ACCUMULATOR:
+                self._gpu_telemetry_accumulator = results_processor
+
+        elif isinstance(results_processor, ServerMetricsProcessorProtocol):
+            self._server_metrics_processors.append(results_processor)
+            if entry.name == ResultsProcessorType.SERVER_METRICS_ACCUMULATOR:
+                self._server_metrics_accumulator = results_processor
+
+        elif isinstance(results_processor, NetworkLatencyProcessorProtocol):
+            self._network_latency_processors.append(results_processor)
+
+        else:
+            self._metric_results_processors.append(results_processor)
+            if (
+                entry.name == ResultsProcessorType.OTEL_METRICS_STREAMER
+                and self.run.cfg.otel.stream_timing_enabled
+            ):
+                self._timing_results_processors.append(results_processor)
 
     @on_pull_message(MessageType.METRIC_RECORDS)
     async def _on_metric_records(self, message: MetricRecordsMessage) -> None:
@@ -294,6 +322,47 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         else:
             if message.error:
                 self._server_metrics_state.error_counts[message.error] += 1
+
+    @on_pull_message(MessageType.NETWORK_LATENCY_RECORD)
+    async def _on_network_latency_records(
+        self, message: NetworkLatencyRecordMessage
+    ) -> None:
+        """Handle a network latency RTT probe sample from the NetworkLatencyManager.
+
+        Accumulates the sample for the run-level mean RTT (delivered to the
+        metric processors before summarize) and forwards it to the JSONL writer.
+        A transport-level delivery error is tracked separately.
+
+        Args:
+            message: Network latency probe sample from a probe collector
+        """
+        if message.valid:
+            if self._network_latency_accumulator is not None:
+                self._network_latency_accumulator.add_sample(message.sample)
+            await self._send_network_latency_to_results_processors(message.sample)
+        else:
+            if message.error:
+                self._network_latency_state.error_counts[message.error] += 1
+
+    async def _send_network_latency_to_results_processors(
+        self, sample: NetworkLatencySample
+    ) -> None:
+        """Forward a probe sample to the network latency results processors."""
+        if not self._network_latency_processors:
+            return
+        errors = await asyncio.gather(
+            *[
+                processor.process_network_latency_sample(sample)
+                for processor in self._network_latency_processors
+            ],
+            return_exceptions=True,
+        )
+        for error in errors:
+            if isinstance(error, BaseException):
+                self.exception(f"Failed to process network latency sample: {error!r}")
+                self._network_latency_state.error_counts[
+                    ErrorDetails.from_exception(error)
+                ] += 1
 
     async def _handle_all_records_received(self, phase: CreditPhase) -> None:
         """Handle the case where all records have been received."""
@@ -793,6 +862,63 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         )
         records_results.extend(efficiency_metrics)
 
+    def _deliver_network_rtt_to_processors(self) -> None:
+        """Set the run-level mean network RTT (ns) on each metric results processor.
+
+        Two cases, resolved here just before MetricResultsProcessor.summarize():
+
+        1. Manual mean (``--network-latency-mean``): if ``network_latency.mean_ms``
+           is set, the NetworkLatencyManager service is never spawned; convert the
+           mean ms to ns and deliver it directly.
+        2. Automatic (``--network-latency-automatic``): the accumulator computed a
+           mean over successful probe samples. If zero successful samples were
+           collected, log a warning and apply no adjustment.
+
+        A resolved RTT of 0 (or no RTT) is a no-op: the adjustment would emit
+        network_adjusted_* metrics identical to the raw ones, so it is skipped.
+        Also a no-op when network latency calibration is disabled entirely.
+        """
+        network_cfg = self.run.cfg.network_latency
+        if not network_cfg.enabled:
+            return
+
+        if network_cfg.mean_ms is not None:
+            rtt_ns: float | None = network_cfg.mean_ms * 1e6
+        else:
+            rtt_ns = (
+                self._network_latency_accumulator.mean_rtt_ns
+                if self._network_latency_accumulator is not None
+                else None
+            )
+            if rtt_ns is None:
+                self.warning(
+                    "Network latency calibration enabled but no successful RTT "
+                    "probes were collected; skipping network_adjusted_* metrics."
+                )
+
+        # A resolved RTT of 0/None is a no-op (adjusted == raw): skip injection so we
+        # don't emit duplicate network_adjusted_* metrics. The None case already warned.
+        if not rtt_ns:
+            return
+
+        if network_cfg.mean_ms is not None:
+            self.notice(
+                f"Network latency calibration: subtracting a fixed mean RTT of "
+                f"{rtt_ns / 1e6:.3f} ms from latency metrics (network_adjusted_* metrics)."
+            )
+        else:
+            sample_count = self._network_latency_accumulator.successful_sample_count
+            self.notice(
+                f"Network latency calibration: subtracting measured mean RTT of "
+                f"{rtt_ns / 1e6:.3f} ms (over {sample_count} TCP-handshake probes) "
+                "from latency metrics (network_adjusted_* metrics)."
+            )
+
+        for processor in self._metric_results_processors:
+            set_rtt = getattr(processor, "set_network_rtt_ns", None)
+            if callable(set_rtt):
+                set_rtt(rtt_ns)
+
     async def _process_results(
         self, phase: CreditPhase, cancelled: bool
     ) -> ProcessRecordsResult:
@@ -801,6 +927,10 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         self.info("Processing records results...")
 
         await self._flush_metric_results_processors(force=True)
+
+        # Deliver the run-level mean network RTT to each metric results processor
+        # BEFORE summarize() so network_adjusted_* metrics can be injected.
+        self._deliver_network_rtt_to_processors()
 
         # Debug: log processors being summarized
         self.debug(

--- a/tests/integration/test_network_latency_calibration.py
+++ b/tests/integration/test_network_latency_calibration.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end integration tests for network latency calibration.
+
+Drives a full ``aiperf profile`` run against the mock server and asserts that
+enabling calibration produces the per-sample JSONL artifact and the
+``network_adjusted_*`` / ``network_rtt`` keys in the JSON export, while a
+baseline run without the flag is unaffected (non-regression).
+"""
+
+import orjson
+import pytest
+
+from tests.harness.utils import AIPerfCLI, AIPerfMockServer, AIPerfResults
+from tests.integration.conftest import IntegrationTestDefaults as defaults
+
+_NETWORK_LATENCY_GLOB = "**/*network_latency.jsonl"
+_ADJUSTED_KEYS = (
+    "network_adjusted_time_to_first_token",
+    "network_rtt",
+)
+
+
+def _load_json_export(results: AIPerfResults) -> dict:
+    """Load the raw aiperf.json export as a dict (extra metric keys preserved)."""
+    path = next(results.artifacts_dir.glob("**/*aiperf.json"), None)
+    assert path is not None, "profile_export_aiperf.json was not written"
+    return orjson.loads(path.read_bytes())
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestNetworkLatencyCalibration:
+    """Tests for the --network-latency-automatic feature."""
+
+    async def test_calibration_writes_jsonl_and_adjusted_metrics(
+        self, cli: AIPerfCLI, aiperf_mock_server: AIPerfMockServer
+    ):
+        """Active probing emits the JSONL artifact and adjusted metric keys."""
+        results = await cli.run(
+            f"""
+            aiperf profile \
+                --model Qwen/Qwen2.5-32B-Instruct \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --streaming \
+                --network-latency-automatic \
+                --network-latency-ping-interval 0.05 \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+        assert results.request_count == defaults.request_count
+
+        jsonl_path = next(results.artifacts_dir.glob(_NETWORK_LATENCY_GLOB), None)
+        assert jsonl_path is not None, "network latency JSONL artifact was not written"
+
+        lines = [line for line in jsonl_path.read_text().splitlines() if line.strip()]
+        assert lines, "network latency JSONL artifact is empty"
+        for line in lines:
+            sample = orjson.loads(line)
+            assert "success" in sample
+            assert sample["target_port"] is not None
+
+        export = _load_json_export(results)
+        for key in _ADJUSTED_KEYS:
+            assert key in export, f"{key} missing from JSON export"
+
+    async def test_baseline_without_flag_has_no_network_artifacts(
+        self, cli: AIPerfCLI, aiperf_mock_server: AIPerfMockServer
+    ):
+        """Non-regression: omitting the flag emits no network latency outputs."""
+        results = await cli.run(
+            f"""
+            aiperf profile \
+                --model Qwen/Qwen2.5-32B-Instruct \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --streaming \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+        assert results.request_count == defaults.request_count
+
+        assert next(results.artifacts_dir.glob(_NETWORK_LATENCY_GLOB), None) is None
+
+        export = _load_json_export(results)
+        assert not any(key.startswith("network_adjusted_") for key in export)
+        assert "network_rtt" not in export
+
+    async def test_rtt_override_adjusts_without_probing(
+        self, cli: AIPerfCLI, mock_server_factory
+    ):
+        """A fixed override produces adjusted metrics with no active probing.
+
+        Uses a controlled-latency mock (TTFT well above the 5 ms override) so the
+        subtraction never clamps at 0, letting us lock in the exact-shift property.
+        """
+        async with mock_server_factory(ttft=80, itl=10, workers=8) as server:
+            results = await cli.run(
+                f"""
+                aiperf profile \
+                    --model Qwen/Qwen2.5-32B-Instruct \
+                    --url {server.url} \
+                    --endpoint-type chat \
+                    --streaming \
+                    --network-latency-mean 5.0 \
+                    --request-count {defaults.request_count} \
+                    --concurrency {defaults.concurrency} \
+                    --workers-max {defaults.workers_max} \
+                    --ui {defaults.ui}
+                """
+            )
+        assert results.request_count == defaults.request_count
+
+        export = _load_json_export(results)
+        for key in _ADJUSTED_KEYS:
+            assert key in export, f"{key} missing from JSON export with override"
+
+        # A fixed 5 ms mean is deterministic, so lock in the core correctness
+        # property end-to-end: each adjusted latency is shifted down by exactly the
+        # RTT and its standard deviation is unchanged (display units are ms).
+        assert export["network_rtt"]["avg"] == pytest.approx(5.0, abs=1e-3)
+        for raw_tag, adjusted_tag in (
+            ("time_to_first_token", "network_adjusted_time_to_first_token"),
+            ("request_latency", "network_adjusted_request_latency"),
+        ):
+            raw, adjusted = export[raw_tag], export[adjusted_tag]
+            assert raw["avg"] - adjusted["avg"] == pytest.approx(5.0, abs=1e-2)
+            assert raw["std"] == pytest.approx(adjusted["std"], abs=1e-6)
+
+        # No active probing: the per-sample JSONL artifact should not be written.
+        assert next(results.artifacts_dir.glob(_NETWORK_LATENCY_GLOB), None) is None

--- a/tests/unit/config/test_network_latency_config.py
+++ b/tests/unit/config/test_network_latency_config.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the network-latency CLI converter and NetworkLatencyConfig model.
+
+Covers every branch of ``build_network_latency`` (mean / automatic / mutex /
+disabled), the ``NetworkLatencyConfig`` Field constraints and default factory,
+and the ``should_probe`` property.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aiperf.common.environment import Environment
+from aiperf.config.flags._converter_telemetry import build_network_latency
+from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.config.network_latency import NetworkLatencyConfig
+
+
+def _make_cli(**overrides) -> CLIConfig:
+    base = {
+        "url": "http://localhost:8000/test",
+        "model_names": ["test-model"],
+    }
+    base.update(overrides)
+    return CLIConfig(**base)
+
+
+class TestBuildNetworkLatency:
+    """Branch coverage for the CLIConfig -> network-latency dict converter."""
+
+    def test_neither_flag_disabled(self) -> None:
+        assert build_network_latency(_make_cli()) == {"enabled": False}
+
+    def test_automatic_only_enables(self) -> None:
+        cli = _make_cli(network_latency_automatic=True)
+        assert build_network_latency(cli) == {"enabled": True}
+
+    def test_automatic_with_ping_interval_sets_interval(self) -> None:
+        cli = _make_cli(
+            network_latency_automatic=True, network_latency_ping_interval=0.25
+        )
+        assert build_network_latency(cli) == {
+            "enabled": True,
+            "ping_interval": 0.25,
+        }
+
+    def test_mean_only_enables_with_rtt(self) -> None:
+        cli = _make_cli(network_latency_mean=5.0)
+        assert build_network_latency(cli) == {
+            "enabled": True,
+            "mean_ms": 5.0,
+        }
+
+    def test_mean_without_automatic_flag_still_enables(self) -> None:
+        cli = _make_cli(network_latency_mean=0.0)
+        assert build_network_latency(cli) == {
+            "enabled": True,
+            "mean_ms": 0.0,
+        }
+
+    def test_automatic_and_mean_together_raises(self) -> None:
+        cli = _make_cli(network_latency_automatic=True, network_latency_mean=5.0)
+        with pytest.raises(
+            ValueError,
+            match="Cannot use both --network-latency-automatic and --network-latency-mean",
+        ):
+            build_network_latency(cli)
+
+    def test_mean_with_ping_interval_raises(self) -> None:
+        cli = _make_cli(network_latency_mean=5.0, network_latency_ping_interval=0.5)
+        with pytest.raises(
+            ValueError,
+            match="--network-latency-ping-interval only applies with --network-latency-automatic",
+        ):
+            build_network_latency(cli)
+
+    def test_ping_interval_without_automatic_raises(self) -> None:
+        cli = _make_cli(network_latency_ping_interval=0.5)
+        with pytest.raises(
+            ValueError, match="only applies when --network-latency-automatic"
+        ):
+            build_network_latency(cli)
+
+
+class TestNetworkLatencyConfigDefaults:
+    """Default values and the default-factory wiring for ping_interval."""
+
+    def test_defaults(self) -> None:
+        config = NetworkLatencyConfig()
+        assert config.enabled is False
+        assert config.mean_ms is None
+        assert config.ping_interval == pytest.approx(
+            Environment.NETWORK_LATENCY.DEFAULT_PROBE_INTERVAL
+        )
+
+
+class TestNetworkLatencyConfigConstraints:
+    """Field constraints reject invalid ping_interval / mean_ms."""
+
+    @pytest.mark.parametrize("ping_interval", [0.0, -1.0])
+    def test_non_positive_ping_interval_rejected(self, ping_interval: float) -> None:
+        with pytest.raises(ValidationError):
+            NetworkLatencyConfig(ping_interval=ping_interval)
+
+    def test_negative_mean_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            NetworkLatencyConfig(mean_ms=-1.0)
+
+    def test_zero_mean_accepted(self) -> None:
+        assert NetworkLatencyConfig(mean_ms=0.0).mean_ms == 0.0
+
+
+class TestShouldProbe:
+    """should_probe is True only when enabled and no manual mean is set."""
+
+    @pytest.mark.parametrize(
+        ("enabled", "mean_ms", "expected"),
+        [
+            (False, None, False),
+            (True, None, True),
+            (True, 5.0, False),
+            (False, 5.0, False),
+        ],
+    )
+    def test_should_probe(
+        self, enabled: bool, mean_ms: float | None, expected: bool
+    ) -> None:
+        config = NetworkLatencyConfig(enabled=enabled, mean_ms=mean_ms)
+        assert config.should_probe is expected

--- a/tests/unit/network_latency/__init__.py
+++ b/tests/unit/network_latency/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/network_latency/test_accumulator.py
+++ b/tests/unit/network_latency/test_accumulator.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for NetworkLatencyAccumulator stat aggregation.
+
+Successful samples feed the percentile stats; failed samples are excluded from
+the RTT distribution but counted as failures. With zero successful samples the
+mean is None (the metric processor then applies no adjustment).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aiperf.common.models import ErrorDetails, NetworkLatencySample
+from aiperf.network_latency.accumulator import NetworkLatencyAccumulator
+
+_TARGET_URL = "http://localhost:8000/v1/chat/completions"
+_HOST = "localhost"
+_PORT = 8000
+
+
+def _success_sample(rtt_ns: int) -> NetworkLatencySample:
+    return NetworkLatencySample(
+        timestamp_ns=1_000,
+        target_url=_TARGET_URL,
+        target_host=_HOST,
+        target_port=_PORT,
+        rtt_ns=rtt_ns,
+        success=True,
+    )
+
+
+def _failure_sample() -> NetworkLatencySample:
+    return NetworkLatencySample(
+        timestamp_ns=2_000,
+        target_url=_TARGET_URL,
+        target_host=_HOST,
+        target_port=_PORT,
+        rtt_ns=None,
+        success=False,
+        error=ErrorDetails(type="ConnectionRefusedError", message="refused"),
+    )
+
+
+# Known RTT sequence (ns): mean=550, median=550, etc.
+_RTTS = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+
+
+class TestMeanRttNs:
+    def test_mean_over_successful_samples(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        for rtt in _RTTS:
+            acc.add_sample(_success_sample(rtt))
+
+        assert acc.mean_rtt_ns == pytest.approx(float(np.mean(_RTTS)))
+
+    def test_failed_samples_excluded_from_mean(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        for rtt in _RTTS:
+            acc.add_sample(_success_sample(rtt))
+        for _ in range(5):
+            acc.add_sample(_failure_sample())
+
+        assert acc.mean_rtt_ns == pytest.approx(float(np.mean(_RTTS)))
+
+    def test_zero_successful_samples_mean_is_none(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        acc.add_sample(_failure_sample())
+        acc.add_sample(_failure_sample())
+
+        assert acc.mean_rtt_ns is None
+
+    def test_empty_accumulator_mean_is_none(self) -> None:
+        assert NetworkLatencyAccumulator().mean_rtt_ns is None
+
+
+class TestExportResults:
+    def test_aggregate_stats_match_numpy(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        for rtt in _RTTS:
+            acc.add_sample(_success_sample(rtt))
+
+        results = acc.export_results()
+        arr = np.asarray(_RTTS, dtype=np.float64)
+
+        assert results.min_ns == pytest.approx(float(np.min(arr)))
+        assert results.mean_ns == pytest.approx(float(np.mean(arr)))
+        assert results.median_ns == pytest.approx(float(np.median(arr)))
+        assert results.p90_ns == pytest.approx(float(np.percentile(arr, 90)))
+        assert results.p99_ns == pytest.approx(float(np.percentile(arr, 99)))
+        assert results.stddev_ns == pytest.approx(float(np.std(arr)))
+
+    def test_counts_split_success_and_failure(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        for rtt in _RTTS:
+            acc.add_sample(_success_sample(rtt))
+        for _ in range(3):
+            acc.add_sample(_failure_sample())
+
+        results = acc.export_results()
+
+        assert results.count == len(_RTTS) + 3
+        assert results.success_count == len(_RTTS)
+        assert results.failure_count == 3
+
+    def test_failed_samples_excluded_from_distribution(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        for rtt in _RTTS:
+            acc.add_sample(_success_sample(rtt))
+        for _ in range(3):
+            acc.add_sample(_failure_sample())
+
+        results = acc.export_results()
+        arr = np.asarray(_RTTS, dtype=np.float64)
+
+        assert results.mean_ns == pytest.approx(float(np.mean(arr)))
+        assert results.min_ns == pytest.approx(float(np.min(arr)))
+
+    def test_zero_successful_samples_stats_are_none(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        acc.add_sample(_failure_sample())
+
+        results = acc.export_results()
+
+        assert results.mean_ns is None
+        assert results.min_ns is None
+        assert results.median_ns is None
+        assert results.p90_ns is None
+        assert results.p99_ns is None
+        assert results.stddev_ns is None
+        assert results.success_count == 0
+        assert results.failure_count == 1
+
+    def test_error_summary_counts_unique_errors(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        for _ in range(4):
+            acc.add_sample(_failure_sample())
+
+        results = acc.export_results()
+
+        assert len(results.error_summary) == 1
+        assert results.error_summary[0].count == 4
+
+    def test_benchmark_id_propagated(self) -> None:
+        acc = NetworkLatencyAccumulator(benchmark_id="bench-123")
+        acc.add_sample(_success_sample(100))
+
+        assert acc.export_results().benchmark_id == "bench-123"
+
+    def test_per_target_summary_keyed_by_host_port(self) -> None:
+        acc = NetworkLatencyAccumulator()
+        for rtt in _RTTS:
+            acc.add_sample(_success_sample(rtt))
+
+        results = acc.export_results()
+
+        key = f"{_HOST}:{_PORT}"
+        assert key in results.target_summaries
+        summary = results.target_summaries[key]
+        assert summary.success_count == len(_RTTS)
+        assert summary.mean_ns == pytest.approx(float(np.mean(_RTTS)))

--- a/tests/unit/network_latency/test_jsonl_writer.py
+++ b/tests/unit/network_latency/test_jsonl_writer.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for NetworkLatencyJSONLWriter.
+
+Mirrors ``tests/unit/server_metrics/test_jsonl_writer.py``: a v2 BenchmarkRun is
+built with probing enabled, the processor is driven through its lifecycle (so the
+buffered writer flushes), and the JSONL artifact is asserted on disk. Also covers
+the self-disable (PostProcessorDisabled) path when probing is not active.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import orjson
+import pytest
+
+from aiperf.common.exceptions import PostProcessorDisabled
+from aiperf.common.models import NetworkLatencySample
+from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.config.resolution.plan import BenchmarkRun
+from aiperf.network_latency.jsonl_writer import NetworkLatencyJSONLWriter
+from aiperf.plugin.enums import EndpointType
+from tests.unit.conftest import make_run_from_cli
+from tests.unit.post_processors.conftest import aiperf_lifecycle
+
+
+@pytest.fixture
+def cfg_probing_enabled(tmp_artifact_dir: Path) -> BenchmarkRun:
+    """BenchmarkRun with active RTT probing (export enabled)."""
+    user_cfg = CLIConfig(
+        model_names=["test-model"],
+        endpoint_type=EndpointType.CHAT,
+        urls=["http://localhost:8000/v1/chat"],
+        artifact_directory=tmp_artifact_dir,
+        network_latency_automatic=True,
+    )
+    return make_run_from_cli(user_cfg)
+
+
+def _sample(
+    rtt_ns: int | None = 1_234_567, success: bool = True
+) -> NetworkLatencySample:
+    return NetworkLatencySample(
+        timestamp_ns=1_000_000_000,
+        target_url="http://localhost:8000/v1/chat",
+        target_host="localhost",
+        target_port=8000,
+        probe_type="tcp_connect",
+        rtt_ns=rtt_ns,
+        success=success,
+    )
+
+
+class TestInitialization:
+    def test_output_file_is_network_latency_jsonl(
+        self, cfg_probing_enabled: BenchmarkRun
+    ) -> None:
+        processor = NetworkLatencyJSONLWriter(
+            run=cfg_probing_enabled, service_id="records-manager"
+        )
+        assert (
+            processor.output_file
+            == cfg_probing_enabled.cfg.artifacts.network_latency_export_jsonl_file
+        )
+        assert processor.output_file.name == "profile_export_network_latency.jsonl"
+
+    def test_disabled_when_probing_not_active(self, tmp_artifact_dir: Path) -> None:
+        """Manual mean (no active probing) self-disables the export processor."""
+        user_cfg = CLIConfig(
+            model_names=["test-model"],
+            endpoint_type=EndpointType.CHAT,
+            urls=["http://localhost:8000/v1/chat"],
+            artifact_directory=tmp_artifact_dir,
+            network_latency_mean=2.5,  # manual mean -> should_probe is False
+        )
+        run = make_run_from_cli(user_cfg)
+
+        with pytest.raises(PostProcessorDisabled):
+            NetworkLatencyJSONLWriter(run=run, service_id="records-manager")
+
+
+class TestSampleProcessing:
+    @pytest.mark.asyncio
+    async def test_process_single_sample_writes_one_line(
+        self, cfg_probing_enabled: BenchmarkRun
+    ) -> None:
+        processor = NetworkLatencyJSONLWriter(
+            run=cfg_probing_enabled, service_id="records-manager"
+        )
+
+        async with aiperf_lifecycle(processor):
+            await processor.process_network_latency_sample(_sample())
+
+        output_file = (
+            cfg_probing_enabled.cfg.artifacts.network_latency_export_jsonl_file
+        )
+        assert output_file.exists()
+        lines = output_file.read_text().strip().split("\n")
+        assert len(lines) == 1
+
+        data = orjson.loads(lines[0])
+        assert data["target_host"] == "localhost"
+        assert data["target_port"] == 8000
+        assert data["rtt_ns"] == 1_234_567
+        assert data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_process_multiple_samples_writes_multiple_lines(
+        self, cfg_probing_enabled: BenchmarkRun
+    ) -> None:
+        processor = NetworkLatencyJSONLWriter(
+            run=cfg_probing_enabled, service_id="records-manager"
+        )
+
+        async with aiperf_lifecycle(processor):
+            for i in range(5):
+                await processor.process_network_latency_sample(
+                    _sample(rtt_ns=1_000 + i)
+                )
+
+        output_file = (
+            cfg_probing_enabled.cfg.artifacts.network_latency_export_jsonl_file
+        )
+        lines = output_file.read_text().strip().split("\n")
+        assert len(lines) == 5
+
+    @pytest.mark.asyncio
+    async def test_summarize_returns_empty(
+        self, cfg_probing_enabled: BenchmarkRun
+    ) -> None:
+        processor = NetworkLatencyJSONLWriter(
+            run=cfg_probing_enabled, service_id="records-manager"
+        )
+        assert await processor.summarize() == []

--- a/tests/unit/network_latency/test_manager.py
+++ b/tests/unit/network_latency/test_manager.py
@@ -1,0 +1,496 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for NetworkLatencyManager command handlers + probe-collector wiring.
+
+Mirrors ``tests/unit/server_metrics/test_server_metrics_manager.py``: the manager
+is constructed directly with a real ``BenchmarkRun`` (comms/push client come from
+the auto-mocked singleton communication) and the ``@on_command`` handlers are
+invoked with command messages. ``NetworkLatencyProbeCollector`` /
+``asyncio.open_connection`` are patched so no real network I/O happens.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aiperf.common.enums import CommandType
+from aiperf.common.environment import Environment
+from aiperf.common.messages import (
+    NetworkLatencyRecordMessage,
+    ProfileCancelCommand,
+    ProfileCompleteCommand,
+    ProfileStartCommand,
+)
+from aiperf.common.models import ErrorDetails, NetworkLatencySample
+from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.network_latency.manager import NetworkLatencyManager
+from aiperf.plugin.enums import EndpointType
+from tests.unit.conftest import make_run_from_cli
+
+
+@pytest.fixture
+def cfg_automatic() -> CLIConfig:
+    """CLIConfig with active RTT probing enabled (no manual mean)."""
+    return CLIConfig(
+        model_names=["test-model"],
+        endpoint_type=EndpointType.CHAT,
+        urls=["http://localhost:8000/v1/chat"],
+        network_latency_automatic=True,
+    )
+
+
+@pytest.fixture
+def cfg_automatic_multi_url() -> CLIConfig:
+    """CLIConfig with two distinct host:port targets plus a duplicate."""
+    return CLIConfig(
+        model_names=["test-model"],
+        endpoint_type=EndpointType.CHAT,
+        urls=[
+            "http://localhost:8000/v1/chat",
+            "http://localhost:8000/v1/completions",  # dupe host:port
+            "http://other-host:9000/v1/chat",
+        ],
+        network_latency_automatic=True,
+    )
+
+
+def _make_manager(cli_config: CLIConfig) -> NetworkLatencyManager:
+    return NetworkLatencyManager(run=make_run_from_cli(cli_config))
+
+
+class _StubProbeCollector:
+    """Per-instance stand-in for a probe collector in PROFILE_COMPLETE top-up tests.
+
+    Uses a real instance (not the shared AsyncMock type) so ``successful_samples``
+    can be a property without leaking onto every AsyncMock process-wide.
+    """
+
+    def __init__(
+        self,
+        *,
+        samples: int = 0,
+        bump_per_probe: int = 0,
+        probe_error: Exception | None = None,
+    ) -> None:
+        self._samples = samples
+        self._bump_per_probe = bump_per_probe
+        self._probe_error = probe_error
+        self.probe_calls = 0
+        self.stop = AsyncMock()
+
+    @property
+    def successful_samples(self) -> int:
+        return self._samples
+
+    async def probe_once(self) -> None:
+        self.probe_calls += 1
+        if self._probe_error is not None:
+            raise self._probe_error
+        self._samples += self._bump_per_probe
+
+
+def _success_sample() -> NetworkLatencySample:
+    return NetworkLatencySample(
+        timestamp_ns=1_000,
+        target_url="http://localhost:8000/v1/chat",
+        target_host="localhost",
+        target_port=8000,
+        probe_type="tcp_connect",
+        rtt_ns=1_234,
+        success=True,
+    )
+
+
+class TestNetworkLatencyManagerInitialization:
+    """Target discovery + deduplication at construction time."""
+
+    def test_init_discovers_single_target(self, cfg_automatic: CLIConfig) -> None:
+        manager = _make_manager(cfg_automatic)
+        assert "localhost:8000" in manager._targets
+        assert manager._collectors == {}
+
+    def test_init_dedupes_targets_by_host_port(
+        self, cfg_automatic_multi_url: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic_multi_url)
+        # Two URLs share localhost:8000; only one target key for that host:port.
+        assert set(manager._targets) == {"localhost:8000", "other-host:9000"}
+
+    def test_derive_target_applies_scheme_default_port(self) -> None:
+        assert NetworkLatencyManager._derive_target("https://example.com/v1") == (
+            "example.com",
+            443,
+        )
+        assert NetworkLatencyManager._derive_target("http://example.com/v1") == (
+            "example.com",
+            80,
+        )
+
+    def test_derive_target_explicit_port_wins(self) -> None:
+        assert NetworkLatencyManager._derive_target("http://h:1234/x") == ("h", 1234)
+
+    def test_derive_target_no_host_returns_none(self) -> None:
+        assert (
+            NetworkLatencyManager._derive_target("not-a-url-with-empty-host://") is None
+        )
+
+
+class TestProfileStartCommand:
+    """PROFILE_START builds, resolves, and starts one collector per target."""
+
+    @pytest.mark.asyncio
+    async def test_start_builds_one_collector_per_unique_target(
+        self, cfg_automatic_multi_url: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic_multi_url)
+
+        with patch(
+            "aiperf.network_latency.manager.NetworkLatencyProbeCollector",
+            side_effect=[AsyncMock(), AsyncMock()],
+        ):
+            await manager._on_start_profiling(
+                ProfileStartCommand(
+                    service_id=manager.id, command=CommandType.PROFILE_START
+                )
+            )
+
+        # One collector per unique host:port target.
+        assert set(manager._collectors) == {"localhost:8000", "other-host:9000"}
+        for collector in manager._collectors.values():
+            collector.initialize.assert_awaited_once()
+            collector.resolve.assert_awaited_once()
+            collector.start.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_tolerates_partial_collector_failure(
+        self, cfg_automatic_multi_url: CLIConfig
+    ) -> None:
+        """One bad target must not abort the others."""
+        manager = _make_manager(cfg_automatic_multi_url)
+
+        good = AsyncMock()
+        bad = AsyncMock()
+        bad.start.side_effect = RuntimeError("boom")
+
+        with patch(
+            "aiperf.network_latency.manager.NetworkLatencyProbeCollector",
+            side_effect=[good, bad],
+        ):
+            await manager._on_start_profiling(
+                ProfileStartCommand(
+                    service_id=manager.id, command=CommandType.PROFILE_START
+                )
+            )
+
+        # Only the collector that started successfully is retained.
+        assert len(manager._collectors) == 1
+        assert good in manager._collectors.values()
+
+    @pytest.mark.asyncio
+    async def test_start_with_no_targets_schedules_delayed_shutdown(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager._targets = {}
+
+        def close_coroutine(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("asyncio.create_task", side_effect=close_coroutine) as mock_create:
+            await manager._on_start_profiling(
+                ProfileStartCommand(
+                    service_id=manager.id, command=CommandType.PROFILE_START
+                )
+            )
+
+        mock_create.assert_called_once()
+        assert manager._collectors == {}
+
+    @pytest.mark.asyncio
+    async def test_start_with_all_collectors_failing_schedules_delayed_shutdown(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+
+        bad = AsyncMock()
+        bad.initialize.side_effect = RuntimeError("init failed")
+
+        def close_coroutine(coro):
+            coro.close()
+            return MagicMock()
+
+        with (
+            patch(
+                "aiperf.network_latency.manager.NetworkLatencyProbeCollector",
+                return_value=bad,
+            ),
+            patch("asyncio.create_task", side_effect=close_coroutine) as mock_create,
+        ):
+            await manager._on_start_profiling(
+                ProfileStartCommand(
+                    service_id=manager.id, command=CommandType.PROFILE_START
+                )
+            )
+
+        mock_create.assert_called_once()
+        assert manager._collectors == {}
+
+
+class TestProfileCompleteCommand:
+    """PROFILE_COMPLETE tops up to MIN_SAMPLES then stops all collectors."""
+
+    @pytest.mark.asyncio
+    async def test_complete_tops_up_to_min_samples_then_stops(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        min_samples = Environment.NETWORK_LATENCY.MIN_SAMPLES
+
+        # Below the floor; each probe_once bumps the count by one.
+        collector = _StubProbeCollector(bump_per_probe=1)
+        manager._collectors = {"localhost:8000": collector}
+
+        await manager._handle_profile_complete_command(
+            ProfileCompleteCommand(
+                service_id=manager.id, command=CommandType.PROFILE_COMPLETE
+            )
+        )
+
+        # Topped up exactly to the floor, then stopped + cleared.
+        assert collector.successful_samples == min_samples
+        collector.stop.assert_awaited_once()
+        assert manager._collectors == {}
+
+    @pytest.mark.asyncio
+    async def test_complete_no_topup_when_already_at_floor(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+
+        collector = _StubProbeCollector(samples=Environment.NETWORK_LATENCY.MIN_SAMPLES)
+        manager._collectors = {"localhost:8000": collector}
+
+        await manager._handle_profile_complete_command(
+            ProfileCompleteCommand(
+                service_id=manager.id, command=CommandType.PROFILE_COMPLETE
+            )
+        )
+
+        assert collector.probe_calls == 0
+        collector.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_complete_topup_probe_failure_breaks_loop_and_still_stops(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+
+        collector = _StubProbeCollector(probe_error=RuntimeError("probe boom"))
+        manager._collectors = {"localhost:8000": collector}
+
+        await manager._handle_profile_complete_command(
+            ProfileCompleteCommand(
+                service_id=manager.id, command=CommandType.PROFILE_COMPLETE
+            )
+        )
+
+        # The failing probe breaks the top-up loop after one attempt; stop still runs.
+        assert collector.probe_calls == 1
+        collector.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_complete_topup_respects_wallclock_budget(
+        self, cfg_automatic: CLIConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A zero budget means the deadline is already passed: no top-up probes are
+        # issued (so a slow endpoint can't stall PROFILE_COMPLETE), but stop still runs.
+        monkeypatch.setattr(Environment.NETWORK_LATENCY, "COMPLETE_TOPUP_TIMEOUT", 0.0)
+        manager = _make_manager(cfg_automatic)
+        collector = _StubProbeCollector(bump_per_probe=1)
+        manager._collectors = {"localhost:8000": collector}
+
+        await manager._handle_profile_complete_command(
+            ProfileCompleteCommand(
+                service_id=manager.id, command=CommandType.PROFILE_COMPLETE
+            )
+        )
+
+        assert collector.probe_calls == 0
+        collector.stop.assert_awaited_once()
+        assert manager._collectors == {}
+
+    @pytest.mark.asyncio
+    async def test_complete_is_idempotent_when_already_stopped(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager._collectors = {}
+
+        # Must not raise.
+        await manager._handle_profile_complete_command(
+            ProfileCompleteCommand(
+                service_id=manager.id, command=CommandType.PROFILE_COMPLETE
+            )
+        )
+
+
+class TestProfileCancelAndStop:
+    @pytest.mark.asyncio
+    async def test_cancel_stops_all_collectors(self, cfg_automatic: CLIConfig) -> None:
+        manager = _make_manager(cfg_automatic)
+        collector = AsyncMock()
+        manager._collectors = {"localhost:8000": collector}
+
+        await manager._handle_profile_cancel_command(
+            ProfileCancelCommand(
+                service_id=manager.id, command=CommandType.PROFILE_CANCEL
+            )
+        )
+
+        collector.stop.assert_awaited_once()
+        assert manager._collectors == {}
+
+    @pytest.mark.asyncio
+    async def test_on_stop_hook_stops_all_collectors(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        collector = AsyncMock()
+        manager._collectors = {"localhost:8000": collector}
+
+        await manager._network_latency_manager_stop()
+
+        collector.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_all_collectors_tolerates_stop_failure(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        collector = AsyncMock()
+        collector.stop.side_effect = RuntimeError("stop boom")
+        manager._collectors = {"localhost:8000": collector}
+
+        # Must not raise; collectors cleared.
+        await manager._stop_all_collectors()
+        assert manager._collectors == {}
+
+    @pytest.mark.asyncio
+    async def test_stop_all_collectors_noop_when_empty(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager._collectors = {}
+        await manager._stop_all_collectors()
+
+    @pytest.mark.asyncio
+    async def test_delayed_shutdown_sleeps_then_stops(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager.stop = AsyncMock()
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("asyncio.shield", new_callable=AsyncMock) as mock_shield,
+        ):
+            await manager._delayed_shutdown()
+
+        mock_sleep.assert_awaited_once()
+        mock_shield.assert_awaited_once()
+
+
+class TestSampleAndErrorCallbacks:
+    """Sample/error callbacks push NetworkLatencyRecordMessage to RECORDS."""
+
+    @pytest.mark.asyncio
+    async def test_sample_callback_pushes_record_message(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager.records_push_client.push = AsyncMock()
+
+        sample = _success_sample()
+        await manager._on_network_latency_samples([sample], "localhost:8000")
+
+        manager.records_push_client.push.assert_awaited_once()
+        message = manager.records_push_client.push.call_args[0][0]
+        assert isinstance(message, NetworkLatencyRecordMessage)
+        assert message.sample == sample
+        assert message.collector_id == "localhost:8000"
+        assert message.error is None
+
+    @pytest.mark.asyncio
+    async def test_sample_callback_empty_list_pushes_nothing(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager.records_push_client.push = AsyncMock()
+
+        await manager._on_network_latency_samples([], "localhost:8000")
+
+        manager.records_push_client.push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sample_callback_push_failure_falls_back_to_error_message(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        # First push (sample) fails; fallback push (error) succeeds.
+        manager.records_push_client.push = AsyncMock(
+            side_effect=[RuntimeError("push boom"), None]
+        )
+
+        await manager._on_network_latency_samples([_success_sample()], "localhost:8000")
+
+        assert manager.records_push_client.push.await_count == 2
+        fallback = manager.records_push_client.push.call_args_list[1][0][0]
+        assert isinstance(fallback, NetworkLatencyRecordMessage)
+        assert fallback.sample is None
+        assert fallback.error is not None
+
+    @pytest.mark.asyncio
+    async def test_sample_callback_nested_failure_does_not_raise(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager.records_push_client.push = AsyncMock(
+            side_effect=RuntimeError("always fails")
+        )
+
+        # Both the sample push and the error fallback push fail; must not raise.
+        await manager._on_network_latency_samples([_success_sample()], "localhost:8000")
+        assert manager.records_push_client.push.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_error_callback_pushes_error_message(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager.records_push_client.push = AsyncMock()
+
+        error = ErrorDetails.from_exception(ConnectionRefusedError("refused"))
+        await manager._on_network_latency_error(error, "localhost:8000")
+
+        manager.records_push_client.push.assert_awaited_once()
+        message = manager.records_push_client.push.call_args[0][0]
+        assert isinstance(message, NetworkLatencyRecordMessage)
+        assert message.sample is None
+        assert message.error == error
+
+    @pytest.mark.asyncio
+    async def test_error_callback_push_failure_does_not_raise(
+        self, cfg_automatic: CLIConfig
+    ) -> None:
+        manager = _make_manager(cfg_automatic)
+        manager.records_push_client.push = AsyncMock(
+            side_effect=RuntimeError("push boom")
+        )
+
+        error = ErrorDetails.from_exception(ConnectionRefusedError("refused"))
+        # Must not raise.
+        await manager._on_network_latency_error(error, "localhost:8000")

--- a/tests/unit/network_latency/test_probe_branches.py
+++ b/tests/unit/network_latency/test_probe_branches.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Branch/error-path coverage for NetworkLatencyProbeCollector.
+
+Complements ``test_probe_collector.py`` (success/failure sampling) by covering
+``resolve()`` (success + failure), the ``ping_interval`` property, the
+``_probe_loop`` background tick, the writer-close OSError branch, and the nested
+error-callback failure isolation in ``_send_sample``.
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aiperf.network_latency.probe import NetworkLatencyProbeCollector
+
+
+def _make_collector(**overrides) -> NetworkLatencyProbeCollector:
+    kwargs = dict(
+        target_url="http://localhost:8000/v1/chat/completions",
+        target_host="localhost",
+        target_port=8000,
+        ping_interval=0.05,
+        connect_timeout=1.0,
+        collector_id="localhost:8000",
+    )
+    kwargs.update(overrides)
+    return NetworkLatencyProbeCollector(**kwargs)
+
+
+class TestPingIntervalProperty:
+    def test_ping_interval_reports_configured_value(self) -> None:
+        collector = _make_collector(ping_interval=0.25)
+        assert collector.ping_interval == 0.25
+
+
+class TestResolve:
+    @pytest.mark.asyncio
+    async def test_resolve_success_caches_resolved_address(self) -> None:
+        collector = _make_collector()
+        sockaddr = ("127.0.0.1", 8000)
+        infos = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", sockaddr)]
+
+        with patch("asyncio.get_running_loop") as mock_get_loop:
+            mock_loop = MagicMock()
+            mock_loop.getaddrinfo = AsyncMock(return_value=infos)
+            mock_get_loop.return_value = mock_loop
+
+            await collector.resolve()
+
+        assert collector._resolved_host == "127.0.0.1"
+        assert collector._resolved_family == socket.AF_INET
+
+    @pytest.mark.asyncio
+    async def test_resolve_empty_infos_keeps_original_host(self) -> None:
+        collector = _make_collector()
+
+        with patch("asyncio.get_running_loop") as mock_get_loop:
+            mock_loop = MagicMock()
+            mock_loop.getaddrinfo = AsyncMock(return_value=[])
+            mock_get_loop.return_value = mock_loop
+
+            await collector.resolve()
+
+        # No infos returned -> falls back to the original host.
+        assert collector._resolved_host == "localhost"
+
+    @pytest.mark.asyncio
+    async def test_resolve_oserror_is_non_fatal(self) -> None:
+        collector = _make_collector()
+
+        with patch("asyncio.get_running_loop") as mock_get_loop:
+            mock_loop = MagicMock()
+            mock_loop.getaddrinfo = AsyncMock(side_effect=OSError("dns failure"))
+            mock_get_loop.return_value = mock_loop
+
+            # Must not raise; host stays the original for per-connect resolution.
+            await collector.resolve()
+
+        assert collector._resolved_host == "localhost"
+
+
+class TestProbeLoop:
+    @pytest.mark.asyncio
+    async def test_probe_loop_fires_probe_once(self) -> None:
+        collector = _make_collector()
+        collector.probe_once = MagicMock(return_value=AsyncMock()())
+        collector.execute_async = MagicMock()
+
+        await collector._probe_loop()
+
+        collector.execute_async.assert_called_once()
+
+
+class TestWriterCloseError:
+    @pytest.mark.asyncio
+    async def test_writer_close_oserror_still_records_success(self) -> None:
+        """A failure closing the probe socket must not void a successful handshake."""
+        recorded = []
+
+        async def record_callback(samples, collector_id):
+            recorded.extend(samples)
+
+        collector = _make_collector(record_callback=record_callback)
+
+        reader = MagicMock()
+        writer = MagicMock()
+        writer.close = MagicMock(side_effect=OSError("close failed"))
+        writer.wait_closed = AsyncMock()
+
+        with patch(
+            "aiperf.network_latency.probe.asyncio.open_connection",
+            AsyncMock(return_value=(reader, writer)),
+        ):
+            await collector.probe_once()
+
+        assert len(recorded) == 1
+        assert recorded[0].success is True
+        assert recorded[0].rtt_ns is not None
+        assert collector.successful_samples == 1
+
+
+class TestSendSampleNestedCallbackFailure:
+    @pytest.mark.asyncio
+    async def test_record_and_error_callback_both_fail_does_not_raise(self) -> None:
+        """When both record and error callbacks raise, errors are isolated."""
+
+        async def failing_record_callback(samples, collector_id):
+            raise RuntimeError("record boom")
+
+        async def failing_error_callback(error, collector_id):
+            raise RuntimeError("error boom")
+
+        collector = _make_collector(
+            record_callback=failing_record_callback,
+            error_callback=failing_error_callback,
+        )
+
+        with patch(
+            "aiperf.network_latency.probe.asyncio.open_connection",
+            AsyncMock(return_value=(MagicMock(), MagicMock(wait_closed=AsyncMock()))),
+        ):
+            # Must not raise despite both callbacks failing.
+            await collector.probe_once()

--- a/tests/unit/network_latency/test_probe_collector.py
+++ b/tests/unit/network_latency/test_probe_collector.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for NetworkLatencyProbeCollector.probe_once error isolation + sampling.
+
+The probe opens a fresh ``asyncio.open_connection`` per probe; these tests patch
+that call so the handshake "succeeds" or "fails" deterministically without a real
+socket. Every probe must produce exactly one NetworkLatencySample and never raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aiperf.common.models import NetworkLatencySample
+from aiperf.network_latency.probe import NetworkLatencyProbeCollector
+
+
+def _make_collector(record_callback) -> NetworkLatencyProbeCollector:
+    return NetworkLatencyProbeCollector(
+        target_url="http://localhost:8000/v1/chat/completions",
+        target_host="localhost",
+        target_port=8000,
+        ping_interval=0.05,
+        connect_timeout=1.0,
+        record_callback=record_callback,
+        collector_id="localhost:8000",
+    )
+
+
+def _mock_open_connection_success():
+    """Return an AsyncMock standing in for a successful open_connection."""
+    reader = MagicMock()
+    writer = MagicMock()
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+    return AsyncMock(return_value=(reader, writer))
+
+
+class TestProbeOnceSuccess:
+    @pytest.mark.asyncio
+    async def test_successful_handshake_records_positive_rtt(self) -> None:
+        recorded: list[NetworkLatencySample] = []
+
+        async def record_callback(samples, collector_id):
+            recorded.extend(samples)
+
+        collector = _make_collector(record_callback)
+
+        with patch(
+            "aiperf.network_latency.probe.asyncio.open_connection",
+            _mock_open_connection_success(),
+        ):
+            await collector.probe_once()
+
+        assert len(recorded) == 1
+        sample = recorded[0]
+        assert sample.success is True
+        assert sample.rtt_ns is not None
+        assert sample.rtt_ns > 0
+        assert sample.error is None
+        assert sample.target_host == "localhost"
+        assert sample.target_port == 8000
+        assert sample.probe_type == "tcp_connect"
+        assert collector.successful_samples == 1
+
+    @pytest.mark.asyncio
+    async def test_successful_handshake_closes_writer(self) -> None:
+        async def record_callback(samples, collector_id):
+            pass
+
+        collector = _make_collector(record_callback)
+        open_conn = _mock_open_connection_success()
+        _reader, writer = open_conn.return_value
+
+        with patch("aiperf.network_latency.probe.asyncio.open_connection", open_conn):
+            await collector.probe_once()
+
+        writer.close.assert_called_once()
+        writer.wait_closed.assert_awaited_once()
+
+
+class TestProbeOnceFailure:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ConnectionRefusedError("refused"),
+            asyncio.TimeoutError(),
+            OSError("network unreachable"),
+        ],
+    )  # fmt: skip
+    @pytest.mark.asyncio
+    async def test_failed_handshake_records_failed_sample_without_raising(
+        self, exc: BaseException
+    ) -> None:
+        recorded: list[NetworkLatencySample] = []
+
+        async def record_callback(samples, collector_id):
+            recorded.extend(samples)
+
+        collector = _make_collector(record_callback)
+
+        with patch(
+            "aiperf.network_latency.probe.asyncio.open_connection",
+            AsyncMock(side_effect=exc),
+        ):
+            await collector.probe_once()
+
+        assert len(recorded) == 1
+        sample = recorded[0]
+        assert sample.success is False
+        assert sample.rtt_ns is None
+        assert sample.error is not None
+        assert collector.successful_samples == 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_wrapped_failure_records_failed_sample(self) -> None:
+        """A handshake that outlives connect_timeout becomes a failed sample."""
+        recorded: list[NetworkLatencySample] = []
+
+        async def record_callback(samples, collector_id):
+            recorded.extend(samples)
+
+        collector = NetworkLatencyProbeCollector(
+            target_url="http://localhost:8000/v1",
+            target_host="localhost",
+            target_port=8000,
+            ping_interval=0.05,
+            connect_timeout=0.01,
+            record_callback=record_callback,
+            collector_id="localhost:8000",
+        )
+
+        with patch(
+            "aiperf.network_latency.probe.asyncio.wait_for",
+            AsyncMock(side_effect=asyncio.TimeoutError()),
+        ):
+            await collector.probe_once()
+
+        assert len(recorded) == 1
+        assert recorded[0].success is False
+        assert recorded[0].rtt_ns is None
+        assert recorded[0].error is not None
+
+
+class TestProbeOnceCallbackIsolation:
+    @pytest.mark.asyncio
+    async def test_record_callback_error_is_routed_to_error_callback(self) -> None:
+        errors = []
+
+        async def failing_record_callback(samples, collector_id):
+            raise RuntimeError("callback boom")
+
+        async def error_callback(error, collector_id):
+            errors.append(error)
+
+        collector = NetworkLatencyProbeCollector(
+            target_url="http://localhost:8000/v1",
+            target_host="localhost",
+            target_port=8000,
+            ping_interval=0.05,
+            connect_timeout=1.0,
+            record_callback=failing_record_callback,
+            error_callback=error_callback,
+            collector_id="localhost:8000",
+        )
+
+        with patch(
+            "aiperf.network_latency.probe.asyncio.open_connection",
+            _mock_open_connection_success(),
+        ):
+            await collector.probe_once()
+
+        assert len(errors) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_record_callback_does_not_raise(self) -> None:
+        collector = NetworkLatencyProbeCollector(
+            target_url="http://localhost:8000/v1",
+            target_host="localhost",
+            target_port=8000,
+            ping_interval=0.05,
+            connect_timeout=1.0,
+            record_callback=None,
+            collector_id="localhost:8000",
+        )
+
+        with patch(
+            "aiperf.network_latency.probe.asyncio.open_connection",
+            _mock_open_connection_success(),
+        ):
+            await collector.probe_once()
+
+        assert collector.successful_samples == 1

--- a/tests/unit/post_processors/test_network_adjusted_metrics.py
+++ b/tests/unit/post_processors/test_network_adjusted_metrics.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the network-RTT-adjusted metric injection in MetricResultsProcessor.
+
+These tests exercise the real MetricRegistry (not the mocked one) so that the
+registered ``network_adjusted_*`` / ``network_rtt`` classes resolve and flow
+through the normal ``_create_metric_result`` / ``to_display_unit`` path.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aiperf.common.models import MetricResult
+from aiperf.metrics.metric_dicts import MetricArray
+from aiperf.metrics.metric_registry import MetricRegistry
+from aiperf.metrics.types.network_adjusted_metrics import (
+    NETWORK_ADJUSTED_SOURCES,
+    NetworkRttMetric,
+)
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+from aiperf.metrics.types.time_to_first_output_token_metric import (
+    TimeToFirstOutputTokenMetric,
+)
+from aiperf.metrics.types.ttft_metric import TTFTMetric
+from aiperf.post_processors.metric_results_processor import MetricResultsProcessor
+
+_PERCENTILE_ATTRS = ("p1", "p5", "p10", "p25", "p50", "p75", "p90", "p95", "p99")
+_SHIFT_ATTRS = ("min", "max", "avg", *_PERCENTILE_ATTRS)
+
+# Known request_latency distribution in nanoseconds (1ms .. 10ms).
+_REQUEST_LATENCY_NS = [
+    1_000_000.0,
+    2_000_000.0,
+    3_000_000.0,
+    4_000_000.0,
+    5_000_000.0,
+    6_000_000.0,
+    7_000_000.0,
+    8_000_000.0,
+    9_000_000.0,
+    10_000_000.0,
+]
+
+
+def _seed_array(processor: MetricResultsProcessor, tag: str, values_ns) -> None:
+    """Seed a MetricArray of nanosecond values into the processor results dict."""
+    array = MetricArray()
+    array.extend(values_ns)
+    processor._results[tag] = array
+
+
+def _results_by_tag(results: list[MetricResult]) -> dict[str, MetricResult]:
+    return {r.tag: r for r in results}
+
+
+class TestNetworkAdjustedShift:
+    """The adjustment subtracts a constant RTT, shifting every quantile uniformly."""
+
+    @pytest.mark.asyncio
+    async def test_adjusted_request_latency_every_stat_shifts_by_rtt(
+        self, mock_run
+    ) -> None:
+        rtt_ns = 500_000.0  # 0.5 ms, below the minimum sample so no clamping
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        processor.set_network_rtt_ns(rtt_ns)
+
+        results = _results_by_tag(await processor.summarize())
+
+        raw = results[RequestLatencyMetric.tag]
+        adjusted = results["network_adjusted_request_latency"]
+        rtt_ms = rtt_ns / 1e6
+
+        for attr in _SHIFT_ATTRS:
+            assert getattr(adjusted, attr) == pytest.approx(
+                getattr(raw, attr) - rtt_ms
+            ), f"{attr} did not shift by exactly rtt_ms"
+
+    @pytest.mark.asyncio
+    async def test_adjusted_request_latency_std_unchanged(self, mock_run) -> None:
+        rtt_ns = 500_000.0
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        processor.set_network_rtt_ns(rtt_ns)
+
+        results = _results_by_tag(await processor.summarize())
+
+        assert results["network_adjusted_request_latency"].std == pytest.approx(
+            results[RequestLatencyMetric.tag].std
+        )
+
+    @pytest.mark.asyncio
+    async def test_adjusted_count_matches_source(self, mock_run) -> None:
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        processor.set_network_rtt_ns(500_000.0)
+
+        results = _results_by_tag(await processor.summarize())
+
+        assert (
+            results["network_adjusted_request_latency"].count
+            == results[RequestLatencyMetric.tag].count
+            == len(_REQUEST_LATENCY_NS)
+        )
+
+
+class TestNetworkAdjustedClamp:
+    """RTT larger than some samples clamps the adjusted distribution at 0."""
+
+    @pytest.mark.asyncio
+    async def test_rtt_exceeds_some_samples_floors_at_zero(self, mock_run) -> None:
+        # RTT of 3.5 ms exceeds the three smallest samples (1, 2, 3 ms).
+        rtt_ns = 3_500_000.0
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        processor.set_network_rtt_ns(rtt_ns)
+
+        results = _results_by_tag(await processor.summarize())
+        adjusted = results["network_adjusted_request_latency"]
+
+        for attr in _SHIFT_ATTRS:
+            assert getattr(adjusted, attr) >= 0.0, f"{attr} went negative after clamp"
+        assert adjusted.min == pytest.approx(0.0)
+        assert adjusted.p1 == pytest.approx(0.0)
+
+
+class TestNetworkAdjustedInterTokenInvariance:
+    """The headline property: ITL is network-invariant and must NOT be adjusted."""
+
+    @pytest.mark.asyncio
+    async def test_no_network_adjusted_inter_token_latency_tag_emitted(
+        self, mock_run
+    ) -> None:
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        _seed_array(processor, TTFTMetric.tag, [v / 2 for v in _REQUEST_LATENCY_NS])
+        processor.set_network_rtt_ns(500_000.0)
+
+        tags = {r.tag for r in await processor.summarize()}
+
+        assert "network_adjusted_inter_token_latency" not in tags
+        assert "network_adjusted_inter_chunk_latency" not in tags
+
+    @pytest.mark.asyncio
+    async def test_itl_algebraically_cancels_rtt(self, mock_run) -> None:
+        """ITL = request_latency - ttft, so the subtracted RTT cancels exactly."""
+        rtt_ns = 500_000.0
+        ttft_ns = [v / 2 for v in _REQUEST_LATENCY_NS]
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        _seed_array(processor, TTFTMetric.tag, ttft_ns)
+        processor.set_network_rtt_ns(rtt_ns)
+
+        results = _results_by_tag(await processor.summarize())
+
+        adj_rl = results["network_adjusted_request_latency"].avg
+        adj_ttft = results["network_adjusted_time_to_first_token"].avg
+        raw_rl = results[RequestLatencyMetric.tag].avg
+        raw_ttft = results[TTFTMetric.tag].avg
+
+        assert (adj_rl - adj_ttft) == pytest.approx(raw_rl - raw_ttft)
+
+
+class TestNetworkAdjustedNonDestructive:
+    """Setting the RTT must never mutate the raw source metric results."""
+
+    @pytest.mark.asyncio
+    async def test_raw_metrics_identical_with_and_without_rtt(self, mock_run) -> None:
+        ttft_ns = [v / 2 for v in _REQUEST_LATENCY_NS]
+
+        baseline = MetricResultsProcessor(mock_run)
+        _seed_array(baseline, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        _seed_array(baseline, TTFTMetric.tag, ttft_ns)
+        baseline_results = _results_by_tag(await baseline.summarize())
+
+        adjusted = MetricResultsProcessor(mock_run)
+        _seed_array(adjusted, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        _seed_array(adjusted, TTFTMetric.tag, ttft_ns)
+        adjusted.set_network_rtt_ns(500_000.0)
+        adjusted_results = _results_by_tag(await adjusted.summarize())
+
+        for tag in (RequestLatencyMetric.tag, TTFTMetric.tag):
+            for attr in (*_SHIFT_ATTRS, "std", "count", "sum"):
+                assert getattr(adjusted_results[tag], attr) == pytest.approx(
+                    getattr(baseline_results[tag], attr)
+                ), f"raw {tag}.{attr} was mutated by RTT injection"
+
+    @pytest.mark.asyncio
+    async def test_source_array_object_not_mutated_in_place(self, mock_run) -> None:
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        original = np.array(processor._results[RequestLatencyMetric.tag].data)
+        processor.set_network_rtt_ns(500_000.0)
+
+        await processor.summarize()
+
+        np.testing.assert_array_equal(
+            processor._results[RequestLatencyMetric.tag].data, original
+        )
+
+
+class TestNetworkAdjustedNoOp:
+    """No RTT set means no adjusted metrics are emitted."""
+
+    @pytest.mark.asyncio
+    async def test_rtt_never_set_emits_no_adjusted_rows(self, mock_run) -> None:
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+
+        tags = {r.tag for r in await processor.summarize()}
+
+        assert not any(tag.startswith("network_adjusted_") for tag in tags)
+        assert NetworkRttMetric.tag not in tags
+
+    @pytest.mark.asyncio
+    async def test_set_rtt_none_emits_no_adjusted_rows(self, mock_run) -> None:
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        processor.set_network_rtt_ns(None)
+
+        tags = {r.tag for r in await processor.summarize()}
+
+        assert not any(tag.startswith("network_adjusted_") for tag in tags)
+        assert NetworkRttMetric.tag not in tags
+
+
+class TestNetworkRttSummary:
+    """The network_rtt summary row reports the subtracted RTT in display units (ms)."""
+
+    @pytest.mark.asyncio
+    async def test_network_rtt_row_present_with_avg_in_ms(self, mock_run) -> None:
+        rtt_ns = 750_000.0
+        processor = MetricResultsProcessor(mock_run)
+        _seed_array(processor, RequestLatencyMetric.tag, _REQUEST_LATENCY_NS)
+        processor.set_network_rtt_ns(rtt_ns)
+
+        results = _results_by_tag(await processor.summarize())
+
+        assert NetworkRttMetric.tag in results
+        net_rtt = results[NetworkRttMetric.tag]
+        assert net_rtt.unit == "ms"
+        assert net_rtt.avg == pytest.approx(rtt_ns / 1e6)
+
+
+class TestNetworkAdjustedRegistry:
+    """All injected tags must be registered in the real MetricRegistry."""
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "network_adjusted_request_latency",
+            "network_adjusted_time_to_first_token",
+            "network_adjusted_time_to_first_output_token",
+            "network_rtt",
+        ],
+    )
+    def test_tag_resolves_in_registry(self, tag: str) -> None:
+        assert tag in MetricRegistry.all_tags()
+        assert MetricRegistry.get_class(tag).tag == tag
+
+    def test_time_to_second_token_is_not_adjusted(self) -> None:
+        # TTST is an intra-stream gap (second_response - first_response), not
+        # request-start-anchored, so it does not carry the network RTT.
+        assert "network_adjusted_time_to_second_token" not in MetricRegistry.all_tags()
+        assert "network_adjusted_time_to_second_token" not in NETWORK_ADJUSTED_SOURCES
+
+    def test_network_adjusted_sources_map_to_registered_metrics(self) -> None:
+        expected = {
+            "network_adjusted_request_latency": RequestLatencyMetric.tag,
+            "network_adjusted_time_to_first_token": TTFTMetric.tag,
+            "network_adjusted_time_to_first_output_token": (
+                TimeToFirstOutputTokenMetric.tag
+            ),
+        }
+        assert expected == NETWORK_ADJUSTED_SOURCES
+        for adjusted_tag, source_tag in NETWORK_ADJUSTED_SOURCES.items():
+            assert adjusted_tag in MetricRegistry.all_tags()
+            assert source_tag in MetricRegistry.all_tags()

--- a/tests/unit/property/_numeric_bounds_baseline.txt
+++ b/tests/unit/property/_numeric_bounds_baseline.txt
@@ -255,6 +255,7 @@ MooncakeTrace.input_length: numeric field has no ge/gt/le/lt bound and is not Fi
 MooncakeTrace.output_length: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 MooncakeTrace.timestamp: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 NewTokensPerTurnConfig.mu: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
+NetworkLatencyRecordMessage.request_ns: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 PercentileStats.count: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 PercentileStats.mean: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.
 PercentileStats.median: numeric field has no ge/gt/le/lt bound and is not FiniteFloat. Add a Pydantic numeric constraint, annotate as FiniteFloat, or add to NUMERIC_BOUNDS_WHITELIST.

--- a/tests/unit/records/test_records_manager.py
+++ b/tests/unit/records/test_records_manager.py
@@ -855,6 +855,7 @@ class TestRecordsManagerEfficiencyMetricsSnapshot:
         manager.run = MagicMock()
         manager.run.cfg.gpu_telemetry_disabled = True
         manager.run.cfg.server_metrics_disabled = True
+        manager.run.cfg.network_latency.enabled = False
 
         request_records = [
             MetricResult(tag="request_latency", header="h", unit="ms", avg=1.0),
@@ -936,6 +937,7 @@ class TestRecordsManagerEfficiencyMetricsDegeneratePhase:
         manager.run = MagicMock()
         manager.run.cfg.gpu_telemetry_disabled = True
         manager.run.cfg.server_metrics_disabled = True
+        manager.run.cfg.network_latency.enabled = False
 
         request_records = [
             MetricResult(tag="request_latency", header="h", unit="ms", avg=1.0),
@@ -992,6 +994,7 @@ class TestRecordsManagerEfficiencyMetricsDegeneratePhase:
         manager.run = MagicMock()
         manager.run.cfg.gpu_telemetry_disabled = True
         manager.run.cfg.server_metrics_disabled = True
+        manager.run.cfg.network_latency.enabled = False
 
         processor = MagicMock()
         processor.summarize = AsyncMock(return_value=[])

--- a/tests/unit/records/test_records_manager_network_latency.py
+++ b/tests/unit/records/test_records_manager_network_latency.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the network-latency handler + RTT delivery in RecordsManager.
+
+Mirrors the ``RecordsManager.__new__(RecordsManager)`` dispatch-test pattern in
+``test_records_manager.py``: only the attributes a method touches are populated,
+so each method is exercised in isolation without spinning up the full service.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiperf.common.messages import NetworkLatencyRecordMessage
+from aiperf.common.models import ErrorDetails, NetworkLatencySample
+from aiperf.records.records_manager import ErrorTrackingState, RecordsManager
+
+
+def _sample(rtt_ns: int = 1_500_000, success: bool = True) -> NetworkLatencySample:
+    return NetworkLatencySample(
+        timestamp_ns=1_000,
+        target_url="http://localhost:8000/v1/chat",
+        target_host="localhost",
+        target_port=8000,
+        probe_type="tcp_connect",
+        rtt_ns=rtt_ns if success else None,
+        success=success,
+    )
+
+
+class TestOnNetworkLatencyRecords:
+    @pytest.mark.asyncio
+    async def test_valid_sample_accumulates_and_forwards(self) -> None:
+        manager = RecordsManager.__new__(RecordsManager)
+        manager._network_latency_accumulator = MagicMock()
+        manager._send_network_latency_to_results_processors = AsyncMock()
+
+        sample = _sample()
+        message = NetworkLatencyRecordMessage(
+            service_id="net-mgr", collector_id="localhost:8000", sample=sample
+        )
+
+        await manager._on_network_latency_records(message)
+
+        manager._network_latency_accumulator.add_sample.assert_called_once_with(sample)
+        manager._send_network_latency_to_results_processors.assert_awaited_once_with(
+            sample
+        )
+
+    @pytest.mark.asyncio
+    async def test_valid_sample_without_accumulator_still_forwards(self) -> None:
+        manager = RecordsManager.__new__(RecordsManager)
+        manager._network_latency_accumulator = None
+        manager._send_network_latency_to_results_processors = AsyncMock()
+
+        sample = _sample()
+        await manager._on_network_latency_records(
+            NetworkLatencyRecordMessage(
+                service_id="net-mgr", collector_id="localhost:8000", sample=sample
+            )
+        )
+
+        manager._send_network_latency_to_results_processors.assert_awaited_once_with(
+            sample
+        )
+
+    @pytest.mark.asyncio
+    async def test_error_message_increments_error_count_and_does_not_forward(
+        self,
+    ) -> None:
+        manager = RecordsManager.__new__(RecordsManager)
+        manager._network_latency_accumulator = MagicMock()
+        manager._network_latency_state = ErrorTrackingState()
+        manager._send_network_latency_to_results_processors = AsyncMock()
+
+        error = ErrorDetails.from_exception(ConnectionRefusedError("refused"))
+        message = NetworkLatencyRecordMessage(
+            service_id="net-mgr",
+            collector_id="localhost:8000",
+            sample=None,
+            error=error,
+        )
+
+        await manager._on_network_latency_records(message)
+
+        assert manager._network_latency_state.error_counts[error] == 1
+        manager._network_latency_accumulator.add_sample.assert_not_called()
+        manager._send_network_latency_to_results_processors.assert_not_awaited()
+
+
+class TestSendNetworkLatencyToResultsProcessors:
+    @pytest.mark.asyncio
+    async def test_empty_processor_list_is_noop(self) -> None:
+        manager = RecordsManager.__new__(RecordsManager)
+        manager._network_latency_processors = []
+        manager.exception = MagicMock()
+
+        await manager._send_network_latency_to_results_processors(_sample())
+
+        manager.exception.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_forwards_sample_to_each_processor(self) -> None:
+        manager = RecordsManager.__new__(RecordsManager)
+        p1 = MagicMock()
+        p1.process_network_latency_sample = AsyncMock()
+        p2 = MagicMock()
+        p2.process_network_latency_sample = AsyncMock()
+        manager._network_latency_processors = [p1, p2]
+        manager.exception = MagicMock()
+
+        sample = _sample()
+        await manager._send_network_latency_to_results_processors(sample)
+
+        p1.process_network_latency_sample.assert_awaited_once_with(sample)
+        p2.process_network_latency_sample.assert_awaited_once_with(sample)
+        manager.exception.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_processor_failure_is_tracked_not_raised(self) -> None:
+        manager = RecordsManager.__new__(RecordsManager)
+        ok = MagicMock()
+        ok.process_network_latency_sample = AsyncMock()
+        failing = MagicMock()
+        failing.process_network_latency_sample = AsyncMock(
+            side_effect=RuntimeError("processor boom")
+        )
+        manager._network_latency_processors = [ok, failing]
+        manager._network_latency_state = ErrorTrackingState()
+        manager.exception = MagicMock()
+
+        # Must not raise.
+        await manager._send_network_latency_to_results_processors(_sample())
+
+        manager.exception.assert_called_once()
+        assert sum(manager._network_latency_state.error_counts.values()) == 1
+
+
+class TestDeliverNetworkRttToProcessors:
+    def _make_manager(self, network_cfg) -> RecordsManager:
+        manager = RecordsManager.__new__(RecordsManager)
+        manager.run = SimpleNamespace(cfg=SimpleNamespace(network_latency=network_cfg))
+        manager.notice = MagicMock()
+        manager.warning = MagicMock()
+        manager._network_latency_accumulator = None
+        manager._metric_results_processors = []
+        return manager
+
+    def test_disabled_is_noop(self) -> None:
+        processor = MagicMock()
+        manager = self._make_manager(SimpleNamespace(enabled=False, mean_ms=None))
+        manager._metric_results_processors = [processor]
+
+        manager._deliver_network_rtt_to_processors()
+
+        processor.set_network_rtt_ns.assert_not_called()
+        manager.notice.assert_not_called()
+
+    def test_manual_mean_sets_rtt_ns_and_logs_notice(self) -> None:
+        processor = MagicMock()
+        manager = self._make_manager(SimpleNamespace(enabled=True, mean_ms=2.5))
+        manager._metric_results_processors = [processor]
+
+        manager._deliver_network_rtt_to_processors()
+
+        # 2.5 ms -> 2.5e6 ns delivered to the processor.
+        processor.set_network_rtt_ns.assert_called_once_with(2.5 * 1e6)
+        manager.notice.assert_called_once()
+
+    def test_measured_mean_from_accumulator_sets_rtt_ns(self) -> None:
+        processor = MagicMock()
+        manager = self._make_manager(SimpleNamespace(enabled=True, mean_ms=None))
+        manager._metric_results_processors = [processor]
+        manager._network_latency_accumulator = MagicMock(
+            mean_rtt_ns=1_750_000.0, successful_sample_count=12
+        )
+
+        manager._deliver_network_rtt_to_processors()
+
+        processor.set_network_rtt_ns.assert_called_once_with(1_750_000.0)
+        manager.notice.assert_called_once()
+        manager.warning.assert_not_called()
+
+    def test_zero_successful_samples_warns_and_applies_no_adjustment(self) -> None:
+        processor = MagicMock()
+        manager = self._make_manager(SimpleNamespace(enabled=True, mean_ms=None))
+        manager._metric_results_processors = [processor]
+        manager._network_latency_accumulator = MagicMock(mean_rtt_ns=None)
+
+        manager._deliver_network_rtt_to_processors()
+
+        # No measurable RTT: warn and leave processors at their default (no injection).
+        manager.warning.assert_called_once()
+        processor.set_network_rtt_ns.assert_not_called()
+
+    def test_zero_mean_override_is_noop(self) -> None:
+        # mean_ms=0 would emit network_adjusted_* identical to the raw metrics; skip it.
+        processor = MagicMock()
+        manager = self._make_manager(SimpleNamespace(enabled=True, mean_ms=0.0))
+        manager._metric_results_processors = [processor]
+
+        manager._deliver_network_rtt_to_processors()
+
+        processor.set_network_rtt_ns.assert_not_called()
+        manager.notice.assert_not_called()
+
+    def test_processor_without_setter_is_skipped(self) -> None:
+        # A processor lacking set_network_rtt_ns must not break delivery.
+        processor = MagicMock(spec=[])
+        manager = self._make_manager(SimpleNamespace(enabled=True, mean_ms=2.5))
+        manager._metric_results_processors = [processor]
+
+        # Must not raise.
+        manager._deliver_network_rtt_to_processors()
+        manager.notice.assert_called_once()


### PR DESCRIPTION
## Summary

Opt-in **network latency calibration**: probe the endpoint's TCP-handshake RTT throughout a run and subtract the mean from the request-start-anchored latency metrics, so benchmark runs taken from different client network locations are comparable. Raw metrics are preserved; adjusted values are emitted as new `network_adjusted_*` metrics plus a `network_rtt` summary and a `profile_export_network_latency.jsonl` artifact. **Default off** — a run without the flag is byte-identical to today.

Closes ai-dynamo/aiperf#1065.

## Behavior

* `--network-latency-automatic` — opens a fresh, unpooled `asyncio.open_connection` to the endpoint host:port every `--network-latency-ping-interval` (default 1s) during profiling, recording the handshake RTT. Handshake RTT is one network round-trip with no server compute, so it isolates the network leg and is immune to server load. Probe failures are recorded and never crash the run.
* `--network-latency-mean <ms>` — supply a fixed mean RTT and skip probing. **Mutually exclusive** with `--network-latency-automatic` (automatic measures it; mean sets it).
* The subtracted RTT is logged at `notice` level, e.g. `Network latency calibration: subtracting measured mean RTT of 65.322 ms (over 31 TCP-handshake probes) ...`.
* New metrics: `network_adjusted_request_latency`, `network_adjusted_time_to_first_token`, `network_adjusted_time_to_first_output_token`, and a `network_rtt` summary.

## Why it's correct / safe

* Subtracting a run-level constant shifts the mean and **every percentile** by that constant and leaves the **standard deviation unchanged**, so it is applied post-aggregation to each source metric's array, clamped at 0.
* Only metrics anchored at the client request-send timestamp are adjusted. **Time to Second Token** (`second_response - first_response`), **ITL**, and **ICL** are intra-stream gaps that do not carry the RTT, so they are intentionally **not** adjusted (verified: subtracting equal RTT from `request_latency` and `ttft` cancels in ITL).
* Non-destructive (new tags; raw metrics unchanged), so historical runs stay comparable.

## Validation

Validated end-to-end against a real remote endpoin): every statistic (min, p1..p99, max, avg) shifts by exactly the RTT, std bit-identical, ITL/TTST adjusted variants absent, CSV places the three adjusted latencies in the request-metrics section and `Network RTT` as a single-value system metric. 100/100 requests, zero errors.

* Unit: percentile-shift correctness, stddev invariance, clamp-at-0, ITL invariance, TTST-not-adjusted, non-destructive raw metrics, automatic/mean converter mutex + config constraints, TCP-probe success/failure isolation, accumulator stats.
* Integration: end-to-end run vs the mock server asserting the artifact + adjusted metrics; baseline non-regression; manual-mean path.
* Regenerated `docs/cli-options.md`, `docs/environment-variables.md`, config schema; added a Network Latency Calibration Metrics section to `docs/metrics-reference.md`.

## Summary by CodeRabbit

* **New Features**
  * Added network latency calibration with automatic probing or a fixed RTT override.
  * Introduced network-adjusted latency metrics alongside a run-level RTT summary.
  * Added a new JSONL export for per-sample network latency measurements.
* **Bug Fixes**
  * Adjusted displayed latency metrics by subtracting measured or configured network RTT, with results clamped at zero.
  * Network latency handling now appears in CLI help and configuration documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network latency calibration for profiling runs, supporting automatic TCP-handshake RTT probing or a fixed mean RTT override, plus probe interval and sampling controls.
  * Introduced network-latency JSONL artifact export and new derived `network_adjusted_*` latency metrics with `network_rtt`.
  * Added an optional network-latency manager service and routing for RTT probe results.
* **Bug Fixes**
  * Clamped RTT-adjusted latency values at zero to prevent negative adjusted timings.
* **Documentation**
  * Updated CLI options, environment variables, and metrics reference with the new network-latency sections and flags.
* **Tests**
  * Added integration and unit coverage for probing, JSONL export, aggregation, and RTT-based metric adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->