### PR TITLE
fix(accuracy): allow LCB grader to spawn from daemon record processor (cherry-pick to release/0.11.0)

### DIFF
--- a/src/aiperf/accuracy/accuracy_record_processor.py
+++ b/src/aiperf/accuracy/accuracy_record_processor.py
@@ -54,6 +54,7 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
         grader_cls = plugins.get_class(PluginType.ACCURACY_GRADER, grader_name)
         self.grader: BaseGrader = grader_cls(run=run)
 
+        self._verbose = acc_cfg.verbose
         self._ground_truths: list[str] | None = None
 
     def on_dataset_configured(self, metadata: DatasetMetadata) -> None:
@@ -98,7 +99,42 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
         record_metrics["accuracy.correct"] = 1.0 if result.correct else 0.0
         record_metrics["accuracy.unparsed"] = 1.0 if result.unparsed else 0.0
 
+        self._log_grading_detail(metadata.session_num, response_text, result)
+
         return record_metrics
+
+    def _log_grading_detail(
+        self, session_num: int, response_text: str, result: GradingResult
+    ) -> None:
+        """Surface per-problem grading diagnostics.
+
+        Every grader fills in ``reasoning`` (why a response was graded
+        correct/unparsed) and ``extracted_answer``, but only ``correct`` and
+        ``unparsed`` reach the metrics. Without this, a run reporting 100%
+        unparsed gives no clue whether the response was empty, the answer
+        format didn't match, or grading raised an exception (e.g. LCB's
+        sandboxed execution failing to fork from the daemon record processor).
+
+        Emits at info level under ``--accuracy-verbose`` (the flag's
+        documented "per-problem grading details") and always at debug, so the
+        reason is recoverable from logs without re-running.
+        """
+        if not self._verbose and not self.is_debug_enabled:
+            return
+
+        def _detail() -> str:
+            preview = response_text.strip().replace("\n", "\\n")[:200]
+            return (
+                f"[accuracy] session={session_num} correct={result.correct} "
+                f"unparsed={result.unparsed} reason={result.reasoning!r} "
+                f"extracted={result.extracted_answer[:120]!r} "
+                f"response_len={len(response_text)} response_preview={preview!r}"
+            )
+
+        if self._verbose:
+            self.info(_detail)
+        else:
+            self.debug(_detail)
 
     @staticmethod
     def _extract_response_text(record: ParsedResponseRecord) -> str:

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -40,6 +40,7 @@ import orjson
 
 from aiperf.accuracy.graders.base import BaseGrader
 from aiperf.accuracy.models import GradingResult
+from aiperf.common.utils import allow_daemon_children
 
 if TYPE_CHECKING:
     from aiperf.config.resolution.plan import BenchmarkRun
@@ -145,11 +146,7 @@ class CodeExecutionGrader(BaseGrader):
             # thread keeps the event loop free for other concurrent
             # grade() calls during a benchmark run.
             metrics, _ = await asyncio.to_thread(
-                codegen_metrics,
-                evaluation_sample,
-                generated_code,
-                k_list=list(_LCB_PASS_AT_K),
-                num_process_evaluate=_LCB_NUM_PROCESSES,
+                _run_codegen_metrics, evaluation_sample, generated_code
             )
         except Exception as exc:  # noqa: BLE001
             _log.debug("lighteval codegen_metrics raised: %s", exc, exc_info=True)
@@ -174,6 +171,33 @@ class CodeExecutionGrader(BaseGrader):
             ),
             extracted_answer=snippet,
             ground_truth="<lcb test cases>",
+        )
+
+
+def _run_codegen_metrics(
+    evaluation_sample: list[dict[str, str]], generated_code: list[list[str]]
+) -> tuple[dict[str, Any], Any]:
+    """Run lighteval's ``codegen_metrics`` with the daemon flag cleared.
+
+    ``codegen_metrics`` fans out to a ProcessPoolExecutor. AIPerf runs the
+    record processor as a daemon (every service is spawned with
+    ``daemon=True``), and Python forbids daemons from spawning child
+    processes, so the flag must be cleared for the duration of the fork or
+    grading dies with "daemonic processes are not allowed to have children"
+    — silently mislabeled as unparsed.
+
+    TODO: This flag-flipping is a pragmatic workaround. The cleaner design is
+    to own the sandboxed-execution pool outside the daemon (e.g. a non-daemon
+    executor service the record processor delegates to) so no daemon state is
+    mutated. Revisit if sandboxed grading needs to scale beyond a single
+    per-record pool.
+    """
+    with allow_daemon_children():
+        return codegen_metrics(
+            evaluation_sample,
+            generated_code,
+            k_list=list(_LCB_PASS_AT_K),
+            num_process_evaluate=_LCB_NUM_PROCESSES,
         )
 
 

--- a/src/aiperf/common/utils.py
+++ b/src/aiperf/common/utils.py
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import inspect
+import multiprocessing as mp
 import os
 import sys
+import threading
 import types
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
 from typing import Any
 
 import orjson
@@ -142,6 +145,62 @@ def compute_time_ns(
     if perf_ns < start_perf_ns:
         raise ValueError(f"perf_ns {perf_ns} is before start_perf_ns {start_perf_ns}")
     return start_time_ns + (perf_ns - start_perf_ns)
+
+
+def _set_daemon(daemon: bool) -> None:
+    """Set the daemon flag on the current process."""
+    try:
+        mp.current_process().daemon = daemon
+    except AssertionError:
+        # Fallback to the internal _config dict when assertions are enabled.
+        mp.current_process()._config["daemon"] = daemon
+
+
+# Reentrancy/thread-safety for allow_daemon_children: the daemon flag is
+# process-global, but callers may enter concurrently — e.g. LCB grading pushes
+# codegen_metrics to asyncio.to_thread so multiple grade() calls fan out at
+# once. A naive clear/restore lets one caller restore daemon=True while another
+# is still spawning workers, intermittently reintroducing the very
+# "daemonic processes are not allowed to have children" crash. A lock-protected
+# depth counter clears on the first entry and restores only when the last
+# concurrent caller exits.
+_daemon_override_lock = threading.Lock()
+_daemon_override_depth = 0
+_daemon_override_was_daemon = False
+
+
+@contextmanager
+def allow_daemon_children() -> Iterator[None]:
+    """Temporarily clear the current process's daemon flag (reentrant, thread-safe).
+
+    Python's multiprocessing refuses to spawn children from daemon
+    processes, and AIPerf services run as daemons (see
+    ``multiprocess_service_manager.py``: every service is spawned with
+    ``daemon=True``). Any code that fans out with ``ProcessPoolExecutor``
+    or ``multiprocessing.Pool`` from inside a service must run under this
+    context, or it raises ``AssertionError: daemonic processes are not
+    allowed to have children``.
+
+    Safe under concurrent/nested use within a process: the flag is cleared
+    while any caller is active and restored to its original value only when the
+    outermost/last caller exits. The lock is held only around the flag
+    mutation, not during the wrapped work, so concurrent pools still run in
+    parallel.
+    """
+    global _daemon_override_depth, _daemon_override_was_daemon
+    with _daemon_override_lock:
+        if _daemon_override_depth == 0:
+            _daemon_override_was_daemon = mp.current_process().daemon
+            if _daemon_override_was_daemon:
+                _set_daemon(False)
+        _daemon_override_depth += 1
+    try:
+        yield
+    finally:
+        with _daemon_override_lock:
+            _daemon_override_depth -= 1
+            if _daemon_override_depth == 0 and _daemon_override_was_daemon:
+                _set_daemon(True)
 
 
 # This is used to identify the source file of the call_all_functions function

--- a/src/aiperf/dataset/generator/parallel_decode.py
+++ b/src/aiperf/dataset/generator/parallel_decode.py
@@ -17,6 +17,8 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING
 
+from aiperf.common.utils import allow_daemon_children
+
 if TYPE_CHECKING:
     from aiperf.common.tokenizer import Tokenizer
 
@@ -123,8 +125,8 @@ def parallel_decode(
 
     num_workers = max_workers or min(mp.cpu_count() or 4, 8)
 
-    # Temporarily clear the daemon flag so ProcessPoolExecutor can spawn workers.
-    # Python's multiprocessing refuses to spawn children from daemon processes,
+    # ``allow_daemon_children`` clears the daemon flag so ProcessPoolExecutor
+    # can spawn workers: Python refuses to spawn children from daemon processes,
     # and AIPerf services run as daemons.
     #
     # Alternatives considered:
@@ -132,29 +134,16 @@ def parallel_decode(
     #   BrokenProcessPool on macOS due to terminal FD inheritance issues.
     # - loky: robust reusable executor, but still requires the same daemon flag
     #   hack, so no advantage over stdlib.
-    was_daemon = mp.current_process().daemon
-    try:
-        if was_daemon:
-            _set_daemon(False)
-        with ProcessPoolExecutor(
+    with (
+        allow_daemon_children(),
+        ProcessPoolExecutor(
             max_workers=num_workers,
             initializer=_init_worker,
             initargs=(tokenizer_name, trust_remote_code, revision),
-        ) as executor:
-            results = list(
-                executor.map(_decode_tokens, token_sequences, chunksize=chunksize)
-            )
-    finally:
-        if was_daemon:
-            _set_daemon(True)
+        ) as executor,
+    ):
+        results = list(
+            executor.map(_decode_tokens, token_sequences, chunksize=chunksize)
+        )
 
     return results
-
-
-def _set_daemon(daemon: bool) -> None:
-    """Set the daemon flag on the current process."""
-    try:
-        mp.current_process().daemon = daemon
-    except AssertionError:
-        # Fallback to using the internal _config dictionary if assertions are enabled
-        mp.current_process()._config["daemon"] = daemon

--- a/tests/component_integration/test_code_execution_daemon_grading.py
+++ b/tests/component_integration/test_code_execution_daemon_grading.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guards the daemon-fork path for LCB code-execution grading.
+
+AIPerf spawns every service as a daemon process
+(``multiprocess_service_manager.py``: ``daemon=True``). The LCB
+``code_execution`` grader runs lighteval's ``codegen_metrics``, which fans out
+to a ``ProcessPoolExecutor`` — and Python forbids daemon processes from
+spawning children. Unit tests mock ``codegen_metrics``, so they never hit the
+fork restriction; that gap let LCB grading ship 100%-``unparsed`` (the daemon
+error was caught and mislabeled).
+
+These tests close that gap by exercising the real thing: spawning a
+``ProcessPoolExecutor`` from inside a genuine daemon process. The negative case
+pins *why* the workaround is needed (without it the spawn raises); the positive
+case proves ``allow_daemon_children`` lets grading fan out.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from concurrent.futures import ProcessPoolExecutor
+
+import pytest
+
+pytestmark = pytest.mark.component_integration
+
+
+def _double(x: int) -> int:
+    return x * 2
+
+
+def _pool_without_guard(queue: mp.Queue) -> None:
+    """Run a ProcessPoolExecutor with no daemon workaround (mirrors the
+    pre-fix grader). Reports the outcome back over ``queue``."""
+    try:
+        with ProcessPoolExecutor(max_workers=1) as executor:
+            list(executor.map(_double, [1, 2, 3]))
+        queue.put(("ok", None))
+    except Exception as exc:  # noqa: BLE001
+        queue.put(("error", repr(exc)))
+
+
+def _pool_with_guard(queue: mp.Queue) -> None:
+    """Run the same fan-out under ``allow_daemon_children`` (mirrors the fix)."""
+    from aiperf.common.utils import allow_daemon_children
+
+    try:
+        with allow_daemon_children(), ProcessPoolExecutor(max_workers=1) as executor:
+            result = list(executor.map(_double, [1, 2, 3]))
+        queue.put(("ok", result))
+    except Exception as exc:  # noqa: BLE001
+        queue.put(("error", repr(exc)))
+
+
+def _run_in_daemon(target) -> tuple[str, object]:
+    """Run ``target(queue)`` inside a real daemon process and return its report.
+
+    Uses the default start method so this matches how AIPerf actually spawns
+    services on each platform (spawn on macOS/Windows, fork on Linux).
+    """
+    ctx = mp.get_context()
+    queue: mp.Queue = ctx.Queue()
+    proc = ctx.Process(target=target, args=(queue,), daemon=True)
+    proc.start()
+    try:
+        status, payload = queue.get(timeout=120)
+    finally:
+        proc.join(timeout=30)
+    return status, payload
+
+
+@pytest.mark.slow
+class TestDaemonProcessPoolSpawn:
+    def test_daemon_cannot_spawn_pool_without_guard(self) -> None:
+        """Pins the restriction the fix exists for: a daemon process spawning a
+        ProcessPoolExecutor raises 'daemonic processes are not allowed to have
+        children'. This is the failure the LCB grader hit."""
+        status, payload = _run_in_daemon(_pool_without_guard)
+        assert status == "error", f"expected daemon spawn to fail, got: {payload}"
+        assert "daemonic processes are not allowed to have children" in str(payload)
+
+    def test_daemon_can_spawn_pool_with_guard(self) -> None:
+        """``allow_daemon_children`` lets the same daemon process fan out — the
+        exact path LCB grading relies on."""
+        status, payload = _run_in_daemon(_pool_with_guard)
+        assert status == "ok", f"expected daemon spawn to succeed, got: {payload}"
+        assert payload == [2, 4, 6]

--- a/tests/unit/accuracy/test_accuracy_record_processor.py
+++ b/tests/unit/accuracy/test_accuracy_record_processor.py
@@ -188,6 +188,62 @@ class TestAccuracyRecordProcessorSessionBounds:
             await processor.process_record(sample_parsed_record, metadata)
 
 
+class TestLogGradingDetail:
+    """``_log_grading_detail`` surfaces the grader's reasoning/extracted answer
+    that otherwise never reaches metrics — the diagnostic that turns a
+    "100% unparsed" report from a guess into a one-line answer."""
+
+    def _result(self) -> GradingResult:
+        return GradingResult(
+            correct=False,
+            unparsed=True,
+            confidence=0.0,
+            reasoning="LCB grader failed: sandboxed exec failed: daemonic ...",
+            extracted_answer="```python\nprint(1)\n```",
+            ground_truth="<lcb test cases>",
+        )
+
+    def test_verbose_logs_reason_at_info(self, monkeypatch) -> None:
+        processor = _make_processor(monkeypatch)
+        processor._verbose = True
+        logged: list[str] = []
+        monkeypatch.setattr(
+            processor, "info", lambda m: logged.append(m() if callable(m) else m)
+        )
+        processor._log_grading_detail(0, "some response", self._result())
+        assert len(logged) == 1
+        assert "sandboxed exec failed" in logged[0]
+        assert "unparsed=True" in logged[0]
+
+    def test_non_verbose_debug_disabled_is_noop(self, monkeypatch) -> None:
+        """No verbose flag and debug off → skip entirely (no info, no debug)."""
+        processor = _make_processor(monkeypatch)
+        processor._verbose = False
+        monkeypatch.setattr(
+            type(processor), "is_debug_enabled", property(lambda _s: False)
+        )
+        info_calls, debug_calls = [], []
+        monkeypatch.setattr(processor, "info", lambda m: info_calls.append(m))
+        monkeypatch.setattr(processor, "debug", lambda m: debug_calls.append(m))
+        processor._log_grading_detail(0, "some response", self._result())
+        assert info_calls == []
+        assert debug_calls == []
+
+    def test_non_verbose_debug_enabled_logs_at_debug(self, monkeypatch) -> None:
+        processor = _make_processor(monkeypatch)
+        processor._verbose = False
+        monkeypatch.setattr(
+            type(processor), "is_debug_enabled", property(lambda _s: True)
+        )
+        logged: list[str] = []
+        monkeypatch.setattr(
+            processor, "debug", lambda m: logged.append(m() if callable(m) else m)
+        )
+        processor._log_grading_detail(0, "some response", self._result())
+        assert len(logged) == 1
+        assert "sandboxed exec failed" in logged[0]
+
+
 class TestAccuracyResultsProcessorOnDatasetConfigured:
     def test_populates_tasks_from_metadata(self) -> None:
         processor = _make_results_processor()

--- a/tests/unit/accuracy/test_code_execution_grader.py
+++ b/tests/unit/accuracy/test_code_execution_grader.py
@@ -3,25 +3,30 @@
 
 """Targeted unit tests for ``code_execution`` grader internals.
 
-The full sandboxed grading path (``CodeExecutionGrader.grade``) needs
-``lighteval``'s ``codegen_metrics`` plus a ``ProcessPoolExecutor``, so
-end-to-end grading is exercised in the component_integration suite.
-These tests cover the in-process helpers that don't need a sandbox:
-``_decode_private_test_cases``, which translates LCB's upstream-encoded
-``private_test_cases`` blob (base64 → zlib → pickle → json) into the
-list of ``{"input", "output"}`` dicts ``codegen_metrics`` expects.
+Covers the in-process helpers that don't need a real sandbox
+(``_decode_private_test_cases``, which translates LCB's upstream-encoded
+``private_test_cases`` blob: base64 → zlib → pickle → json) plus the
+daemon-flag handling in ``grade`` (with ``codegen_metrics`` mocked).
+
+The real daemon-fork path — spawning a ``ProcessPoolExecutor`` from a
+daemon process, which is what actually broke LCB grading — is guarded in
+``tests/component_integration/test_code_execution_daemon_grading.py``.
 """
 
 from __future__ import annotations
 
 import base64
+import multiprocessing as mp
 import pickle
 import zlib
+from unittest.mock import MagicMock
 
 import orjson
 import pytest
 
+import aiperf.accuracy.graders.code_execution as code_execution
 from aiperf.accuracy.graders.code_execution import (
+    CodeExecutionGrader,
     _decode_private_test_cases,
 )
 
@@ -87,3 +92,76 @@ class TestDecodePrivateTestCases:
         assert _decode_private_test_cases(None) == []
         assert _decode_private_test_cases("") == []
         assert _decode_private_test_cases([]) == []
+
+
+@pytest.mark.asyncio
+class TestGradeClearsDaemonFlag:
+    """Regression: AIPerf runs the record processor as a daemon (every service
+    is spawned ``daemon=True``). ``codegen_metrics`` fans out to a
+    ProcessPoolExecutor, which Python forbids from a daemon process. Before the
+    fix, grading died with "daemonic processes are not allowed to have children"
+    and was silently mislabeled ``unparsed``. ``grade`` must clear the daemon
+    flag around the ``codegen_metrics`` call.
+    """
+
+    def _set_daemon(self, value: bool) -> None:
+        try:
+            mp.current_process().daemon = value
+        except AssertionError:
+            mp.current_process()._config["daemon"] = value
+
+    async def test_codegen_metrics_runs_with_daemon_cleared(self, monkeypatch) -> None:
+        # Record the daemon flag as seen from inside codegen_metrics.
+        seen: dict[str, bool] = {}
+
+        def fake_codegen_metrics(*_args, **_kwargs):
+            seen["daemon"] = mp.current_process().daemon
+            return {"pass@1": 1.0}, {}
+
+        monkeypatch.setattr(code_execution, "_HAS_LIGHTEVAL_LCB", True)
+        monkeypatch.setattr(code_execution, "codegen_metrics", fake_codegen_metrics)
+        monkeypatch.setattr(code_execution, "extract_code", lambda _text: "print(1)")
+
+        grader = CodeExecutionGrader(run=MagicMock())
+        payload = orjson.dumps(
+            {"public_test_cases": [{"input": "1", "output": "1"}], "metadata": ""}
+        ).decode()
+
+        original = mp.current_process().daemon
+        try:
+            self._set_daemon(True)
+            result = await grader.grade("```python\nprint(1)\n```", payload)
+        finally:
+            self._set_daemon(original)
+
+        # codegen_metrics saw a non-daemon process (the fix), and the daemon
+        # flag was restored afterward.
+        assert seen["daemon"] is False
+        assert mp.current_process().daemon == original
+        # Grading ran to completion instead of being mislabeled unparsed.
+        assert result.unparsed is False
+        assert result.correct is True
+
+    async def test_codegen_metrics_exception_becomes_grading_failure(
+        self, monkeypatch
+    ) -> None:
+        """If sandboxed execution raises (e.g. the daemon-fork error), grade()
+        must return a clean failure result — not propagate and crash the
+        record processor."""
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("daemonic processes are not allowed to have children")
+
+        monkeypatch.setattr(code_execution, "_HAS_LIGHTEVAL_LCB", True)
+        monkeypatch.setattr(code_execution, "codegen_metrics", _boom)
+        monkeypatch.setattr(code_execution, "extract_code", lambda _text: "print(1)")
+
+        grader = CodeExecutionGrader(run=MagicMock())
+        payload = orjson.dumps(
+            {"public_test_cases": [{"input": "1", "output": "1"}], "metadata": ""}
+        ).decode()
+
+        result = await grader.grade("```python\nprint(1)\n```", payload)
+        assert result.correct is False
+        assert result.unparsed is True
+        assert "sandboxed exec failed" in result.reasoning

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -1,15 +1,150 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import multiprocessing as mp
+import threading
+
 import orjson
 import pytest
 
 from aiperf.common.exceptions import AIPerfMultiError
 from aiperf.common.utils import (
+    _set_daemon,
+    allow_daemon_children,
     call_all_functions,
     call_all_functions_self,
     load_json_str,
 )
+
+
+class TestAllowDaemonChildren:
+    """``allow_daemon_children`` clears the current process's daemon flag so
+    daemon services (every AIPerf service is spawned ``daemon=True``) can fan
+    out to ProcessPoolExecutor / multiprocessing.Pool.
+    """
+
+    def _set_daemon(self, value: bool) -> None:
+        try:
+            mp.current_process().daemon = value
+        except AssertionError:
+            mp.current_process()._config["daemon"] = value
+
+    def test_clears_daemon_flag_inside_context(self) -> None:
+        original = mp.current_process().daemon
+        try:
+            self._set_daemon(True)
+            with allow_daemon_children():
+                assert mp.current_process().daemon is False
+        finally:
+            self._set_daemon(original)
+
+    def test_restores_daemon_flag_on_exit(self) -> None:
+        original = mp.current_process().daemon
+        try:
+            self._set_daemon(True)
+            with allow_daemon_children():
+                pass
+            assert mp.current_process().daemon is True
+        finally:
+            self._set_daemon(original)
+
+    def test_restores_daemon_flag_on_exception(self) -> None:
+        original = mp.current_process().daemon
+        try:
+            self._set_daemon(True)
+            with pytest.raises(RuntimeError), allow_daemon_children():
+                raise RuntimeError("boom")
+            assert mp.current_process().daemon is True
+        finally:
+            self._set_daemon(original)
+
+    def test_noop_when_not_daemon(self) -> None:
+        original = mp.current_process().daemon
+        try:
+            self._set_daemon(False)
+            with allow_daemon_children():
+                assert mp.current_process().daemon is False
+            assert mp.current_process().daemon is False
+        finally:
+            self._set_daemon(original)
+
+    def test_reentrant_nested_use_restores_only_at_outermost_exit(self) -> None:
+        """Nested entries must keep the flag cleared until the outermost exits,
+        so an inner block completing doesn't restore daemon=True while the outer
+        one still needs it cleared."""
+        original = mp.current_process().daemon
+        try:
+            self._set_daemon(True)
+            with allow_daemon_children():
+                with allow_daemon_children():
+                    assert mp.current_process().daemon is False
+                # inner exited, but outer is still active → stay cleared
+                assert mp.current_process().daemon is False
+            # outermost exited → restored
+            assert mp.current_process().daemon is True
+        finally:
+            self._set_daemon(original)
+
+    def test_concurrent_threads_keep_flag_cleared_until_all_exit(self) -> None:
+        """Under concurrent use (the LCB asyncio.to_thread grading pattern), the
+        flag must remain cleared while ANY thread is inside the context — an
+        early-finishing thread must not restore daemon=True under the others."""
+        original = mp.current_process().daemon
+        entered = threading.Barrier(3)  # 2 workers + main
+        release = threading.Event()
+        observed: list[bool] = []
+
+        def worker() -> None:
+            with allow_daemon_children():
+                entered.wait(timeout=5)
+                release.wait(timeout=5)
+                observed.append(mp.current_process().daemon)
+
+        try:
+            self._set_daemon(True)
+            threads = [threading.Thread(target=worker) for _ in range(2)]
+            for t in threads:
+                t.start()
+            entered.wait(timeout=5)  # both workers are inside the context
+            # While both are active, the flag must be cleared.
+            assert mp.current_process().daemon is False
+            release.set()
+            for t in threads:
+                t.join(timeout=5)
+            # Every worker saw a cleared flag; none clobbered it early.
+            assert observed == [False, False]
+            # All exited → restored.
+            assert mp.current_process().daemon is True
+        finally:
+            self._set_daemon(original)
+
+
+class TestSetDaemon:
+    """``_set_daemon`` sets the flag via the public property, falling back to
+    the internal ``_config`` dict when the property setter raises (Python
+    asserts non-daemon parents)."""
+
+    def test_uses_property(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        mock_proc = MagicMock()
+        mock_proc.daemon = True
+        with patch("aiperf.common.utils.mp.current_process", return_value=mock_proc):
+            _set_daemon(False)
+        assert mock_proc.daemon is False
+
+    def test_falls_back_to_config_on_assertion_error(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        mock_proc = MagicMock()
+        type(mock_proc).daemon = property(
+            fget=lambda self: self._config.get("daemon"),
+            fset=MagicMock(side_effect=AssertionError),
+        )
+        mock_proc._config = {"daemon": True}
+        with patch("aiperf.common.utils.mp.current_process", return_value=mock_proc):
+            _set_daemon(False)
+        assert mock_proc._config["daemon"] is False
 
 
 class TestLoadJsonStrErrors:

--- a/tests/unit/dataset/generator/test_parallel_decode.py
+++ b/tests/unit/dataset/generator/test_parallel_decode.py
@@ -5,11 +5,12 @@
 
 import importlib
 import os
-from unittest.mock import MagicMock, call, patch
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aiperf.dataset.generator.parallel_decode import _set_daemon, parallel_decode
+from aiperf.dataset.generator.parallel_decode import parallel_decode
 
 # Import the module directly (not through __init__.py which exports the function)
 pd_module = importlib.import_module("aiperf.dataset.generator.parallel_decode")
@@ -99,92 +100,70 @@ class TestParallelDecode:
         assert call_kwargs["max_workers"] == 8
 
 
-class TestSetDaemon:
-    """Test suite for _set_daemon helper."""
-
-    def test_set_daemon_uses_property(self):
-        """_set_daemon sets daemon via the public property when possible."""
-        mock_proc = MagicMock()
-        mock_proc.daemon = True
-        with patch.object(pd_module.mp, "current_process", return_value=mock_proc):
-            _set_daemon(False)
-        assert mock_proc.daemon is False
-
-    def test_set_daemon_falls_back_to_config_on_assertion_error(self):
-        """_set_daemon falls back to _config when property raises AssertionError."""
-        mock_proc = MagicMock()
-        type(mock_proc).daemon = property(
-            fget=lambda self: self._config.get("daemon"),
-            fset=MagicMock(side_effect=AssertionError),
-        )
-        mock_proc._config = {"daemon": True}
-        with patch.object(pd_module.mp, "current_process", return_value=mock_proc):
-            _set_daemon(False)
-        assert mock_proc._config["daemon"] is False
-
-
 class TestParallelDecodeDaemonFlag:
-    """Test that parallel_decode properly manages the daemon flag."""
+    """parallel_decode delegates daemon-flag management to the shared
+    ``allow_daemon_children`` context manager (the daemon clear/restore
+    behavior itself is covered in ``tests/unit/common/test_utils.py``).
+    """
 
     @patch.object(pd_module, "ProcessPoolExecutor")
-    def test_daemon_flag_cleared_before_executor_and_restored_after(
-        self, mock_executor_class
-    ):
-        """Daemon flag is cleared before spawning and restored after."""
+    def test_runs_executor_inside_allow_daemon_children(self, mock_executor_class):
+        """The ProcessPoolExecutor is created inside the allow_daemon_children
+        context, so worker spawning happens with the daemon flag cleared."""
         mock_executor = MagicMock()
         mock_executor.__enter__ = MagicMock(return_value=mock_executor)
         mock_executor.__exit__ = MagicMock(return_value=False)
         mock_executor.map.return_value = ["decoded"] * 15
         mock_executor_class.return_value = mock_executor
 
-        mock_process = MagicMock()
-        mock_process.daemon = True
-        with (
-            patch.object(pd_module.mp, "current_process", return_value=mock_process),
-            patch.object(pd_module, "_set_daemon") as mock_set,
-        ):
+        order: list[str] = []
+
+        @contextmanager
+        def tracking_cm():
+            order.append("enter")
+            try:
+                yield
+            finally:
+                order.append("exit")
+
+        def record_executor(*_args, **_kwargs):
+            order.append("executor")
+            return mock_executor
+
+        mock_executor_class.side_effect = record_executor
+
+        with patch.object(pd_module, "allow_daemon_children", tracking_cm):
             parallel_decode([[i] for i in range(15)], "gpt2")
 
-        assert mock_set.call_args_list == [call(False), call(True)]
+        # Executor is created after entering and before exiting the context.
+        assert order == ["enter", "executor", "exit"]
 
     @patch.object(pd_module, "ProcessPoolExecutor")
-    def test_daemon_flag_not_toggled_for_non_daemon_process(self, mock_executor_class):
-        """Daemon flag is not toggled when the process is not a daemon."""
-        mock_executor = MagicMock()
-        mock_executor.__enter__ = MagicMock(return_value=mock_executor)
-        mock_executor.__exit__ = MagicMock(return_value=False)
-        mock_executor.map.return_value = ["decoded"] * 15
-        mock_executor_class.return_value = mock_executor
-
-        mock_process = MagicMock()
-        mock_process.daemon = False
-        with (
-            patch.object(pd_module.mp, "current_process", return_value=mock_process),
-            patch.object(pd_module, "_set_daemon") as mock_set,
-        ):
-            parallel_decode([[i] for i in range(15)], "gpt2")
-
-        mock_set.assert_not_called()
-
-    @patch.object(pd_module, "ProcessPoolExecutor")
-    def test_daemon_flag_restored_on_executor_error(self, mock_executor_class):
-        """Daemon flag is restored even when the executor raises."""
+    def test_context_exited_on_executor_error(self, mock_executor_class):
+        """The daemon-restoring context is exited even when the executor
+        raises, so a failed decode never leaves the flag cleared."""
         mock_executor = MagicMock()
         mock_executor.__enter__ = MagicMock(return_value=mock_executor)
         mock_executor.__exit__ = MagicMock(return_value=False)
         mock_executor.map.side_effect = RuntimeError("boom")
         mock_executor_class.return_value = mock_executor
 
-        mock_process = MagicMock()
-        mock_process.daemon = True
+        exited = []
+
+        @contextmanager
+        def tracking_cm():
+            try:
+                yield
+            finally:
+                exited.append(True)
+
         with (
-            patch.object(pd_module.mp, "current_process", return_value=mock_process),
-            patch.object(pd_module, "_set_daemon") as mock_set,
+            patch.object(pd_module, "allow_daemon_children", tracking_cm),
             pytest.raises(RuntimeError, match="boom"),
         ):
             parallel_decode([[i] for i in range(15)], "gpt2")
 
-        assert mock_set.call_args_list == [call(False), call(True)]
+        assert exited == [True]
 
 
 class TestWorkerFunctions:


### PR DESCRIPTION
## Summary
- Cherry-pick of `37060439e` from `main` into `release/0.11.0`
- Original PR: #1082 — fix(accuracy): allow LCB grader to spawn from daemon record processor

LCB `lcb_codegeneration` grading reported 100% unparsed because aiperf spawns the record-processor as a daemon, and lighteval's `codegen_metrics` `ProcessPoolExecutor` can't fork from a daemon; the error was caught and mislabeled as unparsed. Fixed via a reentrant/thread-safe `allow_daemon_children()` context; also makes `--accuracy-verbose` surface per-problem grading reasons, and adds a component_integration test that spawns a pool from a real daemon process.

## Conflicts
None — clean cherry-pick.