### PR TITLE
fix(accuracy): preflight grader deps so missing lighteval fails cleanly

### DIFF
--- a/src/aiperf/accuracy/benchmarks/bigbench.py
+++ b/src/aiperf/accuracy/benchmarks/bigbench.py
@@ -140,10 +140,20 @@ class BigBenchBenchmark(AIPerfLoggerMixin):
     ``ExactMatchGrader`` for the recipe's strict equality scoring.
     """
 
-    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if deepeval is missing (see grader ``check_available``).
+
+        Called by the main-process preflight so a missing optional dependency
+        surfaces as a clean ConfigurationError before any service spawns,
+        rather than raising deep in the dataset-manager loader.
+        """
         if not _HAS_DEEPEVAL:
             raise RuntimeError(_MISSING_DEEPEVAL_HINT)
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.check_available()
         self.run = run
 
     async def load_problems(

--- a/src/aiperf/accuracy/benchmarks/hellaswag.py
+++ b/src/aiperf/accuracy/benchmarks/hellaswag.py
@@ -202,10 +202,20 @@ class HellaSwagBenchmark(AIPerfLoggerMixin):
     ``ExactMatchGrader`` (strict equality) for grading parity.
     """
 
-    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if deepeval is missing (see grader ``check_available``).
+
+        Called by the main-process preflight so a missing optional dependency
+        surfaces as a clean ConfigurationError before any service spawns,
+        rather than raising deep in the dataset-manager loader.
+        """
         if not _HAS_DEEPEVAL:
             raise RuntimeError(_MISSING_DEEPEVAL_HINT)
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.check_available()
         self.run = run
 
     async def load_problems(

--- a/src/aiperf/accuracy/graders/base.py
+++ b/src/aiperf/accuracy/graders/base.py
@@ -23,6 +23,24 @@ class BaseGrader(AIPerfLoggerMixin):
         super().__init__(**kwargs)
         self.run = run
 
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if this grader's optional dependencies are missing.
+
+        Called from the main-process preflight (``cli_runner._preflight``)
+        BEFORE any service is spawned, so a missing optional dependency (e.g.
+        lighteval) surfaces as a clean ``ConfigurationError`` instead of
+        crashing the daemon record-processor mid-run — which prints a raw
+        multiprocessing traceback and hangs the parent waiting for records
+        that never arrive.
+
+        Default is a no-op: graders with no optional dependencies (the
+        hand-ported ``exact_match`` / ``multiple_choice`` / ``gsm8k`` / ``math``
+        graders) are always available. Graders backed by an optional package
+        override this to check their import flag.
+        """
+        return
+
     async def grade(
         self, response_text: str, ground_truth: str, **kwargs
     ) -> GradingResult:

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -89,10 +89,15 @@ class CodeExecutionGrader(BaseGrader):
     raised an exception during execution.
     """
 
-    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
-        super().__init__(run=run, **kwargs)
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if lighteval is missing (see ``BaseGrader.check_available``)."""
         if not _HAS_LIGHTEVAL_LCB:
             raise RuntimeError(_MISSING_LIGHTEVAL_HINT)
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(run=run, **kwargs)
+        self.check_available()
 
     def extract_answer(self, response_text: str, **kwargs: Any) -> str:
         """Return the code block lighteval would extract from the response.

--- a/src/aiperf/accuracy/graders/lighteval_grader.py
+++ b/src/aiperf/accuracy/graders/lighteval_grader.py
@@ -108,6 +108,11 @@ class _LightevalBaseGrader(BaseGrader):
 
     _CORRECTNESS_THRESHOLD = 0.5
 
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if lighteval is missing (see ``BaseGrader.check_available``)."""
+        _require_lighteval()
+
     def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
         super().__init__(run=run, **kwargs)
         _require_lighteval()

--- a/src/aiperf/cli_runner/__init__.py
+++ b/src/aiperf/cli_runner/__init__.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 from aiperf.cli_runner._callbacks import CompletedRun, OnComplete
 from aiperf.cli_runner._multi_run import _run_multi_benchmark
 from aiperf.cli_runner._preflight import (
+    _preflight_accuracy_grader_deps,
     _preflight_artifact_dir,
     _preflight_endpoint_ready,
     _preflight_fd_limit,
@@ -50,6 +51,7 @@ def run_benchmark(plan: BenchmarkPlan) -> None:
         )
 
     _preflight_artifact_dir(plan)
+    _preflight_accuracy_grader_deps(plan)
     _preflight_fd_limit()
     _preflight_endpoint_ready(plan)
 

--- a/src/aiperf/cli_runner/__init__.py
+++ b/src/aiperf/cli_runner/__init__.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 from aiperf.cli_runner._callbacks import CompletedRun, OnComplete
 from aiperf.cli_runner._multi_run import _run_multi_benchmark
 from aiperf.cli_runner._preflight import (
-    _preflight_accuracy_grader_deps,
+    _preflight_accuracy_deps,
     _preflight_artifact_dir,
     _preflight_endpoint_ready,
     _preflight_fd_limit,
@@ -51,7 +51,7 @@ def run_benchmark(plan: BenchmarkPlan) -> None:
         )
 
     _preflight_artifact_dir(plan)
-    _preflight_accuracy_grader_deps(plan)
+    _preflight_accuracy_deps(plan)
     _preflight_fd_limit()
     _preflight_endpoint_ready(plan)
 

--- a/src/aiperf/cli_runner/_preflight.py
+++ b/src/aiperf/cli_runner/_preflight.py
@@ -85,6 +85,45 @@ def _preflight_fd_limit() -> None:
         resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
 
 
+def _preflight_accuracy_grader_deps(plan: BenchmarkPlan) -> None:
+    """Fail fast if a selected accuracy grader's optional dependency is missing.
+
+    Why: graders backed by an optional package (lighteval) raise at
+    instantiation inside the record-processor service, which runs as a daemon
+    child. That crash isn't propagated to the controller, so the user sees a
+    raw multiprocessing traceback and the main process hangs waiting for
+    records that never arrive. Checking here — in the main process, before any
+    service spawns — turns it into a single clean ``ConfigurationError`` panel
+    with a non-zero exit and no hang.
+    """
+    from aiperf.config.loader.errors import ConfigurationError
+    from aiperf.plugin import plugins
+    from aiperf.plugin.enums import PluginType
+
+    checked: set[str] = set()
+    for config in plan.configs:
+        acc_cfg = getattr(config, "accuracy", None)
+        if acc_cfg is None or not acc_cfg.enabled:
+            continue
+
+        grader_name = acc_cfg.grader
+        if grader_name is None:
+            meta = plugins.get_metadata(
+                PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
+            )
+            grader_name = meta.get("default_grader", "multiple_choice")
+
+        if grader_name in checked:
+            continue
+        checked.add(grader_name)
+
+        grader_cls = plugins.get_class(PluginType.ACCURACY_GRADER, grader_name)
+        try:
+            grader_cls.check_available()
+        except RuntimeError as exc:
+            raise ConfigurationError(str(exc)) from exc
+
+
 def _preflight_endpoint_ready(plan: BenchmarkPlan) -> None:
     """Block until the target endpoint is ready (see ready_checker).
 

--- a/src/aiperf/cli_runner/_preflight.py
+++ b/src/aiperf/cli_runner/_preflight.py
@@ -99,6 +99,7 @@ def _preflight_accuracy_grader_deps(plan: BenchmarkPlan) -> None:
     from aiperf.config.loader.errors import ConfigurationError
     from aiperf.plugin import plugins
     from aiperf.plugin.enums import PluginType
+    from aiperf.plugin.types import TypeNotFoundError
 
     checked: set[str] = set()
     for config in plan.configs:
@@ -106,21 +107,32 @@ def _preflight_accuracy_grader_deps(plan: BenchmarkPlan) -> None:
         if acc_cfg is None or not acc_cfg.enabled:
             continue
 
-        grader_name = acc_cfg.grader
-        if grader_name is None:
-            meta = plugins.get_metadata(
-                PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
-            )
-            grader_name = meta.get("default_grader", "multiple_choice")
-
-        if grader_name in checked:
-            continue
-        checked.add(grader_name)
-
-        grader_cls = plugins.get_class(PluginType.ACCURACY_GRADER, grader_name)
+        # Keep every preflight failure on the ConfigurationError path: plugin
+        # lookups raise TypeNotFoundError/KeyError for an unknown benchmark or
+        # grader name, and check_available raises RuntimeError for a missing
+        # optional dependency. Either would otherwise leak a raw traceback.
         try:
-            grader_cls.check_available()
-        except RuntimeError as exc:
+            grader_name = acc_cfg.grader
+            if grader_name is None:
+                meta = plugins.get_metadata(
+                    PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
+                )
+                grader_name = meta.get("default_grader", "multiple_choice")
+
+            if grader_name in checked:
+                continue
+            checked.add(grader_name)
+
+            grader_cls = plugins.get_class(PluginType.ACCURACY_GRADER, grader_name)
+            # ``check_available`` is an optional hook: the accuracy_grader
+            # contract is ``AccuracyGraderProtocol`` (grade + extract_answer
+            # only), so a custom grader plugin need not define it. Built-in
+            # graders inherit a no-op default from ``BaseGrader``; treat its
+            # absence as "no optional deps to verify".
+            check = getattr(grader_cls, "check_available", None)
+            if callable(check):
+                check()
+        except (TypeNotFoundError, KeyError, RuntimeError) as exc:
             raise ConfigurationError(str(exc)) from exc
 
 

--- a/src/aiperf/cli_runner/_preflight.py
+++ b/src/aiperf/cli_runner/_preflight.py
@@ -4,9 +4,9 @@
 
 These run before any service bootstrap so misconfiguration surfaces as a
 clean ``ConfigurationError`` instead of a stack trace from deep inside the
-controller. The three checks are: artifact-dir creatable+writable, file
-descriptor soft limit raised (and hard limit large enough), and the target
-endpoint reachable.
+controller. The checks are: artifact-dir creatable+writable, accuracy
+benchmark/grader optional dependencies present, file descriptor soft limit
+raised (and hard limit large enough), and the target endpoint reachable.
 """
 
 from __future__ import annotations
@@ -85,54 +85,68 @@ def _preflight_fd_limit() -> None:
         resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
 
 
-def _preflight_accuracy_grader_deps(plan: BenchmarkPlan) -> None:
-    """Fail fast if a selected accuracy grader's optional dependency is missing.
+def _preflight_accuracy_deps(plan: BenchmarkPlan) -> None:
+    """Fail fast if a selected accuracy benchmark's or grader's optional
+    dependency (lighteval / deepeval, the ``[accuracy]`` extra) is missing.
 
-    Why: graders backed by an optional package (lighteval) raise at
-    instantiation inside the record-processor service, which runs as a daemon
-    child. That crash isn't propagated to the controller, so the user sees a
-    raw multiprocessing traceback and the main process hangs waiting for
-    records that never arrive. Checking here — in the main process, before any
-    service spawns — turns it into a single clean ``ConfigurationError`` panel
-    with a non-zero exit and no hang.
+    Why: both the benchmark loader (dataset-manager service) and the grader
+    (record-processor daemon) raise at instantiation when their optional
+    package is absent. The grader crash isn't propagated to the controller, so
+    the user sees a raw multiprocessing traceback and the run hangs waiting for
+    records that never arrive; the loader crash surfaces later and less
+    cleanly. Checking here — in the main process, before any service spawns —
+    turns both into a single clean ``ConfigurationError`` panel with a non-zero
+    exit and no hang.
     """
     from aiperf.config.loader.errors import ConfigurationError
     from aiperf.plugin import plugins
     from aiperf.plugin.enums import PluginType
     from aiperf.plugin.types import TypeNotFoundError
 
-    checked: set[str] = set()
+    checked: set[tuple[str, str]] = set()
     for config in plan.configs:
         acc_cfg = getattr(config, "accuracy", None)
         if acc_cfg is None or not acc_cfg.enabled:
             continue
 
         # Keep every preflight failure on the ConfigurationError path: plugin
-        # lookups raise TypeNotFoundError/KeyError for an unknown benchmark or
-        # grader name, and check_available raises RuntimeError for a missing
-        # optional dependency. Either would otherwise leak a raw traceback.
+        # lookups raise TypeNotFoundError/KeyError/ValueError for an unknown or
+        # malformed benchmark/grader name (ImportError for a broken external
+        # plugin), and check_available raises RuntimeError for a missing
+        # optional dependency. Any of these would otherwise leak a raw traceback.
         try:
-            grader_name = acc_cfg.grader
-            if grader_name is None:
-                meta = plugins.get_metadata(
-                    PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
-                )
-                grader_name = meta.get("default_grader", "multiple_choice")
+            meta = plugins.get_metadata(
+                PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
+            )
+            grader_name = acc_cfg.grader or meta.get(
+                "default_grader", "multiple_choice"
+            )
 
-            if grader_name in checked:
+            key = (str(acc_cfg.benchmark), grader_name)
+            if key in checked:
                 continue
-            checked.add(grader_name)
+            checked.add(key)
 
+            # ``check_available`` is an optional hook on both the benchmark
+            # loader and grader: the plugin contracts don't require it, so a
+            # custom plugin need not define it. Built-in graders inherit a
+            # no-op default from ``BaseGrader``; the deepeval-gated benchmark
+            # loaders define it. Treat absence as "no optional deps to verify".
+            benchmark_cls = plugins.get_class(
+                PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
+            )
             grader_cls = plugins.get_class(PluginType.ACCURACY_GRADER, grader_name)
-            # ``check_available`` is an optional hook: the accuracy_grader
-            # contract is ``AccuracyGraderProtocol`` (grade + extract_answer
-            # only), so a custom grader plugin need not define it. Built-in
-            # graders inherit a no-op default from ``BaseGrader``; treat its
-            # absence as "no optional deps to verify".
-            check = getattr(grader_cls, "check_available", None)
-            if callable(check):
-                check()
-        except (TypeNotFoundError, KeyError, RuntimeError) as exc:
+            for cls in (benchmark_cls, grader_cls):
+                check = getattr(cls, "check_available", None)
+                if callable(check):
+                    check()
+        except (
+            TypeNotFoundError,
+            KeyError,
+            ValueError,
+            ImportError,
+            RuntimeError,
+        ) as exc:
             raise ConfigurationError(str(exc)) from exc
 
 

--- a/src/aiperf/cli_runner/_preflight.py
+++ b/src/aiperf/cli_runner/_preflight.py
@@ -111,9 +111,11 @@ def _preflight_accuracy_deps(plan: BenchmarkPlan) -> None:
 
         # Keep every preflight failure on the ConfigurationError path: plugin
         # lookups raise TypeNotFoundError/KeyError/ValueError for an unknown or
-        # malformed benchmark/grader name (ImportError for a broken external
-        # plugin), and check_available raises RuntimeError for a missing
-        # optional dependency. Any of these would otherwise leak a raw traceback.
+        # malformed benchmark/grader name, ImportError for a broken external
+        # plugin module, and AttributeError when the module imports but the
+        # configured class is missing (PluginEntry.load); check_available raises
+        # RuntimeError for a missing optional dependency. Any of these would
+        # otherwise leak a raw traceback.
         try:
             meta = plugins.get_metadata(
                 PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
@@ -145,6 +147,7 @@ def _preflight_accuracy_deps(plan: BenchmarkPlan) -> None:
             KeyError,
             ValueError,
             ImportError,
+            AttributeError,
             RuntimeError,
         ) as exc:
             raise ConfigurationError(str(exc)) from exc

--- a/src/aiperf/cli_utils.py
+++ b/src/aiperf/cli_utils.py
@@ -11,6 +11,7 @@ from contextlib import AbstractContextManager
 
 from rich.align import AlignMethod
 from rich.console import Console, RenderableType
+from rich.markup import escape
 from rich.panel import Panel
 from rich.style import StyleType
 from rich.text import Text
@@ -115,8 +116,14 @@ class exit_on_error(AbstractContextManager):
                 )
                 console.file.flush()
 
+            # Escape the exception text before substituting it into the
+            # markup template: exception messages routinely contain square
+            # brackets (e.g. ``list[str]``, ``uv pip install 'aiperf[accuracy]'``)
+            # that Rich would otherwise parse as style tags and silently drop,
+            # corrupting the message. Any intentional markup in the template
+            # itself is preserved.
             message = (
-                self.message.format(e=exc_value)
+                self.message.format(e=escape(str(exc_value)))
                 if isinstance(self.message, str)
                 else self.message
             )

--- a/tests/unit/cli_runner/test_preflight_accuracy_deps.py
+++ b/tests/unit/cli_runner/test_preflight_accuracy_deps.py
@@ -117,13 +117,17 @@ class TestPreflightAccuracyDeps:
         )
         _preflight_accuracy_deps(_plan(_acc(enabled=True, grader="custom")))
 
-    @pytest.mark.parametrize("exc_type", [KeyError, ValueError, ImportError])
+    @pytest.mark.parametrize(
+        "exc_type", [KeyError, ValueError, ImportError, AttributeError]
+    )
     def test_lookup_errors_become_configuration_error(
         self, monkeypatch, exc_type
     ) -> None:
-        """Unknown/malformed names (TypeNotFoundError/KeyError/ValueError) and
-        broken external plugins (ImportError) must convert to ConfigurationError,
-        not leak a raw traceback."""
+        """Unknown/malformed names (TypeNotFoundError/KeyError/ValueError),
+        broken external plugin modules (ImportError), and a module that imports
+        but is missing its configured class (AttributeError, from
+        PluginEntry.load) must all convert to ConfigurationError, not leak a
+        raw traceback."""
         monkeypatch.setattr(
             "aiperf.plugin.plugins.get_metadata",
             lambda _type, _name: {"default_grader": "g"},

--- a/tests/unit/cli_runner/test_preflight_accuracy_deps.py
+++ b/tests/unit/cli_runner/test_preflight_accuracy_deps.py
@@ -1,24 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Preflight for accuracy grader optional-dependency checks.
+"""Preflight for accuracy benchmark/grader optional-dependency checks.
 
-A grader backed by an optional package (lighteval) used to raise at
-instantiation inside the daemon record-processor: the crash wasn't propagated,
-so the user got a raw multiprocessing traceback and the main process hung. The
-preflight moves that check into the main process, before any service spawns, so
-a missing dependency is a clean ``ConfigurationError`` with a non-zero exit.
+The grader (record-processor daemon) and benchmark loader (dataset-manager)
+both raise at instantiation when their optional package (lighteval / deepeval)
+is missing. The grader crash isn't propagated, so the user got a raw
+multiprocessing traceback and a hung run. The preflight moves both checks into
+the main process, before any service spawns, so a missing dependency is a clean
+``ConfigurationError`` with a non-zero exit.
 """
 
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 
-from aiperf.cli_runner._preflight import _preflight_accuracy_grader_deps
+from aiperf.cli_runner._preflight import _preflight_accuracy_deps
 from aiperf.config.loader.errors import ConfigurationError
+from aiperf.plugin.enums import PluginType
 
 
 def _plan(accuracy: object) -> SimpleNamespace:
@@ -29,8 +30,32 @@ def _acc(enabled: bool, benchmark: str = "math_500", grader: str | None = None):
     return SimpleNamespace(enabled=enabled, benchmark=benchmark, grader=grader)
 
 
-class TestPreflightAccuracyGraderDeps:
-    def test_missing_dep_raises_configuration_error(self, monkeypatch) -> None:
+def _patch_registry(monkeypatch, *, benchmark_cls, grader_cls, default_grader="g"):
+    """Stub the plugin registry: metadata carries default_grader; get_class
+    returns benchmark_cls for ACCURACY_BENCHMARK and grader_cls for ACCURACY_GRADER."""
+    monkeypatch.setattr(
+        "aiperf.plugin.plugins.get_metadata",
+        lambda _type, _name: {"default_grader": default_grader},
+    )
+
+    def _get_class(plugin_type, _name):
+        return (
+            benchmark_cls
+            if plugin_type == PluginType.ACCURACY_BENCHMARK
+            else grader_cls
+        )
+
+    monkeypatch.setattr("aiperf.plugin.plugins.get_class", _get_class)
+
+
+class _Available:
+    @classmethod
+    def check_available(cls) -> None:
+        return None
+
+
+class TestPreflightAccuracyDeps:
+    def test_missing_grader_dep_raises_configuration_error(self, monkeypatch) -> None:
         """A grader whose check_available raises must surface as a clean
         ConfigurationError (not a daemon crash / hang)."""
 
@@ -39,106 +64,150 @@ class TestPreflightAccuracyGraderDeps:
             def check_available(cls) -> None:
                 raise RuntimeError("lighteval is not installed; ... 'aiperf[accuracy]'")
 
-        monkeypatch.setattr(
-            "aiperf.plugin.plugins.get_class",
-            lambda _type, _name: _UnavailableGrader,
+        _patch_registry(
+            monkeypatch, benchmark_cls=_Available, grader_cls=_UnavailableGrader
         )
         with pytest.raises(ConfigurationError, match=r"aiperf\[accuracy\]"):
-            _preflight_accuracy_grader_deps(
+            _preflight_accuracy_deps(
                 _plan(_acc(enabled=True, grader="lighteval_latex"))
             )
 
-    def test_available_grader_does_not_raise(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            "aiperf.plugin.plugins.get_class",
-            lambda _type, _name: MagicMock(check_available=lambda: None),
+    def test_missing_benchmark_loader_dep_raises_configuration_error(
+        self, monkeypatch
+    ) -> None:
+        """A benchmark loader whose check_available raises (e.g. HellaSwag/BigBench
+        without deepeval) must also surface cleanly — its default grader is the
+        dep-free exact_match, so only the loader check catches it."""
+
+        class _UnavailableBenchmark:
+            @classmethod
+            def check_available(cls) -> None:
+                raise RuntimeError("deepeval is not installed; ... 'aiperf[accuracy]'")
+
+        _patch_registry(
+            monkeypatch, benchmark_cls=_UnavailableBenchmark, grader_cls=_Available
         )
-        _preflight_accuracy_grader_deps(_plan(_acc(enabled=True, grader="exact_match")))
+        with pytest.raises(ConfigurationError, match=r"deepeval"):
+            _preflight_accuracy_deps(_plan(_acc(enabled=True, benchmark="hellaswag")))
+
+    def test_available_deps_do_not_raise(self, monkeypatch) -> None:
+        _patch_registry(monkeypatch, benchmark_cls=_Available, grader_cls=_Available)
+        _preflight_accuracy_deps(_plan(_acc(enabled=True, grader="exact_match")))
 
     def test_skips_when_accuracy_disabled(self, monkeypatch) -> None:
-        """Non-accuracy runs must not touch the grader registry at all."""
-        called = False
+        """Non-accuracy runs must not touch the plugin registry at all."""
 
         def _boom(*_a, **_k):
-            nonlocal called
-            called = True
-            raise AssertionError("get_class should not be called")
+            raise AssertionError("registry should not be touched")
 
         monkeypatch.setattr("aiperf.plugin.plugins.get_class", _boom)
-        _preflight_accuracy_grader_deps(_plan(_acc(enabled=False)))
-        _preflight_accuracy_grader_deps(_plan(None))
-        assert called is False
+        monkeypatch.setattr("aiperf.plugin.plugins.get_metadata", _boom)
+        _preflight_accuracy_deps(_plan(_acc(enabled=False)))
+        _preflight_accuracy_deps(_plan(None))
 
-    def test_grader_without_check_available_is_allowed(self, monkeypatch) -> None:
-        """A custom grader satisfying only AccuracyGraderProtocol (no
+    def test_plugin_without_check_available_is_allowed(self, monkeypatch) -> None:
+        """A custom benchmark/grader satisfying only its protocol (no
         check_available) must pass preflight, not raise AttributeError."""
 
-        class _ProtocolOnlyGrader:
-            async def grade(self, response_text, ground_truth, **kwargs): ...
-            def extract_answer(self, response_text, **kwargs): ...
+        class _ProtocolOnly:
+            pass
 
-        monkeypatch.setattr(
-            "aiperf.plugin.plugins.get_class",
-            lambda _type, _name: _ProtocolOnlyGrader,
+        _patch_registry(
+            monkeypatch, benchmark_cls=_ProtocolOnly, grader_cls=_ProtocolOnly
         )
-        # Must not raise (check_available absent → treated as no-op).
-        _preflight_accuracy_grader_deps(_plan(_acc(enabled=True, grader="custom")))
+        _preflight_accuracy_deps(_plan(_acc(enabled=True, grader="custom")))
 
-    def test_unknown_grader_name_raises_configuration_error(self, monkeypatch) -> None:
-        """A bad grader name makes the plugin registry raise TypeNotFoundError;
-        it must be converted to a clean ConfigurationError, not leak a traceback."""
-        from aiperf.plugin.types import TypeNotFoundError
+    @pytest.mark.parametrize("exc_type", [KeyError, ValueError, ImportError])
+    def test_lookup_errors_become_configuration_error(
+        self, monkeypatch, exc_type
+    ) -> None:
+        """Unknown/malformed names (TypeNotFoundError/KeyError/ValueError) and
+        broken external plugins (ImportError) must convert to ConfigurationError,
+        not leak a raw traceback."""
+        monkeypatch.setattr(
+            "aiperf.plugin.plugins.get_metadata",
+            lambda _type, _name: {"default_grader": "g"},
+        )
 
         def _raise(*_a, **_k):
-            raise TypeNotFoundError("accuracy_grader", "nope", ["exact_match"])
+            raise exc_type("boom")
 
         monkeypatch.setattr("aiperf.plugin.plugins.get_class", _raise)
         with pytest.raises(ConfigurationError):
-            _preflight_accuracy_grader_deps(_plan(_acc(enabled=True, grader="nope")))
+            _preflight_accuracy_deps(_plan(_acc(enabled=True, grader="nope")))
 
     def test_resolves_default_grader_from_benchmark_metadata(self, monkeypatch) -> None:
         """When grader is unset, the default_grader from benchmark metadata is
         resolved and checked."""
-        seen: dict[str, str] = {}
+        grader_names: list[str] = []
 
-        def _get_metadata(_type, name):
-            return {"default_grader": "lighteval_latex"}
+        def _get_class(plugin_type, name):
+            if plugin_type == PluginType.ACCURACY_GRADER:
+                grader_names.append(name)
+            return _Available
 
-        def _get_class(_type, name):
-            seen["grader"] = name
-            return MagicMock(check_available=lambda: None)
-
-        monkeypatch.setattr("aiperf.plugin.plugins.get_metadata", _get_metadata)
+        monkeypatch.setattr(
+            "aiperf.plugin.plugins.get_metadata",
+            lambda _type, _name: {"default_grader": "lighteval_latex"},
+        )
         monkeypatch.setattr("aiperf.plugin.plugins.get_class", _get_class)
-        _preflight_accuracy_grader_deps(_plan(_acc(enabled=True, grader=None)))
-        assert seen["grader"] == "lighteval_latex"
+        _preflight_accuracy_deps(_plan(_acc(enabled=True, grader=None)))
+        assert grader_names == ["lighteval_latex"]
+
+    def test_real_accuracy_config_attribute_contract(self) -> None:
+        """Pin the attribute contract against the real AccuracyConfig (not a
+        SimpleNamespace mock): if .enabled/.benchmark/.grader are renamed, this
+        fails loudly here instead of silently no-opping. GSM8K's benchmark and
+        default grader are dependency-free, so a real preflight passes."""
+        from aiperf.config.accuracy import AccuracyConfig
+        from aiperf.plugin.enums import AccuracyBenchmarkType
+
+        acc = AccuracyConfig(benchmark=AccuracyBenchmarkType.GSM8K)
+        # Real registry + real config, no optional deps needed → no raise.
+        _preflight_accuracy_deps(_plan(acc))
 
 
-class TestGraderCheckAvailable:
-    """The grader classes report missing optional deps via check_available."""
+class TestCheckAvailable:
+    """Benchmark loaders and graders report missing optional deps via check_available."""
 
-    def test_code_execution_check_available(self, monkeypatch) -> None:
+    def test_code_execution_grader(self, monkeypatch) -> None:
         import aiperf.accuracy.graders.code_execution as ce
 
         monkeypatch.setattr(ce, "_HAS_LIGHTEVAL_LCB", False)
         with pytest.raises(RuntimeError, match="lighteval is not installed"):
             ce.CodeExecutionGrader.check_available()
-
         monkeypatch.setattr(ce, "_HAS_LIGHTEVAL_LCB", True)
-        ce.CodeExecutionGrader.check_available()  # no raise
+        ce.CodeExecutionGrader.check_available()
 
-    def test_lighteval_grader_check_available(self, monkeypatch) -> None:
+    def test_lighteval_grader(self, monkeypatch) -> None:
         import aiperf.accuracy.graders.lighteval_grader as le
 
         monkeypatch.setattr(le, "_HAS_LIGHTEVAL", False)
         with pytest.raises(RuntimeError, match="lighteval is not installed"):
             le._LightevalBaseGrader.check_available()
-
         monkeypatch.setattr(le, "_HAS_LIGHTEVAL", True)
-        le._LightevalBaseGrader.check_available()  # no raise
+        le._LightevalBaseGrader.check_available()
+
+    def test_hellaswag_benchmark(self, monkeypatch) -> None:
+        import aiperf.accuracy.benchmarks.hellaswag as hs
+
+        monkeypatch.setattr(hs, "_HAS_DEEPEVAL", False)
+        with pytest.raises(RuntimeError, match="deepeval is not installed"):
+            hs.HellaSwagBenchmark.check_available()
+        monkeypatch.setattr(hs, "_HAS_DEEPEVAL", True)
+        hs.HellaSwagBenchmark.check_available()
+
+    def test_bigbench_benchmark(self, monkeypatch) -> None:
+        import aiperf.accuracy.benchmarks.bigbench as bb
+
+        monkeypatch.setattr(bb, "_HAS_DEEPEVAL", False)
+        with pytest.raises(RuntimeError, match="deepeval is not installed"):
+            bb.BigBenchBenchmark.check_available()
+        monkeypatch.setattr(bb, "_HAS_DEEPEVAL", True)
+        bb.BigBenchBenchmark.check_available()
 
     def test_base_grader_check_available_is_noop(self) -> None:
-        """Graders with no optional deps are always available."""
+        """Graders/benchmarks with no optional deps are always available."""
         from aiperf.accuracy.graders.exact_match import ExactMatchGrader
 
-        ExactMatchGrader.check_available()  # no raise
+        ExactMatchGrader.check_available()

--- a/tests/unit/cli_runner/test_preflight_accuracy_deps.py
+++ b/tests/unit/cli_runner/test_preflight_accuracy_deps.py
@@ -69,6 +69,33 @@ class TestPreflightAccuracyGraderDeps:
         _preflight_accuracy_grader_deps(_plan(None))
         assert called is False
 
+    def test_grader_without_check_available_is_allowed(self, monkeypatch) -> None:
+        """A custom grader satisfying only AccuracyGraderProtocol (no
+        check_available) must pass preflight, not raise AttributeError."""
+
+        class _ProtocolOnlyGrader:
+            async def grade(self, response_text, ground_truth, **kwargs): ...
+            def extract_answer(self, response_text, **kwargs): ...
+
+        monkeypatch.setattr(
+            "aiperf.plugin.plugins.get_class",
+            lambda _type, _name: _ProtocolOnlyGrader,
+        )
+        # Must not raise (check_available absent → treated as no-op).
+        _preflight_accuracy_grader_deps(_plan(_acc(enabled=True, grader="custom")))
+
+    def test_unknown_grader_name_raises_configuration_error(self, monkeypatch) -> None:
+        """A bad grader name makes the plugin registry raise TypeNotFoundError;
+        it must be converted to a clean ConfigurationError, not leak a traceback."""
+        from aiperf.plugin.types import TypeNotFoundError
+
+        def _raise(*_a, **_k):
+            raise TypeNotFoundError("accuracy_grader", "nope", ["exact_match"])
+
+        monkeypatch.setattr("aiperf.plugin.plugins.get_class", _raise)
+        with pytest.raises(ConfigurationError):
+            _preflight_accuracy_grader_deps(_plan(_acc(enabled=True, grader="nope")))
+
     def test_resolves_default_grader_from_benchmark_metadata(self, monkeypatch) -> None:
         """When grader is unset, the default_grader from benchmark metadata is
         resolved and checked."""

--- a/tests/unit/cli_runner/test_preflight_accuracy_deps.py
+++ b/tests/unit/cli_runner/test_preflight_accuracy_deps.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preflight for accuracy grader optional-dependency checks.
+
+A grader backed by an optional package (lighteval) used to raise at
+instantiation inside the daemon record-processor: the crash wasn't propagated,
+so the user got a raw multiprocessing traceback and the main process hung. The
+preflight moves that check into the main process, before any service spawns, so
+a missing dependency is a clean ``ConfigurationError`` with a non-zero exit.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiperf.cli_runner._preflight import _preflight_accuracy_grader_deps
+from aiperf.config.loader.errors import ConfigurationError
+
+
+def _plan(accuracy: object) -> SimpleNamespace:
+    return SimpleNamespace(configs=[SimpleNamespace(accuracy=accuracy)])
+
+
+def _acc(enabled: bool, benchmark: str = "math_500", grader: str | None = None):
+    return SimpleNamespace(enabled=enabled, benchmark=benchmark, grader=grader)
+
+
+class TestPreflightAccuracyGraderDeps:
+    def test_missing_dep_raises_configuration_error(self, monkeypatch) -> None:
+        """A grader whose check_available raises must surface as a clean
+        ConfigurationError (not a daemon crash / hang)."""
+
+        class _UnavailableGrader:
+            @classmethod
+            def check_available(cls) -> None:
+                raise RuntimeError("lighteval is not installed; ... 'aiperf[accuracy]'")
+
+        monkeypatch.setattr(
+            "aiperf.plugin.plugins.get_class",
+            lambda _type, _name: _UnavailableGrader,
+        )
+        with pytest.raises(ConfigurationError, match=r"aiperf\[accuracy\]"):
+            _preflight_accuracy_grader_deps(
+                _plan(_acc(enabled=True, grader="lighteval_latex"))
+            )
+
+    def test_available_grader_does_not_raise(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "aiperf.plugin.plugins.get_class",
+            lambda _type, _name: MagicMock(check_available=lambda: None),
+        )
+        _preflight_accuracy_grader_deps(_plan(_acc(enabled=True, grader="exact_match")))
+
+    def test_skips_when_accuracy_disabled(self, monkeypatch) -> None:
+        """Non-accuracy runs must not touch the grader registry at all."""
+        called = False
+
+        def _boom(*_a, **_k):
+            nonlocal called
+            called = True
+            raise AssertionError("get_class should not be called")
+
+        monkeypatch.setattr("aiperf.plugin.plugins.get_class", _boom)
+        _preflight_accuracy_grader_deps(_plan(_acc(enabled=False)))
+        _preflight_accuracy_grader_deps(_plan(None))
+        assert called is False
+
+    def test_resolves_default_grader_from_benchmark_metadata(self, monkeypatch) -> None:
+        """When grader is unset, the default_grader from benchmark metadata is
+        resolved and checked."""
+        seen: dict[str, str] = {}
+
+        def _get_metadata(_type, name):
+            return {"default_grader": "lighteval_latex"}
+
+        def _get_class(_type, name):
+            seen["grader"] = name
+            return MagicMock(check_available=lambda: None)
+
+        monkeypatch.setattr("aiperf.plugin.plugins.get_metadata", _get_metadata)
+        monkeypatch.setattr("aiperf.plugin.plugins.get_class", _get_class)
+        _preflight_accuracy_grader_deps(_plan(_acc(enabled=True, grader=None)))
+        assert seen["grader"] == "lighteval_latex"
+
+
+class TestGraderCheckAvailable:
+    """The grader classes report missing optional deps via check_available."""
+
+    def test_code_execution_check_available(self, monkeypatch) -> None:
+        import aiperf.accuracy.graders.code_execution as ce
+
+        monkeypatch.setattr(ce, "_HAS_LIGHTEVAL_LCB", False)
+        with pytest.raises(RuntimeError, match="lighteval is not installed"):
+            ce.CodeExecutionGrader.check_available()
+
+        monkeypatch.setattr(ce, "_HAS_LIGHTEVAL_LCB", True)
+        ce.CodeExecutionGrader.check_available()  # no raise
+
+    def test_lighteval_grader_check_available(self, monkeypatch) -> None:
+        import aiperf.accuracy.graders.lighteval_grader as le
+
+        monkeypatch.setattr(le, "_HAS_LIGHTEVAL", False)
+        with pytest.raises(RuntimeError, match="lighteval is not installed"):
+            le._LightevalBaseGrader.check_available()
+
+        monkeypatch.setattr(le, "_HAS_LIGHTEVAL", True)
+        le._LightevalBaseGrader.check_available()  # no raise
+
+    def test_base_grader_check_available_is_noop(self) -> None:
+        """Graders with no optional deps are always available."""
+        from aiperf.accuracy.graders.exact_match import ExactMatchGrader
+
+        ExactMatchGrader.check_available()  # no raise

--- a/tests/unit/test_cli_utils_escape.py
+++ b/tests/unit/test_cli_utils_escape.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``exit_on_error`` must not let Rich eat square brackets in exception text.
+
+Exception messages routinely contain brackets — ``list[str]``,
+``uv pip install 'aiperf[accuracy]'`` — which Rich parses as style tags and
+silently drops when a raw string is rendered in a Panel. That corrupted the
+missing-lighteval hint (``'aiperf[accuracy]'`` → ``'aiperf'``). The fix escapes
+the exception text before substitution; this test pins it.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+import aiperf.cli_utils as cli_utils
+from aiperf.cli_utils import exit_on_error
+
+
+def test_exit_on_error_preserves_bracketed_exception_text(monkeypatch) -> None:
+    buffer = io.StringIO()
+    # force_terminal=False keeps output plain; the point is the literal text,
+    # not styling.
+    monkeypatch.setattr(
+        cli_utils, "console", Console(file=buffer, force_terminal=False, width=200)
+    )
+
+    with (
+        pytest.raises(SystemExit) as exc_info,
+        exit_on_error(RuntimeError, message="{e}", title="Error", show_traceback=False),
+    ):
+        raise RuntimeError("Install with: uv pip install 'aiperf[accuracy]'.")
+
+    assert exc_info.value.code == 1
+    output = buffer.getvalue()
+    # The bracketed extra must survive verbatim — not be stripped to 'aiperf'.
+    assert "aiperf[accuracy]" in output


### PR DESCRIPTION
## Summary
Running an accuracy benchmark that needs `lighteval` without it installed produced a **raw multiprocessing stack trace** and then **hung the main process forever** (exit never happened).

**Root cause:** aiperf spawns services as daemon processes. The grader's dependency check (`_require_lighteval` / `_HAS_LIGHTEVAL_LCB`) runs at grader init *inside the record-processor daemon child*. When it raises: (1) the crash is an uncaught child-process exception, so Python prints the raw traceback instead of aiperf's clean error panel; and (2) the crash isn't propagated to the controller, so the main process blocks waiting for graded records that never arrive.

## Fix
Check the optional dependency **in the main process, before any service spawns**:
- Add `BaseGrader.check_available()` — no-op by default; the lighteval-backed graders (`lighteval_*`, `code_execution`) override it to raise a clear "install `aiperf[accuracy]`" message.
- Add a `_preflight_accuracy_grader_deps` step (alongside the existing artifact-dir / fd-limit / endpoint preflights) that resolves the selected grader and calls `check_available()`, converting a missing dep into a clean `ConfigurationError` → single error panel, non-zero exit, no services spawned, no hang.

## Second bug found & fixed
Routing the message through the Rich error panel exposed a latent bug: `cli_utils` substituted raw exception text into a markup string, so Rich parsed `[accuracy]` as a style tag and **silently dropped it** (`'aiperf[accuracy]'` → `'aiperf'`, telling users to install the wrong thing). Fixed by escaping exception text before rendering — benefits any bracketed message (`list[str]`, etc.).

## Verification (mock server, lighteval uninstalled)
| | before | after |
|---|---|---|
| output | raw multiprocessing traceback | clean error panel |
| message | (n/a) | `uv pip install 'aiperf[accuracy]'` (intact) |
| exit code | hangs forever | 1 |
| services spawned | yes, then hang | 0 (fails at preflight) |

## Tests (8, all pass; no regressions in cli_runner/accuracy suites)
- preflight: raises `ConfigurationError` on missing dep, no-op when available, skips when accuracy disabled, resolves default grader from benchmark metadata
- `check_available` per grader (code_execution, lighteval base, no-op base)
- regression test pinning the bracket-escaping fix

## Scope note
The broader gap — any background service crash can leave the main process hanging — is a larger architectural fix and is intentionally out of scope; this PR fails fast for the known missing-dependency case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy preflight to validate optional accuracy benchmark/grader dependencies early, surfacing missing extras as clean configuration errors.
  * Standardized optional-dependency checks across accuracy graders/benchmarks via a unified `check_available()` hook.
  * Fixed CLI error-panel rendering by escaping exception text so bracket characters (e.g., `aiperf[accuracy]`) display literally.
* **Tests**
  * Added unit tests for accuracy preflight dependency handling, default grader resolution, and escaped error-message output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->