### PR TITLE
feat: add interactive `aiperf chat` command for quick perf sanity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Log File: /home/user/Code/aiperf/artifacts/granite4:350m-openai-chat-concurrency
 ### Getting Started
 - [Basic Tutorial](docs/tutorial.md) - Profile Qwen3-0.6B with vLLM
 - [Comprehensive Benchmarking Guide](docs/comprehensive-llm-benchmarking.md) - 5 real-world use cases
+- [Interactive Chat Sanity Checks](docs/tutorials/interactive-chat.md) - Talk to an endpoint with `aiperf chat` and see per-turn TTFT/TPS/ITL
 - [YAML Configuration Files](docs/tutorials/yaml-config.md) - Drive AIPerf from a config file instead of CLI flags
 - [Sampling Distributions in YAML Configs](docs/tutorials/yaml-distributions.md) - Fixed, Normal, Log-normal, Multimodal, and Empirical shapes for ISL/OSL/turns/etc.
 - [User Interface](docs/tutorials/ui-types.md) - Dashboard, simple, or headless

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -16,6 +16,10 @@ Install shell completion for this application.
 
 Analyze a mooncake trace file for ISL/OSL distributions and cache hit rates.
 
+### [`chat`](#aiperf-chat)
+
+Chat interactively with an endpoint, printing per-turn speed stats.
+
 ### [`config init`](#aiperf-config-init)
 
 Generate, list, or search bundled AIPerf config templates.
@@ -94,6 +98,57 @@ KV cache block size for analysis (default: 512).
 #### `--output-file` `<str>`
 
 Optional output path for analysis report (JSON).
+
+<hr/>
+
+## `aiperf chat`
+
+Chat interactively with an endpoint, printing per-turn speed stats.
+
+A lightweight sanity-check sibling of ``aiperf profile``: send one message at a time and see TTFT, TPS, generated tokens, and end-to-end latency for each reply. Multi-turn by default (history retained and resent each turn); pass ``--no-history`` for stateless turns, or ``--quick`` for a single request. For full benchmarking, use ``aiperf profile``.
+
+**Examples:**
+
+```bash
+# Interactive multi-turn chat
+aiperf chat --model Qwen/Qwen3-0.6B --url http://localhost:8000
+
+# Stateless turns (no history retained between messages)
+aiperf chat --model Qwen/Qwen3-0.6B --no-history
+
+# Single-shot sanity check
+aiperf chat --model Qwen/Qwen3-0.6B --quick "hello, who are you?"
+```
+
+#### `-m`, `--model` `<str>` _(Required)_
+
+Model name served by the endpoint.
+
+#### `-u`, `--url` `<str>`
+
+Base URL of the OpenAI-compatible server (e.g. http://localhost:8000), matching `aiperf profile`.
+<br/>_Default: `http://localhost:8000`_
+
+#### `--system-prompt` `<str>`
+
+Optional system prompt prepended to the conversation.
+
+#### `-q`, `--quick` `<str>`
+
+Send a single MESSAGE and print the response + stats, then exit.
+
+#### `--history`, `--no-history`
+
+Retain and resend conversation history each turn (default). Pass --no-history for stateless, completion-style turns. Ignored with --quick.
+<br/>_Default: `True`_
+
+#### `--api-key` `<str>`
+
+API key sent as a Bearer token. Defaults to the OPENAI_API_KEY environment variable.
+
+#### `--tokenizer` `<str>`
+
+Tokenizer for client-side token counts. Defaults to the model name.
 
 <hr/>
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -148,7 +148,7 @@ API key sent as a Bearer token. Defaults to the OPENAI_API_KEY environment varia
 
 #### `--tokenizer` `<str>`
 
-Tokenizer for client-side token counts. Defaults to the model name.
+Tokenizer for client-side token counts. Defaults to the model name. Pass `builtin` for a zero-network tokenizer.
 
 <hr/>
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -50,6 +50,15 @@ API server settings. Controls the host and port of the API server.
 | `AIPERF_API_SERVER_SHUTDOWN_TIMEOUT` | `5.0` | ≥ 1.0, ≤ 300.0 | Timeout in seconds for graceful API server shutdown before force-cancelling |
 | `AIPERF_API_SERVER_POST_COMPLETE_GRACE` | `5.0` | ≥ 0.0, ≤ 300.0 | Seconds the API listener stays open after a benchmark terminates so polling clients can observe the final status before the server shuts down. Set to 0 to skip the grace window and shut down immediately. |
 
+## CHAT
+
+Settings for the interactive ``aiperf chat`` command.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_CHAT_CONNECT_TIMEOUT` | `10.0` | > 0.0 | Seconds to wait to establish a connection to the endpoint before a turn fails. Kept short so an unreachable URL fails fast. |
+| `AIPERF_CHAT_READ_TIMEOUT` | `300.0` | > 0.0 | Seconds to wait for the next streamed chunk before a turn fails. No overall (total) timeout is applied, so long generations are never truncated mid-reply; this only fires if the server stalls. |
+
 ## COMPRESSION
 
 Compression settings for streaming file transfers. Controls chunk size and compression levels for zstd and gzip encodings used in dataset and results file transfers.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -11,6 +11,8 @@ navigation:
     path: tutorial.md
   - page: "AIPerf: Comprehensive LLM Benchmarking"
     path: comprehensive-llm-benchmarking.md
+  - page: Interactive Chat Sanity Checks
+    path: tutorials/interactive-chat.md
   - page: Migrating from GenAI-Perf
     path: migrating.md
   - page: GenAI-Perf vs AIPerf CLI Feature Comparison Matrix

--- a/docs/tutorials/interactive-chat.md
+++ b/docs/tutorials/interactive-chat.md
@@ -7,18 +7,19 @@ sidebar-title: Interactive Chat Sanity Checks
 # Interactive Chat Sanity Checks
 
 `aiperf chat` lets you talk to an OpenAI-compatible endpoint one message at a
-time and see per-turn speed stats (TTFT, TPS, generated tokens, end-to-end
-latency) after every reply. It is a lightweight sanity-check companion to
-`aiperf profile`: handy for confirming an endpoint is wired up correctly and
-getting a ballpark feel for performance before committing to a full benchmark
-run, and for eyeballing speculative-decoding or reasoning-model behavior where
-speedups are prompt-dependent.
+time and see per-turn speed stats — time to first token, throughput,
+inter-token latency, and prompt-cache hit rate — after every reply. It is a
+lightweight sanity-check companion to `aiperf profile`: handy for confirming an
+endpoint is wired up correctly and getting a ballpark feel for performance
+before committing to a full benchmark run, and for eyeballing
+speculative-decoding or reasoning-model behavior where speedups are
+prompt-dependent.
 
 It is deliberately minimal. For real benchmarking — concurrency, request rates,
 datasets, sampling knobs, artifacts, and statistical aggregation — use
-[`aiperf profile`](../../README.md#tutorials-and-feature-guides). The per-turn
-numbers `aiperf chat` prints are produced by the same metric definitions
-`profile` uses, so they stay consistent (including reasoning-token accounting).
+`aiperf profile`. Every number `aiperf chat` prints is produced by the same
+metric classes `profile` uses, so they stay consistent (including
+reasoning-token accounting).
 
 ---
 
@@ -50,19 +51,61 @@ Using model: Qwen/Qwen3-0.6B
 Hello! How can I help you today?
 TTFT: 20.06 ms
 TPS:  154.11 tokens/s (9 tokens in 0.06s)
+ITL:  6.31 ms/token (decode 158.40 tokens/s)
+Cache: 14/18 prompt tokens cached (77.8%)
 ```
 
+Every reply is followed by the same per-turn stats block, explained next.
+
+---
+
+## Reading the per-turn stats
+
+The block is the same in every mode (single-shot, multi-turn, or
+`--no-history`). All four values come from the same metric classes `aiperf
+profile` uses:
+
 - **TTFT** — time to first token (client-observed).
-- **TPS** — generated tokens divided by end-to-end latency. This is the
-  vLLM-familiar rate and *includes* TTFT, so it blends prefill and decode into
-  one number.
+- **TPS** — generated tokens divided by end-to-end latency. The vLLM-familiar
+  rate; it *includes* TTFT, so it blends prefill and decode into one number.
+- **ITL** (inter-token latency) / **decode** — a decode-focused rate that
+  excludes prefill. Because it ignores TTFT, it stays comparable across turns
+  even when a growing history inflates prefill (where TPS sags). Omitted for
+  single-token replies, where it is undefined.
+- **Cache** — prompt-cache hit rate (`cached / prompt tokens`). Prefix caches
+  are **server-side and shared across requests and sessions**, so a hit does
+  not require a prior turn in this conversation — a shared system prompt or any
+  prefix the server already cached (from earlier requests, other sessions, or
+  other clients) can hit, even on a first or single-shot message. It is read
+  from the server's `usage`, so it appears only when the server reports prompt
+  caching (see below), and reflects the same counts `aiperf profile` records.
+
+> **Don't see the `Cache:` line?** The server has to *report* cached tokens in
+> its `usage`, which is separate from merely *enabling* caching. Launch the
+> server accordingly:
+>
+> - **vLLM:** `--enable-prefix-caching` **and** `--enable-prompt-tokens-details`.
+>   The reporting flag is off by default and independent of prefix caching —
+>   without it vLLM sends `prompt_tokens_details: null` and no `Cache:` line
+>   appears.
+> - **SGLang:** `--enable-cache-report` (off by default).
+> - **TRT-LLM:** reports `cached_tokens` by default; no extra flag.
+>
+> A genuinely novel prefix is a cold miss (`Cache: 0/N … (0.0%)`); the rate
+> rises as prefixes are reused — within this session or already resident in the
+> server's cache. See
+> [Vendor Usage Field Reference](../reference/vendor-usage-fields.md) for the
+> full matrix.
 
 ---
 
 ## Interactive Multi-Turn Chat
 
-Omit `--quick` to start an interactive session. Conversation history is retained
-and resent each turn, so the model has full context. Press `Ctrl-D` to exit.
+Omit `--quick` to start an interactive session. History is retained and resent
+each turn, so the model has full context (press `Ctrl-D` to exit). Watching the
+same stats evolve turn over turn is the point: TTFT and the cache hit rate climb
+as the resent prefix grows, while ITL — the decode-only rate — stays roughly
+flat even as the headline TPS sags.
 
 ```bash
 aiperf chat --model Qwen/Qwen3-0.6B --url http://localhost:8000
@@ -84,40 +127,6 @@ ITL:  6.11 ms/token (decode 163.67 tokens/s)
 Cache: 56/72 prompt tokens cached (77.8%)
 ```
 
-Multi-turn mode adds two extra lines:
-
-**ITL** (inter-token latency) / **decode TPS**. This is intentional: as the
-conversation grows, the resent history makes prefill (and therefore TTFT) larger
-each turn, which drags the headline TPS down even though the model's raw decode
-speed hasn't changed. ITL isolates decode speed from prefill, so it stays
-comparable across turns — making it the more honest number to watch in a
-multi-turn session. (ITL is undefined for single-token replies and is omitted in
-those cases.)
-
-**Cache** — prompt-cache hit rate. Because each turn resends the conversation,
-the shared prefix can be served from the server's prefix cache. This line shows
-how many of the prompt tokens were cache hits (`cached / prompt tokens`), which
-typically climbs as the conversation grows. It is reported from the server's
-`usage` (`prompt_tokens_details.cached_tokens` and friends), so it appears only
-when the server supports and reports prompt caching, and reflects the same
-counts `aiperf profile` would record.
-
-> **Don't see the `Cache:` line?** The server has to *report* cached tokens in
-> its `usage`, which is separate from merely *enabling* caching. Launch the
-> server accordingly:
->
-> - **vLLM:** `--enable-prefix-caching` **and** `--enable-prompt-tokens-details`.
->   The reporting flag is off by default and independent of prefix caching —
->   without it vLLM sends `prompt_tokens_details: null` and no `Cache:` line
->   appears.
-> - **SGLang:** `--enable-cache-report` (off by default).
-> - **TRT-LLM:** reports `cached_tokens` by default; no extra flag.
->
-> The first turn is always a cold miss (`Cache: 0/N … (0.0%)`); the rate rises
-> on later turns as the shared prefix is reused. See
-> [Vendor Usage Field Reference](../reference/vendor-usage-fields.md) for the
-> full matrix.
-
 ---
 
 ## Stateless Turns (`--no-history`)
@@ -130,11 +139,12 @@ flow, where the model has no memory of prior turns:
 aiperf chat --model Qwen/Qwen3-0.6B --no-history
 ```
 
-This is useful for measuring cold, single-turn performance repeatedly without
-the prefill cost of a growing history. TTFT and ITL stay meaningful; the cache
-line will be low (there is no shared prefix being resent, beyond an optional
-system prompt). `--no-history` is ignored with `--quick`, which is already a
-single request.
+This is useful for measuring single-turn performance repeatedly without the
+prefill cost of a growing history. The same stats block still prints; the cache
+hit rate won't climb from *this* session's history (none is resent), but it can
+still be non-zero when the server already holds a matching prefix — e.g. a
+shared system prompt or a prefix cached from earlier requests. `--no-history` is
+ignored with `--quick`, which is already a single request.
 
 ---
 
@@ -144,7 +154,7 @@ When the endpoint serves a reasoning model, `aiperf chat` counts reasoning
 tokens the same way `aiperf profile` does. Whether the server emits reasoning in
 a dedicated `reasoning_content` field (via a reasoning parser) or inline as
 `<think>...</think>` in the content, the generated reasoning tokens are included
-in the token total, and a separate reasoning count is shown:
+in the token total, and a separate reasoning count is shown in the TPS line:
 
 ```
 TTFT: 20.06 ms

--- a/docs/tutorials/interactive-chat.md
+++ b/docs/tutorials/interactive-chat.md
@@ -1,0 +1,188 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Interactive Chat Sanity Checks
+---
+
+# Interactive Chat Sanity Checks
+
+`aiperf chat` lets you talk to an OpenAI-compatible endpoint one message at a
+time and see per-turn speed stats (TTFT, TPS, generated tokens, end-to-end
+latency) after every reply. It is a lightweight sanity-check companion to
+`aiperf profile`: handy for confirming an endpoint is wired up correctly and
+getting a ballpark feel for performance before committing to a full benchmark
+run, and for eyeballing speculative-decoding or reasoning-model behavior where
+speedups are prompt-dependent.
+
+It is deliberately minimal. For real benchmarking — concurrency, request rates,
+datasets, sampling knobs, artifacts, and statistical aggregation — use
+[`aiperf profile`](../../README.md#tutorials-and-feature-guides). The per-turn
+numbers `aiperf chat` prints are produced by the same metric definitions
+`profile` uses, so they stay consistent (including reasoning-token accounting).
+
+---
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- AIPerf installed
+- An OpenAI-compatible inference server running (e.g. vLLM, SGLang) and
+  reachable, exposing `/v1/chat/completions`
+
+---
+
+## Single-Shot Sanity Check
+
+Send one message and exit with `--quick`:
+
+```bash
+aiperf chat \
+    --model Qwen/Qwen3-0.6B \
+    --url http://localhost:8000 \
+    --quick "say hello in one short sentence"
+```
+
+**Sample Output:**
+
+```
+Using model: Qwen/Qwen3-0.6B
+Hello! How can I help you today?
+TTFT: 20.06 ms
+TPS:  154.11 tokens/s (9 tokens in 0.06s)
+```
+
+- **TTFT** — time to first token (client-observed).
+- **TPS** — generated tokens divided by end-to-end latency. This is the
+  vLLM-familiar rate and *includes* TTFT, so it blends prefill and decode into
+  one number.
+
+---
+
+## Interactive Multi-Turn Chat
+
+Omit `--quick` to start an interactive session. Conversation history is retained
+and resent each turn, so the model has full context. Press `Ctrl-D` to exit.
+
+```bash
+aiperf chat --model Qwen/Qwen3-0.6B --url http://localhost:8000
+```
+
+```
+Please enter a message for the chat model (Ctrl-D to exit):
+> what's the capital of France?
+The capital of France is Paris.
+TTFT: 21.483 ms
+TPS:  148.20 tokens/s (8 tokens in 0.05s)
+ITL:  6.05 ms/token (decode 165.29 tokens/s)
+Cache: 12/40 prompt tokens cached (30.0%)
+> and its population?
+As of recent estimates, the population of Paris is about 2.1 million.
+TTFT: 34.92 ms
+TPS:  121.66 tokens/s (15 tokens in 0.12s)
+ITL:  6.11 ms/token (decode 163.67 tokens/s)
+Cache: 56/72 prompt tokens cached (77.8%)
+```
+
+Multi-turn mode adds two extra lines:
+
+**ITL** (inter-token latency) / **decode TPS**. This is intentional: as the
+conversation grows, the resent history makes prefill (and therefore TTFT) larger
+each turn, which drags the headline TPS down even though the model's raw decode
+speed hasn't changed. ITL isolates decode speed from prefill, so it stays
+comparable across turns — making it the more honest number to watch in a
+multi-turn session. (ITL is undefined for single-token replies and is omitted in
+those cases.)
+
+**Cache** — prompt-cache hit rate. Because each turn resends the conversation,
+the shared prefix can be served from the server's prefix cache. This line shows
+how many of the prompt tokens were cache hits (`cached / prompt tokens`), which
+typically climbs as the conversation grows. It is reported from the server's
+`usage` (`prompt_tokens_details.cached_tokens` and friends), so it appears only
+when the server supports and reports prompt caching, and reflects the same
+counts `aiperf profile` would record.
+
+> **Don't see the `Cache:` line?** The server has to *report* cached tokens in
+> its `usage`, which is separate from merely *enabling* caching. Launch the
+> server accordingly:
+>
+> - **vLLM:** `--enable-prefix-caching` **and** `--enable-prompt-tokens-details`.
+>   The reporting flag is off by default and independent of prefix caching —
+>   without it vLLM sends `prompt_tokens_details: null` and no `Cache:` line
+>   appears.
+> - **SGLang:** `--enable-cache-report` (off by default).
+> - **TRT-LLM:** reports `cached_tokens` by default; no extra flag.
+>
+> The first turn is always a cold miss (`Cache: 0/N … (0.0%)`); the rate rises
+> on later turns as the shared prefix is reused. See
+> [Vendor Usage Field Reference](../reference/vendor-usage-fields.md) for the
+> full matrix.
+
+---
+
+## Stateless Turns (`--no-history`)
+
+By default each turn resends the full conversation. Pass `--no-history` to make
+every message an independent, stateless request instead — the completion-style
+flow, where the model has no memory of prior turns:
+
+```bash
+aiperf chat --model Qwen/Qwen3-0.6B --no-history
+```
+
+This is useful for measuring cold, single-turn performance repeatedly without
+the prefill cost of a growing history. TTFT and ITL stay meaningful; the cache
+line will be low (there is no shared prefix being resent, beyond an optional
+system prompt). `--no-history` is ignored with `--quick`, which is already a
+single request.
+
+---
+
+## Reasoning Models
+
+When the endpoint serves a reasoning model, `aiperf chat` counts reasoning
+tokens the same way `aiperf profile` does. Whether the server emits reasoning in
+a dedicated `reasoning_content` field (via a reasoning parser) or inline as
+`<think>...</think>` in the content, the generated reasoning tokens are included
+in the token total, and a separate reasoning count is shown:
+
+```
+TTFT: 20.06 ms
+TPS:  154.11 tokens/s (186 tokens, 142 reasoning in 1.20s)
+ITL:  6.12 ms/token (decode 163.40 tokens/s)
+```
+
+---
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--model`, `-m` | Model name served by the endpoint (required). |
+| `--url`, `-u` | Base URL of the OpenAI-compatible server (default `http://localhost:8000`). |
+| `--system-prompt` | Optional system prompt prepended to the conversation. |
+| `--quick`, `-q` | Send a single message and exit instead of looping. |
+| `--no-history` | Treat each interactive message as a stateless request (no history retained). Ignored with `--quick`. |
+| `--api-key` | API key sent as a Bearer token (defaults to `OPENAI_API_KEY`). |
+| `--tokenizer` | Tokenizer for client-side token counts (defaults to the model name). Pass `builtin` for a zero-network tokenizer. |
+
+---
+
+## Tuning request timeouts
+
+`aiperf chat` fails fast on an unreachable endpoint but never caps overall
+generation time, so long replies are not truncated. Both timeouts are tunable
+via environment variables (no total timeout is applied):
+
+- `AIPERF_CHAT_CONNECT_TIMEOUT` (default `10.0`) — seconds to establish a
+  connection before a turn fails.
+- `AIPERF_CHAT_READ_TIMEOUT` (default `300.0`) — seconds to wait for the next
+  streamed chunk before a turn fails (only fires if the server stalls).
+
+See [Environment Variables](../environment-variables.md) for the full list.
+
+## See Also
+
+- [Multi-Turn Conversations](multi-turn.md) - Benchmark multi-turn sessions at scale
+- [Using Local Tokenizers Without HuggingFace](local-tokenizer.md)
+- [Metrics Reference](../metrics-reference.md) - Definitions of TTFT, ITL, OSL, and more

--- a/src/aiperf/cli.py
+++ b/src/aiperf/cli.py
@@ -30,6 +30,7 @@ app.register_install_completion_command()
 # Register all CLI commands (lazily loaded at invocation time)
 # NOTE: The order here determines the order they will appear in docs/cli-options.md
 app.command("aiperf.cli_commands.analyze_trace:app", name="analyze-trace")
+app.command("aiperf.cli_commands.chat:app", name="chat")
 app.command("aiperf.cli_commands.config:app", name="config")
 app.command("aiperf.cli_commands.profile:app", name="profile")
 app.command("aiperf.cli_commands.plot:app", name="plot")

--- a/src/aiperf/cli_commands/_chat_stats.py
+++ b/src/aiperf/cli_commands/_chat_stats.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pure response-parsing, token-counting, and per-turn stats helpers for the
+``aiperf chat`` command.
+
+Separated from ``chat.py`` (which owns the HTTP/REPL I/O) so this layer stays
+free of transport concerns and easy to unit test. Everything here is built on
+the same metric classes ``aiperf profile`` uses, keeping the numbers
+definitionally consistent.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable
+
+from aiperf.common.constants import NANOS_PER_MILLIS, NANOS_PER_SECOND
+from aiperf.common.exceptions import NoMetricValue
+from aiperf.common.models.record_models import (
+    ParsedResponse,
+    ParsedResponseRecord,
+    ReasoningResponseData,
+    RequestRecord,
+    TextResponseData,
+    TokenCounts,
+)
+from aiperf.common.models.usage_models import Usage
+from aiperf.metrics.metric_dicts import MetricRecordDict
+from aiperf.metrics.metric_registry import MetricRegistry
+from aiperf.metrics.types.input_sequence_length_metric import InputSequenceLengthMetric
+from aiperf.metrics.types.inter_token_latency_metric import InterTokenLatencyMetric
+from aiperf.metrics.types.output_sequence_length_metric import (
+    OutputSequenceLengthMetric,
+)
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+from aiperf.metrics.types.ttft_metric import TTFTMetric
+from aiperf.metrics.types.usage_cache_metrics import UsagePromptCacheReadTokensMetric
+
+# Per-record metrics surfaced after each turn. Reusing the real metric classes
+# (instead of recomputing TTFT/latency/OSL/ITL/cache inline) keeps the numbers
+# definitionally identical to ``aiperf profile``.
+_METRIC_TAGS = (
+    TTFTMetric.tag,
+    RequestLatencyMetric.tag,
+    OutputSequenceLengthMetric.tag,
+    InterTokenLatencyMetric.tag,
+    InputSequenceLengthMetric.tag,
+    UsagePromptCacheReadTokensMetric.tag,
+)
+
+
+def split_delta(delta: dict) -> tuple[str | None, str | None]:
+    """Split one streaming ``delta`` into ``(content, reasoning)`` text pieces.
+
+    Mirrors ``ChatEndpoint.extract_chat_response_data`` (``openai_chat.py``):
+    a server emits reasoning either in a dedicated ``reasoning_content`` /
+    ``reasoning`` field (when it runs a reasoning parser) or inline inside
+    ``content`` as ``<think>...</think>``. Keep this in sync with that method
+    so reasoning-token accounting matches ``aiperf profile``.
+    """
+    content = delta.get("content")
+    reasoning = delta.get("reasoning_content") or delta.get("reasoning")
+    return content, reasoning
+
+
+def make_response_data(
+    content: str | None, reasoning: str | None
+) -> ReasoningResponseData | TextResponseData | None:
+    """Build the parsed data object for one chunk, typed the way ``profile``
+    types it so client-side output/reasoning token buckets match."""
+    if reasoning:
+        return ReasoningResponseData(content=content or None, reasoning=reasoning)
+    if content:
+        return TextResponseData(text=content)
+    return None
+
+
+def count_tokens(encode: Callable[[str], list], text: str) -> int | None:
+    """Token count for ``text`` (``None`` when empty), matching profile's
+    empty-separator join + single encode in ``_compute_token_count``."""
+    if not text:
+        return None
+    return len(encode(text))
+
+
+def input_tokens_from_usage(usage: dict | None) -> int | None:
+    """Server-reported prompt token count, used as ISL.
+
+    Unlike output tokens (we have the full generated text), client-side input
+    tokenization can't reproduce the server's chat template, so we take the
+    server's exact ``prompt_tokens`` when usage is available.
+    """
+    if not usage:
+        return None
+    return Usage(usage).prompt_tokens
+
+
+def build_record(
+    *,
+    model: str,
+    start_ns: int,
+    end_ns: int,
+    timestamp_ns: int,
+    responses: list[ParsedResponse],
+    input_tokens: int | None,
+    output_tokens: int | None,
+    reasoning_tokens: int | None,
+) -> ParsedResponseRecord:
+    """Assemble the same ``ParsedResponseRecord`` shape the profile pipeline
+    feeds to the metric classes."""
+    request = RequestRecord(
+        model_name=model,
+        start_perf_ns=start_ns,
+        timestamp_ns=timestamp_ns,
+        end_perf_ns=end_ns,
+    )
+    return ParsedResponseRecord(
+        request=request,
+        responses=responses,
+        token_counts=TokenCounts(
+            input=input_tokens, output=output_tokens, reasoning=reasoning_tokens
+        ),
+    )
+
+
+def compute_record_metrics(record: ParsedResponseRecord) -> MetricRecordDict:
+    """Run the per-record metric classes in dependency order, mirroring the
+    record stage of the profile metric pipeline.
+
+    Metrics that do not apply to a turn (e.g. OSL with no tokens received)
+    raise ``NoMetricValue`` and are skipped, exactly as in the pipeline.
+    """
+    metrics: MetricRecordDict = MetricRecordDict()
+    for tag in MetricRegistry.create_dependency_order_for(_METRIC_TAGS):
+        with contextlib.suppress(NoMetricValue):
+            metrics[tag] = MetricRegistry.get_class(tag)().parse_record(record, metrics)
+    return metrics
+
+
+def format_stats(
+    metrics: MetricRecordDict,
+    reasoning_tokens: int | None,
+    *,
+    interactive: bool = False,
+) -> str:
+    """Render the per-turn stats block from computed metric values.
+
+    TPS is the vLLM-familiar end-to-end rate (generated tokens / e2e latency,
+    which includes TTFT); OSL and latency themselves come straight from the
+    reused metric classes.
+
+    In ``interactive`` mode (the REPL loop, with or without history) two extra
+    lines are appended where they apply:
+    - ITL / decode-TPS, which isolates decode speed from prefill and so stays
+      comparable across turns even as resent history inflates TTFT.
+    - Prompt-cache hit rate, which climbs as the shared conversation prefix
+      gets served from the server's cache (low when ``--no-history`` is set,
+      since no prefix is resent). Both are omitted when the server does not
+      provide the underlying data.
+    """
+    ttft_ns = metrics.get(TTFTMetric.tag)
+    latency_ns = metrics.get(RequestLatencyMetric.tag)
+    osl = metrics.get(OutputSequenceLengthMetric.tag)
+    if ttft_ns is None or latency_ns is None or not osl:
+        return "(no tokens received)"
+
+    latency_s = latency_ns / NANOS_PER_SECOND
+    tps = osl / latency_s if latency_s > 0 else 0.0
+    tokens_desc = f"{osl} tokens"
+    if reasoning_tokens:
+        tokens_desc += f", {reasoning_tokens} reasoning"
+    lines = [
+        f"TTFT: {ttft_ns / NANOS_PER_MILLIS:.2f} ms",
+        f"TPS:  {tps:.2f} tokens/s ({tokens_desc} in {latency_s:.2f}s)",
+    ]
+    if interactive:
+        lines.extend(_interactive_stat_lines(metrics))
+    return "\n".join(lines)
+
+
+def _interactive_stat_lines(metrics: MetricRecordDict) -> list[str]:
+    """Build the interactive-only ITL and cache lines from computed metrics."""
+    lines: list[str] = []
+
+    # ITL requires >=2 output tokens; the metric raised NoMetricValue otherwise
+    # and the tag is simply absent.
+    itl_ns = metrics.get(InterTokenLatencyMetric.tag)
+    if itl_ns:
+        decode_tps = NANOS_PER_SECOND / itl_ns
+        lines.append(
+            f"ITL:  {itl_ns / NANOS_PER_MILLIS:.2f} ms/token "
+            f"(decode {decode_tps:.2f} tokens/s)"
+        )
+
+    # Cache hit rate needs both the prompt-token count and the server-reported
+    # cached-read count. Absent when the server doesn't report prompt-cache
+    # usage (no prefix caching, or the field isn't surfaced).
+    isl = metrics.get(InputSequenceLengthMetric.tag)
+    cache_read = metrics.get(UsagePromptCacheReadTokensMetric.tag)
+    if isl and cache_read is not None:
+        rate = 100 * cache_read / isl
+        lines.append(f"Cache: {cache_read}/{isl} prompt tokens cached ({rate:.1f}%)")
+    return lines

--- a/src/aiperf/cli_commands/_chat_stats.py
+++ b/src/aiperf/cli_commands/_chat_stats.py
@@ -52,11 +52,14 @@ _METRIC_TAGS = (
 def split_delta(delta: dict) -> tuple[str | None, str | None]:
     """Split one streaming ``delta`` into ``(content, reasoning)`` text pieces.
 
-    Mirrors ``ChatEndpoint.extract_chat_response_data`` (``openai_chat.py``):
-    a server emits reasoning either in a dedicated ``reasoning_content`` /
-    ``reasoning`` field (when it runs a reasoning parser) or inline inside
-    ``content`` as ``<think>...</think>``. Keep this in sync with that method
-    so reasoning-token accounting matches ``aiperf profile``.
+    Reasoning is taken only from a dedicated ``reasoning_content`` /
+    ``reasoning`` field -- what a server emits when it runs a reasoning parser.
+    This matches ``ChatEndpoint.extract_chat_response_data`` (``openai_chat.py``),
+    which keys off the same fields. When a server instead emits reasoning inline
+    as ``<think>...</think>`` inside ``content`` (no reasoning parser), that text
+    stays in ``content`` and counts as output -- again exactly as ``aiperf
+    profile`` does, since neither path strips inline think tags. Either way,
+    reasoning-token accounting stays consistent with ``profile``.
     """
     content = delta.get("content")
     reasoning = delta.get("reasoning_content") or delta.get("reasoning")
@@ -137,26 +140,17 @@ def compute_record_metrics(record: ParsedResponseRecord) -> MetricRecordDict:
     return metrics
 
 
-def format_stats(
-    metrics: MetricRecordDict,
-    reasoning_tokens: int | None,
-    *,
-    interactive: bool = False,
-) -> str:
-    """Render the per-turn stats block from computed metric values.
+def format_stats(metrics: MetricRecordDict, reasoning_tokens: int | None) -> str:
+    """Render the per-turn stats block: TTFT, TPS, inter-token latency (ITL),
+    and prompt-cache hit rate.
 
-    TPS is the vLLM-familiar end-to-end rate (generated tokens / e2e latency,
-    which includes TTFT); OSL and latency themselves come straight from the
-    reused metric classes.
-
-    In ``interactive`` mode (the REPL loop, with or without history) two extra
-    lines are appended where they apply:
-    - ITL / decode-TPS, which isolates decode speed from prefill and so stays
-      comparable across turns even as resent history inflates TTFT.
-    - Prompt-cache hit rate, which climbs as the shared conversation prefix
-      gets served from the server's cache (low when ``--no-history`` is set,
-      since no prefix is resent). Both are omitted when the server does not
-      provide the underlying data.
+    Every value comes from the same metric classes ``aiperf profile`` uses.
+    TTFT and TPS always render (TPS is the vLLM-familiar end-to-end rate, which
+    includes TTFT). ITL and the cache hit rate render alongside them when their
+    data is available: ITL is defined only for >=2 output tokens, and the cache
+    rate needs the server to report cached prompt tokens (prefix caches are
+    server-side and shared across requests/sessions, so a hit does not require a
+    prior turn). Returns a placeholder when no tokens were received.
     """
     ttft_ns = metrics.get(TTFTMetric.tag)
     latency_ns = metrics.get(RequestLatencyMetric.tag)
@@ -169,21 +163,12 @@ def format_stats(
     tokens_desc = f"{osl} tokens"
     if reasoning_tokens:
         tokens_desc += f", {reasoning_tokens} reasoning"
+
     lines = [
         f"TTFT: {ttft_ns / NANOS_PER_MILLIS:.2f} ms",
         f"TPS:  {tps:.2f} tokens/s ({tokens_desc} in {latency_s:.2f}s)",
     ]
-    if interactive:
-        lines.extend(_interactive_stat_lines(metrics))
-    return "\n".join(lines)
 
-
-def _interactive_stat_lines(metrics: MetricRecordDict) -> list[str]:
-    """Build the interactive-only ITL and cache lines from computed metrics."""
-    lines: list[str] = []
-
-    # ITL requires >=2 output tokens; the metric raised NoMetricValue otherwise
-    # and the tag is simply absent.
     itl_ns = metrics.get(InterTokenLatencyMetric.tag)
     if itl_ns:
         decode_tps = NANOS_PER_SECOND / itl_ns
@@ -192,12 +177,10 @@ def _interactive_stat_lines(metrics: MetricRecordDict) -> list[str]:
             f"(decode {decode_tps:.2f} tokens/s)"
         )
 
-    # Cache hit rate needs both the prompt-token count and the server-reported
-    # cached-read count. Absent when the server doesn't report prompt-cache
-    # usage (no prefix caching, or the field isn't surfaced).
     isl = metrics.get(InputSequenceLengthMetric.tag)
     cache_read = metrics.get(UsagePromptCacheReadTokensMetric.tag)
     if isl and cache_read is not None:
         rate = 100 * cache_read / isl
         lines.append(f"Cache: {cache_read}/{isl} prompt tokens cached ({rate:.1f}%)")
-    return lines
+
+    return "\n".join(lines)

--- a/src/aiperf/cli_commands/chat.py
+++ b/src/aiperf/cli_commands/chat.py
@@ -40,6 +40,7 @@ from aiperf.cli_commands._chat_stats import (
 from aiperf.common.environment import Environment
 from aiperf.common.exceptions import SSEResponseError
 from aiperf.common.models.record_models import ParsedResponse
+from aiperf.config.loader.parsing import normalize_http_url
 from aiperf.transports.sse_utils import AsyncSSEStreamReader
 
 app = App(name="chat")
@@ -58,12 +59,13 @@ def _chat_completions_url(url: str) -> str:
     """Resolve a user-supplied base URL to a chat-completions endpoint.
 
     Accepts a bare host (``http://host:8000``), a ``/v1`` base, or a full
-    ``/chat/completions`` path. Appending ``/v1/chat/completions`` to a bare
-    base matches how ``aiperf profile`` joins the endpoint's metadata path, so
-    a server mounted under a sub-path (e.g. ``/openai``) resolves the same way
-    in both commands.
+    ``/chat/completions`` path. A scheme-less URL (``localhost:8000``) gets
+    ``http://`` prepended, matching how ``aiperf profile`` normalizes ``--url``;
+    and appending ``/v1/chat/completions`` to a bare base matches how ``profile``
+    joins the endpoint's metadata path, so a server mounted under a sub-path
+    (e.g. ``/openai``) resolves the same way in both commands.
     """
-    base = url.rstrip("/")
+    base = normalize_http_url(url).rstrip("/")
     if base.endswith("/chat/completions"):
         return base
     if base.endswith("/v1"):
@@ -147,7 +149,17 @@ async def _run_turn(
     body = orjson.dumps(payload)
     post_headers = {**headers, "Content-Type": "application/json"}
     async with session.post(url, data=body, headers=post_headers) as resp:
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            # OpenAI-compatible servers put the real diagnostic (unknown model,
+            # context-length exceeded, ...) in the response body, which
+            # raise_for_status() discards. Surface a bounded prefix of it -- for
+            # a sanity-check tool that error message is the whole point.
+            detail = (await resp.text())[:500].strip()
+            if detail:
+                e.message = f"{e.message}: {detail}"
+            raise
         responses, output_parts, reasoning_parts, last_usage = await _consume_stream(
             resp
         )
@@ -175,9 +187,11 @@ async def _run_turn(
         reasoning_tokens=reasoning_tokens,
     )
     print(format_stats(compute_record_metrics(record), reasoning_tokens))
-    # Fall back to the reasoning text when the reply had no visible content, so a
-    # reasoning-only turn isn't recorded as an empty assistant message in history
-    # (mirrors profile's build_assistant_turn reasoning-only fallback).
+    # Fall back to the reasoning text only when the reply had no visible content,
+    # so a reasoning-only turn isn't recorded as an empty assistant message.
+    # Intentionally content-only when content exists: unlike profile's per-chunk
+    # build_assistant_turn (which concatenates reasoning + content), we don't
+    # resend reasoning, matching how chat APIs replay assistant turns.
     return "".join(output_parts) or "".join(reasoning_parts)
 
 
@@ -377,7 +391,8 @@ def chat(
     tokenizer: Annotated[
         str | None,
         Parameter(
-            help="Tokenizer for client-side token counts. Defaults to the model name."
+            help="Tokenizer for client-side token counts. Defaults to the model "
+            "name. Pass `builtin` for a zero-network tokenizer."
         ),
     ] = None,
 ) -> None:

--- a/src/aiperf/cli_commands/chat.py
+++ b/src/aiperf/cli_commands/chat.py
@@ -38,15 +38,11 @@ from aiperf.cli_commands._chat_stats import (
     split_delta,
 )
 from aiperf.common.environment import Environment
+from aiperf.common.exceptions import SSEResponseError
 from aiperf.common.models.record_models import ParsedResponse
+from aiperf.transports.sse_utils import AsyncSSEStreamReader
 
 app = App(name="chat")
-
-# SSE line markers for our hand-rolled streaming parse. aiperf's
-# AsyncSSEStreamReader parses fields generically and exposes no shared
-# ``data:`` / ``[DONE]`` constant to import, so they live here.
-_SSE_DATA_PREFIX = b"data:"
-_SSE_DONE = b"[DONE]"
 
 # Fail fast on an unreachable endpoint, but leave generous time for a slow first
 # token / long generation -- no ``total`` cap so streaming is never truncated
@@ -87,28 +83,24 @@ def _build_turn_messages(
 async def _consume_stream(
     resp: aiohttp.ClientResponse,
 ) -> tuple[list[ParsedResponse], list[str], list[str], dict | None]:
-    """Read the SSE stream: collect parsed responses (timestamped at arrival),
-    print content/reasoning live, and capture the final usage chunk.
+    """Read the SSE stream via aiperf's ``AsyncSSEStreamReader``: collect parsed
+    responses (timestamped at arrival), print content/reasoning live, and
+    capture the final usage chunk.
 
     Returns ``(responses, output_parts, reasoning_parts, last_usage)``.
+
+    Raises:
+        SSEResponseError: if the server signals a mid-stream ``event: error``
+            after a 200 OK (surfaced instead of reported as a truncated reply).
     """
     responses: list[ParsedResponse] = []
     output_parts: list[str] = []
     reasoning_parts: list[str] = []
     last_usage: dict | None = None
-    async for raw_line in resp.content:
-        line = raw_line.strip()
-        if not line.startswith(_SSE_DATA_PREFIX):
-            continue
-        data = line[len(_SSE_DATA_PREFIX) :].strip()
-        if data == _SSE_DONE:
-            break
-        try:
-            chunk = orjson.loads(data)
-        except orjson.JSONDecodeError:
-            # Tolerate a malformed/non-JSON data line (proxy error page,
-            # truncated stream) rather than crashing the turn, mirroring the
-            # endpoint parser's degrade-to-skip behavior.
+    async for message in AsyncSSEStreamReader(resp.content):
+        AsyncSSEStreamReader.inspect_message_for_error(message)
+        chunk = message.get_json()
+        if not chunk:  # keep-alive, ``[DONE]``, or unparsable frame
             continue
         if chunk.get("usage"):
             last_usage = chunk["usage"]
@@ -119,7 +111,7 @@ async def _consume_stream(
         data_obj = make_response_data(content, reasoning)
         if data_obj is None:
             continue
-        responses.append(ParsedResponse(perf_ns=time.perf_counter_ns(), data=data_obj))
+        responses.append(ParsedResponse(perf_ns=message.perf_ns, data=data_obj))
         if reasoning:
             reasoning_parts.append(reasoning)
             print(reasoning, end="", flush=True)
@@ -137,7 +129,6 @@ async def _run_turn(
     model: str,
     conversation: list[dict],
     encode: Callable[[str], list],
-    interactive: bool,
 ) -> str:
     """Stream one chat completion, print the reply live + a stats block, and
     return the assistant's text content (for appending to the conversation)."""
@@ -151,7 +142,11 @@ async def _run_turn(
     }
     start_ns = time.perf_counter_ns()
     timestamp_ns = time.time_ns()
-    async with session.post(url, json=payload, headers=headers) as resp:
+    # Serialize with orjson (repo-wide JSON rule) and send bytes; setting the
+    # content type ourselves since we bypass aiohttp's ``json=`` encoder.
+    body = orjson.dumps(payload)
+    post_headers = {**headers, "Content-Type": "application/json"}
+    async with session.post(url, data=body, headers=post_headers) as resp:
         resp.raise_for_status()
         responses, output_parts, reasoning_parts, last_usage = await _consume_stream(
             resp
@@ -179,12 +174,11 @@ async def _run_turn(
         output_tokens=output_tokens,
         reasoning_tokens=reasoning_tokens,
     )
-    print(
-        format_stats(
-            compute_record_metrics(record), reasoning_tokens, interactive=interactive
-        )
-    )
-    return "".join(output_parts)
+    print(format_stats(compute_record_metrics(record), reasoning_tokens))
+    # Fall back to the reasoning text when the reply had no visible content, so a
+    # reasoning-only turn isn't recorded as an empty assistant message in history
+    # (mirrors profile's build_assistant_turn reasoning-only fallback).
+    return "".join(output_parts) or "".join(reasoning_parts)
 
 
 async def _read_user_message(prompt: str) -> str:
@@ -207,19 +201,38 @@ async def _read_user_message(prompt: str) -> str:
         # in this thread. Signals never reach a non-main thread, so Exception
         # (not BaseException) is the correct breadth.
         except Exception as e:  # noqa: BLE001
-            _settle(loop, future.set_exception, e)
+            _settle(loop, future, exc=e)
         else:
-            _settle(loop, future.set_result, line)
+            _settle(loop, future, result=line)
 
     threading.Thread(target=_read, daemon=True, name="aiperf-chat-input").start()
     return await future
 
 
-def _settle(loop: asyncio.AbstractEventLoop, setter: Callable, value: object) -> None:
-    """Resolve the future from the read thread, ignoring a closed loop (e.g.
-    when the read returns during Ctrl-C shutdown)."""
+def _settle(
+    loop: asyncio.AbstractEventLoop,
+    future: asyncio.Future[str],
+    *,
+    result: str | None = None,
+    exc: BaseException | None = None,
+) -> None:
+    """Resolve ``future`` from the read thread.
+
+    No-ops if the future is already done -- Ctrl-C / task cancellation can
+    complete it before ``input()`` returns, and setting a result on a done
+    future raises ``InvalidStateError`` -- or if the loop is already closed.
+    """
+
+    def _apply() -> None:
+        if future.done():
+            return
+        if exc is not None:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
+
     with contextlib.suppress(RuntimeError):
-        loop.call_soon_threadsafe(setter, value)
+        loop.call_soon_threadsafe(_apply)
 
 
 async def _chat_loop(
@@ -238,9 +251,6 @@ async def _chat_loop(
     )
 
     async with aiohttp.ClientSession(timeout=_REQUEST_TIMEOUT) as session:
-        # Single-shot keeps the minimal vLLM-style block; the interactive loop
-        # adds the ITL/decode + cache lines, where the headline TPS starts to
-        # mislead as growing history inflates TTFT.
         if quick is not None:
             await _run_turn(
                 session,
@@ -249,7 +259,6 @@ async def _chat_loop(
                 model=model,
                 conversation=_build_turn_messages(system_messages, [], quick),
                 encode=encode,
-                interactive=False,
             )
             return
 
@@ -275,12 +284,11 @@ async def _chat_loop(
                         system_messages, history, message
                     ),
                     encode=encode,
-                    interactive=True,
                 )
-            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            except (aiohttp.ClientError, asyncio.TimeoutError, SSEResponseError) as e:
                 # Keep the REPL alive on a transient failure (HTTP error, dropped
-                # connection, stall) -- report it and let the user retry instead
-                # of tearing down the whole session.
+                # connection, stall, or a mid-stream SSE error) -- report it and
+                # let the user retry instead of tearing down the whole session.
                 print(f"request failed: {e}", file=sys.stderr)
                 continue
             if not no_history:

--- a/src/aiperf/cli_commands/chat.py
+++ b/src/aiperf/cli_commands/chat.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CLI command for the interactive ``chat`` subcommand.
+
+A lightweight, interactive sanity-check companion to ``aiperf profile``: chat
+with an OpenAI-compatible endpoint one message at a time and print per-turn
+speed stats (TTFT, TPS, generated tokens, end-to-end latency) after each reply.
+
+Deliberately minimal. For the full benchmarking surface (concurrency,
+datasets, sampling knobs, artifacts) use ``aiperf profile``. The per-turn
+numbers are produced by the same metric classes ``profile`` uses (see
+``_chat_stats``), so they stay definitionally consistent -- including
+reasoning-token accounting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import sys
+import threading
+import time
+from collections.abc import Callable
+from typing import Annotated
+
+import aiohttp
+import orjson
+from cyclopts import App, Parameter
+
+from aiperf.cli_commands._chat_stats import (
+    build_record,
+    compute_record_metrics,
+    count_tokens,
+    format_stats,
+    input_tokens_from_usage,
+    make_response_data,
+    split_delta,
+)
+from aiperf.common.environment import Environment
+from aiperf.common.models.record_models import ParsedResponse
+
+app = App(name="chat")
+
+# SSE line markers for our hand-rolled streaming parse. aiperf's
+# AsyncSSEStreamReader parses fields generically and exposes no shared
+# ``data:`` / ``[DONE]`` constant to import, so they live here.
+_SSE_DATA_PREFIX = b"data:"
+_SSE_DONE = b"[DONE]"
+
+# Fail fast on an unreachable endpoint, but leave generous time for a slow first
+# token / long generation -- no ``total`` cap so streaming is never truncated
+# mid-reply; ``sock_read`` only fires if the server stalls between chunks. Both
+# are tunable via AIPERF_CHAT_CONNECT_TIMEOUT / AIPERF_CHAT_READ_TIMEOUT.
+_REQUEST_TIMEOUT = aiohttp.ClientTimeout(
+    connect=Environment.CHAT.CONNECT_TIMEOUT,
+    sock_read=Environment.CHAT.READ_TIMEOUT,
+)
+
+
+def _chat_completions_url(url: str) -> str:
+    """Resolve a user-supplied base URL to a chat-completions endpoint.
+
+    Accepts a bare host (``http://host:8000``), a ``/v1`` base, or a full
+    ``/chat/completions`` path. Appending ``/v1/chat/completions`` to a bare
+    base matches how ``aiperf profile`` joins the endpoint's metadata path, so
+    a server mounted under a sub-path (e.g. ``/openai``) resolves the same way
+    in both commands.
+    """
+    base = url.rstrip("/")
+    if base.endswith("/chat/completions"):
+        return base
+    if base.endswith("/v1"):
+        return f"{base}/chat/completions"
+    return f"{base}/v1/chat/completions"
+
+
+def _build_turn_messages(
+    system_messages: list[dict], history: list[dict], user_message: str
+) -> list[dict]:
+    """Assemble the messages to send for one turn: optional system prompt,
+    accumulated history (empty under ``--no-history``), then the new user
+    message."""
+    return [*system_messages, *history, {"role": "user", "content": user_message}]
+
+
+async def _consume_stream(
+    resp: aiohttp.ClientResponse,
+) -> tuple[list[ParsedResponse], list[str], list[str], dict | None]:
+    """Read the SSE stream: collect parsed responses (timestamped at arrival),
+    print content/reasoning live, and capture the final usage chunk.
+
+    Returns ``(responses, output_parts, reasoning_parts, last_usage)``.
+    """
+    responses: list[ParsedResponse] = []
+    output_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    last_usage: dict | None = None
+    async for raw_line in resp.content:
+        line = raw_line.strip()
+        if not line.startswith(_SSE_DATA_PREFIX):
+            continue
+        data = line[len(_SSE_DATA_PREFIX) :].strip()
+        if data == _SSE_DONE:
+            break
+        try:
+            chunk = orjson.loads(data)
+        except orjson.JSONDecodeError:
+            # Tolerate a malformed/non-JSON data line (proxy error page,
+            # truncated stream) rather than crashing the turn, mirroring the
+            # endpoint parser's degrade-to-skip behavior.
+            continue
+        if chunk.get("usage"):
+            last_usage = chunk["usage"]
+        choices = chunk.get("choices")
+        if not choices:
+            continue
+        content, reasoning = split_delta(choices[0].get("delta") or {})
+        data_obj = make_response_data(content, reasoning)
+        if data_obj is None:
+            continue
+        responses.append(ParsedResponse(perf_ns=time.perf_counter_ns(), data=data_obj))
+        if reasoning:
+            reasoning_parts.append(reasoning)
+            print(reasoning, end="", flush=True)
+        if content:
+            output_parts.append(content)
+            print(content, end="", flush=True)
+    return responses, output_parts, reasoning_parts, last_usage
+
+
+async def _run_turn(
+    session: aiohttp.ClientSession,
+    *,
+    url: str,
+    headers: dict[str, str],
+    model: str,
+    conversation: list[dict],
+    encode: Callable[[str], list],
+    interactive: bool,
+) -> str:
+    """Stream one chat completion, print the reply live + a stats block, and
+    return the assistant's text content (for appending to the conversation)."""
+    # include_usage gets the trailing usage chunk (prompt tokens + prompt-cache
+    # reads) for the ISL and cache-hit lines; it does not change the reply.
+    payload = {
+        "messages": conversation,
+        "model": model,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    start_ns = time.perf_counter_ns()
+    timestamp_ns = time.time_ns()
+    async with session.post(url, json=payload, headers=headers) as resp:
+        resp.raise_for_status()
+        responses, output_parts, reasoning_parts, last_usage = await _consume_stream(
+            resp
+        )
+    end_ns = time.perf_counter_ns()
+    print()
+
+    # A usage-only response (data=None) carries the server usage to
+    # ``record.final_usage`` without affecting the content-timing metrics.
+    if last_usage is not None:
+        responses.append(
+            ParsedResponse(perf_ns=time.perf_counter_ns(), usage=last_usage)
+        )
+    output_tokens = await asyncio.to_thread(count_tokens, encode, "".join(output_parts))
+    reasoning_tokens = await asyncio.to_thread(
+        count_tokens, encode, "".join(reasoning_parts)
+    )
+    record = build_record(
+        model=model,
+        start_ns=start_ns,
+        end_ns=end_ns,
+        timestamp_ns=timestamp_ns,
+        responses=responses,
+        input_tokens=input_tokens_from_usage(last_usage),
+        output_tokens=output_tokens,
+        reasoning_tokens=reasoning_tokens,
+    )
+    print(
+        format_stats(
+            compute_record_metrics(record), reasoning_tokens, interactive=interactive
+        )
+    )
+    return "".join(output_parts)
+
+
+async def _read_user_message(prompt: str) -> str:
+    """Read one input line off a daemon thread.
+
+    Using a daemon thread (rather than ``asyncio.to_thread``'s default
+    executor) means a Ctrl-C while we're blocked at the prompt exits on the
+    first press: the abandoned read thread never blocks asyncio's executor
+    shutdown or the interpreter's exit-time thread join. Raises ``EOFError`` on
+    Ctrl-D / closed stdin, matching ``input()``.
+    """
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[str] = loop.create_future()
+
+    def _read() -> None:
+        try:
+            line = input(prompt)
+        # noqa: BLE001 - forward any read failure (EOFError, OSError, ...) to
+        # the awaiting coroutine so it surfaces there instead of dying silently
+        # in this thread. Signals never reach a non-main thread, so Exception
+        # (not BaseException) is the correct breadth.
+        except Exception as e:  # noqa: BLE001
+            _settle(loop, future.set_exception, e)
+        else:
+            _settle(loop, future.set_result, line)
+
+    threading.Thread(target=_read, daemon=True, name="aiperf-chat-input").start()
+    return await future
+
+
+def _settle(loop: asyncio.AbstractEventLoop, setter: Callable, value: object) -> None:
+    """Resolve the future from the read thread, ignoring a closed loop (e.g.
+    when the read returns during Ctrl-C shutdown)."""
+    with contextlib.suppress(RuntimeError):
+        loop.call_soon_threadsafe(setter, value)
+
+
+async def _chat_loop(
+    *,
+    model: str,
+    url: str,
+    headers: dict[str, str],
+    system_prompt: str | None,
+    quick: str | None,
+    no_history: bool,
+    encode: Callable[[str], list],
+) -> None:
+    """Drive the (single-shot or interactive) chat session."""
+    system_messages: list[dict] = (
+        [{"role": "system", "content": system_prompt}] if system_prompt else []
+    )
+
+    async with aiohttp.ClientSession(timeout=_REQUEST_TIMEOUT) as session:
+        # Single-shot keeps the minimal vLLM-style block; the interactive loop
+        # adds the ITL/decode + cache lines, where the headline TPS starts to
+        # mislead as growing history inflates TTFT.
+        if quick is not None:
+            await _run_turn(
+                session,
+                url=url,
+                headers=headers,
+                model=model,
+                conversation=_build_turn_messages(system_messages, [], quick),
+                encode=encode,
+                interactive=False,
+            )
+            return
+
+        # ``history`` stays empty under ``--no-history``, making each turn an
+        # independent, stateless request (completion-style) instead of resending
+        # the growing conversation.
+        history: list[dict] = []
+        print("Please enter a message for the chat model (Ctrl-D to exit):")
+        while True:
+            try:
+                message = await _read_user_message("> ")
+            except (EOFError, KeyboardInterrupt):
+                print()
+                break
+            user_message = {"role": "user", "content": message}
+            try:
+                assistant = await _run_turn(
+                    session,
+                    url=url,
+                    headers=headers,
+                    model=model,
+                    conversation=_build_turn_messages(
+                        system_messages, history, message
+                    ),
+                    encode=encode,
+                    interactive=True,
+                )
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                # Keep the REPL alive on a transient failure (HTTP error, dropped
+                # connection, stall) -- report it and let the user retry instead
+                # of tearing down the whole session.
+                print(f"request failed: {e}", file=sys.stderr)
+                continue
+            if not no_history:
+                history.append(user_message)
+                history.append({"role": "assistant", "content": assistant})
+
+
+def _run_chat(
+    *,
+    model: str,
+    url: str,
+    system_prompt: str | None,
+    quick: str | None,
+    no_history: bool,
+    api_key: str | None,
+    tokenizer: str | None,
+) -> None:
+    """Load the tokenizer, build auth headers, and drive the chat session."""
+    from aiperf.cli_utils import exit_on_error
+
+    with exit_on_error(title="Error running aiperf chat", show_traceback=False):
+        from aiperf.common.tokenizer import Tokenizer
+
+        tok = Tokenizer.from_pretrained(tokenizer or model)
+        headers: dict[str, str] = {}
+        key = api_key or os.environ.get("OPENAI_API_KEY")
+        if key:
+            headers["Authorization"] = f"Bearer {key}"
+
+        # Ctrl-C during a request should exit quietly, not dump a traceback.
+        with contextlib.suppress(KeyboardInterrupt):
+            asyncio.run(
+                _chat_loop(
+                    model=model,
+                    url=_chat_completions_url(url),
+                    headers=headers,
+                    system_prompt=system_prompt,
+                    quick=quick,
+                    no_history=no_history,
+                    encode=tok.encode,
+                )
+            )
+
+
+@app.default
+def chat(
+    *,
+    model: Annotated[
+        str,
+        Parameter(name=["--model", "-m"], help="Model name served by the endpoint."),
+    ],
+    url: Annotated[
+        str,
+        Parameter(
+            name=["--url", "-u"],
+            help="Base URL of the OpenAI-compatible server "
+            "(e.g. http://localhost:8000), matching `aiperf profile`.",
+        ),
+    ] = "http://localhost:8000",
+    system_prompt: Annotated[
+        str | None,
+        Parameter(help="Optional system prompt prepended to the conversation."),
+    ] = None,
+    quick: Annotated[
+        str | None,
+        Parameter(
+            name=["--quick", "-q"],
+            help="Send a single MESSAGE and print the response + stats, then exit.",
+        ),
+    ] = None,
+    history: Annotated[
+        bool,
+        Parameter(
+            help="Retain and resend conversation history each turn (default). "
+            "Pass --no-history for stateless, completion-style turns. "
+            "Ignored with --quick.",
+        ),
+    ] = True,
+    api_key: Annotated[
+        str | None,
+        Parameter(
+            help="API key sent as a Bearer token. "
+            "Defaults to the OPENAI_API_KEY environment variable."
+        ),
+    ] = None,
+    tokenizer: Annotated[
+        str | None,
+        Parameter(
+            help="Tokenizer for client-side token counts. Defaults to the model name."
+        ),
+    ] = None,
+) -> None:
+    """Chat interactively with an endpoint, printing per-turn speed stats.
+
+    A lightweight sanity-check sibling of ``aiperf profile``: send one message
+    at a time and see TTFT, TPS, generated tokens, and end-to-end latency for
+    each reply. Multi-turn by default (history retained and resent each turn);
+    pass ``--no-history`` for stateless turns, or ``--quick`` for a single
+    request. For full benchmarking, use ``aiperf profile``.
+
+    Examples:
+        # Interactive multi-turn chat
+        aiperf chat --model Qwen/Qwen3-0.6B --url http://localhost:8000
+
+        # Stateless turns (no history retained between messages)
+        aiperf chat --model Qwen/Qwen3-0.6B --no-history
+
+        # Single-shot sanity check
+        aiperf chat --model Qwen/Qwen3-0.6B --quick "hello, who are you?"
+    """
+    _run_chat(
+        model=model,
+        url=url,
+        system_prompt=system_prompt,
+        quick=quick,
+        no_history=not history,
+        api_key=api_key,
+        tokenizer=tokenizer,
+    )

--- a/src/aiperf/cli_commands/chat.py
+++ b/src/aiperf/cli_commands/chat.py
@@ -299,7 +299,7 @@ async def _chat_loop(
                     ),
                     encode=encode,
                 )
-            except (aiohttp.ClientError, asyncio.TimeoutError, SSEResponseError) as e:
+            except (TimeoutError, aiohttp.ClientError, SSEResponseError) as e:
                 # Keep the REPL alive on a transient failure (HTTP error, dropped
                 # connection, stall, or a mid-stream SSE error) -- report it and
                 # let the user retry instead of tearing down the whole session.

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -122,6 +122,28 @@ class _APIServerSettings(BaseSettings):
     )
 
 
+class _ChatSettings(BaseSettings):
+    """Settings for the interactive ``aiperf chat`` command."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="AIPERF_CHAT_",
+    )
+
+    CONNECT_TIMEOUT: float = Field(
+        gt=0.0,
+        default=10.0,
+        description="Seconds to wait to establish a connection to the endpoint "
+        "before a turn fails. Kept short so an unreachable URL fails fast.",
+    )
+    READ_TIMEOUT: float = Field(
+        gt=0.0,
+        default=300.0,
+        description="Seconds to wait for the next streamed chunk before a turn "
+        "fails. No overall (total) timeout is applied, so long generations are "
+        "never truncated mid-reply; this only fires if the server stalls.",
+    )
+
+
 class _CompressionSettings(BaseSettings):
     """Compression settings for streaming file transfers.
 
@@ -1375,6 +1397,10 @@ class _Environment(BaseSettings):
     API_SERVER: _APIServerSettings = Field(
         default_factory=_APIServerSettings,
         description="API server settings",
+    )
+    CHAT: _ChatSettings = Field(
+        default_factory=_ChatSettings,
+        description="Interactive `aiperf chat` command settings",
     )
     COMPRESSION: _CompressionSettings = Field(
         default_factory=_CompressionSettings,

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -35,10 +35,12 @@ def _prompt_token_counts(stdout: str) -> list[int]:
 class TestChatCommand:
     """End-to-end checks that ``aiperf chat`` streams a reply and prints stats."""
 
-    async def test_quick_prints_minimal_stats(
+    async def test_quick_prints_stats(
         self, aiperf_runner: AIPerfRunnerFn, aiperf_mock_server: AIPerfMockServer
     ) -> None:
-        """``--quick`` streams one reply and prints only the TTFT/TPS block."""
+        """``--quick`` streams one reply and prints the stats block, including
+        the cache line (prefix caches are server-side, so even a single-shot
+        request reports a hit rate when the server surfaces cached tokens)."""
         result = await aiperf_runner(
             [
                 "chat",
@@ -55,9 +57,7 @@ class TestChatCommand:
         assert result.exit_code == 0, result.stderr
         assert "TTFT:" in result.stdout
         assert "TPS:" in result.stdout
-        # Single-shot stays minimal: no multi-turn-only lines.
-        assert "ITL:" not in result.stdout
-        assert "Cache:" not in result.stdout
+        assert "Cache:" in result.stdout
 
     async def test_multi_turn_resends_history(
         self, aiperf_mock_server: AIPerfMockServer
@@ -67,9 +67,10 @@ class TestChatCommand:
         stdout = await _run_chat_over_stdin(
             aiperf_mock_server.url, "tell me a short story\ncontinue the story\n"
         )
+        # The full per-turn block (all four metrics) prints for each turn.
         assert stdout.count("TTFT:") == 2
-        assert "ITL:" in stdout
-        assert "Cache:" in stdout
+        for label in ("TPS:", "ITL:", "Cache:"):
+            assert label in stdout
         prompts = _prompt_token_counts(stdout)
         assert len(prompts) == 2
         # Turn 2 resends turn 1 (user + assistant), so its prompt is larger.

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the ``aiperf chat`` command against the mock server.
+
+Complements the unit tests (which cover the pure parsing/metric logic) by
+exercising the full path end to end: real HTTP streaming, the metric pipeline,
+and the printed stats block. Uses the in-repo mock server, which reports
+``prompt_tokens_details.cached_tokens`` so the cache-hit line resolves.
+
+Statefulness is asserted via the prompt-token count in each turn's ``Cache:``
+line (the server counts the real prompt it received): with history it grows
+turn over turn; with ``--no-history`` and an identical message it does not.
+"""
+
+import asyncio
+import os
+import re
+
+import pytest
+
+from tests.harness.utils import AIPerfMockServer, AIPerfRunnerFn
+from tests.integration.conftest import get_venv_python
+
+# Captures the prompt-token count (ISL) from a ``Cache: <hit>/<prompt> ...`` line.
+_PROMPT_TOKENS = re.compile(r"\d+/(\d+) prompt tokens cached")
+
+
+def _prompt_token_counts(stdout: str) -> list[int]:
+    """Per-turn prompt-token counts parsed from the cache lines, in order."""
+    return [int(m) for m in _PROMPT_TOKENS.findall(stdout)]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestChatCommand:
+    """End-to-end checks that ``aiperf chat`` streams a reply and prints stats."""
+
+    async def test_quick_prints_minimal_stats(
+        self, aiperf_runner: AIPerfRunnerFn, aiperf_mock_server: AIPerfMockServer
+    ) -> None:
+        """``--quick`` streams one reply and prints only the TTFT/TPS block."""
+        result = await aiperf_runner(
+            [
+                "chat",
+                "--model",
+                "mock-model",
+                "--url",
+                aiperf_mock_server.url,
+                "--tokenizer",
+                "builtin",
+                "--quick",
+                "hello there, who are you?",
+            ]
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "TTFT:" in result.stdout
+        assert "TPS:" in result.stdout
+        # Single-shot stays minimal: no multi-turn-only lines.
+        assert "ITL:" not in result.stdout
+        assert "Cache:" not in result.stdout
+
+    async def test_multi_turn_resends_history(
+        self, aiperf_mock_server: AIPerfMockServer
+    ) -> None:
+        """Default mode prints the ITL/decode + cache lines per turn, and the
+        prompt grows turn over turn because history is resent."""
+        stdout = await _run_chat_over_stdin(
+            aiperf_mock_server.url, "tell me a short story\ncontinue the story\n"
+        )
+        assert stdout.count("TTFT:") == 2
+        assert "ITL:" in stdout
+        assert "Cache:" in stdout
+        prompts = _prompt_token_counts(stdout)
+        assert len(prompts) == 2
+        # Turn 2 resends turn 1 (user + assistant), so its prompt is larger.
+        assert prompts[1] > prompts[0]
+
+    async def test_no_history_is_stateless(
+        self, aiperf_mock_server: AIPerfMockServer
+    ) -> None:
+        """``--no-history`` sends each message independently: an identical
+        message yields an identical prompt size across turns (no history)."""
+        stdout = await _run_chat_over_stdin(
+            aiperf_mock_server.url,
+            "repeat this exactly\nrepeat this exactly\n",
+            extra_args=["--no-history"],
+        )
+        assert stdout.count("TTFT:") == 2
+        assert "ITL:" in stdout
+        prompts = _prompt_token_counts(stdout)
+        assert len(prompts) == 2
+        # No history resent -> identical message -> identical prompt size.
+        assert prompts[0] == prompts[1]
+
+
+async def _run_chat_over_stdin(
+    url: str,
+    stdin_text: str,
+    timeout: float = 60.0,
+    extra_args: list[str] | None = None,
+) -> str:
+    """Run ``aiperf chat`` interactively, feeding ``stdin_text`` then EOF.
+
+    Returns captured stdout; asserts a clean exit.
+    """
+    cmd = [
+        get_venv_python(),
+        "-m",
+        "aiperf",
+        "chat",
+        "--model",
+        "mock-model",
+        "--url",
+        url,
+        "--tokenizer",
+        "builtin",
+        *(extra_args or []),
+    ]
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            process.communicate(input=stdin_text.encode()), timeout=timeout
+        )
+    except asyncio.TimeoutError:
+        process.kill()
+        raise
+    assert process.returncode == 0, stderr_bytes.decode("utf-8", "replace")
+    return stdout_bytes.decode("utf-8", "replace")

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -128,7 +128,7 @@ async def _run_chat_over_stdin(
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
             process.communicate(input=stdin_text.encode()), timeout=timeout
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         process.kill()
         raise
     assert process.returncode == 0, stderr_bytes.decode("utf-8", "replace")

--- a/tests/unit/cli_commands/test_chat.py
+++ b/tests/unit/cli_commands/test_chat.py
@@ -7,10 +7,22 @@ integration tests; the stats/metric logic lives in ``test_chat_stats``.
 
 from __future__ import annotations
 
+import asyncio
+
+import orjson
 import pytest
 from pytest import param
 
-from aiperf.cli_commands.chat import _build_turn_messages, _chat_completions_url
+from aiperf.cli_commands import chat as chat_mod
+from aiperf.cli_commands.chat import (
+    _build_turn_messages,
+    _chat_completions_url,
+    _consume_stream,
+    _read_user_message,
+    _run_turn,
+    _settle,
+)
+from aiperf.common.exceptions import SSEResponseError
 
 
 @pytest.mark.parametrize(
@@ -56,3 +68,275 @@ def test_build_turn_messages_with_history() -> None:
 def test_build_turn_messages_no_history_is_stateless() -> None:
     # Empty history (the --no-history case) sends only system + new message.
     assert _build_turn_messages([], [], "solo") == [{"role": "user", "content": "solo"}]
+
+
+class _FakeContent:
+    """Minimal stand-in for ``aiohttp`` ``response.content`` (async byte iter)."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeResponse:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.content = _FakeContent(chunks)
+
+
+@pytest.mark.asyncio
+async def test_consume_stream_parses_content_reasoning_and_usage() -> None:
+    resp = _FakeResponse(
+        [
+            # Opening role-only delta carries no content/reasoning -> skipped.
+            b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n',
+            b'data: {"choices":[{"delta":{"reasoning_content":"hmm"}}]}\n\n',
+            b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+            b'data: {"choices":[],"usage":{"prompt_tokens":5}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+    )
+    responses, output_parts, reasoning_parts, last_usage = await _consume_stream(resp)  # type: ignore[arg-type]
+    assert output_parts == ["hi"]
+    assert reasoning_parts == ["hmm"]
+    assert last_usage == {"prompt_tokens": 5}
+    assert len(responses) == 2  # two content-bearing messages (role-only skipped)
+
+
+@pytest.mark.asyncio
+async def test_consume_stream_surfaces_mid_stream_sse_error() -> None:
+    # A 200-OK stream that fails mid-way with an SSE `event: error` frame must
+    # surface as an error, not be reported as a truncated/empty reply.
+    resp = _FakeResponse([b"event: error\n: upstream exploded\n\n"])
+    with pytest.raises(SSEResponseError):
+        await _consume_stream(resp)  # type: ignore[arg-type]
+
+
+class _FakeStreamResponse:
+    """Async-context-manager stand-in for the aiohttp response in `_run_turn`."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.content = _FakeContent(chunks)
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def __aenter__(self) -> _FakeStreamResponse:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class _FakeSession:
+    """Minimal aiohttp.ClientSession stand-in returning canned SSE chunks."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.posted: list[dict] = []
+
+    def post(self, url: str, *, data: bytes, headers: dict) -> _FakeStreamResponse:
+        self.posted.append({"url": url, "data": data, "headers": headers})
+        return _FakeStreamResponse(self._chunks)
+
+
+_CHAT_CHUNKS = [
+    b'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
+    b'data: {"choices":[{"delta":{"content":" there"}}]}\n\n',
+    b'data: {"choices":[],"usage":{"prompt_tokens":4,'
+    b'"prompt_tokens_details":{"cached_tokens":2}}}\n\n',
+    b"data: [DONE]\n\n",
+]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_streams_reply_and_prints_stats(capsys) -> None:
+    session = _FakeSession(_CHAT_CHUNKS)
+    text = await _run_turn(
+        session,  # type: ignore[arg-type]
+        url="http://h/v1/chat/completions",
+        headers={},
+        model="m",
+        conversation=[{"role": "user", "content": "hey"}],
+        encode=lambda s: list(s),  # char-per-token
+    )
+    assert text == "Hi there"
+    # Body is orjson-serialized bytes; include_usage is set so ISL/cache resolve.
+    sent = orjson.loads(session.posted[0]["data"])
+    assert sent["stream_options"] == {"include_usage": True}
+    assert session.posted[0]["headers"]["Content-Type"] == "application/json"
+    out = capsys.readouterr().out
+    assert "Hi there" in out
+    for label in ("TTFT:", "TPS:", "ITL:", "Cache:"):
+        assert label in out
+
+
+@pytest.mark.asyncio
+async def test_run_turn_reasoning_only_reply_returns_reasoning_for_history() -> None:
+    # A reply with only reasoning (no content) must return the reasoning text so
+    # multi-turn history records a non-empty assistant turn, not "".
+    chunks = [
+        b'data: {"choices":[{"delta":{"reasoning_content":"thinking hard"}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    text = await _run_turn(
+        _FakeSession(chunks),  # type: ignore[arg-type]
+        url="http://h/v1/chat/completions",
+        headers={},
+        model="m",
+        conversation=[{"role": "user", "content": "hey"}],
+        encode=lambda s: list(s),
+    )
+    assert text == "thinking hard"
+
+
+@pytest.mark.asyncio
+async def test_read_user_message_returns_line(monkeypatch) -> None:
+    monkeypatch.setattr("builtins.input", lambda prompt="": "hello")
+    assert await _read_user_message("> ") == "hello"
+
+
+@pytest.mark.asyncio
+async def test_read_user_message_propagates_eof(monkeypatch) -> None:
+    def _raise(prompt: str = "") -> str:
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _raise)
+    with pytest.raises(EOFError):
+        await _read_user_message("> ")
+
+
+def _fake_reader(lines: list[str]):
+    """Return an async `_read_user_message` stand-in yielding `lines` then EOF."""
+    it = iter(lines)
+
+    async def _read(prompt: str) -> str:
+        try:
+            return next(it)
+        except StopIteration:
+            raise EOFError from None
+
+    return _read
+
+
+@pytest.mark.asyncio
+async def test_chat_loop_quick_sends_one_turn(monkeypatch) -> None:
+    seen = []
+
+    async def _fake_run_turn(session, *, url, headers, model, conversation, encode):
+        seen.append(conversation)
+        return "reply"
+
+    monkeypatch.setattr(chat_mod, "_run_turn", _fake_run_turn)
+    await chat_mod._chat_loop(
+        model="m",
+        url="http://h/v1/chat/completions",
+        headers={},
+        system_prompt=None,
+        quick="hi",
+        no_history=False,
+        encode=lambda s: [],
+    )
+    assert len(seen) == 1
+    assert seen[0] == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.parametrize(
+    "no_history,expected_turns",
+    [
+        # Default: turn 2 resends turn 1's user message (history retained).
+        param(False, [["one"], ["one", "two"]], id="retains_history"),
+        # --no-history: each turn carries only its own message (stateless).
+        param(True, [["one"], ["two"]], id="stateless"),
+    ],
+)  # fmt: skip
+@pytest.mark.asyncio
+async def test_chat_loop_history_behavior(
+    monkeypatch, no_history: bool, expected_turns: list[list[str]]
+) -> None:
+    turns = []
+
+    async def _fake_run_turn(session, *, url, headers, model, conversation, encode):
+        turns.append([m["content"] for m in conversation if m["role"] == "user"])
+        return "answer"
+
+    monkeypatch.setattr(chat_mod, "_read_user_message", _fake_reader(["one", "two"]))
+    monkeypatch.setattr(chat_mod, "_run_turn", _fake_run_turn)
+    await chat_mod._chat_loop(
+        model="m",
+        url="http://h/v1/chat/completions",
+        headers={},
+        system_prompt=None,
+        quick=None,
+        no_history=no_history,
+        encode=lambda s: [],
+    )
+    assert turns == expected_turns
+
+
+@pytest.mark.asyncio
+async def test_chat_loop_reports_error_and_continues(monkeypatch, capsys) -> None:
+    async def _boom(session, *, url, headers, model, conversation, encode):
+        raise SSEResponseError("upstream exploded", error_code=502)
+
+    monkeypatch.setattr(chat_mod, "_read_user_message", _fake_reader(["x"]))
+    monkeypatch.setattr(chat_mod, "_run_turn", _boom)
+    await chat_mod._chat_loop(
+        model="m",
+        url="http://h/v1/chat/completions",
+        headers={},
+        system_prompt=None,
+        quick=None,
+        no_history=False,
+        encode=lambda s: [],
+    )
+    assert "request failed" in capsys.readouterr().err
+
+
+def test_run_chat_builds_auth_header_and_resolves_url(monkeypatch) -> None:
+    import aiperf.common.tokenizer as tokenizer_mod
+
+    monkeypatch.setattr(
+        tokenizer_mod.Tokenizer,
+        "from_pretrained",
+        classmethod(lambda cls, name: type("_T", (), {"encode": staticmethod(list)})()),
+    )
+    captured: dict = {}
+
+    async def _fake_loop(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(chat_mod, "_chat_loop", _fake_loop)
+    chat_mod._run_chat(
+        model="m",
+        url="http://h",
+        system_prompt=None,
+        quick="hi",
+        no_history=False,
+        api_key="secret",
+        tokenizer=None,
+    )
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert captured["url"] == "http://h/v1/chat/completions"
+
+
+def test_chat_entry_inverts_history_flag(monkeypatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(chat_mod, "_run_chat", lambda **kwargs: captured.update(kwargs))
+    chat_mod.chat(model="m", history=False)
+    assert captured["no_history"] is True
+    assert captured["model"] == "m"
+
+
+@pytest.mark.asyncio
+async def test_settle_ignores_already_done_future() -> None:
+    # A Ctrl-C / cancellation can complete the future before input() returns;
+    # settling it again must be a no-op, not an InvalidStateError.
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[str] = loop.create_future()
+    future.set_result("first")
+    _settle(loop, future, result="second")
+    await asyncio.sleep(0)  # let the scheduled callback run
+    assert future.result() == "first"

--- a/tests/unit/cli_commands/test_chat.py
+++ b/tests/unit/cli_commands/test_chat.py
@@ -8,7 +8,9 @@ integration tests; the stats/metric logic lives in ``test_chat_stats``.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
+import aiohttp
 import orjson
 import pytest
 from pytest import param
@@ -44,6 +46,11 @@ from aiperf.common.exceptions import SSEResponseError
             "http://h:8000/openai",
             "http://h:8000/openai/v1/chat/completions",
             id="sub_path_base",
+        ),
+        param(
+            "localhost:8000",
+            "http://localhost:8000/v1/chat/completions",
+            id="schemeless",
         ),
     ],
 )  # fmt: skip
@@ -117,11 +124,32 @@ async def test_consume_stream_surfaces_mid_stream_sse_error() -> None:
 class _FakeStreamResponse:
     """Async-context-manager stand-in for the aiohttp response in `_run_turn`."""
 
-    def __init__(self, chunks: list[bytes]) -> None:
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        url: str = "http://h/v1/chat/completions",
+        status: int = 200,
+        reason: str = "OK",
+        body: bytes = b"",
+    ) -> None:
         self.content = _FakeContent(chunks)
+        self._url = url
+        self.status = status
+        self.reason = reason
+        self._body = body
 
     def raise_for_status(self) -> None:
-        pass
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(
+                SimpleNamespace(real_url=self._url),
+                (),
+                status=self.status,
+                message=self.reason,
+            )
+
+    async def text(self) -> str:
+        return self._body.decode()
 
     async def __aenter__(self) -> _FakeStreamResponse:
         return self
@@ -133,13 +161,29 @@ class _FakeStreamResponse:
 class _FakeSession:
     """Minimal aiohttp.ClientSession stand-in returning canned SSE chunks."""
 
-    def __init__(self, chunks: list[bytes]) -> None:
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        status: int = 200,
+        reason: str = "OK",
+        body: bytes = b"",
+    ) -> None:
         self._chunks = chunks
+        self._status = status
+        self._reason = reason
+        self._body = body
         self.posted: list[dict] = []
 
     def post(self, url: str, *, data: bytes, headers: dict) -> _FakeStreamResponse:
         self.posted.append({"url": url, "data": data, "headers": headers})
-        return _FakeStreamResponse(self._chunks)
+        return _FakeStreamResponse(
+            self._chunks,
+            url=url,
+            status=self._status,
+            reason=self._reason,
+            body=self._body,
+        )
 
 
 _CHAT_CHUNKS = [
@@ -190,6 +234,25 @@ async def test_run_turn_reasoning_only_reply_returns_reasoning_for_history() -> 
         encode=lambda s: list(s),
     )
     assert text == "thinking hard"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_surfaces_http_error_body() -> None:
+    # Servers put the real diagnostic in the response body; it must reach the
+    # user, not be discarded by raise_for_status().
+    session = _FakeSession(
+        [], status=404, reason="Not Found", body=b'{"detail":"model x does not exist"}'
+    )
+    with pytest.raises(aiohttp.ClientResponseError) as excinfo:
+        await _run_turn(
+            session,  # type: ignore[arg-type]
+            url="http://h/v1/chat/completions",
+            headers={},
+            model="m",
+            conversation=[{"role": "user", "content": "hi"}],
+            encode=lambda s: list(s),
+        )
+    assert "model x does not exist" in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli_commands/test_chat.py
+++ b/tests/unit/cli_commands/test_chat.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``aiperf.cli_commands.chat`` helpers -- URL resolution and
+per-turn message assembly. The streaming/REPL I/O is covered by the
+integration tests; the stats/metric logic lives in ``test_chat_stats``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest import param
+
+from aiperf.cli_commands.chat import _build_turn_messages, _chat_completions_url
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        param("http://h:8000", "http://h:8000/v1/chat/completions", id="bare_host"),
+        param("http://h:8000/v1", "http://h:8000/v1/chat/completions", id="v1_base"),
+        param(
+            "http://h:8000/v1/",
+            "http://h:8000/v1/chat/completions",
+            id="trailing_slash",
+        ),
+        param(
+            "http://h:8000/v1/chat/completions",
+            "http://h:8000/v1/chat/completions",
+            id="full_path",
+        ),
+        param(
+            "http://h:8000/openai",
+            "http://h:8000/openai/v1/chat/completions",
+            id="sub_path_base",
+        ),
+    ],
+)  # fmt: skip
+def test_chat_completions_url_resolves_expected(url: str, expected: str) -> None:
+    assert _chat_completions_url(url) == expected
+
+
+def test_build_turn_messages_with_history() -> None:
+    system = [{"role": "system", "content": "be brief"}]
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    assert _build_turn_messages(system, history, "next") == [
+        {"role": "system", "content": "be brief"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "next"},
+    ]
+
+
+def test_build_turn_messages_no_history_is_stateless() -> None:
+    # Empty history (the --no-history case) sends only system + new message.
+    assert _build_turn_messages([], [], "solo") == [{"role": "user", "content": "solo"}]

--- a/tests/unit/cli_commands/test_chat_stats.py
+++ b/tests/unit/cli_commands/test_chat_stats.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``aiperf.cli_commands._chat_stats`` -- the pure
+response-parsing, token-counting, and per-turn stats logic.
+
+These verify parity with ``aiperf profile`` (reasoning vs output token
+bucketing, metric reuse, stats formatting) without a live server.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest import param
+
+from aiperf.cli_commands._chat_stats import (
+    build_record,
+    compute_record_metrics,
+    format_stats,
+    input_tokens_from_usage,
+    make_response_data,
+    split_delta,
+)
+from aiperf.common.models.record_models import (
+    ParsedResponse,
+    ReasoningResponseData,
+    TextResponseData,
+)
+from aiperf.metrics.types.output_sequence_length_metric import (
+    OutputSequenceLengthMetric,
+)
+from aiperf.metrics.types.request_latency_metric import RequestLatencyMetric
+from aiperf.metrics.types.ttft_metric import TTFTMetric
+
+
+@pytest.mark.parametrize(
+    "delta,expected",
+    [
+        param({"content": "hi"}, ("hi", None), id="content_only"),
+        param(
+            {"reasoning_content": "think"},
+            (None, "think"),
+            id="reasoning_content_field",
+        ),
+        param({"reasoning": "think"}, (None, "think"), id="reasoning_field"),
+        param(
+            {"content": "hi", "reasoning_content": "think"},
+            ("hi", "think"),
+            id="both",
+        ),
+        param({}, (None, None), id="empty"),
+    ],
+)  # fmt: skip
+def test_split_delta_mirrors_profile_extraction(
+    delta: dict, expected: tuple[str | None, str | None]
+) -> None:
+    assert split_delta(delta) == expected
+
+
+def test_make_response_data_reasoning_takes_precedence() -> None:
+    data = make_response_data("answer", "thinking")
+    assert isinstance(data, ReasoningResponseData)
+    assert data.content == "answer"
+    assert data.reasoning == "thinking"
+
+
+def test_make_response_data_content_only_is_text() -> None:
+    assert make_response_data("answer", None) == TextResponseData(text="answer")
+
+
+def test_make_response_data_empty_is_none() -> None:
+    assert make_response_data(None, None) is None
+
+
+def _record(start_ns, perf_nss, *, output, reasoning=None, input=None, usage=None):
+    """Build a record with content responses at the given timestamps.
+
+    Pass ``usage`` (a raw OpenAI-style usage dict) to attach a server usage
+    chunk, which feeds the cache-hit metric.
+    """
+    responses = [
+        ParsedResponse(perf_ns=ns, data=TextResponseData(text="x")) for ns in perf_nss
+    ]
+    if usage is not None:
+        responses.append(ParsedResponse(perf_ns=perf_nss[-1], usage=usage))
+    return build_record(
+        model="test-model",
+        start_ns=start_ns,
+        end_ns=perf_nss[-1],
+        timestamp_ns=start_ns,
+        responses=responses,
+        input_tokens=input,
+        output_tokens=output,
+        reasoning_tokens=reasoning,
+    )
+
+
+def test_compute_record_metrics_matches_profile_formulas() -> None:
+    # start=0, first token at 20ms, last at 1.2s -> TTFT=20ms, latency=1.2s
+    record = _record(0, [20 * 1_000_000, 1_200 * 1_000_000], output=186)
+    metrics = compute_record_metrics(record)
+
+    assert metrics[TTFTMetric.tag] == 20 * 1_000_000
+    assert metrics[RequestLatencyMetric.tag] == 1_200 * 1_000_000
+    assert metrics[OutputSequenceLengthMetric.tag] == 186
+
+
+def test_osl_includes_reasoning_tokens_like_profile() -> None:
+    # OSL formula is output + reasoning (output_sequence_length_metric.py).
+    record = _record(0, [10, 100], output=44, reasoning=142)
+    metrics = compute_record_metrics(record)
+    assert metrics[OutputSequenceLengthMetric.tag] == 186
+
+
+def test_format_stats_renders_vllm_style_block() -> None:
+    record = _record(0, [20 * 1_000_000, 1_200 * 1_000_000], output=186)
+    stats = format_stats(compute_record_metrics(record), reasoning_tokens=None)
+    assert stats == ("TTFT: 20.00 ms\nTPS:  155.00 tokens/s (186 tokens in 1.20s)")
+
+
+def test_format_stats_annotates_reasoning_tokens() -> None:
+    # OSL is output + reasoning (44 + 142 = 186 total generated tokens).
+    record = _record(0, [20 * 1_000_000, 1_200 * 1_000_000], output=44, reasoning=142)
+    stats = format_stats(compute_record_metrics(record), reasoning_tokens=142)
+    assert "186 tokens, 142 reasoning in 1.20s" in stats
+
+
+def test_format_stats_interactive_includes_decode_line() -> None:
+    # ttft=20ms, latency=520ms, osl=101 -> ITL=(520-20)/100=5ms, decode=200 tok/s
+    record = _record(0, [20 * 1_000_000, 520 * 1_000_000], output=101)
+    stats = format_stats(
+        compute_record_metrics(record), reasoning_tokens=None, interactive=True
+    )
+    assert "ITL:  5.00 ms/token (decode 200.00 tokens/s)" in stats
+
+
+def test_format_stats_single_shot_omits_decode_and_cache_lines() -> None:
+    usage = {"prompt_tokens": 480, "prompt_tokens_details": {"cached_tokens": 412}}
+    record = _record(
+        0, [20 * 1_000_000, 520 * 1_000_000], output=101, input=480, usage=usage
+    )
+    stats = format_stats(compute_record_metrics(record), reasoning_tokens=None)
+    assert "ITL:" not in stats
+    assert "Cache:" not in stats
+
+
+def test_format_stats_interactive_includes_cache_hit_rate() -> None:
+    # OpenAI/vLLM shape: prompt_tokens_details.cached_tokens are cache reads.
+    usage = {"prompt_tokens": 480, "prompt_tokens_details": {"cached_tokens": 412}}
+    record = _record(
+        0, [20 * 1_000_000, 520 * 1_000_000], output=101, input=480, usage=usage
+    )
+    stats = format_stats(
+        compute_record_metrics(record), reasoning_tokens=None, interactive=True
+    )
+    assert "Cache: 412/480 prompt tokens cached (85.8%)" in stats
+
+
+def test_format_stats_cache_line_omitted_without_usage() -> None:
+    # No usage chunk -> no cache metric -> no Cache line, even when interactive.
+    record = _record(0, [20 * 1_000_000, 520 * 1_000_000], output=101)
+    stats = format_stats(
+        compute_record_metrics(record), reasoning_tokens=None, interactive=True
+    )
+    assert "Cache:" not in stats
+
+
+def test_input_tokens_from_usage_reads_prompt_tokens() -> None:
+    assert input_tokens_from_usage({"prompt_tokens": 480}) == 480
+    assert input_tokens_from_usage(None) is None
+
+
+def test_format_stats_no_tokens_received() -> None:
+    record = build_record(
+        model="test-model",
+        start_ns=0,
+        end_ns=1,
+        timestamp_ns=0,
+        responses=[],
+        input_tokens=None,
+        output_tokens=None,
+        reasoning_tokens=None,
+    )
+    assert format_stats(compute_record_metrics(record), None) == "(no tokens received)"

--- a/tests/unit/cli_commands/test_chat_stats.py
+++ b/tests/unit/cli_commands/test_chat_stats.py
@@ -15,6 +15,7 @@ from pytest import param
 from aiperf.cli_commands._chat_stats import (
     build_record,
     compute_record_metrics,
+    count_tokens,
     format_stats,
     input_tokens_from_usage,
     make_response_data,
@@ -22,6 +23,7 @@ from aiperf.cli_commands._chat_stats import (
 )
 from aiperf.common.models.record_models import (
     ParsedResponse,
+    ParsedResponseRecord,
     ReasoningResponseData,
     TextResponseData,
 )
@@ -71,7 +73,15 @@ def test_make_response_data_empty_is_none() -> None:
     assert make_response_data(None, None) is None
 
 
-def _record(start_ns, perf_nss, *, output, reasoning=None, input=None, usage=None):
+def _record(
+    start_ns: int,
+    perf_nss: list[int],
+    *,
+    output: int | None,
+    reasoning: int | None = None,
+    input_tokens: int | None = None,
+    usage: dict | None = None,
+) -> ParsedResponseRecord:
     """Build a record with content responses at the given timestamps.
 
     Pass ``usage`` (a raw OpenAI-style usage dict) to attach a server usage
@@ -88,7 +98,7 @@ def _record(start_ns, perf_nss, *, output, reasoning=None, input=None, usage=Non
         end_ns=perf_nss[-1],
         timestamp_ns=start_ns,
         responses=responses,
-        input_tokens=input,
+        input_tokens=input_tokens,
         output_tokens=output,
         reasoning_tokens=reasoning,
     )
@@ -111,10 +121,21 @@ def test_osl_includes_reasoning_tokens_like_profile() -> None:
     assert metrics[OutputSequenceLengthMetric.tag] == 186
 
 
-def test_format_stats_renders_vllm_style_block() -> None:
-    record = _record(0, [20 * 1_000_000, 1_200 * 1_000_000], output=186)
+def test_format_stats_renders_full_block() -> None:
+    # With all data present the block is TTFT, TPS, ITL, and Cache -- one
+    # ordered set of first-class per-turn metrics.
+    # ttft=20ms, latency=520ms, osl=101 -> TPS=101/0.52, ITL=(520-20)/100=5ms.
+    usage = {"prompt_tokens": 480, "prompt_tokens_details": {"cached_tokens": 412}}
+    record = _record(
+        0, [20 * 1_000_000, 520 * 1_000_000], output=101, input_tokens=480, usage=usage
+    )
     stats = format_stats(compute_record_metrics(record), reasoning_tokens=None)
-    assert stats == ("TTFT: 20.00 ms\nTPS:  155.00 tokens/s (186 tokens in 1.20s)")
+    assert stats == (
+        "TTFT: 20.00 ms\n"
+        "TPS:  194.23 tokens/s (101 tokens in 0.52s)\n"
+        "ITL:  5.00 ms/token (decode 200.00 tokens/s)\n"
+        "Cache: 412/480 prompt tokens cached (85.8%)"
+    )
 
 
 def test_format_stats_annotates_reasoning_tokens() -> None:
@@ -124,49 +145,28 @@ def test_format_stats_annotates_reasoning_tokens() -> None:
     assert "186 tokens, 142 reasoning in 1.20s" in stats
 
 
-def test_format_stats_interactive_includes_decode_line() -> None:
-    # ttft=20ms, latency=520ms, osl=101 -> ITL=(520-20)/100=5ms, decode=200 tok/s
-    record = _record(0, [20 * 1_000_000, 520 * 1_000_000], output=101)
-    stats = format_stats(
-        compute_record_metrics(record), reasoning_tokens=None, interactive=True
-    )
-    assert "ITL:  5.00 ms/token (decode 200.00 tokens/s)" in stats
-
-
-def test_format_stats_single_shot_omits_decode_and_cache_lines() -> None:
-    usage = {"prompt_tokens": 480, "prompt_tokens_details": {"cached_tokens": 412}}
-    record = _record(
-        0, [20 * 1_000_000, 520 * 1_000_000], output=101, input=480, usage=usage
-    )
+def test_format_stats_omits_decode_line_for_single_token() -> None:
+    # ITL needs >=2 output tokens; a single-token reply has no inter-token gap.
+    record = _record(0, [20 * 1_000_000], output=1)
     stats = format_stats(compute_record_metrics(record), reasoning_tokens=None)
     assert "ITL:" not in stats
-    assert "Cache:" not in stats
-
-
-def test_format_stats_interactive_includes_cache_hit_rate() -> None:
-    # OpenAI/vLLM shape: prompt_tokens_details.cached_tokens are cache reads.
-    usage = {"prompt_tokens": 480, "prompt_tokens_details": {"cached_tokens": 412}}
-    record = _record(
-        0, [20 * 1_000_000, 520 * 1_000_000], output=101, input=480, usage=usage
-    )
-    stats = format_stats(
-        compute_record_metrics(record), reasoning_tokens=None, interactive=True
-    )
-    assert "Cache: 412/480 prompt tokens cached (85.8%)" in stats
 
 
 def test_format_stats_cache_line_omitted_without_usage() -> None:
-    # No usage chunk -> no cache metric -> no Cache line, even when interactive.
+    # No usage chunk -> no cache metric -> no Cache line.
     record = _record(0, [20 * 1_000_000, 520 * 1_000_000], output=101)
-    stats = format_stats(
-        compute_record_metrics(record), reasoning_tokens=None, interactive=True
-    )
+    stats = format_stats(compute_record_metrics(record), reasoning_tokens=None)
     assert "Cache:" not in stats
 
 
 def test_input_tokens_from_usage_reads_prompt_tokens() -> None:
     assert input_tokens_from_usage({"prompt_tokens": 480}) == 480
     assert input_tokens_from_usage(None) is None
+
+
+def test_count_tokens_encodes_nonempty_and_returns_none_for_empty() -> None:
+    assert count_tokens(lambda s: list(s), "abc") == 3
+    assert count_tokens(lambda s: list(s), "") is None
 
 
 def test_format_stats_no_tokens_received() -> None:

--- a/tests/unit/common/test_chat_settings.py
+++ b/tests/unit/common/test_chat_settings.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestChatSettings:
+    """Test suite for the _ChatSettings environment configuration
+    (the AIPERF_CHAT_* timeouts used by `aiperf chat`)."""
+
+    def test_defaults(self, monkeypatch):
+        monkeypatch.delenv("AIPERF_CHAT_CONNECT_TIMEOUT", raising=False)
+        monkeypatch.delenv("AIPERF_CHAT_READ_TIMEOUT", raising=False)
+        from aiperf.common.environment import _ChatSettings
+
+        settings = _ChatSettings()
+        assert settings.CONNECT_TIMEOUT == 10.0
+        assert settings.READ_TIMEOUT == 300.0
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("AIPERF_CHAT_CONNECT_TIMEOUT", "3")
+        monkeypatch.setenv("AIPERF_CHAT_READ_TIMEOUT", "42.5")
+        from aiperf.common.environment import _ChatSettings
+
+        settings = _ChatSettings()
+        assert settings.CONNECT_TIMEOUT == 3.0
+        assert settings.READ_TIMEOUT == 42.5
+
+    @pytest.mark.parametrize("var", ["CONNECT_TIMEOUT", "READ_TIMEOUT"])
+    @pytest.mark.parametrize("bad", ["0", "-1"])
+    def test_non_positive_rejected(self, monkeypatch, var: str, bad: str):
+        monkeypatch.setenv(f"AIPERF_CHAT_{var}", bad)
+        from aiperf.common.environment import _ChatSettings
+
+        with pytest.raises(ValidationError):
+            _ChatSettings()
+
+    def test_aggregator_exposes_chat(self, monkeypatch):
+        monkeypatch.delenv("AIPERF_CHAT_CONNECT_TIMEOUT", raising=False)
+        monkeypatch.delenv("AIPERF_CHAT_READ_TIMEOUT", raising=False)
+        from aiperf.common.environment import _ChatSettings, _Environment
+
+        env = _Environment()
+        assert isinstance(env.CHAT, _ChatSettings)
+        assert env.CHAT.CONNECT_TIMEOUT == 10.0

--- a/tests/unit/common/test_chat_settings.py
+++ b/tests/unit/common/test_chat_settings.py
@@ -3,13 +3,16 @@
 
 import pytest
 from pydantic import ValidationError
+from pytest import param
 
 
 class TestChatSettings:
     """Test suite for the _ChatSettings environment configuration
     (the AIPERF_CHAT_* timeouts used by `aiperf chat`)."""
 
-    def test_defaults(self, monkeypatch):
+    def test_chat_settings_env_unset_uses_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("AIPERF_CHAT_CONNECT_TIMEOUT", raising=False)
         monkeypatch.delenv("AIPERF_CHAT_READ_TIMEOUT", raising=False)
         from aiperf.common.environment import _ChatSettings
@@ -18,7 +21,9 @@ class TestChatSettings:
         assert settings.CONNECT_TIMEOUT == 10.0
         assert settings.READ_TIMEOUT == 300.0
 
-    def test_env_overrides(self, monkeypatch):
+    def test_chat_settings_env_set_overrides_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("AIPERF_CHAT_CONNECT_TIMEOUT", "3")
         monkeypatch.setenv("AIPERF_CHAT_READ_TIMEOUT", "42.5")
         from aiperf.common.environment import _ChatSettings
@@ -27,16 +32,27 @@ class TestChatSettings:
         assert settings.CONNECT_TIMEOUT == 3.0
         assert settings.READ_TIMEOUT == 42.5
 
-    @pytest.mark.parametrize("var", ["CONNECT_TIMEOUT", "READ_TIMEOUT"])
-    @pytest.mark.parametrize("bad", ["0", "-1"])
-    def test_non_positive_rejected(self, monkeypatch, var: str, bad: str):
+    @pytest.mark.parametrize(
+        "var,bad",
+        [
+            param("CONNECT_TIMEOUT", "0", id="connect_zero"),
+            param("CONNECT_TIMEOUT", "-1", id="connect_negative"),
+            param("READ_TIMEOUT", "0", id="read_zero"),
+            param("READ_TIMEOUT", "-1", id="read_negative"),
+        ],
+    )  # fmt: skip
+    def test_chat_settings_non_positive_timeout_raises(
+        self, monkeypatch: pytest.MonkeyPatch, var: str, bad: str
+    ) -> None:
         monkeypatch.setenv(f"AIPERF_CHAT_{var}", bad)
         from aiperf.common.environment import _ChatSettings
 
         with pytest.raises(ValidationError):
             _ChatSettings()
 
-    def test_aggregator_exposes_chat(self, monkeypatch):
+    def test_environment_aggregator_exposes_chat_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("AIPERF_CHAT_CONNECT_TIMEOUT", raising=False)
         monkeypatch.delenv("AIPERF_CHAT_READ_TIMEOUT", raising=False)
         from aiperf.common.environment import _ChatSettings, _Environment


### PR DESCRIPTION
## `aiperf chat`: an interactive sanity-check companion to `aiperf profile`

Setting up an `aiperf profile` run is the right tool for a real benchmark, but it's heavier than you want when you just need to answer *"is this endpoint wired up correctly, and is it roughly as fast as I expect?"* — especially while eyeballing reasoning models or speculative decoding, where speedups are prompt-dependent.

`aiperf chat` fills that gap. You talk to an OpenAI-compatible endpoint one message at a time and get per-turn speed stats after every reply. Think `vllm chat`, but the numbers are computed by **the same metric classes `aiperf profile` uses**, so they're trustworthy and consistent.

### Quick start

```bash
# Single-shot
aiperf chat --model Qwen/Qwen3-0.6B --url http://localhost:8000 \
  --quick "say hello in one short sentence"
```
```
Using model: Qwen/Qwen3-0.6B
Hello! How can I help you today?
TTFT: 20.06 ms
TPS:  154.11 tokens/s (9 tokens in 0.06s)
ITL:  6.31 ms/token (decode 158.40 tokens/s)
Cache: 14/18 prompt tokens cached (77.8%)
```

```bash
# Interactive, multi-turn (Ctrl-D to exit)
aiperf chat --model Qwen/Qwen3-0.6B --url http://localhost:8000
```

### Reading the stats

The same block prints after every reply, in every mode:

| Line | Meaning |
|---|---|
| **TTFT** | Time to first token (client-observed). |
| **TPS** | Generated tokens ÷ end-to-end latency — the vLLM-familiar rate; *includes* TTFT, so it blends prefill and decode. |
| **ITL / decode** | Inter-token latency and `1/ITL` — decode speed with prefill removed. Omitted for single-token replies (undefined). |
| **Cache** | Prompt-cache hit rate from the server's `usage`. Omitted when the server doesn't report cached tokens. |

Two things worth knowing, both of which this command gets right because it reuses `profile`'s logic:

- **Reasoning tokens count.** Whether the server emits a separate `reasoning_content` field or inline `<think>…</think>`, those tokens are included in the total (shown as `… , N reasoning`), matching `profile`'s output/reasoning bucketing.
- **Prefix caches are server-side and shared across requests and sessions**, so the cache line can be non-zero even on a first or single-shot message (a common system prompt, or any prefix the server already cached). It requires the server to *report* cached tokens: vLLM needs `--enable-prompt-tokens-details` (on top of `--enable-prefix-caching`), SGLang needs `--enable-cache-report`, TRT-LLM reports it by default.

### Modes

- **Multi-turn (default)** — history retained and resent each turn.
- **`--no-history`** — stateless, completion-style turns (no memory between messages).
- **`--quick "msg"`** — one request, print stats, exit.

### Design notes

- **Parity over re-implementation.** A `_chat_stats` module builds a `ParsedResponseRecord` and runs it through the real metric classes (`TTFT`, `RequestLatency`, `OSL`, `ITL`, `InputSequenceLength`, `UsagePromptCacheReadTokens`), so the numbers can't drift from `profile`.
- **Deliberately small surface.** Explicit flags only (`model`/`url`/`system-prompt`/`quick`/`no-history`/`api-key`/`tokenizer`) — no `CLIConfig` firehose. Request timeouts are tunable via `AIPERF_CHAT_CONNECT_TIMEOUT` / `AIPERF_CHAT_READ_TIMEOUT`.
- **Consistent with `profile`.** `-u` takes a bare base URL and normalizes it the same way (`http://` prepended if scheme-less), resolving the chat path identically.
- **Diagnostics-first, resilient REPL.** Streams via aiperf's `AsyncSSEStreamReader` so a mid-stream `event: error` surfaces instead of a truncated reply; HTTP error bodies (the server's real message) are surfaced, not just the status; a failed turn is reported and the loop continues; malformed SSE lines are skipped; Ctrl-C exits cleanly on the first press. No overall request timeout, so long generations are never truncated.

### Testing

- **Unit** — the pure parse/metric/stats layer (`test_chat_stats.py`), chat helpers and the I/O path via lightweight fakes (`test_chat.py`), and the env-var settings (`test_chat_settings.py`). 100% patch coverage on `chat.py` and `_chat_stats.py`.
- **Integration** (in-repo mock server) — `--quick`; multi-turn proven to resend history (turn-2 prompt grows); `--no-history` proven stateless (identical message → identical prompt size).

### Docs

New tutorial (`docs/tutorials/interactive-chat.md`) plus regenerated CLI and environment-variable references.

### Out of scope

Tool calling (neither sent nor needed for a sanity tool) and a separate `aiperf complete` command — `--no-history` already covers the stateless flow.