### PR TITLE
feat(endpoints): add text-to-speech (TTS) benchmarking via /v1/audio/…

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Log File: /home/user/Code/aiperf/artifacts/granite4:350m-openai-chat-concurrency
 - [Rankings](docs/tutorials/rankings.md) - Profile ranking models
 - [OpenAI Responses API](docs/tutorials/openai-responses.md) - Profile OpenAI Responses API endpoints
 - [Audio](docs/tutorials/audio.md) - Profile audio language models
+- [Text-to-Speech (TTS)](docs/tutorials/tts.md) - Profile text-to-speech models (/v1/audio/speech) with TTFA, RTF, and audio throughput
 - [NIM Image Retrieval](docs/tutorials/nim-image-retrieval.md) - Profile NIM image retrieval models
 - [Vision](docs/tutorials/vision.md) - Profile vision language models
 - [Image Generation](docs/tutorials/image-generation.md) - Benchmark any OpenAI-compatible image generation API

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -230,7 +230,7 @@ Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default,
 #### `--endpoint-type` `<str>`
 
 The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
-<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
+<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `speech`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
 <br/>_Default: `chat`_
 
 #### `--streaming`
@@ -1575,7 +1575,7 @@ Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default,
 #### `--endpoint-type` `<str>`
 
 The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
-<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
+<br/>_Choices: [`chat`, `cohere_rankings`, `completions`, `responses`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `speech`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
 <br/>_Default: `chat`_
 
 #### `--streaming`

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -33,6 +33,8 @@ navigation:
       path: tutorials/audio.md
     - page: Profile ASR Models with AIPerf
       path: tutorials/asr.md
+    - page: Profile Text-to-Speech (TTS) Models with AIPerf
+      path: tutorials/tts.md
     - page: Profile Embedding Models with AIPerf
       path: tutorials/embeddings.md
     - page: Profile Ranking Models with AIPerf

--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -43,6 +43,10 @@ This document provides a comprehensive reference of all metrics available in AIP
   - [Audio Metrics](#audio-metrics)
     - [Audio Duration](#audio-duration)
     - [Inverse Real-Time Factor (RTFx)](#inverse-real-time-factor-rtfx)
+    - [Time to First Audio (TTFA)](#time-to-first-audio-ttfa)
+    - [Output Audio Duration](#output-audio-duration)
+    - [Real-Time Factor (RTF)](#real-time-factor-rtf)
+    - [Audio Throughput](#audio-throughput)
   - [Reasoning Metrics](#reasoning-metrics)
     - [Reasoning Token Count](#reasoning-token-count)
     - [Total Reasoning Tokens](#total-reasoning-tokens)
@@ -621,6 +625,58 @@ rtfx = audio_duration_seconds / request_latency_seconds
 - Higher is better. A value of 10 means the server transcribed audio 10× faster than real-time playback.
 - RTFx < 1 means the server is slower than real-time and not suitable for live transcription.
 - Requires `audio_duration` and `request_latency` metrics to be computed first.
+
+> [!NOTE]
+> The metrics below apply to text-to-speech (TTS) endpoints that **produce** audio (`--endpoint-type speech`). The audio is decoded with `soundfile` to recover the output duration; a headerless `pcm` response cannot be measured.
+
+### Time to First Audio (TTFA)
+
+**Type:** [Record Metric](#record-metrics)
+
+Latency from request start to the first audio chunk for streaming TTS responses - the audio analog of [Time to First Token](#time-to-first-token-ttft).
+
+**Formula:**
+```python
+ttfa = first_audio_chunk_timestamp - request_start_timestamp
+```
+
+**Notes:**
+- Streaming only; not computed for non-streaming (whole-clip) responses.
+
+### Output Audio Duration
+
+**Type:** [Record Metric](#record-metrics)
+
+Seconds of audio synthesized per request, decoded from the returned clip (the chunks of a streamed response are concatenated before decoding).
+
+### Real-Time Factor (RTF)
+
+**Type:** [Record Metric](#record-metrics)
+
+The ratio of request latency to output audio duration. The standard TTS quality-of-service metric (the inverse of the ASR RTFx convention).
+
+**Formula:**
+```python
+rtf = request_latency_seconds / output_audio_duration_seconds
+```
+
+**Notes:**
+- Lower is better. RTF < 1.0 means the server synthesizes audio faster than real-time playback.
+- Requires `output_audio_duration` and `request_latency` metrics to be computed first.
+
+### Audio Throughput
+
+**Type:** [Derived Metric](#derived-metrics)
+
+Seconds of audio synthesized per wall-clock second across the whole benchmark.
+
+**Formula:**
+```python
+audio_throughput = total_output_audio_duration_seconds / benchmark_duration_seconds
+```
+
+**Notes:**
+- Higher is better. Under concurrency it can far exceed 1.0 (e.g. 50 means the fleet produces 50s of audio every wall-second).
 
 ---
 

--- a/docs/tutorials/tts.md
+++ b/docs/tutorials/tts.md
@@ -1,0 +1,101 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Profile Text-to-Speech (TTS) Models with AIPerf
+---
+
+# Profile Text-to-Speech (TTS) Models with AIPerf
+
+AIPerf benchmarks text-to-speech (TTS) models served over the OpenAI-compatible
+`/v1/audio/speech` API. A text prompt is sent as the `input`, and the server
+returns synthesized audio - either a full clip (non-streaming) or a stream of
+audio chunks. AIPerf decodes the returned audio to measure how much speech was
+produced and how fast.
+
+Use `--endpoint-type speech`.
+
+## TTS-specific metrics
+
+| Metric | Meaning |
+|---|---|
+| Time to First Audio (TTFA) | Latency to the first audio chunk (streaming only) - the TTS analog of Time to First Token. |
+| Output Audio Duration | Seconds of audio synthesized per request, decoded from the returned clip. |
+| Real-Time Factor (RTF) | `request_latency / output_audio_duration`. Lower is better; RTF < 1.0 means faster than real-time. |
+| Audio Throughput | Seconds of audio synthesized per wall-clock second across the run. Higher is better; exceeds 1.0 under concurrency. |
+
+Standard request-latency and request-throughput metrics are also reported.
+Token-based metrics (TTFT, ITL, output token throughput) do not apply because a
+TTS endpoint produces audio, not tokens.
+
+> [!NOTE]
+> Audio duration is decoded with `soundfile`/libsndfile, which supports
+> self-describing containers (`wav`, `flac`, `opus`, and `mp3` on builds with
+> MP3 support). A headerless `pcm` response cannot be decoded for duration.
+
+---
+
+## Basic Usage
+
+Profile a TTS server with synthetic text prompts:
+
+```bash
+aiperf profile \
+    --model tts-1 \
+    --endpoint-type speech \
+    --tokenizer gpt2 \
+    --url http://localhost:8000 \
+    --extra-inputs voice:alloy \
+    --extra-inputs response_format:mp3 \
+    --request-count 10 \
+    --concurrency 2
+```
+
+The `--tokenizer` is only needed for input token counting (Input Sequence
+Length); the audio metrics do not require it.
+
+## Streaming and Time to First Audio
+
+Add `--streaming` to request incremental audio and measure Time to First Audio:
+
+```bash
+aiperf profile \
+    --model gpt-4o-mini-tts \
+    --endpoint-type speech \
+    --streaming \
+    --url http://localhost:8000 \
+    --extra-inputs voice:alloy \
+    --request-count 10 \
+    --concurrency 4
+```
+
+When streaming, AIPerf requests Server-Sent Events (`stream_format: sse`) so
+each `speech.audio.delta` chunk is timestamped on arrival. Servers that instead
+stream a raw chunked audio body are also supported - AIPerf records per-chunk
+timing for both shapes, so TTFA is always measured.
+
+## Passing voice, format, and speed
+
+TTS parameters are passed through `--extra-inputs` and merged into the request
+body (per-request `extra` in a dataset overrides these):
+
+```bash
+aiperf profile \
+    --model tts-1 \
+    --endpoint-type speech \
+    --url http://localhost:8000 \
+    --extra-inputs voice:echo \
+    --extra-inputs response_format:wav \
+    --extra-inputs speed:1.25 \
+    --request-count 10
+```
+
+## Custom input text
+
+Synthetic prompts are used by default. To benchmark specific sentences, supply a
+custom dataset or input file (any of AIPerf's text dataset paths work), where
+each record's text becomes the speech `input`. See
+[Custom Dataset](custom-dataset.md) and [Inline Datasets](inline-datasets.md).
+
+## References
+
+- [OpenAI Create Speech API](https://platform.openai.com/docs/api-reference/audio/createSpeech)

--- a/src/aiperf/common/enums/metric_enums.py
+++ b/src/aiperf/common/enums/metric_enums.py
@@ -186,6 +186,7 @@ def _unit(tag: str) -> BaseMetricUnitInfo:
 class GenericMetricUnit(BaseMetricUnit):
     """Defines generic units for metrics. These dont have any extra information other than the tag, which is used for display purposes."""
 
+    AUDIO_SECONDS = _unit("audio_sec")
     BLOCKS = _unit("blocks")
     COUNT = _unit("count")
     ERRORS = _unit("errors")
@@ -371,6 +372,10 @@ class MetricOverTimeUnit(BaseMetricUnit):
     )
     VIDEOS_PER_SECOND = MetricOverTimeUnitInfo(
         primary_unit=GenericMetricUnit.VIDEOS,
+        time_unit=MetricTimeUnit.SECONDS,
+    )
+    AUDIO_SECONDS_PER_SECOND = MetricOverTimeUnitInfo(
+        primary_unit=GenericMetricUnit.AUDIO_SECONDS,
         time_unit=MetricTimeUnit.SECONDS,
     )
     MS_PER_VIDEO = MetricOverTimeUnitInfo(
@@ -756,6 +761,9 @@ class MetricFlags(Flag):
 
     PRODUCES_VIDEO_ONLY = 1 << 16
     """Metrics that are only applicable when profiling an endpoint that produces video output."""
+
+    PRODUCES_AUDIO_ONLY = 1 << 17
+    """Metrics that are only applicable when profiling an endpoint that produces audio output (e.g. text-to-speech)."""
 
     def has_flags(self, flags: "MetricFlags") -> bool:
         """Return True if the metric has ALL of the given flag(s) (regardless of other flags)."""

--- a/src/aiperf/common/models/__init__.py
+++ b/src/aiperf/common/models/__init__.py
@@ -58,6 +58,7 @@ from aiperf.common.models.model_endpoint_info import (
 from aiperf.common.models.prerequisites import TurnPrerequisite
 from aiperf.common.models.progress_models import WorkerProcessingStats, WorkerStats
 from aiperf.common.models.record_models import (
+    AudioResponseData,
     BaseResponseData,
     BinaryResponse,
     EmbeddingResponseData,
@@ -146,6 +147,7 @@ __all__ = [
     "AioHttpTraceData",
     "AioHttpTraceDataExport",
     "Audio",
+    "AudioResponseData",
     "AutoRoutedModel",
     "BasePhaseStats",
     "BaseResponseData",

--- a/src/aiperf/common/models/export_models.py
+++ b/src/aiperf/common/models/export_models.py
@@ -297,6 +297,11 @@ class JsonExportData(AIPerfBaseModel):
     min_request_timestamp: JsonMetricResult | None = None
     max_response_timestamp: JsonMetricResult | None = None
     inter_chunk_latency: JsonMetricResult | None = None
+    time_to_first_audio: JsonMetricResult | None = None
+    output_audio_duration: JsonMetricResult | None = None
+    total_output_audio_duration: JsonMetricResult | None = None
+    output_rtf: JsonMetricResult | None = None
+    audio_throughput: JsonMetricResult | None = None
     total_output_tokens: JsonMetricResult | None = None
     total_reasoning_tokens: JsonMetricResult | None = None
     benchmark_duration: JsonMetricResult | None = None

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import base64
 import sys
 import time
 from dataclasses import dataclass, field
@@ -11,11 +12,14 @@ from typing import Annotated, Any, AnyStr, Protocol, runtime_checkable
 
 import orjson
 from pydantic import (
+    BeforeValidator,
     ConfigDict,
     Field,
     PlainSerializer,
     RootModel,
     SerializeAsAny,
+    TypeAdapter,
+    field_serializer,
     field_validator,
 )
 from pydantic.functional_validators import AfterValidator
@@ -349,6 +353,28 @@ class TextResponse:
             return None
 
 
+def _decode_base64_if_str(value: Any) -> Any:
+    """Accept base64 text (from a JSON round-trip) or raw bytes interchangeably."""
+    if isinstance(value, str):
+        return base64.b64decode(value)
+    return value
+
+
+#: Bytes that survive the JSON-encoded ZMQ message bus and raw exports. Pydantic's
+#: default ``bytes`` JSON serialization is utf8, which raises on non-text payloads
+#: like audio/video; this base64-encodes on dump and decodes on load, while raw
+#: bytes still pass through validation unchanged (no double-encoding in memory).
+Base64Bytes = Annotated[
+    bytes,
+    BeforeValidator(_decode_base64_if_str),
+    PlainSerializer(
+        lambda b: base64.b64encode(b).decode("ascii"),
+        return_type=str,
+        when_used="json",
+    ),
+]
+
+
 @dataclass(slots=True)
 class BinaryResponse:
     """Raw binary response from an inference client for non-text content types."""
@@ -360,7 +386,7 @@ class BinaryResponse:
     perf_ns: int
     """The performance timestamp of the response in nanoseconds (perf_counter_ns)."""
 
-    raw_bytes: bytes
+    raw_bytes: Base64Bytes
     """The raw binary body of the response."""
 
     content_type: str | None = None
@@ -492,6 +518,17 @@ class SSEMessage:
             return load_json_str(data_content)
         except orjson.JSONDecodeError:
             return None
+
+
+#: Serializes the raw ``responses`` list through the concrete union so each
+#: member's field annotations apply (notably ``BinaryResponse``'s base64 bytes
+#: encoding). The field type carries ``SerializeAsAny`` for forward-compat
+#: subclass support, but ``SerializeAsAny``'s duck-typed path ignores those
+#: annotations and would utf8-decode raw audio/video bytes; the field_serializer
+#: below routes around it.
+_RAW_RESPONSES_ADAPTER: TypeAdapter = TypeAdapter(
+    list[SSEMessage | TextResponse | BinaryResponse]
+)
 
 
 class RecordContext(AIPerfBaseModel):
@@ -710,6 +747,14 @@ class RequestRecord(AIPerfBaseModel):
         default_factory=list,
         description="The raw responses received from the request.",
     )
+
+    @field_serializer("responses", when_used="json")
+    def _serialize_responses(self, responses: list[Any]) -> list[Any]:
+        """Serialize raw responses via the concrete union so BinaryResponse bytes
+        are base64-encoded for the JSON ZMQ bus and raw exports (see
+        ``_RAW_RESPONSES_ADAPTER``)."""
+        return _RAW_RESPONSES_ADAPTER.dump_python(responses, mode="json")
+
     error: ErrorDetails | None = Field(
         default=None,
         description="The error details if the request failed.",
@@ -985,6 +1030,28 @@ class VideoResponseData(BaseResponseData):
     """Error details if job failed."""
 
 
+@dataclass(slots=True)
+class AudioResponseData(BaseResponseData):
+    """Parsed text-to-speech audio response.
+
+    Carries the decoded audio for one response unit - either a full clip
+    (non-streaming binary body) or a single stream chunk (an SSE
+    ``speech.audio.delta`` or one network chunk of a streamed audio body).
+    Audio metrics concatenate the ``audio_bytes`` of a record's chunks and
+    decode the result with soundfile to recover the output duration, while
+    the per-chunk ``perf_ns`` on the enclosing ``ParsedResponse`` provides
+    time-to-first-audio. Has no text, so it contributes nothing to OSL.
+    """
+
+    audio_bytes: Base64Bytes | None = None
+    """The decoded audio bytes for this response unit (clip or chunk). Uses
+    Base64Bytes (like BinaryResponse.raw_bytes) so a JSON dump base64-encodes
+    rather than utf8-decoding, which would raise on non-text audio payloads."""
+
+    format: str | None = None
+    """The audio container/codec, e.g. 'mp3', 'wav', 'flac', 'opus', 'pcm'."""
+
+
 def find_last_non_empty_usage(responses: list[ParsedResponse]) -> Usage | None:
     """Return the last response chunk's usage that has any data, walking
     the list backwards.
@@ -1031,6 +1098,7 @@ class ParsedResponse:
         | ImageRetrievalResponseData
         | ImageResponseData
         | VideoResponseData
+        | AudioResponseData
         | BaseResponseData
         | None
     ] = None
@@ -1237,6 +1305,13 @@ class RawRecordInfo(AIPerfBaseModel):
         ...,
         description="The raw responses received from the request.",
     )
+
+    @field_serializer("responses", when_used="json")
+    def _serialize_responses(self, responses: list[Any]) -> list[Any]:
+        """Serialize raw responses via the concrete union so BinaryResponse bytes
+        are base64-encoded for JSON raw exports (see ``_RAW_RESPONSES_ADAPTER``)."""
+        return _RAW_RESPONSES_ADAPTER.dump_python(responses, mode="json")
+
     error: ErrorDetails | None = Field(
         default=None,
         description="The error details if the request failed.",

--- a/src/aiperf/endpoints/openai_speech.py
+++ b/src/aiperf/endpoints/openai_speech.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from aiperf.common.models import (
+    AudioResponseData,
+    InferenceServerResponse,
+    ParsedResponse,
+    RequestInfo,
+)
+from aiperf.endpoints.base_endpoint import BaseEndpoint
+
+# Short format tags for the audio MIME types TTS servers commonly return.
+_AUDIO_FORMAT_BY_MIME: dict[str, str] = {
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/wave": "wav",
+    "audio/flac": "flac",
+    "audio/x-flac": "flac",
+    "audio/opus": "opus",
+    "audio/ogg": "ogg",
+    "audio/aac": "aac",
+    "audio/pcm": "pcm",
+}
+
+
+def _format_from_content_type(content_type: str | None) -> str | None:
+    """Map an ``audio/*`` content type to a short format tag (e.g. mp3, wav)."""
+    if not content_type:
+        return None
+    base = content_type.split(";", 1)[0].strip().lower()
+    if base in _AUDIO_FORMAT_BY_MIME:
+        return _AUDIO_FORMAT_BY_MIME[base]
+    if base.startswith("audio/"):
+        return base[len("audio/") :] or None
+    return None
+
+
+class OpenAISpeechEndpoint(BaseEndpoint):
+    """OpenAI-compatible text-to-speech endpoint (/v1/audio/speech).
+
+    Sends text and returns synthesized audio - either a full clip
+    (non-streaming binary body) or a stream of audio chunks. When streaming
+    is enabled the payload requests Server-Sent Events (``stream_format:
+    sse``) so per-chunk timing (time-to-first-audio) is captured; servers
+    that instead stream a raw chunked audio body are handled by the
+    transport's streamed-binary path and also parsed here as binary chunks.
+
+    Voice, response format, and speed are passed via ``--extra-inputs``
+    (e.g. ``--extra-inputs voice:alloy response_format:wav speed:1.0``),
+    mirroring how the image-generation endpoint takes ``size``/``quality``.
+
+    See: https://platform.openai.com/docs/api-reference/audio/createSpeech
+    """
+
+    DEFAULT_VOICE = "alloy"
+    DEFAULT_RESPONSE_FORMAT = "mp3"
+
+    def format_payload(self, request_info: RequestInfo) -> dict[str, Any]:
+        """Format an OpenAI /v1/audio/speech request payload from RequestInfo.
+
+        - input (required): text to synthesize, from ``turn.texts[0]``
+        - model (optional): from ``turn.model`` or the endpoint's primary model
+        - voice / response_format: defaulted; override via ``--extra-inputs``
+        - stream_format: set to ``sse`` when streaming is enabled
+        - speed and any other server tunables: pass via ``--extra-inputs``
+        """
+        if not request_info.turns:
+            raise ValueError("Speech endpoint requires at least one turn.")
+
+        turn = request_info.turns[-1]
+        model_endpoint = request_info.model_endpoint
+
+        if not turn.texts or not turn.texts[0].contents:
+            raise ValueError("Speech endpoint requires a text input to synthesize.")
+
+        text = turn.texts[0].contents[0]
+
+        payload: dict[str, Any] = {
+            "input": text,
+            "model": turn.model or model_endpoint.primary_model_name,
+            "voice": self.DEFAULT_VOICE,
+            "response_format": self.DEFAULT_RESPONSE_FORMAT,
+        }
+
+        if model_endpoint.endpoint.streaming:
+            # SSE audio deltas give per-chunk timing for TTFA plus a final
+            # usage event. Overridable via --extra-inputs stream_format:audio.
+            payload["stream_format"] = "sse"
+
+        if model_endpoint.endpoint.extra:
+            payload.update(model_endpoint.endpoint.extra)
+
+        if turn.extra_body:
+            payload.update(turn.extra_body)
+
+        self.trace(lambda: f"Formatted payload: {payload}")
+        return payload
+
+    def parse_response(
+        self, response: InferenceServerResponse
+    ) -> ParsedResponse | None:
+        """Parse one speech response unit into an AudioResponseData chunk.
+
+        Handles three shapes: a non-streaming binary clip, a streamed binary
+        chunk (both arrive as raw bytes), and an SSE ``speech.audio.delta``
+        (base64 audio). The final ``speech.audio.done`` event carries usage
+        only and is returned with no data so it is excluded from content
+        responses but still contributes token usage.
+        """
+        # Non-streaming clip or a single streamed-binary chunk: raw audio bytes.
+        raw = response.get_raw()
+        if isinstance(raw, bytes):
+            if not raw:
+                return None
+            fmt = _format_from_content_type(getattr(response, "content_type", None))
+            return ParsedResponse(
+                perf_ns=response.perf_ns,
+                data=AudioResponseData(audio_bytes=raw, format=fmt),
+            )
+
+        # Streaming SSE: speech.audio.delta (base64 audio) / speech.audio.done (usage).
+        json_obj = response.get_json()
+        if not json_obj:
+            return None
+
+        audio_b64 = json_obj.get("audio")
+        if audio_b64:
+            try:
+                audio_bytes = base64.b64decode(audio_b64)
+            except (ValueError, TypeError):
+                self.debug(
+                    lambda: "Failed to base64-decode audio delta; skipping chunk."
+                )
+                return None
+            return ParsedResponse(
+                perf_ns=response.perf_ns,
+                data=AudioResponseData(audio_bytes=audio_bytes),
+            )
+
+        # Usage-only event (e.g. speech.audio.done) - no audio data.
+        usage = json_obj.get("usage") or None
+        if usage:
+            return ParsedResponse(perf_ns=response.perf_ns, usage=usage)
+
+        return None

--- a/src/aiperf/metrics/types/audio_throughput_metric.py
+++ b/src/aiperf/metrics/types/audio_throughput_metric.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from aiperf.common.enums import MetricFlags, MetricOverTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.metrics import BaseDerivedMetric
+from aiperf.metrics.metric_dicts import MetricResultsDict
+from aiperf.metrics.types.benchmark_duration_metric import BenchmarkDurationMetric
+from aiperf.metrics.types.output_audio_duration_metric import (
+    TotalOutputAudioDurationMetric,
+)
+
+
+class AudioThroughputMetric(BaseDerivedMetric[float]):
+    """Aggregate audio throughput for text-to-speech benchmarks.
+
+    Formula:
+        Audio Throughput = Total Output Audio Duration (seconds) / Benchmark Duration (seconds)
+
+    Larger is better. Expressed as seconds-of-audio synthesized per
+    wall-clock second across the whole run, so under concurrency it can far
+    exceed 1.0 (e.g. 50 means the fleet produces 50s of audio every second).
+    """
+
+    tag = "audio_throughput"
+    header = "Audio Throughput"
+    short_header = "Audio Thpt"
+    short_header_hide_unit = True
+    unit = MetricOverTimeUnit.AUDIO_SECONDS_PER_SECOND
+    display_order = 800
+    flags = MetricFlags.PRODUCES_AUDIO_ONLY | MetricFlags.LARGER_IS_BETTER
+    required_metrics = {
+        TotalOutputAudioDurationMetric.tag,
+        BenchmarkDurationMetric.tag,
+    }
+
+    def _derive_value(
+        self,
+        metric_results: MetricResultsDict,
+    ) -> float:
+        total_audio_seconds = metric_results.get_or_raise(
+            TotalOutputAudioDurationMetric
+        )
+        benchmark_duration_converted = metric_results.get_converted_or_raise(
+            BenchmarkDurationMetric,
+            self.unit.time_unit,  # type: ignore
+        )
+        if benchmark_duration_converted == 0:
+            raise NoMetricValue(
+                "Benchmark duration is zero, cannot calculate audio throughput metric"
+            )
+        return total_audio_seconds / benchmark_duration_converted  # type: ignore

--- a/src/aiperf/metrics/types/output_audio_duration_metric.py
+++ b/src/aiperf/metrics/types/output_audio_duration_metric.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+
+import soundfile as sf
+
+from aiperf.common.enums import MetricConsoleGroup, MetricFlags, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import AudioResponseData, ParsedResponseRecord
+from aiperf.metrics import BaseRecordMetric
+from aiperf.metrics.derived_sum_metric import DerivedSumMetric
+from aiperf.metrics.metric_dicts import MetricRecordDict
+
+
+def decode_audio_duration_seconds(audio_bytes: bytes) -> float | None:
+    """Decode the duration in seconds of a self-describing audio payload.
+
+    Reads only the header via ``soundfile.info`` (no full decode), so it is
+    cheap even for long clips. Works for container formats that carry their
+    own sample rate and frame count (wav, flac, ogg/opus, mp3 with a
+    libsndfile build that supports it). Headerless ``pcm`` cannot be decoded
+    without an assumed sample rate and returns ``None``.
+
+    Returns ``None`` on any decode failure so callers can raise
+    ``NoMetricValue`` rather than aborting the whole record.
+    """
+    try:
+        info = sf.info(io.BytesIO(audio_bytes))
+    except (OSError, ValueError, RuntimeError):
+        return None
+    return float(info.duration)
+
+
+def _concat_audio_bytes(record: ParsedResponseRecord) -> bytes:
+    """Concatenate the audio bytes of every audio chunk in the record.
+
+    For streamed responses the chunks split the clip at arbitrary byte
+    boundaries, so individual chunks are not independently decodable; the
+    concatenation reconstructs the original audio payload.
+    """
+    return b"".join(
+        response.data.audio_bytes
+        for response in record.content_responses
+        if isinstance(response.data, AudioResponseData) and response.data.audio_bytes
+    )
+
+
+class OutputAudioDurationMetric(BaseRecordMetric[float]):
+    """Per-request duration of the generated (output) audio in seconds.
+
+    Decodes the audio returned by a text-to-speech endpoint to recover how
+    much audio was synthesized. This is the TTS counterpart of the ASR
+    ``audio_duration`` metric (which measures *input* audio), and is the
+    basis for the output real-time factor and audio throughput metrics.
+
+    Example:
+        A request that returns a 7.3s clip produces
+        ``output_audio_duration = 7.3``.
+
+    Raises:
+        NoMetricValue: when the record carries no audio bytes, or the audio
+            cannot be decoded (e.g. a headerless ``pcm`` payload).
+    """
+
+    tag = "output_audio_duration"
+    header = "Output Audio Duration"
+    short_header = "Audio Dur"
+    unit = MetricTimeUnit.SECONDS
+    display_order = 870
+    flags = MetricFlags.PRODUCES_AUDIO_ONLY
+    required_metrics = None
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> float:
+        audio_bytes = _concat_audio_bytes(record)
+        if not audio_bytes:
+            raise NoMetricValue(
+                "Record has no audio response bytes; output audio duration unavailable."
+            )
+
+        duration = decode_audio_duration_seconds(audio_bytes)
+        if duration is None or duration <= 0:
+            raise NoMetricValue(
+                "Could not decode output audio duration (unsupported or headerless "
+                "format such as raw pcm)."
+            )
+        return duration
+
+
+class TotalOutputAudioDurationMetric(
+    DerivedSumMetric[float, OutputAudioDurationMetric]
+):
+    """Total seconds of audio synthesized across the whole benchmark.
+
+    Formula:
+        Total Output Audio Duration = Sum(Output Audio Durations)
+    """
+
+    tag = "total_output_audio_duration"
+    header = "Total Output Audio Duration"
+    short_header = "Total Audio Dur"
+    short_header_hide_unit = True
+    flags = MetricFlags.PRODUCES_AUDIO_ONLY
+    console_group = MetricConsoleGroup.NONE

--- a/src/aiperf/metrics/types/output_rtf_metric.py
+++ b/src/aiperf/metrics/types/output_rtf_metric.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from aiperf.common.enums import GenericMetricUnit, MetricFlags, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import ParsedResponseRecord
+from aiperf.metrics import BaseRecordMetric
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.output_audio_duration_metric import OutputAudioDurationMetric
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+
+
+class OutputRTFMetric(BaseRecordMetric[float]):
+    """Real-Time Factor (RTF) for text-to-speech benchmarks.
+
+    Formula:
+        RTF = request_latency_seconds / output_audio_duration_seconds
+
+    Lower is better; the standard TTS quality-of-service metric. RTF < 1.0
+    means the server synthesizes audio faster than it plays back (suitable
+    for real-time streaming); RTF > 1.0 means it is slower than real-time.
+    This is the inverse of the ASR ``RTFx`` convention - TTS literature
+    reports RTF (smaller is better), so we follow that here.
+
+    Example:
+        A 10s clip produced with 2s of request latency -> RTF = 0.2
+        ("5x faster than real-time").
+
+    Requires ``OutputAudioDurationMetric`` and ``RequestLatencyMetric`` to
+    be computed first.
+
+    Raises:
+        NoMetricValue: when the output audio duration is missing or
+            non-positive, so the ratio is undefined.
+    """
+
+    tag = "output_rtf"
+    header = "Real-Time Factor (RTF)"
+    short_header = "RTF"
+    short_header_hide_unit = True
+    unit = GenericMetricUnit.RATIO
+    display_order = 850
+    flags = MetricFlags.PRODUCES_AUDIO_ONLY
+    required_metrics = {OutputAudioDurationMetric.tag, RequestLatencyMetric.tag}
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> float:
+        audio_duration = record_metrics.get_or_raise(OutputAudioDurationMetric)
+        if audio_duration <= 0:
+            raise NoMetricValue(
+                f"Output audio duration is non-positive ({audio_duration}s); RTF undefined."
+            )
+
+        latency_seconds = record_metrics.get_converted_or_raise(
+            RequestLatencyMetric, MetricTimeUnit.SECONDS
+        )
+        return latency_seconds / audio_duration

--- a/src/aiperf/metrics/types/time_to_first_audio_metric.py
+++ b/src/aiperf/metrics/types/time_to_first_audio_metric.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from aiperf.common.enums import MetricFlags, MetricTimeUnit
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import ParsedResponseRecord
+from aiperf.metrics import BaseRecordMetric
+from aiperf.metrics.metric_dicts import MetricRecordDict
+
+
+class TimeToFirstAudioMetric(BaseRecordMetric[int]):
+    """Time to First Audio (TTFA) for streaming text-to-speech responses.
+
+    The TTS counterpart of Time to First Token: the latency from sending the
+    request to receiving the first audio chunk. Only meaningful when
+    streaming is enabled, since a non-streaming response delivers the entire
+    clip at once.
+
+    Formula:
+        TTFA = First Audio Chunk Timestamp - Request Start Timestamp
+    """
+
+    tag = "time_to_first_audio"
+    header = "Time to First Audio"
+    short_header = "TTFA"
+    unit = MetricTimeUnit.NANOSECONDS
+    display_unit = MetricTimeUnit.MILLISECONDS
+    display_order = 100
+    flags = MetricFlags.PRODUCES_AUDIO_ONLY | MetricFlags.STREAMING_ONLY
+    required_metrics = None
+
+    def _parse_record(
+        self,
+        record: ParsedResponseRecord,
+        record_metrics: MetricRecordDict,
+    ) -> int:
+        if len(record.content_responses) < 1:
+            raise NoMetricValue(
+                "Record must have at least one audio response to calculate TTFA."
+            )
+
+        request_ts: int = record.request.start_perf_ns
+        first_response_ts: int = record.content_responses[0].perf_ns
+        if first_response_ts < request_ts:
+            raise ValueError(
+                "First audio response timestamp is before request start timestamp, "
+                "cannot compute TTFA."
+            )
+
+        return first_response_ts - request_ts

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -67,7 +67,7 @@ PublicDatasetType = plugins.create_enum(PluginType.PUBLIC_DATASET_LOADER, "Publi
 
 EndpointTypeStr: TypeAlias = str
 EndpointType = plugins.create_enum(PluginType.ENDPOINT, "EndpointType", module=__name__)
-"""Dynamic enum for endpoint. Example: EndpointType.CHAT, EndpointType.IMAGE_GENERATION, EndpointType.VIDEO_GENERATION"""
+"""Dynamic enum for endpoint. Example: EndpointType.CHAT, EndpointType.IMAGE_RETRIEVAL, EndpointType.VIDEO_GENERATION"""
 
 TransportTypeStr: TypeAlias = str
 TransportType = plugins.create_enum(PluginType.TRANSPORT, "TransportType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -326,6 +326,22 @@ endpoint:
       requires_form_data: true
       metrics_title: Video Generation Metrics
 
+  speech:
+    class: aiperf.endpoints.openai_speech:OpenAISpeechEndpoint
+    description: |
+      OpenAI-compatible text-to-speech (TTS) endpoint. Synthesizes audio from
+      a text input using models like tts-1 or gpt-4o-mini-tts. Supports
+      non-streaming (binary audio body) and streaming (SSE audio deltas, which
+      enable time-to-first-audio). Pass voice / response_format / speed via
+      --extra-inputs. Uses /v1/audio/speech path.
+    metadata:
+      endpoint_path: /v1/audio/speech
+      supports_streaming: true
+      produces_tokens: false
+      produces_audio: true
+      tokenizes_input: true
+      metrics_title: TTS Metrics
+
   image_retrieval:
     class: aiperf.endpoints.nim_image_retrieval:ImageRetrievalEndpoint
     description: |

--- a/src/aiperf/post_processors/base_metrics_processor.py
+++ b/src/aiperf/post_processors/base_metrics_processor.py
@@ -35,18 +35,20 @@ class BaseMetricsProcessor(AIPerfLifecycleMixin, ABC):
         from aiperf.plugin import plugins
 
         endpoint_metadata = plugins.get_endpoint_metadata(self.run.cfg.endpoint.type)
-        if not endpoint_metadata.produces_tokens:
-            disallowed_flags |= MetricFlags.PRODUCES_TOKENS_ONLY
-        if not endpoint_metadata.tokenizes_input:
-            disallowed_flags |= MetricFlags.TOKENIZES_INPUT_ONLY
-        if not endpoint_metadata.supports_audio:
-            disallowed_flags |= MetricFlags.SUPPORTS_AUDIO_ONLY
-        if not endpoint_metadata.supports_images:
-            disallowed_flags |= MetricFlags.SUPPORTS_IMAGE_ONLY
-        if not endpoint_metadata.supports_videos:
-            disallowed_flags |= MetricFlags.SUPPORTS_VIDEO_ONLY
-        if not endpoint_metadata.produces_videos:
-            disallowed_flags |= MetricFlags.PRODUCES_VIDEO_ONLY
+        # Disable each "<capability>_ONLY" metric flag whose capability the
+        # endpoint does not advertise.
+        capability_gates = (
+            (endpoint_metadata.produces_tokens, MetricFlags.PRODUCES_TOKENS_ONLY),
+            (endpoint_metadata.tokenizes_input, MetricFlags.TOKENIZES_INPUT_ONLY),
+            (endpoint_metadata.supports_audio, MetricFlags.SUPPORTS_AUDIO_ONLY),
+            (endpoint_metadata.supports_images, MetricFlags.SUPPORTS_IMAGE_ONLY),
+            (endpoint_metadata.supports_videos, MetricFlags.SUPPORTS_VIDEO_ONLY),
+            (endpoint_metadata.produces_videos, MetricFlags.PRODUCES_VIDEO_ONLY),
+            (endpoint_metadata.produces_audio, MetricFlags.PRODUCES_AUDIO_ONLY),
+        )
+        for supported, flag in capability_gates:
+            if not supported:
+                disallowed_flags |= flag
         if not self.run.cfg.endpoint.streaming:
             disallowed_flags |= MetricFlags.STREAMING_ONLY
         if self.run.cfg.endpoint.use_server_token_count:

--- a/src/aiperf/transports/aiohttp_client.py
+++ b/src/aiperf/transports/aiohttp_client.py
@@ -21,7 +21,7 @@ from aiperf.common.models import (
 )
 from aiperf.transports.aiohttp_trace import create_aiohttp_trace_config
 from aiperf.transports.http_defaults import AioHttpDefaults, SocketDefaults
-from aiperf.transports.sse_utils import AsyncSSEStreamReader
+from aiperf.transports.sse_utils import AsyncSSEStreamReader, collect_streamed_binary
 
 if TYPE_CHECKING:
     from aiperf.transports.base_transports import FirstTokenCallback
@@ -85,6 +85,7 @@ class AioHttpClient(AIPerfLoggerMixin):
         trace_data: AioHttpTraceData | None = None,
         connector: aiohttp.TCPConnector | None = None,
         connector_owner: bool = False,
+        stream: bool = False,
         **kwargs: Any,
     ) -> RequestRecord:
         """Generic request method that handles common logic for all HTTP methods.
@@ -243,7 +244,22 @@ class AioHttpClient(AIPerfLoggerMixin):
                             or content_type == "application/octet-stream"
                         )
 
-                        if is_binary:
+                        if is_binary and stream:
+                            # Streamed binary body (e.g. chunked text-to-speech audio):
+                            # one BinaryResponse per network chunk with per-chunk arrival
+                            # timing so time-to-first-audio is measurable post-hoc from the
+                            # first chunk's perf_ns. first_token_callback is not fired here
+                            # (it is typed for SSEMessage, not binary chunks).
+                            record.responses.extend(
+                                await collect_streamed_binary(
+                                    response.content.iter_any(),
+                                    record.trace_data,
+                                    content_type,
+                                    collect_chunks,
+                                )
+                            )
+                            record.end_perf_ns = time.perf_counter_ns()
+                        elif is_binary:
                             raw_bytes = await response.read()
                             record.end_perf_ns = time.perf_counter_ns()
                             record.responses.append(
@@ -269,10 +285,13 @@ class AioHttpClient(AIPerfLoggerMixin):
                                 response_start_ns
                             )
                         # Note: response.text()/read() should trigger aiohttp trace callbacks,
-                        # but we set response_receive_end_perf_ns explicitly for consistency
-                        record.trace_data.response_receive_end_perf_ns = (
-                            record.end_perf_ns
-                        )
+                        # but we set response_receive_end_perf_ns explicitly for consistency.
+                        # Guard with `is None` so the streamed-binary path's per-chunk
+                        # last-chunk timestamp (set by collect_streamed_binary) is preserved.
+                        if record.trace_data.response_receive_end_perf_ns is None:
+                            record.trace_data.response_receive_end_perf_ns = (
+                                record.end_perf_ns
+                            )
 
                     self.debug(
                         lambda: (
@@ -312,6 +331,7 @@ class AioHttpClient(AIPerfLoggerMixin):
         first_token_callback: "FirstTokenCallback | None" = None,
         connector: aiohttp.TCPConnector | None = None,
         connector_owner: bool = False,
+        stream: bool = False,
         **kwargs: Any,
     ) -> RequestRecord:
         """Send a POST request to the specified URL.
@@ -339,6 +359,7 @@ class AioHttpClient(AIPerfLoggerMixin):
                 first_token_callback=first_token_callback,
                 connector=connector,
                 connector_owner=connector_owner,
+                stream=stream,
                 **kwargs,
             )
         return await self._request_with_cancellation(
@@ -349,6 +370,7 @@ class AioHttpClient(AIPerfLoggerMixin):
             first_token_callback=first_token_callback,
             connector=connector,
             connector_owner=connector_owner,
+            stream=stream,
         )
 
     async def _request_with_cancellation(
@@ -361,6 +383,7 @@ class AioHttpClient(AIPerfLoggerMixin):
         first_token_callback: "FirstTokenCallback | None" = None,
         connector: aiohttp.TCPConnector | None = None,
         connector_owner: bool = False,
+        stream: bool = False,
     ) -> RequestRecord:
         """Send POST request with cancellation after specified delay.
 
@@ -392,6 +415,7 @@ class AioHttpClient(AIPerfLoggerMixin):
                 trace_data=trace_data,
                 connector=connector,
                 connector_owner=connector_owner,
+                stream=stream,
             )
         )
 

--- a/src/aiperf/transports/aiohttp_transport.py
+++ b/src/aiperf/transports/aiohttp_transport.py
@@ -372,6 +372,7 @@ class AioHttpTransport(BaseTransport):
                 first_token_callback=first_token_callback,
                 connector=connector,
                 connector_owner=connector_owner,
+                stream=self.model_endpoint.endpoint.streaming,
             )
             record.request_headers = redact_headers(headers)
 

--- a/src/aiperf/transports/sse_utils.py
+++ b/src/aiperf/transports/sse_utils.py
@@ -8,9 +8,43 @@ from collections.abc import AsyncIterator
 from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.common.enums import SSEEventType, SSEFieldType
 from aiperf.common.exceptions import SSEResponseError
-from aiperf.common.models import SSEMessage
+from aiperf.common.models import BaseTraceData, BinaryResponse, SSEMessage
 
 _logger = AIPerfLogger(__name__)
+
+
+async def collect_streamed_binary(
+    content: AsyncIterator[bytes],
+    trace: BaseTraceData,
+    content_type: str,
+    collect_chunks: bool,
+) -> list[BinaryResponse]:
+    """Consume a chunked binary response body, one BinaryResponse per network chunk.
+
+    Records each chunk's arrival time (perf_counter_ns) so streamed audio/video
+    bodies yield time-to-first-chunk; downstream parsing concatenates the chunks
+    to reconstruct the full payload. Mirrors the SSE path's chunk-timing trace
+    bookkeeping. The caller passes ``response.content.iter_any()`` so bytes
+    surface as they arrive.
+    """
+    responses: list[BinaryResponse] = []
+    chunks_append = trace.response_chunks.append if collect_chunks else None
+    awaiting_first_chunk = True
+    async for chunk in content:
+        chunk_ns = time.perf_counter_ns()
+        chunk_len = len(chunk)
+        trace.response_chunks_count += 1
+        trace.response_bytes_total += chunk_len
+        if chunks_append is not None:
+            chunks_append((chunk_ns, chunk_len))
+        if awaiting_first_chunk:
+            trace.response_receive_start_perf_ns = chunk_ns
+            awaiting_first_chunk = False
+        trace.response_receive_end_perf_ns = chunk_ns
+        responses.append(
+            BinaryResponse(perf_ns=chunk_ns, content_type=content_type, raw_bytes=chunk)
+        )
+    return responses
 
 
 class AsyncSSEStreamReader:

--- a/tests/aiperf_mock_server/app.py
+++ b/tests/aiperf_mock_server/app.py
@@ -4,9 +4,13 @@
 import asyncio
 import base64
 import hashlib
+import io
 import logging
+import math
 import random
+import struct
 import time
+import wave
 from contextlib import asynccontextmanager
 from time import perf_counter
 from typing import Any
@@ -48,6 +52,7 @@ from aiperf_mock_server.models import (
     ImageRetrievalRequest,
     RankingRequest,
     SolidoRAGRequest,
+    SpeechRequest,
     TGIGenerateRequest,
 )
 from aiperf_mock_server.node_exporter_faker import (
@@ -990,6 +995,102 @@ async def image_generation(
     with track_llm_request(ctx, req.model, endpoint):
         await ctx.latency_sim.wait_for_tokens(len(ctx.tokens))
         return ORJSONResponse(_build_image_response_data(ctx, req))
+
+
+# ============================================================================
+# Text-to-Speech (Audio Speech)
+# ============================================================================
+
+_TTS_SAMPLE_RATE = 16000
+_TTS_SECONDS_PER_CHAR = 0.05
+_TTS_STREAM_CHUNKS = 5
+
+
+def generate_mock_wav(text: str) -> bytes:
+    """Generate a deterministic mono 16-bit WAV clip for a TTS input.
+
+    Duration scales with the input length so longer text yields longer
+    audio, mirroring real TTS. The samples are a quiet sine wave (not
+    silence) so the payload is non-trivial; any standard decoder
+    (soundfile/libsndfile) recovers the duration from the WAV header.
+    """
+    duration_s = max(0.2, round(len(text) * _TTS_SECONDS_PER_CHAR, 3))
+    num_samples = int(duration_s * _TTS_SAMPLE_RATE)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(_TTS_SAMPLE_RATE)
+        frames = bytearray()
+        for n in range(num_samples):
+            sample = int(8000 * math.sin(2 * math.pi * 220 * n / _TTS_SAMPLE_RATE))
+            frames += struct.pack("<h", sample)
+        wav.writeframes(bytes(frames))
+    return buf.getvalue()
+
+
+def iter_speech_audio_sse(
+    audio_bytes: bytes, usage: dict[str, Any], num_chunks: int = _TTS_STREAM_CHUNKS
+) -> list[bytes]:
+    """Build the SSE frames for a streamed speech response.
+
+    Splits the audio into ``num_chunks`` ``speech.audio.delta`` events (each
+    a base64 slice) followed by a ``speech.audio.done`` event carrying usage.
+    Returned as a list of ``data: {...}\\n\\n`` frames so callers can pace
+    them with their own latency model.
+    """
+    frames: list[bytes] = []
+    chunk_size = max(1, math.ceil(len(audio_bytes) / num_chunks))
+    for offset in range(0, len(audio_bytes), chunk_size):
+        delta = {
+            "type": "speech.audio.delta",
+            "audio": base64.b64encode(audio_bytes[offset : offset + chunk_size]).decode(
+                "utf-8"
+            ),
+        }
+        frames.append(b"data: " + orjson.dumps(delta) + b"\n\n")
+    done = {"type": "speech.audio.done", "usage": usage}
+    frames.append(b"data: " + orjson.dumps(done) + b"\n\n")
+    return frames
+
+
+@app.post("/v1/audio/speech", response_model=None)
+@with_error_injection
+async def audio_speech(
+    req: SpeechRequest, request: Request
+) -> Response | StreamingResponse:
+    """Mock OpenAI text-to-speech endpoint (/v1/audio/speech).
+
+    Returns a deterministic WAV clip whose duration scales with the input
+    length. Honors ``stream_format: sse`` by emitting ``speech.audio.delta``
+    events (base64 audio chunks) followed by a ``speech.audio.done`` event
+    with usage; otherwise returns the whole clip as a binary ``audio/wav``
+    body. Always returns WAV regardless of the requested ``response_format``
+    (the mock has no real codec), which every decoder handles.
+    """
+    endpoint = "/v1/audio/speech"
+    start_time = request.state.start_time
+    mock_req = ChatCompletionRequest(
+        model=req.model, messages=[{"role": "user", "content": req.input}]
+    )
+    ctx = make_ctx(mock_req, endpoint, start_time)
+    audio_bytes = generate_mock_wav(req.input)
+
+    if req.stream_format == "sse":
+        STREAMING_REQUESTS_TOTAL.labels(endpoint=endpoint, model=req.model).inc()
+
+        async def speech_stream():
+            async with async_track_llm_request(ctx, req.model, endpoint):
+                tokens_per_chunk = max(1, len(ctx.tokens) // _TTS_STREAM_CHUNKS)
+                for frame in iter_speech_audio_sse(audio_bytes, ctx.usage):
+                    await ctx.latency_sim.wait_for_tokens(tokens_per_chunk)
+                    yield frame
+
+        return StreamingResponse(speech_stream(), media_type="text/event-stream")
+
+    with track_llm_request(ctx, req.model, endpoint):
+        await ctx.latency_sim.wait_for_tokens(len(ctx.tokens))
+        return Response(content=audio_bytes, media_type="audio/wav")
 
 
 # Each parameter calls Form/File fresh so FastAPI builds an independent

--- a/tests/aiperf_mock_server/models.py
+++ b/tests/aiperf_mock_server/models.py
@@ -202,6 +202,17 @@ class ImageGenerationRequest(BaseModel):
     style: str | None = None
 
 
+class SpeechRequest(BaseModel):
+    """Request model for the OpenAI /v1/audio/speech (text-to-speech) endpoint."""
+
+    input: str
+    model: str = "tts-1"
+    voice: str = "alloy"
+    response_format: str = "mp3"
+    speed: float = 1.0
+    stream_format: Literal["audio", "sse"] | None = None
+
+
 class ImageRetrievalInput(BaseModel):
     """Single image input for NIM image retrieval."""
 

--- a/tests/aiperf_mock_server/tokens.py
+++ b/tests/aiperf_mock_server/tokens.py
@@ -17,6 +17,7 @@ from aiperf_mock_server.models import (
     RankingRequest,
     RequestT,
     SolidoRAGRequest,
+    SpeechRequest,
     TGIGenerateRequest,
     flatten_completion_prompt_token_ids,
 )
@@ -208,6 +209,7 @@ def tokenize_request(request: RequestT) -> TokenizedText:
             HFTEIRerankRequest,
             CohereRerankRequest,
             ImageGenerationRequest,
+            SpeechRequest,
         ),
     ):
         return TokenizedText(
@@ -331,6 +333,8 @@ def _extract_request_content(request: RequestT) -> tuple[str, int | None]:
         return text, None
     elif isinstance(request, ImageGenerationRequest):
         return request.prompt, None
+    elif isinstance(request, SpeechRequest):
+        return request.input, None
     elif isinstance(request, SolidoRAGRequest):
         return " ".join(request.query), None
     else:

--- a/tests/aiperf_mock_server/utils.py
+++ b/tests/aiperf_mock_server/utils.py
@@ -36,6 +36,7 @@ from aiperf_mock_server.models import (
     RankingRequest,
     RequestT,
     SolidoRAGRequest,
+    SpeechRequest,
     TGIGenerateRequest,
 )
 from aiperf_mock_server.request_recorder import get_global_recorder
@@ -466,6 +467,8 @@ def _create_request_id(request: RequestT) -> str:
             return f"rank-{uuid.uuid4()}"
         case ImageGenerationRequest():
             return f"img-{uuid.uuid4()}"
+        case SpeechRequest():
+            return f"speech-{uuid.uuid4()}"
         case SolidoRAGRequest():
             return f"rag-{uuid.uuid4()}"
         case _:

--- a/tests/component_integration/endpoints/test_speech_endpoint.py
+++ b/tests/component_integration/endpoints/test_speech_endpoint.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the /v1/audio/speech (text-to-speech) endpoint.
+
+Based on: docs/tutorials/tts.md
+"""
+
+import pytest
+
+from tests.component_integration.conftest import (
+    ComponentIntegrationTestDefaults as defaults,
+)
+from tests.harness.utils import AIPerfCLI
+
+
+@pytest.mark.component_integration
+class TestSpeechEndpoint:
+    """Tests for the OpenAI-compatible text-to-speech endpoint."""
+
+    def test_non_streaming_speech(self, cli: AIPerfCLI):
+        """Text-to-speech with synthetic inputs (non-streaming binary audio).
+
+        Validates the audio output metrics: output audio duration (decoded
+        from the returned clip), real-time factor, and audio throughput.
+        Time-to-first-audio is streaming-only and must be absent here.
+        """
+        result = cli.run_sync(
+            f"""
+            aiperf profile \
+                --model tts-1 \
+                --tokenizer gpt2 \
+                --endpoint-type speech \
+                --synthetic-input-tokens-mean 30 \
+                --synthetic-input-tokens-stddev 5 \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+        assert result.request_count == defaults.request_count
+
+        assert result.json.output_audio_duration is not None
+        assert result.json.output_audio_duration.avg > 0
+        assert result.json.output_rtf is not None
+        assert result.json.audio_throughput is not None
+        assert result.json.audio_throughput.avg > 0
+
+        # TTS produces audio, not tokens: token metrics must be absent.
+        assert result.json.output_token_throughput is None
+        # Non-streaming: no time-to-first-audio.
+        assert result.json.time_to_first_audio is None
+
+    def test_streaming_speech_time_to_first_audio(self, cli: AIPerfCLI):
+        """Streaming text-to-speech yields time-to-first-audio (TTFA)."""
+        result = cli.run_sync(
+            f"""
+            aiperf profile \
+                --model tts-1 \
+                --tokenizer gpt2 \
+                --endpoint-type speech \
+                --streaming \
+                --synthetic-input-tokens-mean 30 \
+                --synthetic-input-tokens-stddev 5 \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+        assert result.request_count == defaults.request_count
+
+        assert result.json.time_to_first_audio is not None
+        assert result.json.time_to_first_audio.avg > 0
+        assert result.json.output_audio_duration is not None
+        assert result.json.output_audio_duration.avg > 0
+        assert result.json.audio_throughput is not None
+
+    def test_speech_with_extra_inputs(self, cli: AIPerfCLI):
+        """Voice and response_format pass through via --extra-inputs."""
+        result = cli.run_sync(
+            f"""
+            aiperf profile \
+                --model tts-1 \
+                --tokenizer gpt2 \
+                --endpoint-type speech \
+                --extra-inputs voice:echo response_format:wav \
+                --request-count {defaults.request_count} \
+                --concurrency {defaults.concurrency} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+        assert result.request_count == defaults.request_count
+        assert result.json.output_audio_duration is not None

--- a/tests/harness/fake_transport.py
+++ b/tests/harness/fake_transport.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 
 import orjson
 from aiperf_mock_server.app import (
+    _TTS_STREAM_CHUNKS,
     _build_chat_response_data,
     _build_cohere_ranking_response_data,
     _build_completion_response_data,
@@ -30,6 +31,8 @@ from aiperf_mock_server.app import (
     _build_tgi_response_data,
     _compute_ranked_scores,
     _wait_for_processing,
+    generate_mock_wav,
+    iter_speech_audio_sse,
 )
 from aiperf_mock_server.config import MockServerConfig
 from aiperf_mock_server.models import (
@@ -42,6 +45,7 @@ from aiperf_mock_server.models import (
     ImageRetrievalRequest,
     RankingRequest,
     SolidoRAGRequest,
+    SpeechRequest,
     TGIGenerateRequest,
 )
 from aiperf_mock_server.utils import (
@@ -55,6 +59,7 @@ from pydantic import BaseModel
 
 from aiperf.common.constants import NANOS_PER_SECOND
 from aiperf.common.models import (
+    BinaryResponse,
     ErrorDetails,
     RequestInfo,
     RequestRecord,
@@ -383,6 +388,14 @@ class FakeTransport(BaseTransport):
                     self._do_simple,
                     build_response=_build_solido_rag_response_data,
                 )
+            case EndpointType.SPEECH:
+                return await self._dispatch(
+                    payload,
+                    endpoint_type,
+                    SpeechRequest,
+                    self._do_speech,
+                    first_token_callback=first_token_callback,
+                )
             case _:
                 raise ValueError(f"Unsupported endpoint type: {endpoint_type}")
 
@@ -445,6 +458,56 @@ class FakeTransport(BaseTransport):
             inp.start_perf_ns,
             inp.start_timestamp_ns,
             inp.build_response(inp.ctx, ranked_scores),
+        )
+
+    def _make_binary_record(
+        self,
+        start_perf_ns: int,
+        start_timestamp_ns: int,
+        raw_bytes: bytes,
+        content_type: str,
+    ) -> RequestRecord:
+        """Create a RequestRecord with a single binary response (e.g. audio)."""
+        end_perf_ns = time.perf_counter_ns()
+        return RequestRecord(
+            start_perf_ns=start_perf_ns,
+            end_perf_ns=end_perf_ns,
+            timestamp_ns=start_timestamp_ns,
+            status=200,
+            responses=[
+                BinaryResponse(
+                    perf_ns=end_perf_ns,
+                    content_type=content_type,
+                    raw_bytes=raw_bytes,
+                )
+            ],
+        )
+
+    async def _do_speech(self, inp: HandlerInput) -> RequestRecord:
+        """Handle text-to-speech requests (binary clip or streamed SSE audio)."""
+        audio_bytes = generate_mock_wav(inp.req.input)
+
+        if self.model_endpoint.endpoint.streaming:
+
+            async def _speech_stream() -> AsyncGenerator[bytes, None]:
+                tokens_per_chunk = max(1, len(inp.ctx.tokens) // _TTS_STREAM_CHUNKS)
+                for frame in iter_speech_audio_sse(audio_bytes, inp.ctx.usage):
+                    await inp.ctx.latency_sim.wait_for_tokens(tokens_per_chunk)
+                    yield frame
+
+            return await self._stream_to_record(
+                _speech_stream(),
+                inp.start_perf_ns,
+                inp.start_timestamp_ns,
+                inp.first_token_callback,
+            )
+
+        await inp.ctx.latency_sim.wait_for_tokens(len(inp.ctx.tokens))
+        return self._make_binary_record(
+            inp.start_perf_ns,
+            inp.start_timestamp_ns,
+            audio_bytes,
+            "audio/wav",
         )
 
     async def _do_image_retrieval(self, payload: RequestInputT) -> RequestRecord:

--- a/tests/unit/common/models/test_binary_response_serialization.py
+++ b/tests/unit/common/models/test_binary_response_serialization.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for binary-response JSON serialization.
+
+BinaryResponse.raw_bytes crosses the JSON-encoded ZMQ bus and raw exports.
+Pydantic's default bytes->JSON is utf8, which raises on non-text audio/video
+payloads; the Base64Bytes annotation + field_serializer on the responses list
+(routing around SerializeAsAny) base64-encode it instead. These tests pin that
+behavior so a regression surfaces here rather than only in a live run.
+"""
+
+import base64
+
+import orjson
+
+from aiperf.common.models import RequestRecord
+from aiperf.common.models.record_models import BinaryResponse, SSEMessage, TextResponse
+
+# Non-utf8 bytes: an mp3 frame header (0xff 0xfb) plus bytes that utf8 rejects.
+_AUDIO = bytes([0xFF, 0xFB, 0x00, 0xA4, 0x80, 0xE4])
+
+
+def _request_record(responses: list) -> RequestRecord:
+    return RequestRecord(
+        start_perf_ns=1,
+        timestamp_ns=1,
+        end_perf_ns=10,
+        status=200,
+        responses=responses,
+    )
+
+
+class TestBinaryResponseSerialization:
+    def test_binary_bytes_base64_encoded_and_orjson_safe(self):
+        rec = _request_record(
+            [BinaryResponse(perf_ns=2, raw_bytes=_AUDIO, content_type="audio/wav")]
+        )
+        dumped = rec.model_dump(exclude_none=True, mode="json")
+        raw = dumped["responses"][0]["raw_bytes"]
+        assert isinstance(raw, str)
+        assert base64.b64decode(raw) == _AUDIO
+        # The whole point: orjson must not raise UnicodeDecodeError on the dump.
+        orjson.dumps(dumped)
+
+    def test_binary_json_roundtrip_restores_exact_bytes(self):
+        rec = _request_record(
+            [BinaryResponse(perf_ns=2, raw_bytes=_AUDIO, content_type="audio/mpeg")]
+        )
+        blob = orjson.dumps(rec.model_dump(exclude_none=True, mode="json"))
+        restored = RequestRecord.model_validate(orjson.loads(blob))
+        assert restored.responses[0].raw_bytes == _AUDIO
+        assert restored.responses[0].content_type == "audio/mpeg"
+
+    def test_mixed_responses_list_roundtrip_preserves_types(self):
+        rec = _request_record(
+            [
+                SSEMessage.parse(b'data: {"a": 1}', 1),
+                TextResponse(perf_ns=2, text="hi", content_type="text/plain"),
+                BinaryResponse(perf_ns=3, raw_bytes=_AUDIO, content_type="audio/wav"),
+            ]
+        )
+        blob = orjson.dumps(rec.model_dump(exclude_none=True, mode="json"))
+        restored = RequestRecord.model_validate(orjson.loads(blob))
+
+        assert isinstance(restored.responses[0], SSEMessage)
+        assert isinstance(restored.responses[1], TextResponse)
+        assert isinstance(restored.responses[2], BinaryResponse)
+        assert restored.responses[1].get_text() == "hi"
+        assert restored.responses[2].raw_bytes == _AUDIO
+
+    def test_in_memory_bytes_not_double_encoded(self):
+        rec = _request_record([BinaryResponse(perf_ns=2, raw_bytes=_AUDIO)])
+        # python mode keeps the raw bytes (no base64 round-trip in memory).
+        assert rec.responses[0].raw_bytes == _AUDIO
+        assert rec.model_dump(mode="python")["responses"][0]["raw_bytes"] == _AUDIO

--- a/tests/unit/endpoints/test_speech_endpoint.py
+++ b/tests/unit/endpoints/test_speech_endpoint.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for OpenAISpeechEndpoint (text-to-speech)."""
+
+import base64
+
+import orjson
+import pytest
+
+from aiperf.common.models import AudioResponseData, Text, Turn
+from aiperf.common.models.record_models import BinaryResponse, SSEMessage, TextResponse
+from aiperf.endpoints.openai_speech import OpenAISpeechEndpoint
+from aiperf.plugin.enums import EndpointType
+from tests.unit.endpoints.conftest import (
+    create_endpoint_with_mock_transport,
+    create_model_endpoint,
+    create_request_info,
+)
+
+
+def _sse(obj: dict, perf_ns: int = 222) -> SSEMessage:
+    return SSEMessage.parse(b"data: " + orjson.dumps(obj), perf_ns)
+
+
+class TestSpeechEndpointFormatPayload:
+    @pytest.fixture
+    def model_endpoint(self):
+        return create_model_endpoint(EndpointType.SPEECH, model_name="tts-1")
+
+    @pytest.fixture
+    def streaming_model_endpoint(self):
+        return create_model_endpoint(
+            EndpointType.SPEECH, model_name="tts-1", streaming=True
+        )
+
+    @pytest.fixture
+    def endpoint(self, model_endpoint):
+        return create_endpoint_with_mock_transport(OpenAISpeechEndpoint, model_endpoint)
+
+    def test_format_payload_defaults(self, endpoint, model_endpoint):
+        request_info = create_request_info(
+            model_endpoint=model_endpoint, texts=["Hello world"], model="tts-1"
+        )
+        payload = endpoint.format_payload(request_info)
+        assert payload["input"] == "Hello world"
+        assert payload["model"] == "tts-1"
+        assert payload["voice"] == "alloy"
+        assert payload["response_format"] == "mp3"
+        assert "stream_format" not in payload
+
+    def test_format_payload_streaming_sets_stream_format(
+        self, streaming_model_endpoint
+    ):
+        endpoint = create_endpoint_with_mock_transport(
+            OpenAISpeechEndpoint, streaming_model_endpoint
+        )
+        request_info = create_request_info(
+            model_endpoint=streaming_model_endpoint, texts=["Hi"]
+        )
+        payload = endpoint.format_payload(request_info)
+        assert payload["stream_format"] == "sse"
+
+    def test_format_payload_extra_inputs_override_defaults(self):
+        model_endpoint = create_model_endpoint(
+            EndpointType.SPEECH,
+            model_name="tts-1",
+            extra=[("voice", "echo"), ("response_format", "wav"), ("speed", 1.5)],
+        )
+        endpoint = create_endpoint_with_mock_transport(
+            OpenAISpeechEndpoint, model_endpoint
+        )
+        request_info = create_request_info(model_endpoint=model_endpoint, texts=["Hi"])
+        payload = endpoint.format_payload(request_info)
+        assert payload["voice"] == "echo"
+        assert payload["response_format"] == "wav"
+        assert payload["speed"] == 1.5
+
+    def test_format_payload_turn_extra_body_overrides(self, model_endpoint, endpoint):
+        turn = Turn(texts=[Text(contents=["Hi"])], extra_body={"voice": "fable"})
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        payload = endpoint.format_payload(request_info)
+        assert payload["voice"] == "fable"
+
+    def test_format_payload_no_text_raises(self, model_endpoint, endpoint):
+        turn = Turn(texts=[])
+        request_info = create_request_info(model_endpoint=model_endpoint, turns=[turn])
+        with pytest.raises(ValueError, match="text input"):
+            endpoint.format_payload(request_info)
+
+
+class TestSpeechEndpointParseResponse:
+    @pytest.fixture
+    def endpoint(self):
+        model_endpoint = create_model_endpoint(EndpointType.SPEECH, model_name="tts-1")
+        return create_endpoint_with_mock_transport(OpenAISpeechEndpoint, model_endpoint)
+
+    def test_parse_binary_clip(self, endpoint):
+        response = BinaryResponse(
+            perf_ns=999, raw_bytes=b"RIFFxxxx", content_type="audio/wav"
+        )
+        parsed = endpoint.parse_response(response)
+        assert parsed is not None
+        assert parsed.perf_ns == 999
+        assert isinstance(parsed.data, AudioResponseData)
+        assert parsed.data.audio_bytes == b"RIFFxxxx"
+        assert parsed.data.format == "wav"
+
+    def test_parse_binary_mpeg_format(self, endpoint):
+        response = BinaryResponse(
+            perf_ns=1, raw_bytes=b"\xff\xfb", content_type="audio/mpeg"
+        )
+        parsed = endpoint.parse_response(response)
+        assert parsed.data.format == "mp3"
+
+    def test_parse_empty_binary_returns_none(self, endpoint):
+        response = BinaryResponse(perf_ns=1, raw_bytes=b"", content_type="audio/wav")
+        assert endpoint.parse_response(response) is None
+
+    def test_parse_sse_audio_delta(self, endpoint):
+        audio = b"\x01\x02\x03\x04"
+        msg = _sse(
+            {
+                "type": "speech.audio.delta",
+                "audio": base64.b64encode(audio).decode("utf-8"),
+            },
+            perf_ns=555,
+        )
+        parsed = endpoint.parse_response(msg)
+        assert parsed is not None
+        assert parsed.perf_ns == 555
+        assert isinstance(parsed.data, AudioResponseData)
+        assert parsed.data.audio_bytes == audio
+
+    def test_parse_sse_done_is_usage_only(self, endpoint):
+        msg = _sse(
+            {"type": "speech.audio.done", "usage": {"input_tokens": 5}}, perf_ns=777
+        )
+        parsed = endpoint.parse_response(msg)
+        assert parsed is not None
+        assert parsed.data is None
+        assert parsed.usage is not None
+
+    def test_parse_sse_done_marker_returns_none(self, endpoint):
+        msg = SSEMessage.parse(b"data: [DONE]", 888)
+        assert endpoint.parse_response(msg) is None
+
+    def test_parse_non_audio_text_returns_none(self, endpoint):
+        response = TextResponse(
+            perf_ns=1, text='{"foo": "bar"}', content_type="application/json"
+        )
+        assert endpoint.parse_response(response) is None

--- a/tests/unit/metrics/test_audio_throughput_metric.py
+++ b/tests/unit/metrics/test_audio_throughput_metric.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.enums import MetricFlags
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.metrics.metric_dicts import MetricResultsDict
+from aiperf.metrics.types.audio_throughput_metric import AudioThroughputMetric
+from aiperf.metrics.types.benchmark_duration_metric import BenchmarkDurationMetric
+from aiperf.metrics.types.output_audio_duration_metric import (
+    TotalOutputAudioDurationMetric,
+)
+
+
+class TestAudioThroughputMetric:
+    def test_throughput_calculation(self):
+        """10s of audio generated in 2s wall-clock -> 5 audio_sec/sec."""
+        metric_results = MetricResultsDict()
+        metric_results[TotalOutputAudioDurationMetric.tag] = 10.0
+        metric_results[BenchmarkDurationMetric.tag] = 2_000_000_000  # 2s in ns
+        result = AudioThroughputMetric().derive_value(metric_results)
+        assert result == pytest.approx(5.0, rel=1e-6)
+
+    def test_throughput_exceeds_realtime_under_concurrency(self):
+        metric_results = MetricResultsDict()
+        metric_results[TotalOutputAudioDurationMetric.tag] = 100.0
+        metric_results[BenchmarkDurationMetric.tag] = 2_000_000_000
+        result = AudioThroughputMetric().derive_value(metric_results)
+        assert result == pytest.approx(50.0, rel=1e-6)
+
+    def test_zero_duration_raises(self):
+        metric_results = MetricResultsDict()
+        metric_results[TotalOutputAudioDurationMetric.tag] = 10.0
+        metric_results[BenchmarkDurationMetric.tag] = 0.0
+        with pytest.raises(NoMetricValue):
+            AudioThroughputMetric().derive_value(metric_results)
+
+    def test_metric_properties(self):
+        metric = AudioThroughputMetric()
+        assert metric.tag == "audio_throughput"
+        assert TotalOutputAudioDurationMetric.tag in metric.required_metrics
+        assert BenchmarkDurationMetric.tag in metric.required_metrics
+        assert MetricFlags.PRODUCES_AUDIO_ONLY in metric.flags
+        assert MetricFlags.LARGER_IS_BETTER in metric.flags

--- a/tests/unit/metrics/test_output_audio_duration_metric.py
+++ b/tests/unit/metrics/test_output_audio_duration_metric.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import wave
+
+import pytest
+
+from aiperf.common.enums import MetricConsoleGroup, MetricFlags
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import (
+    AudioResponseData,
+    ParsedResponse,
+    ParsedResponseRecord,
+    RequestRecord,
+)
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.output_audio_duration_metric import (
+    OutputAudioDurationMetric,
+    decode_audio_duration_seconds,
+)
+
+_SAMPLE_RATE = 16000
+
+
+def _make_wav(duration_s: float, sample_rate: int = _SAMPLE_RATE) -> bytes:
+    """Build a mono 16-bit WAV of the given duration."""
+    num_samples = int(duration_s * sample_rate)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(b"\x00\x00" * num_samples)
+    return buf.getvalue()
+
+
+def _audio_record(chunks: list[bytes], start_ns: int = 100) -> ParsedResponseRecord:
+    request = RequestRecord(
+        model_name="tts-1",
+        start_perf_ns=start_ns,
+        timestamp_ns=start_ns,
+        end_perf_ns=start_ns + 1000,
+    )
+    responses = [
+        ParsedResponse(perf_ns=start_ns + 50 + i, data=AudioResponseData(audio_bytes=c))
+        for i, c in enumerate(chunks)
+    ]
+    return ParsedResponseRecord(request=request, responses=responses)
+
+
+class TestDecodeAudioDurationSeconds:
+    def test_decodes_wav_duration(self):
+        wav = _make_wav(2.0)
+        assert decode_audio_duration_seconds(wav) == pytest.approx(2.0, rel=1e-3)
+
+    def test_undecodable_bytes_returns_none(self):
+        assert decode_audio_duration_seconds(b"not audio at all") is None
+
+
+class TestOutputAudioDurationMetric:
+    def test_duration_from_single_clip(self):
+        record = _audio_record([_make_wav(1.5)])
+        result = OutputAudioDurationMetric().parse_record(record, MetricRecordDict())
+        assert result == pytest.approx(1.5, rel=1e-3)
+
+    def test_duration_from_concatenated_stream_chunks(self):
+        """Streamed chunks split a single clip; the concatenation decodes."""
+        wav = _make_wav(2.0)
+        third = len(wav) // 3
+        chunks = [wav[:third], wav[third : 2 * third], wav[2 * third :]]
+        record = _audio_record(chunks)
+        result = OutputAudioDurationMetric().parse_record(record, MetricRecordDict())
+        assert result == pytest.approx(2.0, rel=1e-3)
+
+    def test_no_audio_bytes_raises(self):
+        record = _audio_record([b""])
+        with pytest.raises(NoMetricValue, match="no audio"):
+            OutputAudioDurationMetric().parse_record(record, MetricRecordDict())
+
+    def test_undecodable_audio_raises(self):
+        record = _audio_record([b"garbage-bytes-here"])
+        with pytest.raises(NoMetricValue, match="decode"):
+            OutputAudioDurationMetric().parse_record(record, MetricRecordDict())
+
+    def test_metric_properties(self):
+        metric = OutputAudioDurationMetric()
+        assert metric.tag == "output_audio_duration"
+        # All four headline TTS metrics share the DEFAULT console table.
+        assert metric.console_group == MetricConsoleGroup.DEFAULT
+        assert MetricFlags.PRODUCES_AUDIO_ONLY in metric.flags

--- a/tests/unit/metrics/test_output_rtf_metric.py
+++ b/tests/unit/metrics/test_output_rtf_metric.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pytest import param
+
+from aiperf.common.enums import MetricFlags
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.output_audio_duration_metric import OutputAudioDurationMetric
+from aiperf.metrics.types.output_rtf_metric import OutputRTFMetric
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+from tests.unit.metrics.conftest import create_record
+
+
+def _metric_dict(audio_duration_s: float, latency_ns: int) -> MetricRecordDict:
+    md = MetricRecordDict()
+    md[OutputAudioDurationMetric.tag] = audio_duration_s
+    md[RequestLatencyMetric.tag] = latency_ns
+    return md
+
+
+class TestOutputRTFMetric:
+    @pytest.mark.parametrize(
+        "audio_duration_s,latency_ns,expected_rtf",
+        [
+            param(10.0, 2_000_000_000, 0.2, id="10s_audio_2s_latency_5x_realtime"),
+            param(5.0, 5_000_000_000, 1.0, id="realtime"),
+            param(1.0, 2_000_000_000, 2.0, id="slower_than_realtime"),
+        ],
+    )  # fmt: skip
+    def test_rtf_values(self, audio_duration_s, latency_ns, expected_rtf):
+        md = _metric_dict(audio_duration_s, latency_ns)
+        result = OutputRTFMetric().parse_record(create_record(), md)
+        assert result == pytest.approx(expected_rtf, rel=1e-6)
+
+    def test_zero_audio_duration_raises(self):
+        md = _metric_dict(0.0, 1_000_000_000)
+        with pytest.raises(NoMetricValue, match="non-positive"):
+            OutputRTFMetric().parse_record(create_record(), md)
+
+    def test_missing_audio_duration_raises(self):
+        md = MetricRecordDict()
+        md[RequestLatencyMetric.tag] = 1_000_000_000
+        with pytest.raises(NoMetricValue):
+            OutputRTFMetric().parse_record(create_record(), md)
+
+    def test_metric_properties(self):
+        metric = OutputRTFMetric()
+        assert metric.tag == "output_rtf"
+        assert metric.short_header == "RTF"
+        assert OutputAudioDurationMetric.tag in metric.required_metrics
+        assert RequestLatencyMetric.tag in metric.required_metrics
+        assert MetricFlags.PRODUCES_AUDIO_ONLY in metric.flags
+        # Lower is better -> must NOT be flagged larger-is-better.
+        assert MetricFlags.LARGER_IS_BETTER not in metric.flags

--- a/tests/unit/metrics/test_time_to_first_audio_metric.py
+++ b/tests/unit/metrics/test_time_to_first_audio_metric.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.common.enums import MetricFlags
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models import (
+    AudioResponseData,
+    ParsedResponse,
+    ParsedResponseRecord,
+    RequestRecord,
+)
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.types.time_to_first_audio_metric import TimeToFirstAudioMetric
+
+
+def _record(start_ns: int, chunk_perf_ns: list[int]) -> ParsedResponseRecord:
+    request = RequestRecord(
+        model_name="tts-1",
+        start_perf_ns=start_ns,
+        timestamp_ns=start_ns,
+        end_perf_ns=chunk_perf_ns[-1] if chunk_perf_ns else start_ns,
+    )
+    responses = [
+        ParsedResponse(perf_ns=ns, data=AudioResponseData(audio_bytes=b"\x00\x01"))
+        for ns in chunk_perf_ns
+    ]
+    return ParsedResponseRecord(request=request, responses=responses)
+
+
+class TestTimeToFirstAudioMetric:
+    def test_ttfa_basic(self):
+        record = _record(start_ns=1000, chunk_perf_ns=[1500, 1800, 2100])
+        result = TimeToFirstAudioMetric().parse_record(record, MetricRecordDict())
+        assert result == 500
+
+    def test_ttfa_no_responses_raises(self):
+        # A record with no content responses is gated as invalid upstream.
+        record = _record(start_ns=1000, chunk_perf_ns=[])
+        with pytest.raises(NoMetricValue):
+            TimeToFirstAudioMetric().parse_record(record, MetricRecordDict())
+
+    def test_metric_properties(self):
+        metric = TimeToFirstAudioMetric()
+        assert metric.tag == "time_to_first_audio"
+        assert metric.short_header == "TTFA"
+        assert MetricFlags.PRODUCES_AUDIO_ONLY in metric.flags
+        assert MetricFlags.STREAMING_ONLY in metric.flags

--- a/tests/unit/post_processors/test_base_metrics_processor.py
+++ b/tests/unit/post_processors/test_base_metrics_processor.py
@@ -60,6 +60,12 @@ class TestBaseMetricsProcessor:
                     MetricFlags.SUPPORTS_IMAGE_ONLY,
                 ],
             ),
+            # Speech (TTS) endpoint with streaming - produces audio output, no tokens
+            (
+                EndpointType.SPEECH,
+                True,
+                [MetricFlags.PRODUCES_AUDIO_ONLY, MetricFlags.STREAMING_ONLY],
+            ),
         ],
     )
     def test_get_filters(
@@ -83,6 +89,24 @@ class TestBaseMetricsProcessor:
             assert not (disallowed_flags & supported_flag), (
                 f"Expected supported flag {supported_flag} should not be disallowed"
             )
+
+    def test_speech_endpoint_enables_audio_disables_token_metrics(
+        self, mock_run
+    ) -> None:
+        """TTS (speech) produces audio output but no tokens: audio-output metrics
+        must be enabled and token metrics disabled. Guards against a future
+        plugins.yaml flip silently dropping all TTS metrics."""
+        mock_run.cfg.endpoint.type = EndpointType.SPEECH
+        mock_run.cfg.endpoint.streaming = True
+
+        _, disallowed_flags = BaseMetricsProcessor(mock_run).get_filters()
+
+        # produces_audio=True -> audio-output metrics retained
+        assert not (disallowed_flags & MetricFlags.PRODUCES_AUDIO_ONLY)
+        # produces_tokens=False -> token metrics gated off
+        assert disallowed_flags & MetricFlags.PRODUCES_TOKENS_ONLY
+        # speech does not accept audio INPUT -> ASR audio-input metrics gated off
+        assert disallowed_flags & MetricFlags.SUPPORTS_AUDIO_ONLY
 
     def test_setup_metrics_basic(
         self,
@@ -108,6 +132,7 @@ class TestBaseMetricsProcessor:
             | MetricFlags.SUPPORTS_IMAGE_ONLY
             | MetricFlags.SUPPORTS_VIDEO_ONLY
             | MetricFlags.PRODUCES_VIDEO_ONLY
+            | MetricFlags.PRODUCES_AUDIO_ONLY
             | MetricFlags.STREAMING_ONLY
             | MetricFlags.GOODPUT
             | MetricFlags.EXPERIMENTAL
@@ -136,6 +161,7 @@ class TestBaseMetricsProcessor:
                 | MetricFlags.SUPPORTS_IMAGE_ONLY
                 | MetricFlags.SUPPORTS_VIDEO_ONLY
                 | MetricFlags.PRODUCES_VIDEO_ONLY
+                | MetricFlags.PRODUCES_AUDIO_ONLY
                 | MetricFlags.STREAMING_ONLY
                 | MetricFlags.GOODPUT,
             ),
@@ -148,6 +174,7 @@ class TestBaseMetricsProcessor:
                 | MetricFlags.SUPPORTS_IMAGE_ONLY
                 | MetricFlags.SUPPORTS_VIDEO_ONLY
                 | MetricFlags.PRODUCES_VIDEO_ONLY
+                | MetricFlags.PRODUCES_AUDIO_ONLY
                 | MetricFlags.STREAMING_ONLY
                 | MetricFlags.ERROR_ONLY
                 | MetricFlags.GOODPUT,
@@ -161,6 +188,7 @@ class TestBaseMetricsProcessor:
                 | MetricFlags.SUPPORTS_IMAGE_ONLY
                 | MetricFlags.SUPPORTS_VIDEO_ONLY
                 | MetricFlags.PRODUCES_VIDEO_ONLY
+                | MetricFlags.PRODUCES_AUDIO_ONLY
                 | MetricFlags.STREAMING_ONLY
                 | MetricFlags.GOODPUT,
             ),
@@ -236,6 +264,7 @@ class TestBaseMetricsProcessor:
             | MetricFlags.SUPPORTS_IMAGE_ONLY
             | MetricFlags.SUPPORTS_VIDEO_ONLY
             | MetricFlags.PRODUCES_VIDEO_ONLY
+            | MetricFlags.PRODUCES_AUDIO_ONLY
             | MetricFlags.STREAMING_ONLY
             | MetricFlags.GOODPUT
             | MetricFlags.EXPERIMENTAL,

--- a/tests/unit/transports/test_collect_streamed_binary.py
+++ b/tests/unit/transports/test_collect_streamed_binary.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the streamed-binary transport helper used by TTS (and any chunked
+binary response). Covers per-chunk BinaryResponse emission, chunk-arrival timing,
+trace bookkeeping, the collect_chunks toggle, and the empty-stream case."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from aiperf.common.models import AioHttpTraceData, BinaryResponse
+from aiperf.transports.sse_utils import collect_streamed_binary
+
+
+async def _aiter(chunks: list[bytes]) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        yield chunk
+
+
+@pytest.mark.asyncio
+class TestCollectStreamedBinary:
+    async def test_one_response_per_chunk_with_timing(self):
+        trace = AioHttpTraceData()
+        chunks = [b"aaa", b"bb", b"c"]
+
+        result = await collect_streamed_binary(
+            _aiter(chunks), trace, "audio/wav", collect_chunks=True
+        )
+
+        assert [r.raw_bytes for r in result] == chunks
+        assert all(isinstance(r, BinaryResponse) for r in result)
+        assert all(r.content_type == "audio/wav" for r in result)
+
+        perfs = [r.perf_ns for r in result]
+        assert all(p > 0 for p in perfs)
+        assert perfs == sorted(perfs)  # non-decreasing arrival times
+
+        assert trace.response_chunks_count == 3
+        assert trace.response_bytes_total == 6
+        assert len(trace.response_chunks) == 3
+        assert trace.response_receive_start_perf_ns == perfs[0]
+        assert trace.response_receive_end_perf_ns == perfs[-1]
+
+    async def test_collect_chunks_false_skips_chunk_list_but_keeps_counts(self):
+        trace = AioHttpTraceData()
+
+        result = await collect_streamed_binary(
+            _aiter([b"x", b"y"]), trace, "audio/mpeg", collect_chunks=False
+        )
+
+        assert len(result) == 2
+        assert trace.response_chunks == []  # per-chunk list not populated
+        assert trace.response_chunks_count == 2
+        assert trace.response_bytes_total == 2
+        assert trace.response_receive_start_perf_ns is not None
+        assert trace.response_receive_end_perf_ns is not None
+
+    async def test_empty_stream_returns_empty_and_leaves_timing_unset(self):
+        trace = AioHttpTraceData()
+
+        result = await collect_streamed_binary(
+            _aiter([]), trace, "audio/wav", collect_chunks=True
+        )
+
+        assert result == []
+        assert trace.response_chunks_count == 0
+        assert trace.response_bytes_total == 0
+        assert trace.response_receive_start_perf_ns is None
+        assert trace.response_receive_end_perf_ns is None


### PR DESCRIPTION
…speech

Add a first-class TTS endpoint (--endpoint-type speech) targeting the OpenAI-compatible /v1/audio/speech API, with audio-output metrics.

- Endpoint: OpenAISpeechEndpoint (openai_speech.py), registered in plugins.yaml with produces_audio metadata; handles non-streaming binary clips, SSE audio deltas, and raw chunked-binary streaming.
- Response model: AudioResponseData; BinaryResponse.raw_bytes is now base64-serialized (Base64Bytes + field_serializer) so binary audio survives the JSON-encoded ZMQ bus and raw exports.
- Metrics: Time to First Audio (TTFA), Output Audio Duration (decoded via soundfile), Real-Time Factor (RTF), and Audio Throughput; new PRODUCES_AUDIO_ONLY MetricFlag wired into endpoint capability gating.
- Transport: streamed-binary path (sse_utils.collect_streamed_binary) records per-chunk arrival timing so TTFA is measurable for both SSE and raw chunked audio bodies.
- Input: synthetic text (existing) and custom datasets; voice / response format / speed pass through via --extra-inputs.
- Tests + tooling: mock server /v1/audio/speech route, FakeTransport handler, unit + component-integration tests, tutorial and metrics-reference docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for text-to-speech benchmarking with a new speech endpoint and tutorial.
  * Introduced audio-focused metrics for first-audio latency, output duration, real-time factor, and audio throughput.

* **Bug Fixes**
  * Improved handling of binary audio responses so exported results remain readable and round-trip safely.
  * Streaming audio responses are now tracked more accurately chunk by chunk.

* **Documentation**
  * Updated CLI, metrics reference, and navigation to include TTS support and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->