### PR TITLE
fix(records): gate record processing on dataset configuration

### DIFF
--- a/src/aiperf/records/dataset_gate.py
+++ b/src/aiperf/records/dataset_gate.py
@@ -33,6 +33,10 @@ async def await_dataset_configured(
     dataset. Returns False in that case so the caller skips processing (``_kill``
     force-exits the process, so this return is a safety net if it ever does not).
     """
+    # Fast path: once configured (the common case), avoid the per-record
+    # wait_for timer allocation on the hot path.
+    if event.is_set():
+        return True
     try:
         await asyncio.wait_for(
             event.wait(), timeout=Environment.DATASET.CONFIGURATION_TIMEOUT

--- a/src/aiperf/records/dataset_gate.py
+++ b/src/aiperf/records/dataset_gate.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared dataset-configuration gate for the record-processing services.
+
+RecordProcessor and RecordsManager receive the DatasetConfiguredNotification on
+the PUB/SUB bus but records on a separate PULL socket, with no ordering guarantee
+between the two. Both must block record processing until the notification has
+configured their processors (e.g. accuracy ground truths / task names).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from aiperf.common.environment import Environment
+from aiperf.common.messages import BaseServiceErrorMessage
+from aiperf.common.models.error_models import ErrorDetails
+
+if TYPE_CHECKING:
+    from aiperf.common.base_component_service import BaseComponentService
+
+
+async def await_dataset_configured(
+    service: BaseComponentService, event: asyncio.Event
+) -> bool:
+    """Block until the dataset-configured ``event`` is set.
+
+    Returns True once configured. On timeout, treats a missing dataset
+    configuration as a fatal misconfiguration: reports it via a
+    BaseServiceErrorMessage (so the run exits non-zero) and kills the service so
+    the run aborts loudly instead of processing records without a configured
+    dataset. Returns False in that case so the caller skips processing (``_kill``
+    force-exits the process, so this return is a safety net if it ever does not).
+    """
+    try:
+        await asyncio.wait_for(
+            event.wait(), timeout=Environment.DATASET.CONFIGURATION_TIMEOUT
+        )
+        return True
+    except asyncio.TimeoutError:
+        message = (
+            "Dataset configuration not received after "
+            f"{Environment.DATASET.CONFIGURATION_TIMEOUT}s; aborting run."
+        )
+        service.error(message)
+        await service.publish(
+            BaseServiceErrorMessage(
+                service_id=service.service_id,
+                error=ErrorDetails(message=message),
+            )
+        )
+        await service._kill()
+        return False

--- a/src/aiperf/records/inference_result_parser.py
+++ b/src/aiperf/records/inference_result_parser.py
@@ -54,8 +54,10 @@ class InferenceResultParser(CommunicationMixin):
             not endpoint_meta.produces_tokens and not endpoint_meta.tokenizes_input
         )
         self.debug(
-            lambda: f"Created endpoint for {self.model_endpoint.endpoint.type}, "
-            f"class: {self.endpoint.__class__.__name__}",
+            lambda: (
+                f"Created endpoint for {self.model_endpoint.endpoint.type}, "
+                f"class: {self.endpoint.__class__.__name__}"
+            ),
         )
 
     @on_init
@@ -118,9 +120,11 @@ class InferenceResultParser(CommunicationMixin):
         request_info = request_record.request_info
         self.trace_or_debug(
             lambda: f"Received inference results message: {request_record}",
-            lambda: f"Received inference results for credit '{request_info.credit_num}' (id: {request_info.x_request_id})"
-            if request_info
-            else "Received inference results (no request_info)",
+            lambda: (
+                f"Received inference results for credit '{request_info.credit_num}' (id: {request_info.x_request_id})"
+                if request_info
+                else "Received inference results (no request_info)"
+            ),
         )
 
         # Make sure any invalid request records are converted to error records for combined processing.
@@ -167,7 +171,9 @@ class InferenceResultParser(CommunicationMixin):
                 else:
                     # Success path: valid record with no errors
                     self.debug(
-                        lambda: f"Received {raw_response_count} response packet(s), token counts: {record.token_counts}"
+                        lambda: (
+                            f"Received {raw_response_count} response packet(s), token counts: {record.token_counts}"
+                        )
                     )
                     return record
 
@@ -199,7 +205,9 @@ class InferenceResultParser(CommunicationMixin):
         """Process a valid request record."""
         if request_record.model_name is None:
             self.warning(
-                lambda: f"Model name is None, unable to process record: {request_record}"
+                lambda: (
+                    f"Model name is None, unable to process record: {request_record}"
+                )
             )
             return ParsedResponseRecord(
                 request=request_record,

--- a/src/aiperf/records/record_processor_service.py
+++ b/src/aiperf/records/record_processor_service.py
@@ -31,6 +31,7 @@ from aiperf.metrics.metric_dicts import MetricRecordDict
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import PluginType
 from aiperf.post_processors.protocols import RecordProcessorProtocol
+from aiperf.records.dataset_gate import await_dataset_configured
 from aiperf.records.inference_result_parser import InferenceResultParser
 
 if TYPE_CHECKING:
@@ -176,10 +177,8 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
     @on_pull_message(MessageType.INFERENCE_RESULTS)
     async def _on_inference_results(self, message: InferenceResultsMessage) -> None:
         """Handle an inference results message."""
-        await asyncio.wait_for(
-            self._dataset_configured_event.wait(),
-            timeout=Environment.DATASET.CONFIGURATION_TIMEOUT,
-        )
+        if not await await_dataset_configured(self, self._dataset_configured_event):
+            return
         record = message.record
 
         # Capture last response timestamp before parsing frees raw SSE data.

--- a/src/aiperf/records/record_processor_service.py
+++ b/src/aiperf/records/record_processor_service.py
@@ -67,6 +67,12 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
             run=self.run,
         )
 
+        # DatasetConfiguredNotification (SUB) and inference results (PULL) arrive on
+        # independent channels with no ordering guarantee. Gate record processing on
+        # this event so processors are configured (e.g. accuracy ground truths) before
+        # any record is graded.
+        self._dataset_configured_event: asyncio.Event = asyncio.Event()
+
         self.records_processors: list[RecordProcessorProtocol] = []
         for entry in plugins.iter_entries(PluginType.RECORD_PROCESSOR):
             try:
@@ -97,6 +103,7 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
         for processor in self.records_processors:
             if hasattr(processor, "on_dataset_configured"):
                 processor.on_dataset_configured(message.metadata)
+        self._dataset_configured_event.set()
 
     @on_command(CommandType.PROFILE_CONFIGURE)
     async def _profile_configure_command(
@@ -169,6 +176,10 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
     @on_pull_message(MessageType.INFERENCE_RESULTS)
     async def _on_inference_results(self, message: InferenceResultsMessage) -> None:
         """Handle an inference results message."""
+        await asyncio.wait_for(
+            self._dataset_configured_event.wait(),
+            timeout=Environment.DATASET.CONFIGURATION_TIMEOUT,
+        )
         record = message.record
 
         # Capture last response timestamp before parsing frees raw SSE data.

--- a/src/aiperf/records/records_manager.py
+++ b/src/aiperf/records/records_manager.py
@@ -149,6 +149,12 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         self._records_tracker = RecordsTracker()
         self._error_tracker = ErrorTracker()
 
+        # DatasetConfiguredNotification (SUB) and metric records (PULL) arrive on
+        # independent channels with no ordering guarantee. Gate record processing on
+        # this event so results processors are configured (e.g. accuracy task names)
+        # before any record is accumulated.
+        self._dataset_configured_event: asyncio.Event = asyncio.Event()
+
         self._previous_realtime_records: int | None = None
 
         # Latest BranchStats snapshot received via CreditPhaseCompleteMessage
@@ -251,6 +257,10 @@ class RecordsManager(PullClientMixin, BaseComponentService):
     @on_pull_message(MessageType.METRIC_RECORDS)
     async def _on_metric_records(self, message: MetricRecordsMessage) -> None:
         """Handle a metric records message."""
+        await asyncio.wait_for(
+            self._dataset_configured_event.wait(),
+            timeout=Environment.DATASET.CONFIGURATION_TIMEOUT,
+        )
         if self.is_trace_enabled:
             self.trace(f"Received metric records: {message}")
 
@@ -585,6 +595,7 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         for processor in self._metric_results_processors:
             if hasattr(processor, "on_dataset_configured"):
                 processor.on_dataset_configured(message.metadata)
+        self._dataset_configured_event.set()
 
     @on_message(MessageType.CREDIT_PHASE_START)
     async def _on_credit_phase_start(

--- a/src/aiperf/records/records_manager.py
+++ b/src/aiperf/records/records_manager.py
@@ -82,6 +82,7 @@ from aiperf.post_processors.protocols import (
     FlushableResultsProcessorProtocol,
     ResultsProcessorProtocol,
 )
+from aiperf.records.dataset_gate import await_dataset_configured
 from aiperf.records.error_tracker import ErrorTracker
 from aiperf.records.records_tracker import RecordsTracker
 from aiperf.server_metrics.protocols import (
@@ -257,10 +258,8 @@ class RecordsManager(PullClientMixin, BaseComponentService):
     @on_pull_message(MessageType.METRIC_RECORDS)
     async def _on_metric_records(self, message: MetricRecordsMessage) -> None:
         """Handle a metric records message."""
-        await asyncio.wait_for(
-            self._dataset_configured_event.wait(),
-            timeout=Environment.DATASET.CONFIGURATION_TIMEOUT,
-        )
+        if not await await_dataset_configured(self, self._dataset_configured_event):
+            return
         if self.is_trace_enabled:
             self.trace(f"Received metric records: {message}")
 

--- a/tests/unit/records/test_record_processor_service.py
+++ b/tests/unit/records/test_record_processor_service.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from aiperf.common.enums import CreditPhase
+from aiperf.common.messages import BaseServiceErrorMessage
 from aiperf.common.utils import compute_time_ns
 from aiperf.records.record_processor_service import RecordProcessor
 
@@ -174,3 +175,32 @@ class TestRecordProcessorDatasetConfiguredBarrier:
         mock_self._dataset_configured_event.set()
         with pytest.raises(RuntimeError, match="REACHED_PROCESSING"):
             await asyncio.wait_for(task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_on_inference_results_fails_run_on_config_timeout(self, monkeypatch):
+        """On dataset-config timeout, abort the run (report error + kill) rather
+        than process the record without a configured dataset."""
+        mock_self = MagicMock(spec=RecordProcessor)
+        mock_self.service_id = "rp-test"
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.publish = AsyncMock()
+        mock_self._kill = AsyncMock()
+        mock_self.inference_result_parser = MagicMock()
+        mock_self.inference_result_parser.parse_request_record = AsyncMock()
+
+        async def _raise_timeout(coro, *args, **kwargs):
+            coro.close()  # avoid "coroutine was never awaited" warning
+            raise asyncio.TimeoutError
+
+        monkeypatch.setattr(
+            "aiperf.records.dataset_gate.asyncio.wait_for", _raise_timeout
+        )
+
+        await RecordProcessor._on_inference_results(mock_self, MagicMock())
+
+        # Run is failed loudly ...
+        mock_self._kill.assert_awaited_once()
+        published = mock_self.publish.await_args.args[0]
+        assert isinstance(published, BaseServiceErrorMessage)
+        # ... and the record is not processed.
+        mock_self.inference_result_parser.parse_request_record.assert_not_called()

--- a/tests/unit/records/test_record_processor_service.py
+++ b/tests/unit/records/test_record_processor_service.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -126,3 +127,50 @@ class TestRecordProcessorCreateMetricRecordMetadata:
 
         assert getattr(metadata, expected_metadata_field) is None
         assert metadata.worker_id == worker_id
+
+
+class TestRecordProcessorDatasetConfiguredBarrier:
+    """The record processor must not process inference results until the
+    DatasetConfiguredNotification has been applied to its processors.
+
+    Records (PULL socket) and the notification (SUB socket) arrive on
+    independent channels with no ordering guarantee, so processing must block
+    on an explicit barrier that _on_dataset_configured releases.
+    """
+
+    @pytest.mark.asyncio
+    async def test_on_dataset_configured_sets_event(self):
+        """_on_dataset_configured must release the barrier once processors are configured."""
+        mock_self = MagicMock(spec=RecordProcessor)
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.records_processors = []
+
+        await RecordProcessor._on_dataset_configured(mock_self, MagicMock())
+
+        assert mock_self._dataset_configured_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_on_inference_results_waits_for_dataset_configured(self):
+        """_on_inference_results must block until the dataset is configured, then proceed."""
+        mock_self = MagicMock(spec=RecordProcessor)
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.inference_result_parser = MagicMock()
+        # First downstream step after the barrier; raising proves the barrier was passed.
+        mock_self.inference_result_parser.parse_request_record = AsyncMock(
+            side_effect=RuntimeError("REACHED_PROCESSING")
+        )
+
+        task = asyncio.create_task(
+            RecordProcessor._on_inference_results(mock_self, MagicMock())
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # Barrier not released: processing has not started.
+        assert not task.done()
+        assert not mock_self.inference_result_parser.parse_request_record.called
+
+        # Barrier released: processing proceeds past the wait.
+        mock_self._dataset_configured_event.set()
+        with pytest.raises(RuntimeError, match="REACHED_PROCESSING"):
+            await asyncio.wait_for(task, timeout=1.0)

--- a/tests/unit/records/test_records_manager.py
+++ b/tests/unit/records/test_records_manager.py
@@ -9,6 +9,7 @@ import pytest
 
 from aiperf.common.enums import CreditPhase
 from aiperf.common.exceptions import PostProcessorDisabled
+from aiperf.common.messages import BaseServiceErrorMessage
 from aiperf.common.messages.inference_messages import (
     MetricRecordsData,
     MetricRecordsMessage,
@@ -1141,3 +1142,34 @@ class TestRecordsManagerDatasetConfiguredBarrier:
         mock_self._dataset_configured_event.set()
         with pytest.raises(RuntimeError, match="REACHED_PROCESSING"):
             await asyncio.wait_for(task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_on_metric_records_fails_run_on_config_timeout(self, monkeypatch):
+        """On dataset-config timeout, abort the run (report error + kill) rather
+        than process the record without a configured dataset."""
+        mock_self = MagicMock(spec=RecordsManager)
+        mock_self.service_id = "rm-test"
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.is_trace_enabled = False
+        mock_self.publish = AsyncMock()
+        mock_self._kill = AsyncMock()
+        mock_self._send_results_to_results_processors = AsyncMock()
+        message = MagicMock()
+        message.metadata.benchmark_phase = CreditPhase.PROFILING
+
+        async def _raise_timeout(coro, *args, **kwargs):
+            coro.close()  # avoid "coroutine was never awaited" warning
+            raise asyncio.TimeoutError
+
+        monkeypatch.setattr(
+            "aiperf.records.dataset_gate.asyncio.wait_for", _raise_timeout
+        )
+
+        await RecordsManager._on_metric_records(mock_self, message)
+
+        # Run is failed loudly ...
+        mock_self._kill.assert_awaited_once()
+        published = mock_self.publish.await_args.args[0]
+        assert isinstance(published, BaseServiceErrorMessage)
+        # ... and the record is not processed.
+        mock_self._send_results_to_results_processors.assert_not_called()

--- a/tests/unit/records/test_records_manager.py
+++ b/tests/unit/records/test_records_manager.py
@@ -318,6 +318,9 @@ def _create_credit_phase_stats() -> CreditPhaseStats:
 
 def _create_manager_for_timing_dispatch() -> RecordsManager:
     manager = RecordsManager.__new__(RecordsManager)
+    # These tests exercise the post-configuration flow; release the barrier.
+    manager._dataset_configured_event = asyncio.Event()
+    manager._dataset_configured_event.set()
     manager._records_tracker = MagicMock()
     manager._error_tracker = MagicMock()
     manager._complete_credit_phases = set()
@@ -1089,3 +1092,52 @@ class TestMidRunCacheReportingHint:
         record_data = SimpleNamespace(metrics={"output_sequence_length": 32})
         manager._maybe_hint_missing_cache_reporting(record_data)
         manager.warning.assert_not_called()
+
+
+class TestRecordsManagerDatasetConfiguredBarrier:
+    """The records manager must not run metric records through its results
+    processors until the DatasetConfiguredNotification has been applied.
+
+    Metric records (PULL socket) and the notification (SUB socket) arrive on
+    independent channels with no ordering guarantee, so processing must block
+    on an explicit barrier that _on_dataset_configured releases.
+    """
+
+    @pytest.mark.asyncio
+    async def test_on_dataset_configured_sets_event(self):
+        """_on_dataset_configured must release the barrier once processors are configured."""
+        mock_self = MagicMock(spec=RecordsManager)
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self._metric_results_processors = []
+
+        await RecordsManager._on_dataset_configured(mock_self, MagicMock())
+
+        assert mock_self._dataset_configured_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_on_metric_records_waits_for_dataset_configured(self):
+        """_on_metric_records must block until the dataset is configured, then proceed."""
+        mock_self = MagicMock(spec=RecordsManager)
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.is_trace_enabled = False
+        # First downstream step after the barrier; raising proves the barrier was passed.
+        mock_self._send_results_to_results_processors = AsyncMock(
+            side_effect=RuntimeError("REACHED_PROCESSING")
+        )
+        message = MagicMock()
+        message.metadata.benchmark_phase = CreditPhase.PROFILING
+
+        task = asyncio.create_task(
+            RecordsManager._on_metric_records(mock_self, message)
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # Barrier not released: processing has not started.
+        assert not task.done()
+        assert not mock_self._send_results_to_results_processors.called
+
+        # Barrier released: processing proceeds past the wait.
+        mock_self._dataset_configured_event.set()
+        with pytest.raises(RuntimeError, match="REACHED_PROCESSING"):
+            await asyncio.wait_for(task, timeout=1.0)


### PR DESCRIPTION
## Summary

  Accuracy benchmarks (**AIME24 / AIME25**) intermittently produced a report with **no accuracy metrics**, while the logs filled with:

  ERROR AccuracyRecordProcessor: dataset not configured;
        on_dataset_configured must be called before process_record

  Root cause is a race between two independent message channels feeding the record-processing services.

  ## The analogy

  Think of the **record processor** as a grader who needs the **answer key** before scoring exams:

  - The answer key (`DatasetConfiguredNotification`, which carries the ground-truth answers) is broadcast on one channel — a ZMQ **SUB** socket.
  - The finished exams (inference results) arrive on a completely separate channel — a ZMQ **PULL** socket.channel — a ZMQ **SUB** socket.
- The finished exams (inference results) arrive on a completely separate channel — a ZMQ **PULL** socket.

The answer key is broadcast *well before* any result comes back, so in the common case it's already been applied by the time grading starts. But the two sockets are drained by independent event-loop tasks with **no ordering guarantee** — nothing enforces "apply the answer key before scoring the first exam." The code just assumed it. When that assumption loses the race, the grader has no key and every record errors out.

## Why it surfaced now

The race was always latent; two factors exposed it:

1. **PR #1057** (the ZMQ FD-driver) batch-drains messages, changing scheduling so a burst of results can be dispatched ahead of the still-pending notification.
2. **Long generation** (`--accuracy-enable-cot`, `generation_size=32768`) widens the timing window. Faster hardware occasionally hid it; longer runs hit it reliably.

Notably, this is *not* the "requests sent before the dataset is ready" case — the Worker and TimingManager already barrier on the dataset, so requests are correctly ordered. The record-processing services were simply the one set of dataset-dependent consumers **missing that same barrier**.

## The fix

Add the barrier those services were missing, using the exact pattern already established in `Worker` and `TimingManager`:

- Set a `_dataset_configured_event` when `DatasetConfiguredNotification` is applied.
- `await` that event before processing any record.

Applied to both `RecordProcessor` (grading path) and `RecordsManager` (results-aggregation path — same latent race). The wait/timeout logic is shared via a `await_dataset_configured()` helper in `src/aiperf/records/dataset_gate.py`.

The wait is bounded by the existing `DATASET.CONFIGURATION_TIMEOUT`. On timeout, a missing dataset configuration is treated as fatal: the service reports a `BaseServiceErrorMessage` and aborts the run (non-zero exit) rather than grading records without a configured dataset. (An earlier best-effort-continue approach was dropped — it couldn't prevent the phase-completion stall, since the accuracy processor stays unconfigured and raises before the record is counted, which would hang the run.)

## Impact

- ✅ Accuracy metrics (`accuracy.overall`, `accuracy.task.aime24`, `accuracy.unparsed`, …) appear reliably.
- ✅ Fixes both the grading and aggregation paths.
- ✅ No effect on normal runs — the event is virtually always already set, so the wait is a no-op.
- ✅ A genuinely missing dataset config fails the run loudly (non-zero exit) instead of silently producing a report with no accuracy data or hanging.

## Testing

- Added unit tests (TDD) verifying each service **blocks until configured, then proceeds**, and **aborts the run on config timeout** (record not processed, `BaseServiceErrorMessage` published, service killed).
- `tests/unit/records/` + `tests/unit/accuracy/`: 528 passed, 9 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Record processing now waits for dataset configuration to complete before handling incoming inference and metric results.
  * If dataset configuration does not arrive in time, processing stops safely and the service reports an error instead of continuing with incomplete state.
* **Refactor**
  * Improved internal coordination between record-processing components to make startup handling more reliable.
* **Tests**
  * Added coverage for dataset-configuration waiting, timeout handling, and safe shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->