### PR TITLE
feat: Dynamic QPS Control via JSON

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -991,6 +991,10 @@ Maximum adaptive scale control value. Inferred from the phase target when omitte
 
 SLA filter for adaptive scale. Format: 'metric_tag:stat:op:threshold'. Latency-family metrics (request_latency, time_to_first_token/ttft, inter_token_latency/itl/tpot) support percentile stats; window scalar/rate metrics (request_throughput, output_token_throughput, goodput, goodput_ratio, success_rate, error_rate, cancellation_rate) support {avg, min, max}. Full metric/stat table: [Adaptive SLA metric support](tutorials/yaml-config.md#adaptive-sla-metric-support). op in {lt, le, gt, ge}; threshold is a float. Repeatable. Example: --adaptive-scale-sla 'request_latency:p95:le:30000'.
 
+#### `--request-rate-series` `<str>`
+
+JSON file containing request-rate points for piecewise-linear request-rate control.
+
 ### Warmup
 
 #### `--warmup-request-count`, `--num-warmup-requests` `<int>`
@@ -2448,6 +2452,10 @@ Maximum adaptive scale control value. Inferred from the phase target when omitte
 #### `--adaptive-scale-sla` `<list>`
 
 SLA filter for adaptive scale. Format: 'metric_tag:stat:op:threshold'. Latency-family metrics (request_latency, time_to_first_token/ttft, inter_token_latency/itl/tpot) support percentile stats; window scalar/rate metrics (request_throughput, output_token_throughput, goodput, goodput_ratio, success_rate, error_rate, cancellation_rate) support {avg, min, max}. Full metric/stat table: [Adaptive SLA metric support](tutorials/yaml-config.md#adaptive-sla-metric-support). op in {lt, le, gt, ge}; threshold is a float. Repeatable. Example: --adaptive-scale-sla 'request_latency:p95:le:30000'.
+
+#### `--request-rate-series` `<str>`
+
+JSON file containing request-rate points for piecewise-linear request-rate control.
 
 ### Warmup
 

--- a/docs/tutorials/ramping.md
+++ b/docs/tutorials/ramping.md
@@ -321,6 +321,67 @@ Rate updates continuously (every 0.1 seconds by default):
 
 This creates smooth traffic curves without sudden jumps.
 
+### Request Rate Series (Custom Curves)
+
+For full control over the load shape, provide a JSON file with `time_s` and `qps`
+points. AIPerf linearly interpolates between points, holds the first QPS before
+the first point, and holds the last QPS after the final point.
+
+```json
+{
+  "points": [
+    {"time_s": 0, "qps": 1},
+    {"time_s": 60, "qps": 7},
+    {"time_s": 300, "qps": 65},
+    {"time_s": 600, "qps": 20},
+    {"time_s": 900, "qps": 40}
+  ]
+}
+```
+
+```bash
+aiperf profile \
+    --model your-model \
+    --url localhost:8000 \
+    --request-rate-ramp-duration 60 \
+    --request-rate-series rate.json \
+    --arrival-pattern constant \
+    --benchmark-duration 960
+```
+
+Use `--arrival-pattern constant` for the clearest match to the requested curve.
+Use `poisson` or `gamma` when you want random arrivals around the instantaneous
+QPS target. When combined with `--request-rate-ramp-duration`, AIPerf ramps to
+the first series QPS, then starts the series timeline after the ramp completes.
+
+YAML configs can also inline the same points, which is useful when the config is
+the complete deployment artifact, such as a Kubernetes `AIPerfJob` custom
+resource:
+
+```yaml
+phases:
+  - name: profiling
+    type: constant
+    duration: 960
+    rateSeries:
+      points:
+        - timeS: 0
+          qps: 1
+        - timeS: 60
+          qps: 7
+        - timeS: 300
+          qps: 65
+        - timeS: 600
+          qps: 20
+        - timeS: 900
+          qps: 40
+```
+
+The profiling series supplied by `--request-rate-series` is not inherited by an
+automatically generated warmup phase. To use a request-rate series during
+warmup, define `rateSeries` explicitly on the YAML warmup phase; that warmup
+then follows its own series timeline.
+
 ## Quick Reference
 
 | Option | Description | Default |
@@ -328,6 +389,7 @@ This creates smooth traffic curves without sudden jumps.
 | `--concurrency-ramp-duration <sec>` | Ramp session concurrency over N seconds | No ramping |
 | `--prefill-concurrency-ramp-duration <sec>` | Ramp prefill concurrency over N seconds | No ramping |
 | `--request-rate-ramp-duration <sec>` | Ramp request rate over N seconds | No ramping |
+| `--request-rate-series <path>` | Follow a JSON request-rate curve | No series |
 | `--warmup-concurrency-ramp-duration <sec>` | Warmup phase concurrency ramp | Uses main value |
 | `--warmup-prefill-concurrency-ramp-duration <sec>` | Warmup phase prefill ramp | Uses main value |
 | `--warmup-request-rate-ramp-duration <sec>` | Warmup phase rate ramp | Uses main value |
@@ -337,6 +399,7 @@ This creates smooth traffic curves without sudden jumps.
 - Request rate starts proportionally low and interpolates smoothly
 - Ramps complete exactly at the specified duration
 - After ramping, values stay at the target for the rest of the phase
+- Request-rate series starts after request-rate ramping when both are configured
 
 ## Related Documentation
 

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -66,7 +66,7 @@ def _profiling_phase_type(cli: CLIConfig) -> Any:
         return PhaseType.FIXED_SCHEDULE
     if cli.user_centric_rate is not None:
         return PhaseType.USER_CENTRIC
-    if cli.request_rate is not None:
+    if cli.request_rate is not None or cli.request_rate_series is not None:
         match cli.arrival_pattern:
             case ArrivalPattern.GAMMA:
                 return PhaseType.GAMMA
@@ -117,6 +117,23 @@ def _apply_adaptive_scale_control(prof: dict[str, Any], cli: CLIConfig) -> None:
     prof.update(control)
     prof["_adaptive_control_variable_source"] = "--adaptive-scale-control"
     prof.pop("adaptive_scale_control", None)
+
+
+def _apply_profiling_rate_series(prof: dict[str, Any], cli: CLIConfig) -> None:
+    if "request_rate_series" not in cli.model_fields_set:
+        return
+    if "request_rate" in cli.model_fields_set:
+        raise ValueError(
+            "--request-rate and --request-rate-series are mutually exclusive."
+        )
+    if cli.user_centric_rate is not None:
+        raise ValueError(
+            "--request-rate-series is not supported with --user-centric-rate."
+        )
+    from aiperf.config.rate_series import RateSeriesConfig
+
+    series = RateSeriesConfig(path=str(cli.request_rate_series))
+    prof["rate_series"] = series.model_dump(exclude_none=True, exclude={"path"})
 
 
 def _reject_orphan_load_generator_flags(prof: dict[str, Any], cli: CLIConfig) -> None:
@@ -184,6 +201,15 @@ def _reject_orphan_load_generator_flags(prof: dict[str, Any], cli: CLIConfig) ->
             "--request-rate-ramp-duration can only be used with rate-controlled "
             "scheduling (--request-rate or --user-centric-rate). Pass one of "
             "those to enable rate ramping, or drop --request-rate-ramp-duration."
+        )
+
+    if "rate_series" in prof and phase_type not in (
+        PhaseType.POISSON,
+        PhaseType.GAMMA,
+        PhaseType.CONSTANT,
+    ):
+        raise ValueError(
+            "--request-rate-series can only be used with rate-controlled scheduling."
         )
 
 
@@ -464,6 +490,7 @@ def build_profiling(cli: CLIConfig) -> dict[str, Any]:
             prof[output_key] = getattr(cli, attr_name)
 
     _apply_profiling_ramps(prof, cli)
+    _apply_profiling_rate_series(prof, cli)
 
     prof["type"] = _profiling_phase_type(cli)
     _apply_adaptive_scale_control(prof, cli)

--- a/src/aiperf/config/flags/_converter_warmup.py
+++ b/src/aiperf/config/flags/_converter_warmup.py
@@ -88,6 +88,14 @@ def _warmup_ramps(w: dict[str, Any], cli: CLIConfig, s: set[str]) -> None:
     if pr is not None:
         w["prefill_ramp"] = {"duration": pr}
     if rr is not None:
+        if "rate" not in w:
+            if "warmup_request_rate_ramp_duration" in s:
+                raise ValueError(
+                    "--warmup-request-rate-ramp-duration requires warmup "
+                    "rate-controlled scheduling. Pass --warmup-request-rate, "
+                    "or drop --warmup-request-rate-ramp-duration."
+                )
+            return
         w["rate_ramp"] = {"duration": rr}
 
 

--- a/src/aiperf/config/flags/_section_fields.py
+++ b/src/aiperf/config/flags/_section_fields.py
@@ -169,6 +169,7 @@ LOADGEN_FIELDS: frozenset[str] = frozenset(
         "request_count",
         "request_rate",
         "request_rate_ramp_duration",
+        "request_rate_series",
         "user_centric_rate",
         "warmup_arrival_pattern",
         "warmup_concurrency",

--- a/src/aiperf/config/flags/cli_config.py
+++ b/src/aiperf/config/flags/cli_config.py
@@ -2058,6 +2058,17 @@ class CLIConfig(BaseConfig):
         ),
     ] = None
 
+    request_rate_series: Annotated[
+        Path | None,
+        Field(
+            description="JSON file containing request-rate points for piecewise-linear request-rate control.",
+        ),
+        CLIParameter(
+            name=("--request-rate-series",),
+            group=Groups.LOAD_GENERATOR,
+        ),
+    ] = None
+
     ##############################################################################
     # Warmup
     ##############################################################################

--- a/src/aiperf/config/flags/resolver.py
+++ b/src/aiperf/config/flags/resolver.py
@@ -34,6 +34,7 @@ from aiperf.config.flags._section_fields import (
     OUTPUT_FIELDS,
     SWEEPING_FIELDS,
 )
+from aiperf.plugin.enums import ArrivalPattern, PhaseType
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -430,6 +431,19 @@ def _apply_phase_loadgen_overrides(merged: dict[str, Any], cli: CLIConfig) -> No
     _reject_loadgen_target_collisions(fields_set)
     apply_basic_adaptive_scale_overrides(target, cli)
 
+    if "request_rate_series" in fields_set and cli.request_rate_series is not None:
+        from aiperf.config.rate_series import RateSeriesConfig
+
+        series = RateSeriesConfig(path=str(cli.request_rate_series))
+        target["rate_series"] = series.model_dump(exclude_none=True, exclude={"path"})
+        target.pop("rate", None)
+        if "arrival_pattern" in fields_set:
+            target["type"] = {
+                ArrivalPattern.POISSON: PhaseType.POISSON,
+                ArrivalPattern.GAMMA: PhaseType.GAMMA,
+                ArrivalPattern.CONSTANT: PhaseType.CONSTANT,
+            }.get(cli.arrival_pattern, PhaseType.POISSON)
+
     for attr, key in _LOADGEN_PHASE_FIELD_MAP:
         if attr not in fields_set:
             continue
@@ -451,6 +465,8 @@ def _reject_loadgen_target_collisions(fields_set: set[str]) -> None:
     for attr, key in _LOADGEN_PHASE_FIELD_MAP:
         if attr in fields_set:
             collisions.setdefault(key, []).append(attr)
+    if "request_rate_series" in fields_set:
+        collisions.setdefault("rate", []).append("request_rate_series")
     duplicates = {k: v for k, v in collisions.items() if len(v) > 1}
     if not duplicates:
         return

--- a/src/aiperf/config/loader/dotted_path.py
+++ b/src/aiperf/config/loader/dotted_path.py
@@ -35,6 +35,7 @@ _SWEEP_PATH_ALIASES = {
     "concurrency_ramp": "phases.profiling.concurrency_ramp",
     "prefill_ramp": "phases.profiling.prefill_ramp",
     "rate_ramp": "phases.profiling.rate_ramp",
+    "rate_series": "phases.profiling.rate_series",
 }
 
 

--- a/src/aiperf/config/phases.py
+++ b/src/aiperf/config/phases.py
@@ -29,6 +29,7 @@ from aiperf.config.loader.duration import (
 )
 from aiperf.config.ramp import RampConfig, RampSpec, _normalize_ramp
 from aiperf.config.sweep.adaptive import SLAFilter
+from aiperf.config.rate_series import RateSeriesConfig
 from aiperf.plugin.enums import PhaseType, PhaseTypeStr, RampType
 
 __all__ = [
@@ -46,6 +47,7 @@ __all__ = [
     "RampConfig",
     "RampSpec",
     "RampType",
+    "RateSeriesConfig",
     "RatePhaseConfig",
     "UserCentricPhase",
     "_normalize_duration",
@@ -309,10 +311,11 @@ class RatePhaseConfig(BasePhaseConfig):
     """Base for rate-controlled phases. Not instantiated directly."""
 
     rate: Annotated[
-        float,
+        float | None,
         Field(
+            default=None,
             gt=0,
-            description="Target request rate in requests per second (must be > 0).",
+            description="Target request rate in requests per second. Required unless rate_series is set.",
         ),
     ]
 
@@ -324,6 +327,21 @@ class RatePhaseConfig(BasePhaseConfig):
             "Can be number (seconds) or {duration, strategy}.",
         ),
     ]
+
+    rate_series: Annotated[
+        RateSeriesConfig | None,
+        Field(
+            default=None,
+            description="Piecewise-linear request-rate schedule.",
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def validate_rate_source(self) -> Self:
+        """Require either a scalar rate or a rate series."""
+        if self.rate is None and self.rate_series is None:
+            raise ValueError("rate-controlled phases require rate or rate_series")
+        return self
 
 
 class PoissonPhase(RatePhaseConfig):
@@ -387,6 +405,9 @@ class UserCentricPhase(RatePhaseConfig):
     @model_validator(mode="after")
     def validate_user_centric_constraints(self) -> UserCentricPhase:
         """Validate user-centric mode constraints."""
+        if self.rate_series is not None:
+            raise ValueError("user-centric phases do not support rate_series")
+
         if self.sessions is not None and self.sessions < self.users:
             raise ValueError(
                 f"Phase '{self.name}': --num-sessions ({self.sessions}) must be "

--- a/src/aiperf/config/phases.py
+++ b/src/aiperf/config/phases.py
@@ -28,8 +28,8 @@ from aiperf.config.loader.duration import (
     _parse_duration,
 )
 from aiperf.config.ramp import RampConfig, RampSpec, _normalize_ramp
-from aiperf.config.sweep.adaptive import SLAFilter
 from aiperf.config.rate_series import RateSeriesConfig
+from aiperf.config.sweep.adaptive import SLAFilter
 from aiperf.plugin.enums import PhaseType, PhaseTypeStr, RampType
 
 __all__ = [
@@ -338,9 +338,11 @@ class RatePhaseConfig(BasePhaseConfig):
 
     @model_validator(mode="after")
     def validate_rate_source(self) -> Self:
-        """Require either a scalar rate or a rate series."""
+        """Require exactly one of a scalar rate or a rate series."""
         if self.rate is None and self.rate_series is None:
             raise ValueError("rate-controlled phases require rate or rate_series")
+        if self.rate is not None and self.rate_series is not None:
+            raise ValueError("rate and rate_series are mutually exclusive")
         return self
 
 
@@ -498,4 +500,10 @@ def get_phase_rate(phase: BasePhaseConfig) -> float | None:
     Single accessor for the ``rate`` field so a future rename fails fast here
     instead of being silently swallowed by scattered ``getattr(..., None)`` reads.
     """
-    return phase.rate if isinstance(phase, RatePhaseConfig) else None
+    if not isinstance(phase, RatePhaseConfig):
+        return None
+    if phase.rate is not None:
+        return phase.rate
+    if phase.rate_series is not None:
+        return phase.rate_series.initial_qps
+    return None

--- a/src/aiperf/config/rate_series.py
+++ b/src/aiperf/config/rate_series.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Request-rate time series configuration."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import orjson
+from pydantic import ConfigDict, Field, model_validator
+
+from aiperf.common.path_safety import safe_read_template_path
+from aiperf.config.base import BaseConfig
+
+
+class RateSeriesPoint(BaseConfig):
+    """One request-rate control point."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    time_s: float = Field(
+        ge=0.0,
+        description="Elapsed phase time in seconds for this request-rate point.",
+    )
+    qps: float = Field(
+        gt=0.0,
+        description="Request rate in queries per second at this point.",
+    )
+
+
+class RateSeriesConfig(BaseConfig):
+    """Piecewise-linear request-rate schedule."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str | None = Field(
+        default=None,
+        description="JSON file path containing request-rate control points.",
+    )
+    points: list[RateSeriesPoint] = Field(
+        default_factory=list,
+        description="Strictly increasing request-rate control points.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_shorthand(cls, data: Any) -> Any:
+        """Allow `rateSeries: path.json` and `rateSeries: [{...}, ...]` shorthand."""
+        if isinstance(data, str):
+            return {"path": data}
+        if isinstance(data, list):
+            return {"points": data}
+        return data
+
+    @model_validator(mode="after")
+    def load_path_points(self) -> RateSeriesConfig:
+        """Load JSON points when a path is supplied."""
+        if self.path is None:
+            _validate_points(self.points)
+            return self
+        if self.points:
+            raise ValueError(
+                "rate_series.path and rate_series.points are mutually exclusive"
+            )
+        self.points = read_rate_series_json(self.path)
+        self.path = None
+        return self
+
+    @property
+    def initial_qps(self) -> float:
+        """Return the first configured request rate."""
+        return self.points[0].qps
+
+
+def read_rate_series_json(path: str) -> list[RateSeriesPoint]:
+    """Read and validate a JSON request-rate series file."""
+    text = safe_read_template_path(path)
+    if text is None:
+        raise ValueError(f"Cannot read request-rate series JSON '{path}'")
+
+    try:
+        document = orjson.loads(text)
+    except orjson.JSONDecodeError as exc:
+        raise ValueError(f"Invalid request-rate series JSON '{path}'") from exc
+
+    if isinstance(document, list):
+        points_data = document
+    elif isinstance(document, dict):
+        keys = set(document)
+        if keys != {"points"}:
+            raise ValueError(
+                "Request-rate series JSON must contain exactly one top-level key: points"
+            )
+        points_data = document["points"]
+    else:
+        raise ValueError(
+            "Request-rate series JSON must be an object with points or a points array"
+        )
+
+    points: list[RateSeriesPoint] = []
+    if not isinstance(points_data, list):
+        raise ValueError("Request-rate series JSON points must be an array")
+
+    for index, point_data in enumerate(points_data):
+        try:
+            points.append(RateSeriesPoint.model_validate(point_data))
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid request-rate series point {index}: {exc}"
+            ) from exc
+
+    _validate_points(points)
+    return points
+
+
+def _validate_points(points: list[RateSeriesPoint]) -> None:
+    if len(points) < 2:
+        raise ValueError("Request-rate series requires at least two points")
+    for point in points:
+        if not math.isfinite(point.time_s) or not math.isfinite(point.qps):
+            raise ValueError("Request-rate series values must be finite")
+    previous_time = points[0].time_s
+    for point in points[1:]:
+        if point.time_s <= previous_time:
+            raise ValueError(
+                "Request-rate series time_s values must be strictly increasing"
+            )
+        previous_time = point.time_s

--- a/src/aiperf/config/rate_series.py
+++ b/src/aiperf/config/rate_series.py
@@ -21,7 +21,10 @@ class RateSeriesPoint(BaseConfig):
 
     time_s: float = Field(
         ge=0.0,
-        description="Elapsed phase time in seconds for this request-rate point.",
+        description=(
+            "Elapsed time in seconds from the start of the request-rate series, "
+            "after any request-rate ramp completes."
+        ),
     )
     qps: float = Field(
         gt=0.0,

--- a/src/aiperf/config/schema/aiperf-config.schema.json
+++ b/src/aiperf/config/schema/aiperf-config.schema.json
@@ -1567,7 +1567,7 @@
                   "type": "object",
                   "allOf": [
                     {
-                      "anyOf": [
+                      "oneOf": [
                         {
                           "required": [
                             "rate"
@@ -1954,7 +1954,7 @@
                   "type": "object",
                   "allOf": [
                     {
-                      "anyOf": [
+                      "oneOf": [
                         {
                           "required": [
                             "rate"
@@ -2327,7 +2327,7 @@
                   "type": "object",
                   "allOf": [
                     {
-                      "anyOf": [
+                      "oneOf": [
                         {
                           "required": [
                             "rate"
@@ -4372,7 +4372,7 @@
               "type": "object",
               "allOf": [
                 {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "required": [
                         "rate"
@@ -4759,7 +4759,7 @@
               "type": "object",
               "allOf": [
                 {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "required": [
                         "rate"
@@ -5132,7 +5132,7 @@
               "type": "object",
               "allOf": [
                 {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "required": [
                         "rate"
@@ -6511,7 +6511,7 @@
               "type": "object",
               "allOf": [
                 {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "required": [
                         "rate"
@@ -6898,7 +6898,7 @@
               "type": "object",
               "allOf": [
                 {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "required": [
                         "rate"
@@ -7271,7 +7271,7 @@
               "type": "object",
               "allOf": [
                 {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "required": [
                         "rate"
@@ -9222,7 +9222,7 @@
       "type": "object",
       "allOf": [
         {
-          "anyOf": [
+          "oneOf": [
             {
               "required": [
                 "rate"
@@ -11513,7 +11513,7 @@
       "type": "object",
       "allOf": [
         {
-          "anyOf": [
+          "oneOf": [
             {
               "required": [
                 "rate"
@@ -13873,7 +13873,7 @@
       "type": "object",
       "allOf": [
         {
-          "anyOf": [
+          "oneOf": [
             {
               "required": [
                 "rate"
@@ -14486,7 +14486,7 @@
       "type": "object",
       "allOf": [
         {
-          "anyOf": [
+          "oneOf": [
             {
               "required": [
                 "path"
@@ -14518,11 +14518,11 @@
       "description": "One request-rate control point.",
       "properties": {
         "timeS": {
-          "description": "Elapsed phase time in seconds for this request-rate point.",
+          "description": "Elapsed time in seconds from the start of the request-rate series, after any request-rate ramp completes.",
           "title": "Times",
           "oneOf": [
             {
-              "description": "Elapsed phase time in seconds for this request-rate point.",
+              "description": "Elapsed time in seconds from the start of the request-rate series, after any request-rate ramp completes.",
               "minimum": 0.0,
               "title": "Times",
               "type": "number"

--- a/src/aiperf/config/schema/aiperf-config.schema.json
+++ b/src/aiperf/config/schema/aiperf-config.schema.json
@@ -1522,10 +1522,18 @@
                       "type": "boolean"
                     },
                     "rate": {
-                      "description": "Target request rate in requests per second (must be > 0).",
-                      "exclusiveMinimum": 0,
-                      "title": "Rate",
-                      "type": "number"
+                      "anyOf": [
+                        {
+                          "exclusiveMinimum": 0,
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                      "title": "Rate"
                     },
                     "rateRamp": {
                       "anyOf": [
@@ -1538,14 +1546,55 @@
                       ],
                       "default": null,
                       "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                    },
+                    "rateSeries": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/RateSeriesConfig"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Piecewise-linear request-rate schedule."
                     }
                   },
                   "required": [
-                    "type",
-                    "rate"
+                    "type"
                   ],
                   "title": "PoissonPhase",
-                  "type": "object"
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "rate"
+                          ],
+                          "properties": {
+                            "rate": {
+                              "not": {
+                                "type": "null"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "required": [
+                            "rateSeries"
+                          ],
+                          "properties": {
+                            "rateSeries": {
+                              "not": {
+                                "type": "null"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
                 },
                 {
                   "additionalProperties": false,
@@ -1846,10 +1895,18 @@
                       "type": "boolean"
                     },
                     "rate": {
-                      "description": "Target request rate in requests per second (must be > 0).",
-                      "exclusiveMinimum": 0,
-                      "title": "Rate",
-                      "type": "number"
+                      "anyOf": [
+                        {
+                          "exclusiveMinimum": 0,
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                      "title": "Rate"
                     },
                     "rateRamp": {
                       "anyOf": [
@@ -1862,6 +1919,18 @@
                       ],
                       "default": null,
                       "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                    },
+                    "rateSeries": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/RateSeriesConfig"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Piecewise-linear request-rate schedule."
                     },
                     "smoothness": {
                       "anyOf": [
@@ -1879,11 +1948,40 @@
                     }
                   },
                   "required": [
-                    "type",
-                    "rate"
+                    "type"
                   ],
                   "title": "GammaPhase",
-                  "type": "object"
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "rate"
+                          ],
+                          "properties": {
+                            "rate": {
+                              "not": {
+                                "type": "null"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "required": [
+                            "rateSeries"
+                          ],
+                          "properties": {
+                            "rateSeries": {
+                              "not": {
+                                "type": "null"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
                 },
                 {
                   "additionalProperties": false,
@@ -2184,10 +2282,18 @@
                       "type": "boolean"
                     },
                     "rate": {
-                      "description": "Target request rate in requests per second (must be > 0).",
-                      "exclusiveMinimum": 0,
-                      "title": "Rate",
-                      "type": "number"
+                      "anyOf": [
+                        {
+                          "exclusiveMinimum": 0,
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                      "title": "Rate"
                     },
                     "rateRamp": {
                       "anyOf": [
@@ -2200,14 +2306,55 @@
                       ],
                       "default": null,
                       "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                    },
+                    "rateSeries": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/RateSeriesConfig"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Piecewise-linear request-rate schedule."
                     }
                   },
                   "required": [
-                    "type",
-                    "rate"
+                    "type"
                   ],
                   "title": "ConstantPhase",
-                  "type": "object"
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "rate"
+                          ],
+                          "properties": {
+                            "rate": {
+                              "not": {
+                                "type": "null"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "required": [
+                            "rateSeries"
+                          ],
+                          "properties": {
+                            "rateSeries": {
+                              "not": {
+                                "type": "null"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
                 },
                 {
                   "additionalProperties": false,
@@ -2508,10 +2655,18 @@
                       "type": "boolean"
                     },
                     "rate": {
-                      "description": "Target request rate in requests per second (must be > 0).",
-                      "exclusiveMinimum": 0,
-                      "title": "Rate",
-                      "type": "number"
+                      "anyOf": [
+                        {
+                          "exclusiveMinimum": 0,
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                      "title": "Rate"
                     },
                     "rateRamp": {
                       "anyOf": [
@@ -2534,11 +2689,25 @@
                   },
                   "required": [
                     "type",
-                    "rate",
-                    "users"
+                    "users",
+                    "rate"
                   ],
                   "title": "UserCentricPhase",
-                  "type": "object"
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "required": [
+                        "rate"
+                      ],
+                      "properties": {
+                        "rate": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 {
                   "additionalProperties": false,
@@ -4158,10 +4327,18 @@
                   "type": "boolean"
                 },
                 "rate": {
-                  "description": "Target request rate in requests per second (must be > 0).",
-                  "exclusiveMinimum": 0,
-                  "title": "Rate",
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "exclusiveMinimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                  "title": "Rate"
                 },
                 "rateRamp": {
                   "anyOf": [
@@ -4174,14 +4351,55 @@
                   ],
                   "default": null,
                   "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                },
+                "rateSeries": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/RateSeriesConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Piecewise-linear request-rate schedule."
                 }
               },
               "required": [
-                "type",
-                "rate"
+                "type"
               ],
               "title": "PoissonPhase",
-              "type": "object"
+              "type": "object",
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "rate"
+                      ],
+                      "properties": {
+                        "rate": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "rateSeries"
+                      ],
+                      "properties": {
+                        "rateSeries": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "additionalProperties": false,
@@ -4482,10 +4700,18 @@
                   "type": "boolean"
                 },
                 "rate": {
-                  "description": "Target request rate in requests per second (must be > 0).",
-                  "exclusiveMinimum": 0,
-                  "title": "Rate",
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "exclusiveMinimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                  "title": "Rate"
                 },
                 "rateRamp": {
                   "anyOf": [
@@ -4498,6 +4724,18 @@
                   ],
                   "default": null,
                   "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                },
+                "rateSeries": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/RateSeriesConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Piecewise-linear request-rate schedule."
                 },
                 "smoothness": {
                   "anyOf": [
@@ -4515,11 +4753,40 @@
                 }
               },
               "required": [
-                "type",
-                "rate"
+                "type"
               ],
               "title": "GammaPhase",
-              "type": "object"
+              "type": "object",
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "rate"
+                      ],
+                      "properties": {
+                        "rate": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "rateSeries"
+                      ],
+                      "properties": {
+                        "rateSeries": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "additionalProperties": false,
@@ -4820,10 +5087,18 @@
                   "type": "boolean"
                 },
                 "rate": {
-                  "description": "Target request rate in requests per second (must be > 0).",
-                  "exclusiveMinimum": 0,
-                  "title": "Rate",
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "exclusiveMinimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                  "title": "Rate"
                 },
                 "rateRamp": {
                   "anyOf": [
@@ -4836,14 +5111,55 @@
                   ],
                   "default": null,
                   "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                },
+                "rateSeries": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/RateSeriesConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Piecewise-linear request-rate schedule."
                 }
               },
               "required": [
-                "type",
-                "rate"
+                "type"
               ],
               "title": "ConstantPhase",
-              "type": "object"
+              "type": "object",
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "rate"
+                      ],
+                      "properties": {
+                        "rate": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "rateSeries"
+                      ],
+                      "properties": {
+                        "rateSeries": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "additionalProperties": false,
@@ -5144,10 +5460,18 @@
                   "type": "boolean"
                 },
                 "rate": {
-                  "description": "Target request rate in requests per second (must be > 0).",
-                  "exclusiveMinimum": 0,
-                  "title": "Rate",
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "exclusiveMinimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                  "title": "Rate"
                 },
                 "rateRamp": {
                   "anyOf": [
@@ -5170,11 +5494,25 @@
               },
               "required": [
                 "type",
-                "rate",
-                "users"
+                "users",
+                "rate"
               ],
               "title": "UserCentricPhase",
-              "type": "object"
+              "type": "object",
+              "allOf": [
+                {
+                  "required": [
+                    "rate"
+                  ],
+                  "properties": {
+                    "rate": {
+                      "not": {
+                        "type": "null"
+                      }
+                    }
+                  }
+                }
+              ]
             },
             {
               "additionalProperties": false,
@@ -6128,10 +6466,18 @@
                   "type": "boolean"
                 },
                 "rate": {
-                  "description": "Target request rate in requests per second (must be > 0).",
-                  "exclusiveMinimum": 0,
-                  "title": "Rate",
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "exclusiveMinimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                  "title": "Rate"
                 },
                 "rateRamp": {
                   "anyOf": [
@@ -6144,14 +6490,55 @@
                   ],
                   "default": null,
                   "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                },
+                "rateSeries": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/RateSeriesConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Piecewise-linear request-rate schedule."
                 }
               },
               "required": [
-                "type",
-                "rate"
+                "type"
               ],
               "title": "PoissonPhase",
-              "type": "object"
+              "type": "object",
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "rate"
+                      ],
+                      "properties": {
+                        "rate": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "rateSeries"
+                      ],
+                      "properties": {
+                        "rateSeries": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "additionalProperties": false,
@@ -6452,10 +6839,18 @@
                   "type": "boolean"
                 },
                 "rate": {
-                  "description": "Target request rate in requests per second (must be > 0).",
-                  "exclusiveMinimum": 0,
-                  "title": "Rate",
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "exclusiveMinimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                  "title": "Rate"
                 },
                 "rateRamp": {
                   "anyOf": [
@@ -6468,6 +6863,18 @@
                   ],
                   "default": null,
                   "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                },
+                "rateSeries": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/RateSeriesConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Piecewise-linear request-rate schedule."
                 },
                 "smoothness": {
                   "anyOf": [
@@ -6485,11 +6892,40 @@
                 }
               },
               "required": [
-                "type",
-                "rate"
+                "type"
               ],
               "title": "GammaPhase",
-              "type": "object"
+              "type": "object",
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "rate"
+                      ],
+                      "properties": {
+                        "rate": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "rateSeries"
+                      ],
+                      "properties": {
+                        "rateSeries": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "additionalProperties": false,
@@ -6790,10 +7226,18 @@
                   "type": "boolean"
                 },
                 "rate": {
-                  "description": "Target request rate in requests per second (must be > 0).",
-                  "exclusiveMinimum": 0,
-                  "title": "Rate",
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "exclusiveMinimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                  "title": "Rate"
                 },
                 "rateRamp": {
                   "anyOf": [
@@ -6806,14 +7250,55 @@
                   ],
                   "default": null,
                   "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}."
+                },
+                "rateSeries": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/RateSeriesConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Piecewise-linear request-rate schedule."
                 }
               },
               "required": [
-                "type",
-                "rate"
+                "type"
               ],
               "title": "ConstantPhase",
-              "type": "object"
+              "type": "object",
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "rate"
+                      ],
+                      "properties": {
+                        "rate": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "rateSeries"
+                      ],
+                      "properties": {
+                        "rateSeries": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "additionalProperties": false,
@@ -7114,10 +7599,18 @@
                   "type": "boolean"
                 },
                 "rate": {
-                  "description": "Target request rate in requests per second (must be > 0).",
-                  "exclusiveMinimum": 0,
-                  "title": "Rate",
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "exclusiveMinimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Target request rate in requests per second. Required unless rate_series is set.",
+                  "title": "Rate"
                 },
                 "rateRamp": {
                   "anyOf": [
@@ -7140,11 +7633,25 @@
               },
               "required": [
                 "type",
-                "rate",
-                "users"
+                "users",
+                "rate"
               ],
               "title": "UserCentricPhase",
-              "type": "object"
+              "type": "object",
+              "allOf": [
+                {
+                  "required": [
+                    "rate"
+                  ],
+                  "properties": {
+                    "rate": {
+                      "not": {
+                        "type": "null"
+                      }
+                    }
+                  }
+                }
+              ]
             },
             {
               "additionalProperties": false,
@@ -8647,14 +9154,13 @@
           "type": "boolean"
         },
         "rate": {
-          "description": "Target request rate in requests per second (must be > 0).",
-          "title": "Rate",
-          "oneOf": [
+          "anyOf": [
             {
-              "description": "Target request rate in requests per second (must be > 0).",
               "exclusiveMinimum": 0,
-              "title": "Rate",
               "type": "number"
+            },
+            {
+              "type": "null"
             },
             {
               "type": "string",
@@ -8667,6 +9173,9 @@
               "description": "Environment variable (e.g., '${VAR}' or '${VAR:default}')."
             }
           ],
+          "default": null,
+          "description": "Target request rate in requests per second. Required unless rate_series is set.",
+          "title": "Rate",
           "x-jinja2-supported": true
         },
         "rateRamp": {
@@ -8691,15 +9200,56 @@
           "default": null,
           "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}.",
           "x-jinja2-supported": true
+        },
+        "rateSeries": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateSeriesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Piecewise-linear request-rate schedule."
         }
       },
       "required": [
         "name",
-        "type",
-        "rate"
+        "type"
       ],
       "title": "ConstantPhase",
-      "type": "object"
+      "type": "object",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "rate"
+              ],
+              "properties": {
+                "rate": {
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "required": [
+                "rateSeries"
+              ],
+              "properties": {
+                "rateSeries": {
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     },
     "ConvergenceConfig": {
       "additionalProperties": false,
@@ -10870,14 +11420,13 @@
           "type": "boolean"
         },
         "rate": {
-          "description": "Target request rate in requests per second (must be > 0).",
-          "title": "Rate",
-          "oneOf": [
+          "anyOf": [
             {
-              "description": "Target request rate in requests per second (must be > 0).",
               "exclusiveMinimum": 0,
-              "title": "Rate",
               "type": "number"
+            },
+            {
+              "type": "null"
             },
             {
               "type": "string",
@@ -10890,6 +11439,9 @@
               "description": "Environment variable (e.g., '${VAR}' or '${VAR:default}')."
             }
           ],
+          "default": null,
+          "description": "Target request rate in requests per second. Required unless rate_series is set.",
+          "title": "Rate",
           "x-jinja2-supported": true
         },
         "rateRamp": {
@@ -10914,6 +11466,18 @@
           "default": null,
           "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}.",
           "x-jinja2-supported": true
+        },
+        "rateSeries": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateSeriesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Piecewise-linear request-rate schedule."
         },
         "smoothness": {
           "anyOf": [
@@ -10943,11 +11507,40 @@
       },
       "required": [
         "name",
-        "type",
-        "rate"
+        "type"
       ],
       "title": "GammaPhase",
-      "type": "object"
+      "type": "object",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "rate"
+              ],
+              "properties": {
+                "rate": {
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "required": [
+                "rateSeries"
+              ],
+              "properties": {
+                "rateSeries": {
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     },
     "GpuTelemetryConfig": {
       "title": "GpuTelemetryConfig",
@@ -13212,14 +13805,13 @@
           "type": "boolean"
         },
         "rate": {
-          "description": "Target request rate in requests per second (must be > 0).",
-          "title": "Rate",
-          "oneOf": [
+          "anyOf": [
             {
-              "description": "Target request rate in requests per second (must be > 0).",
               "exclusiveMinimum": 0,
-              "title": "Rate",
               "type": "number"
+            },
+            {
+              "type": "null"
             },
             {
               "type": "string",
@@ -13232,6 +13824,9 @@
               "description": "Environment variable (e.g., '${VAR}' or '${VAR:default}')."
             }
           ],
+          "default": null,
+          "description": "Target request rate in requests per second. Required unless rate_series is set.",
+          "title": "Rate",
           "x-jinja2-supported": true
         },
         "rateRamp": {
@@ -13256,15 +13851,56 @@
           "default": null,
           "description": "Ramp rate from lower value. Can be number (seconds) or {duration, strategy}.",
           "x-jinja2-supported": true
+        },
+        "rateSeries": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateSeriesConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Piecewise-linear request-rate schedule."
         }
       },
       "required": [
         "name",
-        "type",
-        "rate"
+        "type"
       ],
       "title": "PoissonPhase",
-      "type": "object"
+      "type": "object",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "rate"
+              ],
+              "properties": {
+                "rate": {
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "required": [
+                "rateSeries"
+              ],
+              "properties": {
+                "rateSeries": {
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     },
     "PostProcessSpec": {
       "additionalProperties": false,
@@ -13817,6 +14453,122 @@
         }
       },
       "title": "RankingsConfig",
+      "type": "object"
+    },
+    "RateSeriesConfig": {
+      "additionalProperties": false,
+      "description": "Piecewise-linear request-rate schedule.",
+      "properties": {
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "JSON file path containing request-rate control points.",
+          "title": "Path"
+        },
+        "points": {
+          "description": "Strictly increasing request-rate control points.",
+          "items": {
+            "$ref": "#/$defs/RateSeriesPoint"
+          },
+          "title": "Points",
+          "type": "array",
+          "minItems": 2
+        }
+      },
+      "title": "RateSeriesConfig",
+      "type": "object",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "required": [
+                "points"
+              ],
+              "properties": {
+                "points": {
+                  "minItems": 2
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "RateSeriesPoint": {
+      "additionalProperties": false,
+      "description": "One request-rate control point.",
+      "properties": {
+        "timeS": {
+          "description": "Elapsed phase time in seconds for this request-rate point.",
+          "title": "Times",
+          "oneOf": [
+            {
+              "description": "Elapsed phase time in seconds for this request-rate point.",
+              "minimum": 0.0,
+              "title": "Times",
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "pattern": ".*\\{\\{.*\\}\\}.*",
+              "description": "Jinja2 template (e.g., '{{ variable }}')."
+            },
+            {
+              "type": "string",
+              "pattern": ".*\\$\\{[A-Za-z_][A-Za-z0-9_]*(?::[^}]*)?\\}.*",
+              "description": "Environment variable (e.g., '${VAR}' or '${VAR:default}')."
+            }
+          ],
+          "x-jinja2-supported": true
+        },
+        "qps": {
+          "description": "Request rate in queries per second at this point.",
+          "title": "Qps",
+          "oneOf": [
+            {
+              "description": "Request rate in queries per second at this point.",
+              "exclusiveMinimum": 0.0,
+              "title": "Qps",
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "pattern": ".*\\{\\{.*\\}\\}.*",
+              "description": "Jinja2 template (e.g., '{{ variable }}')."
+            },
+            {
+              "type": "string",
+              "pattern": ".*\\$\\{[A-Za-z_][A-Za-z0-9_]*(?::[^}]*)?\\}.*",
+              "description": "Environment variable (e.g., '${VAR}' or '${VAR:default}')."
+            }
+          ],
+          "x-jinja2-supported": true
+        }
+      },
+      "required": [
+        "timeS",
+        "qps"
+      ],
+      "title": "RateSeriesPoint",
       "type": "object"
     },
     "RequestContentType": {
@@ -16212,14 +16964,13 @@
           "type": "boolean"
         },
         "rate": {
-          "description": "Target request rate in requests per second (must be > 0).",
-          "title": "Rate",
-          "oneOf": [
+          "anyOf": [
             {
-              "description": "Target request rate in requests per second (must be > 0).",
               "exclusiveMinimum": 0,
-              "title": "Rate",
               "type": "number"
+            },
+            {
+              "type": "null"
             },
             {
               "type": "string",
@@ -16232,6 +16983,9 @@
               "description": "Environment variable (e.g., '${VAR}' or '${VAR:default}')."
             }
           ],
+          "default": null,
+          "description": "Target request rate in requests per second. Required unless rate_series is set.",
+          "title": "Rate",
           "x-jinja2-supported": true
         },
         "rateRamp": {
@@ -16284,11 +17038,25 @@
       "required": [
         "name",
         "type",
-        "rate",
-        "users"
+        "users",
+        "rate"
       ],
       "title": "UserCentricPhase",
-      "type": "object"
+      "type": "object",
+      "allOf": [
+        {
+          "required": [
+            "rate"
+          ],
+          "properties": {
+            "rate": {
+              "not": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
     },
     "UserFile": {
       "description": "One user-declared output file rendered into the run directory before benchmark start.\n\nPath is relative to the run directory; subdirectories are allowed; absolute\npaths and any segment equal to '..' are rejected. Content is rendered with\njinja2 against a documented context (variables: + system-injected names).",

--- a/src/aiperf/timing/config.py
+++ b/src/aiperf/timing/config.py
@@ -11,8 +11,8 @@ from pydantic import ConfigDict, Field, model_validator
 from aiperf.common.enums import CreditPhase
 from aiperf.common.models.base_models import AIPerfBaseModel
 from aiperf.config.dataset.defaults import InputDefaults
-from aiperf.config.sweep.adaptive import SLAFilter
 from aiperf.config.rate_series import RateSeriesConfig
+from aiperf.config.sweep.adaptive import SLAFilter
 from aiperf.plugin.enums import (
     ArrivalPattern,
     PhaseType,

--- a/src/aiperf/timing/config.py
+++ b/src/aiperf/timing/config.py
@@ -12,6 +12,7 @@ from aiperf.common.enums import CreditPhase
 from aiperf.common.models.base_models import AIPerfBaseModel
 from aiperf.config.dataset.defaults import InputDefaults
 from aiperf.config.sweep.adaptive import SLAFilter
+from aiperf.config.rate_series import RateSeriesConfig
 from aiperf.plugin.enums import (
     ArrivalPattern,
     PhaseType,
@@ -217,6 +218,10 @@ class CreditPhaseConfig(AIPerfBaseModel):
         description="Duration in seconds to ramp request rate from 1 QPS to target. "
         "If None, request rate starts at target immediately.",
     )
+    request_rate_series: RateSeriesConfig | None = Field(
+        default=None,
+        description="Piecewise-linear request-rate schedule, if enabled.",
+    )
     auto_offset_timestamps: bool = Field(
         default=InputDefaults.FIXED_SCHEDULE_AUTO_OFFSET,
         description="The auto offset timestamps of the timing manager.",
@@ -381,6 +386,7 @@ def _build_warmup_config(
             getattr(phase, "rate_ramp", None)
         ),
         artifact_dir=artifact_dir,
+        request_rate_series=getattr(phase, "rate_series", None),
     )
 
 
@@ -412,6 +418,7 @@ def _build_profiling_config(
         request_rate_ramp_duration_sec=_ramp_duration(
             getattr(phase, "rate_ramp", None)
         ),
+        request_rate_series=getattr(phase, "rate_series", None),
         # Fixed schedule config
         auto_offset_timestamps=getattr(
             phase, "auto_offset", InputDefaults.FIXED_SCHEDULE_AUTO_OFFSET

--- a/src/aiperf/timing/phase/runner.py
+++ b/src/aiperf/timing/phase/runner.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from aiperf.common.enums import CreditPhase
 from aiperf.common.environment import Environment
@@ -24,6 +24,7 @@ from aiperf.timing.phase.lifecycle import PhaseLifecycle
 from aiperf.timing.phase.progress_tracker import PhaseProgressTracker
 from aiperf.timing.phase.stop_conditions import StopConditionChecker
 from aiperf.timing.ramping import Ramper, RamperConfig, RampType
+from aiperf.timing.rate_series import RateSeriesController
 from aiperf.timing.strategies.core import RateSettableProtocol
 from aiperf.timing.url_samplers import URLSelectionStrategyProtocol
 
@@ -37,6 +38,14 @@ if TYPE_CHECKING:
     from aiperf.timing.phase.publisher import PhasePublisher
     from aiperf.timing.request_cancellation import RequestCancellationSimulator
     from aiperf.timing.strategies.core import TimingStrategyProtocol
+
+
+class RateControllerProtocol(Protocol):
+    """Background controller that can update phase limits over time."""
+
+    def start(self) -> asyncio.Task: ...
+
+    def stop(self) -> None: ...
 
 
 class PhaseRunner(TaskManagerMixin):
@@ -139,7 +148,7 @@ class PhaseRunner(TaskManagerMixin):
         self._progress_task: asyncio.Task | None = None
         self._return_wait_task: asyncio.Task | None = None
         self._was_cancelled = False
-        self._rampers: list[Ramper] = []
+        self._rampers: list[RateControllerProtocol] = []
 
     def _build_credit_issuer(
         self, url_selection_strategy: URLSelectionStrategyProtocol | None
@@ -532,6 +541,36 @@ class PhaseRunner(TaskManagerMixin):
                     f"Strategy {strategy.__class__.__name__} does not implement RateSettableProtocol. "
                     "Request rate will be fixed at the target value."
                 )
+
+        self._create_rate_series_controller(strategy)
+
+    def _create_rate_series_controller(self, strategy: TimingStrategyProtocol) -> None:
+        """Create a request-rate series controller when configured."""
+        config = self._config
+        if not config.request_rate_series or not config.request_rate:
+            return
+        if not isinstance(strategy, RateSettableProtocol):
+            self.warning(
+                f"Strategy {strategy.__class__.__name__} does not implement RateSettableProtocol. "
+                "Request rate series will be ignored."
+            )
+            return
+
+        points = config.request_rate_series.points
+        start_delay = config.request_rate_ramp_duration_sec or 0.0
+        self.info(
+            f"Starting request rate series: {len(points)} points, "
+            f"initial={points[0].qps} QPS, final={points[-1].qps} QPS, "
+            f"start_delay={start_delay}s"
+        )
+        self._rampers.append(
+            RateSeriesController(
+                setter=strategy.set_request_rate,
+                config=config.request_rate_series,
+                update_interval=Environment.TIMING.RATE_RAMP_UPDATE_INTERVAL,
+                start_delay=start_delay,
+            )
+        )
 
     def _format_phase_started(self, stats: CreditPhaseStats) -> str:
         """Format a concise log message for phase start."""

--- a/src/aiperf/timing/rate_series.py
+++ b/src/aiperf/timing/rate_series.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Continuous request-rate series controller."""
+
+from __future__ import annotations
+
+import asyncio
+import bisect
+import logging
+import time
+from collections.abc import Callable
+
+from aiperf.config.rate_series import RateSeriesConfig
+
+logger = logging.getLogger(__name__)
+
+
+class RateSeriesController:
+    """Apply piecewise-linear request-rate updates until stopped."""
+
+    def __init__(
+        self,
+        setter: Callable[[float], None],
+        config: RateSeriesConfig,
+        update_interval: float,
+        start_delay: float = 0.0,
+    ) -> None:
+        self._setter = setter
+        self._config = config
+        self._update_interval = update_interval
+        self._start_delay = start_delay
+        self._times = [point.time_s for point in config.points]
+        self._qps = [point.qps for point in config.points]
+        self._task: asyncio.Task | None = None
+
+    @property
+    def is_running(self) -> bool:
+        """Return True if the rate-series controller task is currently running."""
+        return self._task is not None and not self._task.done()
+
+    def start(self) -> asyncio.Task:
+        """Start request-rate series updates in a background task."""
+        self._task = asyncio.create_task(self._run())
+        return self._task
+
+    def stop(self) -> None:
+        """Stop rate-series updates early."""
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+
+    def value_at(self, elapsed_sec: float) -> float:
+        """Return the interpolated request rate at elapsed phase time."""
+        if elapsed_sec <= self._times[0]:
+            return self._qps[0]
+        if elapsed_sec >= self._times[-1]:
+            return self._qps[-1]
+
+        right = bisect.bisect_right(self._times, elapsed_sec)
+        left = right - 1
+        left_time = self._times[left]
+        right_time = self._times[right]
+        progress = (elapsed_sec - left_time) / (right_time - left_time)
+        return self._qps[left] + (self._qps[right] - self._qps[left]) * progress
+
+    async def _run(self) -> None:
+        try:
+            if self._start_delay > 0:
+                await asyncio.sleep(self._start_delay)
+
+            series_start = time.perf_counter()
+            if not self._set_rate(self.value_at(0.0)):
+                return
+
+            while True:
+                await asyncio.sleep(self._update_interval)
+                elapsed = time.perf_counter() - series_start
+                if elapsed >= self._times[-1]:
+                    self._set_rate(self._qps[-1])
+                    break
+                if not self._set_rate(self.value_at(elapsed)):
+                    return
+        except asyncio.CancelledError:
+            pass
+
+    def _set_rate(self, rate: float) -> bool:
+        try:
+            self._setter(rate)
+        except Exception:
+            logger.exception("Request-rate series update failed for rate=%s", rate)
+            return False
+        return True

--- a/src/aiperf/timing/strategies/request_rate.py
+++ b/src/aiperf/timing/strategies/request_rate.py
@@ -119,6 +119,7 @@ class RequestRateStrategy(AIPerfLoggerMixin):
             PluginType.ARRIVAL_PATTERN, interval_config.arrival_pattern
         )
         self._rate_generator = GeneratorClass(interval_config)
+        self._rate_update_event = asyncio.Event()
 
     async def setup_phase(self) -> None:
         """Setup the phase."""
@@ -153,9 +154,29 @@ class RequestRateStrategy(AIPerfLoggerMixin):
             if next_target_perf < now:
                 next_target_perf = now
 
+            if self._rate_update_event.is_set():
+                self._rate_update_event.clear()
+                next_target_perf = min(
+                    next_target_perf,
+                    time.perf_counter() + self._rate_generator.next_interval(),
+                )
+                continue
+
             sleep_duration = next_target_perf - now
             if sleep_duration > 0:
-                await asyncio.sleep(sleep_duration)
+                try:
+                    await asyncio.wait_for(
+                        self._rate_update_event.wait(), timeout=sleep_duration
+                    )
+                except asyncio.TimeoutError:  # noqa: UP041 - distinct on Python 3.10
+                    pass
+                else:
+                    self._rate_update_event.clear()
+                    next_target_perf = min(
+                        next_target_perf,
+                        time.perf_counter() + self._rate_generator.next_interval(),
+                    )
+                    continue
             else:
                 # CRITICAL: Always yield to event loop to allow callbacks to run.
                 # Without this, CONCURRENCY_BURST mode (0 interval) busy-loops and
@@ -299,4 +320,7 @@ class RequestRateStrategy(AIPerfLoggerMixin):
         """
         if new_rate <= 0:
             raise ValueError(f"Rate must be > 0, got {new_rate}")
+        if getattr(self._rate_generator, "rate", None) == new_rate:
+            return
         self._rate_generator.set_rate(new_rate)
+        self._rate_update_event.set()

--- a/tests/unit/config/test_config_schema_generator_integration.py
+++ b/tests/unit/config/test_config_schema_generator_integration.py
@@ -215,6 +215,64 @@ def test_generated_schema_accepts_runtime_single_dict_phases_shorthand() -> None
     _assert_schema_accepts(schema, config)
 
 
+def test_generated_schema_rejects_rate_phase_without_rate_source() -> None:
+    schema = _generated_schema()
+    config = _minimal_benchmark_config(
+        phases=[{"name": "profiling", "type": "poisson", "requests": 1}]
+    )
+
+    with pytest.raises(ValidationError):
+        AIPerfConfig.model_validate(copy.deepcopy(config))
+
+    assert _schema_error_messages(schema, config) != []
+
+
+@pytest.mark.parametrize("rate_series", [{}, {"points": []}])
+def test_generated_schema_rejects_empty_rate_series(rate_series: dict) -> None:
+    schema = _generated_schema()
+    config = _minimal_benchmark_config(
+        phases=[
+            {
+                "name": "profiling",
+                "type": "poisson",
+                "requests": 1,
+                "rateSeries": rate_series,
+            }
+        ]
+    )
+
+    with pytest.raises(ValidationError):
+        AIPerfConfig.model_validate(copy.deepcopy(config))
+
+    assert _schema_error_messages(schema, config) != []
+
+
+def test_generated_schema_rejects_user_centric_rate_series() -> None:
+    schema = _generated_schema()
+    config = _minimal_benchmark_config(
+        phases=[
+            {
+                "name": "profiling",
+                "type": "user_centric",
+                "requests": 2,
+                "rate": 10,
+                "users": 2,
+                "rateSeries": {
+                    "points": [
+                        {"timeS": 0, "qps": 5},
+                        {"timeS": 10, "qps": 15},
+                    ]
+                },
+            }
+        ]
+    )
+
+    with pytest.raises(ValidationError):
+        AIPerfConfig.model_validate(copy.deepcopy(config))
+
+    assert _schema_error_messages(schema, config) != []
+
+
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/unit/config/test_config_schema_generator_integration.py
+++ b/tests/unit/config/test_config_schema_generator_integration.py
@@ -227,6 +227,31 @@ def test_generated_schema_rejects_rate_phase_without_rate_source() -> None:
     assert _schema_error_messages(schema, config) != []
 
 
+def test_generated_schema_rejects_rate_phase_with_both_rate_sources() -> None:
+    schema = _generated_schema()
+    config = _minimal_benchmark_config(
+        phases=[
+            {
+                "name": "profiling",
+                "type": "poisson",
+                "requests": 1,
+                "rate": 100,
+                "rateSeries": {
+                    "points": [
+                        {"timeS": 0, "qps": 5},
+                        {"timeS": 10, "qps": 15},
+                    ]
+                },
+            }
+        ]
+    )
+
+    with pytest.raises(ValidationError):
+        AIPerfConfig.model_validate(copy.deepcopy(config))
+
+    assert _schema_error_messages(schema, config) != []
+
+
 @pytest.mark.parametrize("rate_series", [{}, {"points": []}])
 def test_generated_schema_rejects_empty_rate_series(rate_series: dict) -> None:
     schema = _generated_schema()

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -20,6 +20,8 @@ Covers former bugs in ``aiperf.config.flags._converter_profiling``:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from aiperf.config.flags._converter_profiling import build_profiling
@@ -46,7 +48,7 @@ def _make_user(
 
 
 class TestArrivalSmoothnessGating:
-    def test_smoothness_without_gamma_raises_clear_error(self):
+    def test_smoothness_without_gamma_raises_clear_error(self) -> None:
         """--arrival-smoothness with default poisson pattern must error."""
         loadgen = CLIConfig(
             request_rate=100.0,
@@ -57,7 +59,7 @@ class TestArrivalSmoothnessGating:
         with pytest.raises(ValueError, match="--arrival-smoothness"):
             build_profiling(user)
 
-    def test_smoothness_with_constant_pattern_raises(self):
+    def test_smoothness_with_constant_pattern_raises(self) -> None:
         """--arrival-smoothness with --arrival-pattern constant must error."""
         loadgen = CLIConfig(
             request_rate=100.0,
@@ -69,7 +71,7 @@ class TestArrivalSmoothnessGating:
         with pytest.raises(ValueError, match="arrival-pattern gamma"):
             build_profiling(user)
 
-    def test_smoothness_without_request_rate_raises(self):
+    def test_smoothness_without_request_rate_raises(self) -> None:
         """Concurrency-mode (no rate) with --arrival-smoothness must error."""
         loadgen = CLIConfig(
             arrival_smoothness=1.5,
@@ -80,7 +82,7 @@ class TestArrivalSmoothnessGating:
         with pytest.raises(ValueError, match="--arrival-smoothness"):
             build_profiling(user)
 
-    def test_smoothness_with_gamma_succeeds(self):
+    def test_smoothness_with_gamma_succeeds(self) -> None:
         """Valid combination: --arrival-pattern gamma + --arrival-smoothness."""
         loadgen = CLIConfig(
             request_rate=100.0,
@@ -94,7 +96,7 @@ class TestArrivalSmoothnessGating:
         assert prof["smoothness"] == 1.5
         assert prof["rate"] == 100.0
 
-    def test_gamma_without_smoothness_succeeds(self):
+    def test_gamma_without_smoothness_succeeds(self) -> None:
         """--arrival-pattern gamma without --arrival-smoothness is allowed
         (smoothness is optional on GammaPhase)."""
         loadgen = CLIConfig(
@@ -114,28 +116,28 @@ class TestArrivalSmoothnessGating:
 
 
 class TestFixedScheduleOffsetGating:
-    def test_start_offset_without_fixed_schedule_raises(self):
+    def test_start_offset_without_fixed_schedule_raises(self) -> None:
         loadgen = CLIConfig(request_rate=100.0, request_count=10)
         input_cfg = CLIConfig(fixed_schedule_start_offset=1000)
         user = _make_user(loadgen=loadgen, input_cfg=input_cfg)
         with pytest.raises(ValueError, match="--fixed-schedule"):
             build_profiling(user)
 
-    def test_end_offset_without_fixed_schedule_raises(self):
+    def test_end_offset_without_fixed_schedule_raises(self) -> None:
         loadgen = CLIConfig(request_rate=100.0, request_count=10)
         input_cfg = CLIConfig(fixed_schedule_end_offset=2000)
         user = _make_user(loadgen=loadgen, input_cfg=input_cfg)
         with pytest.raises(ValueError, match="--fixed-schedule"):
             build_profiling(user)
 
-    def test_auto_offset_without_fixed_schedule_raises(self):
+    def test_auto_offset_without_fixed_schedule_raises(self) -> None:
         loadgen = CLIConfig(concurrency=4, request_count=10)
         input_cfg = CLIConfig(fixed_schedule_auto_offset=True)
         user = _make_user(loadgen=loadgen, input_cfg=input_cfg)
         with pytest.raises(ValueError, match="--fixed-schedule"):
             build_profiling(user)
 
-    def test_offsets_in_concurrency_mode_raises(self):
+    def test_offsets_in_concurrency_mode_raises(self) -> None:
         loadgen = CLIConfig(concurrency=2, request_count=10)
         input_cfg = CLIConfig(fixed_schedule_start_offset=500)
         user = _make_user(loadgen=loadgen, input_cfg=input_cfg)
@@ -144,7 +146,7 @@ class TestFixedScheduleOffsetGating:
         ):
             build_profiling(user)
 
-    def test_offsets_with_fixed_schedule_succeed(self):
+    def test_offsets_with_fixed_schedule_succeed(self) -> None:
         """Valid combination: --fixed-schedule + offsets all together."""
         loadgen = CLIConfig(concurrency=4)
         input_cfg = CLIConfig(
@@ -160,7 +162,7 @@ class TestFixedScheduleOffsetGating:
         # Existing convention: start_offset present => auto_offset defaults False.
         assert prof["auto_offset"] is False
 
-    def test_fixed_schedule_without_offsets_succeeds(self):
+    def test_fixed_schedule_without_offsets_succeeds(self) -> None:
         """--fixed-schedule alone (no offsets) is fine."""
         loadgen = CLIConfig(concurrency=4)
         input_cfg = CLIConfig(fixed_schedule=True)
@@ -177,7 +179,7 @@ class TestFixedScheduleOffsetGating:
 
 
 class TestGracePeriodRequiresDuration:
-    def test_grace_period_without_duration_raises(self):
+    def test_grace_period_without_duration_raises(self) -> None:
         loadgen = CLIConfig(benchmark_grace_period=30, request_count=10, concurrency=1)
         user = _make_user(loadgen=loadgen)
         with pytest.raises(
@@ -185,7 +187,7 @@ class TestGracePeriodRequiresDuration:
         ):
             build_profiling(user)
 
-    def test_grace_period_with_duration_succeeds(self):
+    def test_grace_period_with_duration_succeeds(self) -> None:
         loadgen = CLIConfig(
             benchmark_duration=60.0, benchmark_grace_period=30, concurrency=1
         )
@@ -201,7 +203,7 @@ class TestGracePeriodRequiresDuration:
 
 
 class TestNumUsersRequiresUserCentric:
-    def test_num_users_with_concurrency_mode_raises(self):
+    def test_num_users_with_concurrency_mode_raises(self) -> None:
         loadgen = CLIConfig(num_users=5, request_count=10, concurrency=1)
         user = _make_user(loadgen=loadgen)
         with pytest.raises(
@@ -209,7 +211,7 @@ class TestNumUsersRequiresUserCentric:
         ):
             build_profiling(user)
 
-    def test_num_users_with_request_rate_raises(self):
+    def test_num_users_with_request_rate_raises(self) -> None:
         loadgen = CLIConfig(num_users=5, request_rate=100.0, request_count=10)
         user = _make_user(loadgen=loadgen)
         with pytest.raises(
@@ -217,7 +219,7 @@ class TestNumUsersRequiresUserCentric:
         ):
             build_profiling(user)
 
-    def test_num_users_with_user_centric_succeeds(self):
+    def test_num_users_with_user_centric_succeeds(self) -> None:
         """``--user-centric-rate`` resolves to USER_CENTRIC; --num-users flows through."""
         loadgen = CLIConfig(
             user_centric_rate=10.0,
@@ -237,17 +239,17 @@ class TestNumUsersRequiresUserCentric:
 
 
 class TestRateRampRequiresRequestRate:
-    def test_rate_ramp_with_concurrency_mode_raises(self):
+    def test_rate_ramp_with_concurrency_mode_raises(self) -> None:
         loadgen = CLIConfig(
             request_rate_ramp_duration=30, request_count=10, concurrency=1
         )
         user = _make_user(loadgen=loadgen)
         with pytest.raises(
-            ValueError, match="--request-rate-ramp-duration.*rate-controlled"
+            ValueError, match=r"--request-rate-ramp-duration.*rate-controlled"
         ):
             build_profiling(user)
 
-    def test_rate_ramp_with_request_rate_succeeds(self):
+    def test_rate_ramp_with_request_rate_succeeds(self) -> None:
         loadgen = CLIConfig(
             request_rate=100.0, request_rate_ramp_duration=30, request_count=10
         )
@@ -708,3 +710,57 @@ class TestAdaptiveScaleRoutes:
         )
 
         assert phase.adaptive_scale is False
+
+
+class TestRateSeries:
+    def test_rate_series_without_request_rate_succeeds(self, tmp_path: Path) -> None:
+        json_path = tmp_path / "rate.json"
+        json_path.write_text(
+            '{"points":[{"time_s":0,"qps":1},{"time_s":60,"qps":7},{"time_s":120,"qps":40}]}',
+            encoding="utf-8",
+        )
+        loadgen = CLIConfig(
+            request_rate_series=json_path,
+            arrival_pattern=ArrivalPattern.CONSTANT,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+
+        prof = build_profiling(user)
+
+        assert prof["type"] == PhaseType.CONSTANT
+        assert "rate" not in prof
+        assert prof["rate_series"]["points"][1] == {"time_s": 60.0, "qps": 7.0}
+
+    def test_rate_series_with_request_rate_raises(self, tmp_path: Path) -> None:
+        json_path = tmp_path / "rate.json"
+        json_path.write_text(
+            '{"points":[{"time_s":0,"qps":5},{"time_s":60,"qps":10}]}',
+            encoding="utf-8",
+        )
+        loadgen = CLIConfig(
+            request_rate=100.0,
+            request_rate_series=json_path,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+
+        with pytest.raises(ValueError, match=r"request-rate.*request-rate-series"):
+            build_profiling(user)
+
+    def test_rate_series_with_user_centric_rate_raises(self, tmp_path: Path) -> None:
+        json_path = tmp_path / "rate.json"
+        json_path.write_text(
+            '{"points":[{"time_s":0,"qps":5},{"time_s":60,"qps":10}]}',
+            encoding="utf-8",
+        )
+        loadgen = CLIConfig(
+            user_centric_rate=100.0,
+            request_rate_series=json_path,
+            num_users=4,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+
+        with pytest.raises(ValueError, match="user-centric-rate"):
+            build_profiling(user)

--- a/tests/unit/config/test_converter_warmup_grace_period.py
+++ b/tests/unit/config/test_converter_warmup_grace_period.py
@@ -16,6 +16,8 @@ the user sees which flag combination is incompatible.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from aiperf.config.flags._converter_warmup import build_warmup
@@ -108,3 +110,36 @@ class TestWarmupGracePeriodSuccessPaths:
         loadgen = CLIConfig(warmup_grace_period=5.0)
         with pytest.raises(ValueError, match="--warmup-grace-period.*without any"):
             build_warmup(_make_user(loadgen))
+
+
+class TestWarmupRateRampRequiresWarmupRate:
+    """Warmup must not inherit rate ramping unless it has a scalar rate."""
+
+    def test_explicit_warmup_rate_ramp_without_rate_raises(self):
+        loadgen = CLIConfig(
+            warmup_request_count=10,
+            warmup_request_rate_ramp_duration=5.0,
+        )
+
+        with pytest.raises(ValueError, match="--warmup-request-rate-ramp-duration"):
+            build_warmup(_make_user(loadgen))
+
+    def test_main_rate_series_ramp_not_inherited_by_concurrency_warmup(
+        self, tmp_path: Path
+    ):
+        json_path = tmp_path / "rate.json"
+        json_path.write_text(
+            '{"points":[{"time_s":0,"qps":5},{"time_s":10,"qps":15}]}',
+            encoding="utf-8",
+        )
+        loadgen = CLIConfig(
+            request_rate_series=json_path,
+            request_rate_ramp_duration=5.0,
+            warmup_request_count=10,
+        )
+
+        warmup = build_warmup(_make_user(loadgen))
+
+        assert warmup is not None
+        assert warmup["requests"] == 10
+        assert "rate_ramp" not in warmup

--- a/tests/unit/config/test_rate_series_config.py
+++ b/tests/unit/config/test_rate_series_config.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from aiperf.config.phases import PoissonPhase, UserCentricPhase
+from aiperf.config.rate_series import RateSeriesConfig, read_rate_series_json
+from aiperf.plugin.enums import PhaseType
+
+
+def _write_json(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_rate_series_config_loads_json_path(tmp_path: Path) -> None:
+    json_path = _write_json(
+        tmp_path / "rate.json",
+        '{"points":[{"time_s":0,"qps":1},{"time_s":60,"qps":7},{"time_s":120,"qps":40}]}',
+    )
+
+    config = RateSeriesConfig(path=str(json_path))
+
+    assert config.initial_qps == 1.0
+    assert [(point.time_s, point.qps) for point in config.points] == [
+        (0.0, 1.0),
+        (60.0, 7.0),
+        (120.0, 40.0),
+    ]
+
+
+def test_rate_series_config_canonicalizes_loaded_path(tmp_path: Path) -> None:
+    json_path = _write_json(
+        tmp_path / "rate.json",
+        '{"points":[{"time_s":0,"qps":1},{"time_s":60,"qps":7}]}',
+    )
+
+    config = RateSeriesConfig(path=str(json_path))
+    round_tripped = RateSeriesConfig.model_validate(config.model_dump())
+
+    assert config.path is None
+    assert round_tripped.path is None
+    assert [(point.time_s, point.qps) for point in round_tripped.points] == [
+        (0.0, 1.0),
+        (60.0, 7.0),
+    ]
+
+
+def test_rate_series_config_accepts_inline_points() -> None:
+    config = RateSeriesConfig(
+        points=[{"time_s": 0, "qps": 10}, {"time_s": 5, "qps": 20}]
+    )
+
+    assert config.initial_qps == 10.0
+    assert config.points[1].qps == 20.0
+
+
+def test_read_rate_series_json_accepts_top_level_points_array(tmp_path: Path) -> None:
+    json_path = _write_json(
+        tmp_path / "rate.json",
+        '[{"time_s":0,"qps":1},{"time_s":60,"qps":7}]',
+    )
+
+    points = read_rate_series_json(str(json_path))
+
+    assert [(point.time_s, point.qps) for point in points] == [(0.0, 1.0), (60.0, 7.0)]
+
+
+def test_read_rate_series_json_rejects_wrong_shape(tmp_path: Path) -> None:
+    json_path = _write_json(tmp_path / "bad.json", '{"time_s":0,"qps":1}')
+
+    with pytest.raises(ValueError, match="top-level key: points"):
+        read_rate_series_json(str(json_path))
+
+
+def test_read_rate_series_json_rejects_non_increasing_times(tmp_path: Path) -> None:
+    json_path = _write_json(
+        tmp_path / "bad.json",
+        '{"points":[{"time_s":0,"qps":1},{"time_s":0,"qps":7}]}',
+    )
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        read_rate_series_json(str(json_path))
+
+
+def test_read_rate_series_json_preserves_point_validation_cause(
+    tmp_path: Path,
+) -> None:
+    json_path = _write_json(
+        tmp_path / "bad.json",
+        '{"points":[{"time_s":0,"qps":1},{"time_s":5,"qps":0}]}',
+    )
+
+    with pytest.raises(ValueError) as exc:
+        read_rate_series_json(str(json_path))
+
+    message = str(exc.value)
+    assert "Invalid request-rate series point 1" in message
+    assert "greater than 0" in message
+
+
+def test_rate_series_config_rejects_single_point() -> None:
+    with pytest.raises(ValidationError, match="at least two points"):
+        RateSeriesConfig(points=[{"time_s": 0, "qps": 10}])
+
+
+def test_rate_phase_allows_rate_series_without_scalar_rate() -> None:
+    phase = PoissonPhase(
+        name="profiling",
+        type=PhaseType.POISSON,
+        requests=10,
+        rate_series={"points": [{"time_s": 0, "qps": 5}, {"time_s": 10, "qps": 15}]},
+    )
+
+    assert phase.rate is None
+    assert phase.rate_series is not None
+    assert phase.rate_series.initial_qps == 5.0
+
+
+def test_rate_phase_allows_rate_ramp_with_rate_series() -> None:
+    phase = PoissonPhase(
+        name="profiling",
+        type=PhaseType.POISSON,
+        requests=10,
+        rate_ramp=60,
+        rate_series={"points": [{"time_s": 0, "qps": 5}, {"time_s": 10, "qps": 15}]},
+    )
+
+    assert phase.rate_ramp is not None
+    assert phase.rate_series is not None
+
+
+def test_user_centric_phase_rejects_rate_series() -> None:
+    with pytest.raises(ValidationError, match="user-centric phases"):
+        UserCentricPhase(
+            name="profiling",
+            type=PhaseType.USER_CENTRIC,
+            requests=10,
+            users=2,
+            rate_series={
+                "points": [{"time_s": 0, "qps": 5}, {"time_s": 10, "qps": 15}]
+            },
+        )

--- a/tests/unit/config/test_rate_series_config.py
+++ b/tests/unit/config/test_rate_series_config.py
@@ -119,6 +119,19 @@ def test_rate_phase_allows_rate_series_without_scalar_rate() -> None:
     assert phase.rate_series.initial_qps == 5.0
 
 
+def test_rate_phase_rejects_scalar_rate_with_rate_series() -> None:
+    with pytest.raises(ValidationError, match="mutually exclusive"):
+        PoissonPhase(
+            name="profiling",
+            type=PhaseType.POISSON,
+            requests=10,
+            rate=100,
+            rate_series={
+                "points": [{"time_s": 0, "qps": 5}, {"time_s": 10, "qps": 15}]
+            },
+        )
+
+
 def test_rate_phase_allows_rate_ramp_with_rate_series() -> None:
     phase = PoissonPhase(
         name="profiling",

--- a/tests/unit/config/test_v1_resolver_rate_series.py
+++ b/tests/unit/config/test_v1_resolver_rate_series.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.config.flags.resolver import resolve_config
+from aiperf.plugin.enums import PhaseType
+
+
+def test_yaml_native_inline_rate_series_points(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "rate_series.yaml"
+    cfg_file.write_text(
+        textwrap.dedent("""\
+        benchmark:
+          models:
+            - test-model
+          endpoint:
+            urls:
+              - http://localhost:8000/v1/chat/completions
+          datasets:
+            - name: default
+              type: synthetic
+          phases:
+            - name: profiling
+              type: poisson
+              requests: 10
+              rateSeries:
+                points:
+                  - timeS: 0
+                    qps: 5
+                  - timeS: 10
+                    qps: 15
+        """),
+        encoding="utf-8",
+    )
+
+    config = resolve_config(CLIConfig(), cfg_file)
+    phase = config.benchmark.phases[0]
+
+    assert phase.rate is None
+    assert phase.rate_series is not None
+    assert [(p.time_s, p.qps) for p in phase.rate_series.points] == [
+        (0.0, 5.0),
+        (10.0, 15.0),
+    ]
+
+
+def test_cli_request_rate_series_overrides_yaml_phase(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "base_rate.yaml"
+    cfg_file.write_text(
+        textwrap.dedent("""\
+        benchmark:
+          models:
+            - test-model
+          endpoint:
+            urls:
+              - http://localhost:8000/v1/chat/completions
+          datasets:
+            - name: default
+              type: synthetic
+          phases:
+            - name: profiling
+              type: poisson
+              requests: 10
+              rate: 1
+        """),
+        encoding="utf-8",
+    )
+    series_path = tmp_path / "rate.json"
+    series_path.write_text(
+        '{"points":[{"time_s":0,"qps":4},{"time_s":10,"qps":12}]}',
+        encoding="utf-8",
+    )
+    user = CLIConfig(
+        request_rate_series=series_path,
+        arrival_pattern="constant",
+        request_count=10,
+    )
+
+    config = resolve_config(user, cfg_file)
+    phase = next(p for p in config.benchmark.phases if p.name == "profiling")
+
+    assert phase.type == PhaseType.CONSTANT
+    assert phase.rate is None
+    assert phase.rate_series is not None
+    assert phase.rate_series.points[1].qps == 12.0
+
+
+def test_cli_request_rate_rejects_yaml_rate_series(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "series_only.yaml"
+    cfg_file.write_text(
+        textwrap.dedent("""\
+        benchmark:
+          models:
+            - test-model
+          endpoint:
+            urls:
+              - http://localhost:8000/v1/chat/completions
+          datasets:
+            - name: default
+              type: synthetic
+          phases:
+            - name: profiling
+              type: poisson
+              requests: 10
+              rateSeries:
+                points:
+                  - timeS: 0
+                    qps: 5
+                  - timeS: 10
+                    qps: 15
+        """),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="mutually exclusive"):
+        resolve_config(CLIConfig(request_rate=50), cfg_file)

--- a/tests/unit/property/test_finite_invariants.py
+++ b/tests/unit/property/test_finite_invariants.py
@@ -357,6 +357,9 @@ NUMERIC_BOUNDS_WHITELIST: set[str] = {
     # not a numeric leaf — same shape as the baselined endpoint_summaries
     # sibling; per-summary numeric fields carry their own bounds.
     "ServerMetricsResults.warmup_endpoint_summaries",
+    # RateSeriesConfig.points: list[RateSeriesPoint], not a numeric field. The
+    # substring-based heuristic sees "int" inside "Point".
+    "RateSeriesConfig.points",
 }
 
 

--- a/tests/unit/timing/phase/test_runner.py
+++ b/tests/unit/timing/phase/test_runner.py
@@ -14,6 +14,7 @@ from aiperf.common.models import (
     DatasetMetadata,
     TurnMetadata,
 )
+from aiperf.config.rate_series import RateSeriesConfig
 from aiperf.credit.sticky_router import StickyCreditRouter
 from aiperf.credit.structs import Credit
 from aiperf.plugin.enums import ArrivalPattern, DatasetSamplingStrategy, TimingMode
@@ -62,6 +63,14 @@ class MockStrategy:
         self.handle_credit_return_calls.append(credit)
 
 
+@dataclass
+class MockRateSettableStrategy(MockStrategy):
+    rate_updates: list[float] = field(default_factory=list)
+
+    def set_request_rate(self, rate: float) -> None:
+        self.rate_updates.append(rate)
+
+
 def mock_conc_mgr() -> MagicMock:
     m = MagicMock()
     m.configure_for_phase = MagicMock()
@@ -99,6 +108,7 @@ def cfg(
     conc_ramp: float | None = None,
     prefill_ramp: float | None = None,
     rate_ramp: float | None = None,
+    rate_series: RateSeriesConfig | None = None,
 ) -> CreditPhaseConfig:
     return CreditPhaseConfig(
         phase=phase,
@@ -114,6 +124,7 @@ def cfg(
         concurrency_ramp_duration_sec=conc_ramp,
         prefill_concurrency_ramp_duration_sec=prefill_ramp,
         request_rate_ramp_duration_sec=rate_ramp,
+        request_rate_series=rate_series,
     )
 
 
@@ -391,6 +402,66 @@ class TestRamperCreation:
     ) -> None:
         r = make_runner(
             cfg(rate=100.0, rate_ramp=10.0), conv_src, pub, router, conc, cancel, cb
+        )
+        with patch(
+            "aiperf.timing.phase.runner.plugins.get_class",
+            return_value=lambda **kw: MockStrategy(),
+        ):
+            r._progress.all_credits_sent_event.set()
+            r._progress.all_credits_returned_event.set()
+            await r.run(is_final_phase=True)
+            assert len(r._rampers) == 0
+
+    async def test_rate_series_controller_created_for_rate_settable_strategy(
+        self,
+        conv_src: MagicMock,
+        pub: MagicMock,
+        router: MagicMock,
+        conc: MagicMock,
+        cancel: MagicMock,
+        cb: MagicMock,
+    ) -> None:
+        rate_series = RateSeriesConfig(
+            points=[{"time_s": 0, "qps": 5}, {"time_s": 10, "qps": 15}]
+        )
+        r = make_runner(
+            cfg(rate=5.0, rate_series=rate_series),
+            conv_src,
+            pub,
+            router,
+            conc,
+            cancel,
+            cb,
+        )
+        with patch(
+            "aiperf.timing.phase.runner.plugins.get_class",
+            return_value=lambda **kw: MockRateSettableStrategy(),
+        ):
+            r._progress.all_credits_sent_event.set()
+            r._progress.all_credits_returned_event.set()
+            await r.run(is_final_phase=True)
+            assert len(r._rampers) == 1
+
+    async def test_rate_series_requires_rate_settable_strategy(
+        self,
+        conv_src: MagicMock,
+        pub: MagicMock,
+        router: MagicMock,
+        conc: MagicMock,
+        cancel: MagicMock,
+        cb: MagicMock,
+    ) -> None:
+        rate_series = RateSeriesConfig(
+            points=[{"time_s": 0, "qps": 5}, {"time_s": 10, "qps": 15}]
+        )
+        r = make_runner(
+            cfg(rate=5.0, rate_series=rate_series),
+            conv_src,
+            pub,
+            router,
+            conc,
+            cancel,
+            cb,
         )
         with patch(
             "aiperf.timing.phase.runner.plugins.get_class",

--- a/tests/unit/timing/strategies/test_request_rate.py
+++ b/tests/unit/timing/strategies/test_request_rate.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
 import math
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
@@ -8,13 +11,16 @@ from scipy import stats
 
 from aiperf.common import random_generator as rng
 from aiperf.common.constants import NANOS_PER_SECOND
-from aiperf.plugin.enums import ArrivalPattern
+from aiperf.common.enums import CreditPhase
+from aiperf.plugin.enums import ArrivalPattern, TimingMode
+from aiperf.timing.config import CreditPhaseConfig
 from aiperf.timing.intervals import (
     ConcurrencyBurstIntervalGenerator,
     ConstantIntervalGenerator,
     IntervalGeneratorConfig,
     PoissonIntervalGenerator,
 )
+from aiperf.timing.strategies.request_rate import RequestRateStrategy
 from tests.unit.timing.conftest import OrchestratorHarness, get_session_stats
 
 
@@ -184,6 +190,55 @@ class TestMaxConcurrency:
         s = get_session_stats(h.orchestrator)
         assert s is not None
         assert s.wait_count == 0
+
+
+@pytest.mark.asyncio
+async def test_request_rate_update_wakes_pending_sleep() -> None:
+    class FakeIntervalGenerator:
+        def __init__(self, config):
+            self.rate = config.request_rate
+
+        def next_interval(self) -> float:
+            return 10.0 if self.rate == 0.1 else 0.05
+
+        def set_rate(self, new_rate: float) -> None:
+            self.rate = new_rate
+
+    lifecycle = MagicMock()
+    lifecycle.started_at_perf_ns = int(time.perf_counter() * NANOS_PER_SECOND)
+    conversation_source = MagicMock()
+    conversation_source.next.return_value.build_first_turn.return_value = object()
+    credit_issuer = MagicMock()
+    credit_issuer.try_issue_credit = AsyncMock(return_value=False)
+    stop_checker = MagicMock()
+    stop_checker.can_start_new_session.return_value = True
+
+    config = CreditPhaseConfig(
+        phase=CreditPhase.PROFILING,
+        timing_mode=TimingMode.REQUEST_RATE,
+        request_rate=0.1,
+        total_expected_requests=1,
+    )
+    with patch(
+        "aiperf.timing.strategies.request_rate.plugins.get_class",
+        return_value=FakeIntervalGenerator,
+    ):
+        strategy = RequestRateStrategy(
+            config=config,
+            conversation_source=conversation_source,
+            scheduler=MagicMock(),
+            stop_checker=stop_checker,
+            credit_issuer=credit_issuer,
+            lifecycle=lifecycle,
+        )
+
+    task = asyncio.create_task(strategy.execute_phase())
+    await asyncio.sleep(0)
+
+    strategy.set_request_rate(100.0)
+    await asyncio.wait_for(task, timeout=1.0)
+
+    credit_issuer.try_issue_credit.assert_awaited_once()
 
 
 class TestConcurrencyBurstGenerator:

--- a/tests/unit/timing/test_rate_series.py
+++ b/tests/unit/timing/test_rate_series.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import asyncio
+import contextlib
+
+import pytest
+
+from aiperf.config.rate_series import RateSeriesConfig
+from aiperf.timing.rate_series import RateSeriesController
+from tests.harness.time_traveler import TimeTraveler
+
+
+def series_config() -> RateSeriesConfig:
+    return RateSeriesConfig(
+        points=[
+            {"time_s": 10.0, "qps": 5.0},
+            {"time_s": 20.0, "qps": 15.0},
+            {"time_s": 30.0, "qps": 10.0},
+        ]
+    )
+
+
+class TestRateSeriesController:
+    def test_value_at_interpolates_and_holds_edges(self) -> None:
+        controller = RateSeriesController(
+            setter=lambda value: None,
+            config=series_config(),
+            update_interval=0.1,
+        )
+
+        assert controller.value_at(0.0) == pytest.approx(5.0)
+        assert controller.value_at(10.0) == pytest.approx(5.0)
+        assert controller.value_at(15.0) == pytest.approx(10.0)
+        assert controller.value_at(20.0) == pytest.approx(15.0)
+        assert controller.value_at(25.0) == pytest.approx(12.5)
+        assert controller.value_at(40.0) == pytest.approx(10.0)
+
+    @pytest.mark.asyncio
+    async def test_start_sets_initial_value(self, time_traveler: TimeTraveler) -> None:
+        values: list[float] = []
+        controller = RateSeriesController(
+            setter=values.append,
+            config=series_config(),
+            update_interval=0.5,
+        )
+
+        task = controller.start()
+        await time_traveler.sleep(0.1)
+
+        assert values == [5.0]
+        controller.stop()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_start_waits_for_start_delay(
+        self, time_traveler: TimeTraveler
+    ) -> None:
+        values: list[float] = []
+        controller = RateSeriesController(
+            setter=values.append,
+            config=series_config(),
+            update_interval=0.5,
+            start_delay=2.0,
+        )
+
+        task = controller.start()
+        await time_traveler.sleep(1.0)
+        assert values == []
+
+        await time_traveler.sleep(1.0)
+        assert values == [5.0]
+
+        controller.stop()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_start_stops_after_final_point(
+        self, time_traveler: TimeTraveler
+    ) -> None:
+        values: list[float] = []
+        controller = RateSeriesController(
+            setter=values.append,
+            config=RateSeriesConfig(
+                points=[{"time_s": 0.0, "qps": 5.0}, {"time_s": 1.0, "qps": 10.0}]
+            ),
+            update_interval=0.25,
+        )
+
+        task = controller.start()
+        await time_traveler.sleep(1.25)
+        await task
+
+        assert controller.is_running is False
+        assert values[-1] == 10.0
+
+    @pytest.mark.asyncio
+    async def test_start_logs_setter_failures(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def fail_setter(value: float) -> None:
+            raise RuntimeError(f"cannot set {value}")
+
+        controller = RateSeriesController(
+            setter=fail_setter,
+            config=series_config(),
+            update_interval=0.5,
+        )
+
+        task = controller.start()
+        await task
+
+        assert "Request-rate series update failed" in caplog.text

--- a/tests/unit/timing/test_timing_config.py
+++ b/tests/unit/timing/test_timing_config.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -55,6 +56,7 @@ _LOADGEN_FIELDS: frozenset[str] = frozenset(
         "concurrency_ramp_duration",
         "prefill_concurrency_ramp_duration",
         "request_rate_ramp_duration",
+        "request_rate_series",
         "arrival_smoothness",
     }
 )
@@ -253,6 +255,20 @@ class TestTimingConfigFromCLIConfig:
             p.request_rate,
             p.total_expected_requests,
         ) == (8, 4, 50.0, 500)
+
+    def test_maps_request_rate_series(self, tmp_path: Path) -> None:
+        json_path = tmp_path / "rate.json"
+        json_path.write_text(
+            '{"points":[{"time_s":0,"qps":5},{"time_s":10,"qps":15}]}',
+            encoding="utf-8",
+        )
+
+        cfg = _make_timing_config(request_rate_series=json_path, request_count=500)
+
+        p = next(pc for pc in cfg.phase_configs if pc.phase == CreditPhase.PROFILING)
+        assert p.request_rate == 5.0
+        assert p.request_rate_series is not None
+        assert p.request_rate_series.points[1].qps == 15.0
 
     def test_creates_warmup_when_configured(self) -> None:
         cfg = _make_timing_config(warmup_request_count=25)

--- a/tools/generate_config_schema.py
+++ b/tools/generate_config_schema.py
@@ -253,6 +253,12 @@ class ConfigSchemaGenerator(Generator):
         if self.verbose and jinja2_count > 0:
             print_step(f"Added Jinja2 template support to {jinja2_count} fields")
 
+        rate_series_count = self._tighten_rate_series_schema_contract(enhanced_schema)
+        if self.verbose and rate_series_count > 0:
+            print_step(
+                f"Tightened rate-series schema contract in {rate_series_count} places"
+            )
+
         # Serialize with proper formatting
         content = json.dumps(enhanced_schema, indent=2, ensure_ascii=False) + "\n"
 
@@ -1409,6 +1415,88 @@ class ConfigSchemaGenerator(Generator):
             process_properties(schema["properties"])
 
         return modified_count
+
+    def _tighten_rate_series_schema_contract(self, schema: dict) -> int:
+        """Align generated rate-series JSON schema with runtime validators."""
+
+        def add_all_of_constraint(target: dict, constraint: dict) -> bool:
+            all_of = target.setdefault("allOf", [])
+            if constraint in all_of:
+                return False
+            all_of.append(constraint)
+            return True
+
+        def require_non_null_property(prop_name: str) -> dict:
+            return {
+                "required": [prop_name],
+                "properties": {prop_name: {"not": {"type": "null"}}},
+            }
+
+        def require_rate_source() -> dict:
+            return {
+                "anyOf": [
+                    require_non_null_property("rate"),
+                    require_non_null_property("rateSeries"),
+                ]
+            }
+
+        def tighten_one(node: dict) -> int:
+            title = node.get("title")
+            properties = node.get("properties")
+            if not isinstance(properties, dict):
+                return 0
+
+            count = 0
+            if title == "RateSeriesConfig":
+                points = properties.get("points")
+                if isinstance(points, dict) and points.get("minItems") != 2:
+                    points["minItems"] = 2
+                    count += 1
+                if add_all_of_constraint(
+                    node,
+                    {
+                        "anyOf": [
+                            require_non_null_property("path"),
+                            {
+                                "required": ["points"],
+                                "properties": {"points": {"minItems": 2}},
+                            },
+                        ]
+                    },
+                ):
+                    count += 1
+
+            if title in {
+                "PoissonPhase",
+                "GammaPhase",
+                "ConstantPhase",
+            } and add_all_of_constraint(node, require_rate_source()):
+                count += 1
+
+            if title == "UserCentricPhase":
+                if properties.pop("rateSeries", None) is not None:
+                    count += 1
+                required = node.setdefault("required", [])
+                if isinstance(required, list) and "rate" not in required:
+                    required.append("rate")
+                    count += 1
+                if add_all_of_constraint(node, require_non_null_property("rate")):
+                    count += 1
+
+            return count
+
+        def walk(node: object) -> int:
+            count = 0
+            if isinstance(node, dict):
+                count += tighten_one(node)
+                for value in node.values():
+                    count += walk(value)
+            elif isinstance(node, list):
+                for value in node:
+                    count += walk(value)
+            return count
+
+        return walk(schema)
 
 
 # =============================================================================

--- a/tools/generate_config_schema.py
+++ b/tools/generate_config_schema.py
@@ -1434,7 +1434,7 @@ class ConfigSchemaGenerator(Generator):
 
         def require_rate_source() -> dict:
             return {
-                "anyOf": [
+                "oneOf": [
                     require_non_null_property("rate"),
                     require_non_null_property("rateSeries"),
                 ]
@@ -1455,7 +1455,7 @@ class ConfigSchemaGenerator(Generator):
                 if add_all_of_constraint(
                     node,
                     {
-                        "anyOf": [
+                        "oneOf": [
                             require_non_null_property("path"),
                             {
                                 "required": ["points"],


### PR DESCRIPTION
## Overview
This feature introduces the capability to control Queries Per Second (QPS) dynamically over time using a user-specified JSON file. Rather than relying on a static or linear load configuration, aiperf can now execute time-varying traffic profiles.

## Changes

- Added `RateSeriesConfig` / `RateSeriesPoint` models with JSON loading, inline shorthand, finite-value validation, and strictly increasing `time_s` checks.
- Added `--request-rate-series` CLI support and YAML/schema support for `rate_series`.
- Integrated `RateSeriesController` into phase execution so compatible request-rate strategies can update QPS dynamically.
- Mapped rate series into timing config using the first QPS as the initial request rate.
- Documented request-rate series usage in CLI docs and the ramping tutorial.
- Added validation to prevent unsupported `rate_series` usage with user-centric mode.
- Prevented warmup from inheriting request-rate ramping unless warmup has a scalar rate.

## How To Test

`pytest tests/unit/property/test_finite_invariants.py::test_every_numeric_field_has_bounds tests/unit/config/test_rate_series_config.py tests/unit/config/test_converter_profiling_phase_routes.py tests/unit/config/test_converter_warmup_grace_period.py tests/unit/timing/test_rate_series.py tests/unit/timing/test_timing_config.py tests/unit/timing/phase/test_runner.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--request-rate-series` to define custom piecewise-linear request-rate curves via JSON (or `rateSeries` in config).
  * Request-rate series now works with ramping, starting after ramp completion when both are provided.
* **Bug Fixes**
  * Improved validation for missing/conflicting request-rate settings, including clearer errors for unsupported combinations.
  * Request-rate changes now take effect more smoothly without unnecessary waiting, improving update responsiveness.
* **Documentation**
  * Expanded CLI and ramping tutorial docs with `request-rate-series` examples and key behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->