### PR TITLE
fix(wandb): prevent W&B argv metadata credential leaks

### DIFF
--- a/src/aiperf/exporters/wandb_data_exporter.py
+++ b/src/aiperf/exporters/wandb_data_exporter.py
@@ -90,6 +90,10 @@ class WandbDataExporter(AIPerfLoggerMixin):
             dir=str(self._artifact_directory),
             config=self._build_config_payload(),
             tags=self._build_tags(),
+            settings=wandb.Settings(
+                x_disable_meta=True,
+                save_code=False,
+            ),
         )
         artifact_files: list[Path] = []
         try:

--- a/tests/unit/exporters/test_wandb_data_exporter.py
+++ b/tests/unit/exporters/test_wandb_data_exporter.py
@@ -131,7 +131,18 @@ def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         state["init_kwargs"] = kwargs
         settings = kwargs.get("settings")
         if not getattr(settings, "x_disable_meta", False):
-            state["metadata_output"] = {"args": sys.argv[1:]}
+            state["metadata_output"] = {
+                "wandb-metadata.json": {"args": sys.argv[1:]},
+                "config.yaml": {
+                    "_wandb": {
+                        "value": {
+                            "e": {
+                                "writer-id": {"args": sys.argv[1:]},
+                            }
+                        }
+                    }
+                },
+            }
         return FakeRun()
 
     fake_module = types.ModuleType("wandb")
@@ -317,7 +328,7 @@ class TestWandbDataExporter:
                 "--api-key",
                 "sk-secret-key",
                 "--header",
-                "Authorization:Bearer tok123",
+                "Authorization: Bearer test-secret-token",
                 "--wandb-project",
                 "aiperf-qa",
             ],
@@ -331,7 +342,7 @@ class TestWandbDataExporter:
         assert settings.save_code is False
         metadata_output = str(fake_wandb["metadata_output"])
         assert "sk-secret-key" not in metadata_output
-        assert "Authorization:Bearer tok123" not in metadata_output
+        assert "Authorization: Bearer test-secret-token" not in metadata_output
 
     @pytest.mark.asyncio
     async def test_export_config_payload_redacts_api_key(

--- a/tests/unit/exporters/test_wandb_data_exporter.py
+++ b/tests/unit/exporters/test_wandb_data_exporter.py
@@ -120,6 +120,12 @@ def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
             self.columns = columns
             self.data = data
 
+    class FakeSettings:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
     def fake_init(**kwargs: Any) -> FakeRun:
         state["init_kwargs"] = kwargs
         return FakeRun()
@@ -128,6 +134,7 @@ def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     fake_module.init = fake_init  # type: ignore[attr-defined]
     fake_module.Table = FakeTable  # type: ignore[attr-defined]
     fake_module.Artifact = FakeArtifact  # type: ignore[attr-defined]
+    fake_module.Settings = FakeSettings  # type: ignore[attr-defined]
     state["table_cls"] = FakeTable
     monkeypatch.setitem(sys.modules, "wandb", fake_module)
     return state
@@ -183,6 +190,9 @@ class TestWandbDataExporter:
         assert init_kwargs["project"] == "aiperf-dev"
         assert init_kwargs["name"] == "my-run"
         assert "aa-repro" in init_kwargs["tags"]
+        settings = init_kwargs["settings"]
+        assert settings.x_disable_meta is True
+        assert settings.save_code is False
         config = init_kwargs["config"]
         assert config["models"]["items"][0]["name"] == "test-model"
         assert config["phases"][0]["concurrency"] == 1

--- a/tests/unit/exporters/test_wandb_data_exporter.py
+++ b/tests/unit/exporters/test_wandb_data_exporter.py
@@ -90,6 +90,7 @@ def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         "artifact_files": [],
         "logged_artifacts": [],
         "finished": False,
+        "metadata_output": {},
     }
 
     class FakeArtifact:
@@ -128,6 +129,9 @@ def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
     def fake_init(**kwargs: Any) -> FakeRun:
         state["init_kwargs"] = kwargs
+        settings = kwargs.get("settings")
+        if not getattr(settings, "x_disable_meta", False):
+            state["metadata_output"] = {"args": sys.argv[1:]}
         return FakeRun()
 
     fake_module = types.ModuleType("wandb")
@@ -325,6 +329,9 @@ class TestWandbDataExporter:
         settings = fake_wandb["init_kwargs"]["settings"]
         assert settings.x_disable_meta is True
         assert settings.save_code is False
+        metadata_output = str(fake_wandb["metadata_output"])
+        assert "sk-secret-key" not in metadata_output
+        assert "Authorization:Bearer tok123" not in metadata_output
 
     @pytest.mark.asyncio
     async def test_export_config_payload_redacts_api_key(

--- a/tests/unit/exporters/test_wandb_data_exporter.py
+++ b/tests/unit/exporters/test_wandb_data_exporter.py
@@ -292,6 +292,41 @@ class TestWandbDataExporter:
         assert cli_command.startswith("aiperf profile")
 
     @pytest.mark.asyncio
+    async def test_export_disables_wandb_metadata_capture_with_secrets_in_argv(
+        self,
+        tmp_path: Path,
+        sample_results: ProfileResults,
+        fake_wandb: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """W&B captures raw sys.argv in its own metadata unless disabled.
+
+        AIPerf's uploaded config is redacted separately; this locks in the
+        setting that prevents W&B from independently persisting argv secrets.
+        """
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "aiperf",
+                "profile",
+                "--api-key",
+                "sk-secret-key",
+                "--header",
+                "Authorization:Bearer tok123",
+                "--wandb-project",
+                "aiperf-qa",
+            ],
+        )
+
+        exporter = _make_exporter(_make_cfg(tmp_path), sample_results)
+        await asyncio.to_thread(exporter._export_sync)
+
+        settings = fake_wandb["init_kwargs"]["settings"]
+        assert settings.x_disable_meta is True
+        assert settings.save_code is False
+
+    @pytest.mark.asyncio
     async def test_export_config_payload_redacts_api_key(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Problem
When `--wandb-project` is enabled, AIPerf passes a redacted benchmark config to `wandb.init`, but the W&B SDK also performs its own automatic metadata capture. That capture can record the raw process `sys.argv` into W&B-managed metadata files, which bypasses AIPerf's config serializers and can expose sensitive CLI values such as API keys or authorization headers.

## Fix
Disable W&B's automatic system metadata capture for AIPerf W&B exports by passing `wandb.Settings(x_disable_meta=True, save_code=False)` to `wandb.init`. AIPerf still uploads its explicit, redacted resolved config and benchmark artifacts, but no longer lets the W&B SDK independently persist raw argv metadata.

## Validation
- `uv run pytest tests/unit/exporters/test_wandb_data_exporter.py`
- `uv run ruff check src/aiperf/exporters/wandb_data_exporter.py tests/unit/exporters/test_wandb_data_exporter.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated W&B run uploads to use a privacy-focused configuration that disables extra metadata capture and prevents saving source code with the run.
* **Tests**
  * Strengthened unit tests to verify W&B initialization receives the expected settings and that sensitive command-line values are not included in exported metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->