### PR TITLE
fix(config): honor CLI --server-metrics format overrides

### DIFF
--- a/src/aiperf/config/flags/_resolver_helpers.py
+++ b/src/aiperf/config/flags/_resolver_helpers.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small helpers for config-file resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aiperf.config.flags import CLIConfig
+
+
+def promote_benchmark_magic_lists(
+    merged: dict[str, Any],
+    cli_config: CLIConfig,
+    *,
+    promote_cli_dataset_magic_lists: Any,
+    promote_magic_lists_to_sweep_block: Any,
+    retarget_dataset_magic_lists: Any,
+) -> None:
+    benchmark = merged.get("benchmark")
+    if not isinstance(benchmark, dict):
+        return
+
+    sweep_type = getattr(cli_config, "sweep_type", "grid")
+    promote_cli_dataset_magic_lists(benchmark, cli_config, sweep_type=sweep_type)
+    retarget_dataset_magic_lists(benchmark)
+    promote_magic_lists_to_sweep_block(benchmark, sweep_type=sweep_type)
+    promoted_sweep = benchmark.pop("sweep", None)
+    if not isinstance(promoted_sweep, dict):
+        return
+
+    existing_sweep = merged.get("sweep")
+    if isinstance(existing_sweep, dict):
+        existing_sweep.setdefault("type", promoted_sweep.get("type", sweep_type))
+        existing_sweep.setdefault("parameters", {})
+        existing_sweep["parameters"].update(promoted_sweep.get("parameters", {}))
+    else:
+        merged["sweep"] = promoted_sweep

--- a/src/aiperf/config/flags/_resolver_server_metrics.py
+++ b/src/aiperf/config/flags/_resolver_server_metrics.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -42,3 +43,30 @@ def build_server_metrics_override(cli: CLIConfig) -> dict[str, Any] | None:
         override["formats"] = built["formats"]
 
     return override or None
+
+
+def normalize_server_metrics_base_for_override(
+    base: dict[str, Any],
+    overrides: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Normalize YAML server_metrics shorthand before CLI override merging."""
+    if not _has_benchmark_server_metrics_override(overrides):
+        return base
+
+    benchmark = base.get("benchmark")
+    if not isinstance(benchmark, dict) or "server_metrics" not in benchmark:
+        return base
+
+    from aiperf.config.server_metrics import ServerMetricsConfig
+
+    normalized = copy.deepcopy(base)
+    normalized_benchmark = normalized["benchmark"]
+    normalized_benchmark["server_metrics"] = ServerMetricsConfig.model_validate(
+        normalized_benchmark["server_metrics"]
+    ).model_dump(mode="python")
+    return normalized
+
+
+def _has_benchmark_server_metrics_override(overrides: dict[str, Any] | None) -> bool:
+    benchmark = overrides.get("benchmark") if isinstance(overrides, dict) else None
+    return isinstance(benchmark, dict) and "server_metrics" in benchmark

--- a/src/aiperf/config/flags/_resolver_server_metrics.py
+++ b/src/aiperf/config/flags/_resolver_server_metrics.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Server-metrics CLI override handling for config-file resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aiperf.config.flags import CLIConfig
+
+
+def build_server_metrics_override(cli: CLIConfig) -> dict[str, Any] | None:
+    """Build only explicit server-metrics CLI overrides for config-file mode.
+
+    The CLI-only ``build_server_metrics`` builder intentionally emits a complete
+    section, including default formats and an empty URL list. In config-file
+    mode, only user-set fields should overlay YAML so ``--server-metrics-formats``
+    can replace YAML formats without clobbering YAML URLs.
+    """
+    fields_set = cli.model_fields_set & {
+        "server_metrics",
+        "server_metrics_formats",
+        "no_server_metrics",
+    }
+    if not fields_set:
+        return None
+
+    from aiperf.config.flags._converter_telemetry import build_server_metrics
+
+    built = build_server_metrics(cli)
+    override: dict[str, Any] = {}
+    if "no_server_metrics" in fields_set:
+        override["enabled"] = built["enabled"]
+    elif "server_metrics" in fields_set:
+        override["enabled"] = True
+        override["urls"] = built["urls"]
+
+    if "server_metrics_formats" in fields_set and "formats" in built:
+        override["enabled"] = True
+        override["formats"] = built["formats"]
+
+    return override or None

--- a/src/aiperf/config/flags/resolver.py
+++ b/src/aiperf/config/flags/resolver.py
@@ -24,6 +24,7 @@ from aiperf.config.flags._resolver_adaptive import (
 )
 from aiperf.config.flags._resolver_server_metrics import (
     build_server_metrics_override,
+    normalize_server_metrics_base_for_override,
 )
 from aiperf.config.flags._section_fields import (
     ENDPOINT_FIELDS,
@@ -100,6 +101,7 @@ def resolve_config(
 
     overrides = build_cli_overrides(cli_config, benchmark_config=base_config.benchmark)
     overrides = _wrap_under_envelope(overrides) if overrides else overrides
+    yaml_dict = normalize_server_metrics_base_for_override(yaml_dict, overrides)
     merged = deep_merge(yaml_dict, overrides) if overrides else yaml_dict
     _apply_dataset_filter_overrides(merged, cli_config)
     _apply_phase_loadgen_overrides(merged, cli_config)

--- a/src/aiperf/config/flags/resolver.py
+++ b/src/aiperf/config/flags/resolver.py
@@ -22,6 +22,7 @@ from aiperf.common.enums import DatasetType
 from aiperf.config.flags._resolver_adaptive import (
     apply_basic_adaptive_scale_overrides,
 )
+from aiperf.config.flags._resolver_helpers import promote_benchmark_magic_lists
 from aiperf.config.flags._resolver_server_metrics import (
     build_server_metrics_override,
     normalize_server_metrics_base_for_override,
@@ -105,25 +106,13 @@ def resolve_config(
     merged = deep_merge(yaml_dict, overrides) if overrides else yaml_dict
     _apply_dataset_filter_overrides(merged, cli_config)
     _apply_phase_loadgen_overrides(merged, cli_config)
-    benchmark = merged.get("benchmark")
-    if isinstance(benchmark, dict):
-        sweep_type = getattr(cli_config, "sweep_type", "grid")
-        _promote_cli_dataset_magic_lists(benchmark, cli_config, sweep_type=sweep_type)
-        _retarget_dataset_magic_lists(benchmark)
-        _promote_magic_lists_to_sweep_block(benchmark, sweep_type=sweep_type)
-        promoted_sweep = benchmark.pop("sweep", None)
-        if isinstance(promoted_sweep, dict):
-            existing_sweep = merged.get("sweep")
-            if isinstance(existing_sweep, dict):
-                existing_sweep.setdefault(
-                    "type", promoted_sweep.get("type", sweep_type)
-                )
-                existing_sweep.setdefault("parameters", {})
-                existing_sweep["parameters"].update(
-                    promoted_sweep.get("parameters", {})
-                )
-            else:
-                merged["sweep"] = promoted_sweep
+    promote_benchmark_magic_lists(
+        merged,
+        cli_config,
+        promote_cli_dataset_magic_lists=_promote_cli_dataset_magic_lists,
+        promote_magic_lists_to_sweep_block=_promote_magic_lists_to_sweep_block,
+        retarget_dataset_magic_lists=_retarget_dataset_magic_lists,
+    )
     return AIPerfConfig.model_validate(merged)
 
 

--- a/src/aiperf/config/flags/resolver.py
+++ b/src/aiperf/config/flags/resolver.py
@@ -22,6 +22,9 @@ from aiperf.common.enums import DatasetType
 from aiperf.config.flags._resolver_adaptive import (
     apply_basic_adaptive_scale_overrides,
 )
+from aiperf.config.flags._resolver_server_metrics import (
+    build_server_metrics_override,
+)
 from aiperf.config.flags._section_fields import (
     ENDPOINT_FIELDS,
     INPUT_FIELDS,
@@ -166,6 +169,7 @@ def build_cli_overrides(
     _apply_input_overrides(out, cli)
     _apply_recipe_and_multirun(out, cli, benchmark_config=benchmark_config)
     _apply_artifacts_overrides(out, cli)
+    _apply_optional_section(out, "server_metrics", build_server_metrics_override(cli))
     _apply_optional_section(out, "tokenizer", build_tokenizer(cli))
     _apply_optional_section(out, "accuracy", build_accuracy(cli))
     wandb_base_enabled = benchmark_config is not None and benchmark_config.wandb.enabled

--- a/tests/integration/test_server_metrics.py
+++ b/tests/integration/test_server_metrics.py
@@ -7,7 +7,9 @@ including scraping from multiple mock server endpoints and validating
 the exported data (JSON, JSONL, CSV).
 """
 
+import asyncio
 import platform
+import textwrap
 
 import pytest
 
@@ -261,6 +263,69 @@ class TestServerMetrics:
         assert result.has_server_metrics_csv
         csv_lines = result.server_metrics_csv.strip().split("\n")
         assert len(csv_lines) > 1  # Header + data rows
+
+    async def test_config_file_cli_server_metrics_formats_generates_jsonl(
+        self, cli: AIPerfCLI, aiperf_mock_server: AIPerfMockServer, tmp_path
+    ):
+        """Config-v2 honors CLI --server-metrics-formats jsonl override."""
+        cfg_file = tmp_path / "server_metrics_config_v2.yaml"
+        yaml = textwrap.dedent(
+            f"""\
+            schemaVersion: "2.0"
+
+            benchmark:
+              model: nvidia/llama-3.1-nemotron-70b-instruct
+              endpoint:
+                url: {aiperf_mock_server.url}/v1/chat/completions
+                type: chat
+                streaming: true
+              dataset:
+                type: synthetic
+                entries: 20
+                prompts:
+                  isl: 128
+                  osl: 64
+              phases:
+                type: concurrency
+                requests: 20
+                concurrency: 2
+              server_metrics:
+                enabled: true
+                urls:
+                  - {aiperf_mock_server.server_metrics_urls["vllm"]}
+                formats:
+                  - json
+                  - csv
+            """
+        )
+        await asyncio.to_thread(
+            cfg_file.write_text,
+            yaml,
+            encoding="utf-8",
+        )
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --config "{cfg_file}" \
+                --tokenizer builtin \
+                --server-metrics-formats json csv jsonl
+            """
+        )
+
+        assert result.server_metrics_json is not None
+        assert result.has_server_metrics_csv
+        assert result.server_metrics_jsonl is not None
+        assert len(result.server_metrics_jsonl) > 0
+        jsonl_file = result.artifacts_dir / "server_metrics_export.jsonl"
+        assert jsonl_file.exists()
+        jsonl_content = await asyncio.to_thread(
+            jsonl_file.read_text,
+            encoding="utf-8",
+        )
+        jsonl_lines = [line for line in jsonl_content.splitlines() if line]
+        assert len(jsonl_lines) >= len(result.server_metrics_jsonl)
+
 
     async def test_server_metrics_jsonl_records(
         self, cli: AIPerfCLI, aiperf_mock_server: AIPerfMockServer

--- a/tests/integration/test_server_metrics.py
+++ b/tests/integration/test_server_metrics.py
@@ -326,7 +326,6 @@ class TestServerMetrics:
         jsonl_lines = [line for line in jsonl_content.splitlines() if line]
         assert len(jsonl_lines) >= len(result.server_metrics_jsonl)
 
-
     async def test_server_metrics_jsonl_records(
         self, cli: AIPerfCLI, aiperf_mock_server: AIPerfMockServer
     ):

--- a/tests/unit/config/test_resolver_server_metrics.py
+++ b/tests/unit/config/test_resolver_server_metrics.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from aiperf.common.enums import ServerMetricsFormat
+from aiperf.config.flags._resolver_server_metrics import build_server_metrics_override
+from aiperf.config.flags.cli_config import CLIConfig
+
+
+def _make_cli(**overrides) -> CLIConfig:
+    base = {
+        "url": "http://localhost:8000/test",
+        "model_names": ["test-model"],
+    }
+    base.update(overrides)
+    return CLIConfig(**base)
+
+
+def test_no_explicit_server_metrics_fields_returns_none():
+    assert build_server_metrics_override(_make_cli()) is None
+
+
+def test_formats_only_enables_server_metrics_without_overriding_urls():
+    assert build_server_metrics_override(
+        _make_cli(server_metrics_formats=["json", "csv", "jsonl"])
+    ) == {
+        "enabled": True,
+        "formats": [
+            ServerMetricsFormat.JSON,
+            ServerMetricsFormat.CSV,
+            ServerMetricsFormat.JSONL,
+        ],
+    }
+
+
+def test_server_metrics_urls_only_does_not_override_yaml_formats():
+    assert build_server_metrics_override(
+        _make_cli(server_metrics=["localhost:9400"])
+    ) == {
+        "enabled": True,
+        "urls": ["http://localhost:9400/metrics"],
+    }
+
+
+def test_server_metrics_urls_and_formats_override_both_fields():
+    assert build_server_metrics_override(
+        _make_cli(
+            server_metrics=["localhost:9400"],
+            server_metrics_formats=["jsonl"],
+        )
+    ) == {
+        "enabled": True,
+        "urls": ["http://localhost:9400/metrics"],
+        "formats": [ServerMetricsFormat.JSONL],
+    }
+
+
+def test_no_server_metrics_wins_over_formats():
+    assert build_server_metrics_override(
+        _make_cli(
+            no_server_metrics=True,
+            server_metrics_formats=["json", "csv", "jsonl"],
+        )
+    ) == {"enabled": False}

--- a/tests/unit/config/test_v1_resolver_streaming_override.py
+++ b/tests/unit/config/test_v1_resolver_streaming_override.py
@@ -19,8 +19,11 @@ from pathlib import Path
 
 import pytest
 
+from aiperf.common.enums import ServerMetricsFormat
+from aiperf.config import BenchmarkRun
 from aiperf.config.flags.cli_config import CLIConfig
 from aiperf.config.flags.resolver import resolve_config
+from aiperf.server_metrics.jsonl_writer import ServerMetricsJSONLWriter
 
 _YAML_STREAMING_OFF = textwrap.dedent("""\
 benchmark:
@@ -109,6 +112,102 @@ def test_yaml_cli_dataset_magic_list_targets_existing_dataset(tmp_path: Path) ->
     assert "datasets.main.prompts.isl.mean" not in config.sweep.parameters
 
 
+_YAML_SERVER_METRICS_JSON_CSV = textwrap.dedent("""\
+benchmark:
+  models:
+    - test-model
+  endpoint:
+    urls:
+      - http://localhost:8000/v1/chat/completions
+  datasets:
+    - name: default
+      type: synthetic
+      entries: 100
+      prompts:
+        isl: 128
+        osl: 64
+  phases:
+    - name: profiling
+      type: concurrency
+      requests: 10
+      concurrency: 1
+  server_metrics:
+    enabled: true
+    urls:
+      - http://worker:9090/metrics
+    formats:
+      - json
+      - csv
+""")
+
+
+async def test_server_metrics_formats_cli_override_preserves_yaml_urls(
+    tmp_path: Path,
+) -> None:
+    cfg_file = tmp_path / "server-metrics.yaml"
+    await asyncio.to_thread(cfg_file.write_text, _YAML_SERVER_METRICS_JSON_CSV)
+    artifact_dir = tmp_path / "artifacts"
+    user = CLIConfig(
+        artifact_directory=artifact_dir,
+        server_metrics_formats=["json", "csv", "jsonl"],
+    )
+
+    config = await asyncio.to_thread(resolve_config, user, cfg_file)
+    server_metrics = config.benchmark.server_metrics
+
+    assert server_metrics.enabled is True
+    assert server_metrics.urls == ["http://worker:9090/metrics"]
+    assert server_metrics.formats == [
+        ServerMetricsFormat.JSON,
+        ServerMetricsFormat.CSV,
+        ServerMetricsFormat.JSONL,
+    ]
+
+    run = BenchmarkRun(
+        benchmark_id="server-metrics-jsonl-regression",
+        cfg=config.benchmark,
+        artifact_dir=config.benchmark.artifacts.dir,
+        random_seed=config.random_seed,
+        variables=dict(config.variables),
+        cli_command=None,
+    )
+    writer = ServerMetricsJSONLWriter(run=run)
+
+    assert writer.output_file == artifact_dir / "server_metrics_export.jsonl"
+
+
+async def test_server_metrics_formats_cli_override_enables_yaml_server_metrics(
+    tmp_path: Path,
+) -> None:
+    cfg_file = tmp_path / "server-metrics-disabled.yaml"
+    await asyncio.to_thread(
+        cfg_file.write_text,
+        _YAML_SERVER_METRICS_JSON_CSV.replace("enabled: true", "enabled: false"),
+    )
+    user = CLIConfig(server_metrics_formats=["json", "csv", "jsonl"])
+
+    config = await asyncio.to_thread(resolve_config, user, cfg_file)
+
+    assert config.benchmark.server_metrics.enabled is True
+    assert config.benchmark.server_metrics.urls == ["http://worker:9090/metrics"]
+    assert ServerMetricsFormat.JSONL in config.benchmark.server_metrics.formats
+
+
+async def test_no_server_metrics_wins_over_server_metrics_formats(
+    tmp_path: Path,
+) -> None:
+    cfg_file = tmp_path / "server-metrics.yaml"
+    await asyncio.to_thread(cfg_file.write_text, _YAML_SERVER_METRICS_JSON_CSV)
+    user = CLIConfig(
+        no_server_metrics=True,
+        server_metrics_formats=["json", "csv", "jsonl"],
+    )
+
+    config = await asyncio.to_thread(resolve_config, user, cfg_file)
+
+    assert config.benchmark.server_metrics.enabled is False
+
+
 _YAML_ADVANCED_ADAPTIVE = textwrap.dedent("""\
 benchmark:
   models:
@@ -178,7 +277,7 @@ async def test_adaptive_cli_sla_parse_error_names_adaptive_flag(tmp_path: Path) 
     user = CLIConfig(adaptive_scale_sla=["bad"])
 
     with pytest.raises(TypeError) as exc_info:
-        resolve_config(user, cfg_file)
+        await asyncio.to_thread(resolve_config, user, cfg_file)
 
     message = str(exc_info.value)
     assert "--adaptive-scale-sla" in message

--- a/tests/unit/config/test_v1_resolver_streaming_override.py
+++ b/tests/unit/config/test_v1_resolver_streaming_override.py
@@ -176,6 +176,32 @@ async def test_server_metrics_formats_cli_override_preserves_yaml_urls(
     assert writer.output_file == artifact_dir / "server_metrics_export.jsonl"
 
 
+async def test_server_metrics_formats_cli_override_preserves_yaml_scalar_url(
+    tmp_path: Path,
+) -> None:
+    cfg_file = tmp_path / "server-metrics-scalar.yaml"
+    await asyncio.to_thread(
+        cfg_file.write_text,
+        _YAML_SERVER_METRICS_JSON_CSV.replace(
+            "server_metrics:\n"
+            "    enabled: true\n"
+            "    urls:\n"
+            "      - http://worker:9090/metrics\n"
+            "    formats:\n"
+            "      - json\n"
+            "      - csv",
+            "server_metrics: http://worker:9090/metrics",
+        ),
+    )
+    user = CLIConfig(server_metrics_formats=["jsonl"])
+
+    config = await asyncio.to_thread(resolve_config, user, cfg_file)
+
+    assert config.benchmark.server_metrics.enabled is True
+    assert config.benchmark.server_metrics.urls == ["http://worker:9090/metrics"]
+    assert config.benchmark.server_metrics.formats == [ServerMetricsFormat.JSONL]
+
+
 async def test_server_metrics_formats_cli_override_enables_yaml_server_metrics(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Problem

Config-v2/adaptive runs could ignore an explicit CLI
`--server-metrics-formats json csv jsonl` override when a YAML config already
defined a `server_metrics` block.

That meant the resolved config could keep YAML formats like `json,csv`, leaving
`ServerMetricsJSONLWriter` disabled and preventing `server_metrics_export.jsonl`
from being generated even though the user explicitly requested JSONL.

## Solution

Add a config-file-mode server-metrics override builder:

- Returns only explicitly-set server metrics CLI fields.
- Preserves YAML `server_metrics.urls` when only `--server-metrics-formats` is passed.
- Replaces YAML `server_metrics.formats` with the explicit CLI formats.
- Reuses existing `build_server_metrics(cli)` normalization/validation instead of duplicating URL normalization or flag conflict handling.
- Keeps `resolver.py` under the file-size threshold by isolating the override logic in `_resolver_server_metrics.py`.

## Alternatives Considered

### 1. Always deep-merge full `build_server_metrics(cli)` output

This is the simplest implementation, but it is too broad. `build_server_metrics(cli)` emits a full CLI-only section, including default formats and an empty URL list. In config-file mode, that would clobber YAML `server_metrics.urls` when the user only meant to override formats.

### 2. Inline the override logic directly in `resolver.py`

This keeps the logic near the other config-file overrides, but it pushes `resolver.py` over the file-size limit and makes the resolver absorb more section-specific behavior.

### 3. Add JSONL automatically for adaptive/config-v2 runs

This would address the observed missing artifact, but it changes the user-facing contract. JSONL can be large and should remain explicit opt-in. The contract should be: if the user asks for `jsonl`, generate it; otherwise keep defaults modest.

### 4. Duplicate server-metrics parsing specifically for config-file mode

This would make the override builder fully independent, but it risks drifting from the CLI-only path. Reusing `build_server_metrics(cli)` keeps validation, URL normalization, and mutual-exclusion behavior consistent.

## Tradeoffs

This fix intentionally adds a small config-file-specific builder instead of changing the CLI-only builder. That keeps the blast radius low and avoids altering default server-metrics behavior.

The tradeoff is that config-file resolution now has a small amount of server-metrics-specific logic. The helper is isolated and returns a plain override dict, so `resolver.py` can keep using the same `_apply_optional_section(...)` pattern as other optional config sections.

## Verification

- `uv run pytest tests/unit/config/test_v1_resolver_streaming_override.py tests/unit/server_metrics/test_formats_selection.py -q`
- `uv run pytest tests/integration/test_server_metrics.py::TestServerMetrics::test_config_file_cli_server_metrics_formats_generates_jsonl -q -s -m integration`
- `uv run ruff check src/aiperf/config/flags/resolver.py src/aiperf/config/flags/_resolver_server_metrics.py tests/unit/config/test_v1_resolver_streaming_override.py tests/integration/test_server_metrics.py`
- `wc -l src/aiperf/config/flags/resolver.py` -> 497 lines

Linear: [AIP-973 ](https://linear.app/nvidia/issue/AIP-973/honor-server-metrics-formats-jsonl-for-config-v2-aiperf-runs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved merging of server-metrics settings from the command line with config files, including ordered format selection and JSONL generation.
  * Added support for YAML “benchmark shorthand” normalization to better align with CLI overrides.
* **Bug Fixes**
  * Fixed cases where CLI server-metrics options could be ignored or merged inconsistently, including correct behavior for disabling metrics.
* **Refactor**
  * Streamlined benchmark “magic list” promotion during config resolution for more consistent sweep handling.
* **Tests**
  * Added integration and unit coverage for server-metrics format overrides and output artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->