### PR TITLE
fix(accuracy): preflight grader deps so missing lighteval fails cleanly (cherry-pick to release/0.11.0)

### DIFF
--- a/src/aiperf/accuracy/benchmarks/bigbench.py
+++ b/src/aiperf/accuracy/benchmarks/bigbench.py
@@ -140,10 +140,20 @@ class BigBenchBenchmark(AIPerfLoggerMixin):
     ``ExactMatchGrader`` for the recipe's strict equality scoring.
     """
 
-    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if deepeval is missing (see grader ``check_available``).
+
+        Called by the main-process preflight so a missing optional dependency
+        surfaces as a clean ConfigurationError before any service spawns,
+        rather than raising deep in the dataset-manager loader.
+        """
         if not _HAS_DEEPEVAL:
             raise RuntimeError(_MISSING_DEEPEVAL_HINT)
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.check_available()
         self.run = run
 
     async def load_problems(

--- a/src/aiperf/accuracy/benchmarks/hellaswag.py
+++ b/src/aiperf/accuracy/benchmarks/hellaswag.py
@@ -202,10 +202,20 @@ class HellaSwagBenchmark(AIPerfLoggerMixin):
     ``ExactMatchGrader`` (strict equality) for grading parity.
     """
 
-    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if deepeval is missing (see grader ``check_available``).
+
+        Called by the main-process preflight so a missing optional dependency
+        surfaces as a clean ConfigurationError before any service spawns,
+        rather than raising deep in the dataset-manager loader.
+        """
         if not _HAS_DEEPEVAL:
             raise RuntimeError(_MISSING_DEEPEVAL_HINT)
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.check_available()
         self.run = run
 
     async def load_problems(

--- a/src/aiperf/accuracy/graders/base.py
+++ b/src/aiperf/accuracy/graders/base.py
@@ -23,6 +23,24 @@ class BaseGrader(AIPerfLoggerMixin):
         super().__init__(**kwargs)
         self.run = run
 
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if this grader's optional dependencies are missing.
+
+        Called from the main-process preflight (``cli_runner._preflight``)
+        BEFORE any service is spawned, so a missing optional dependency (e.g.
+        lighteval) surfaces as a clean ``ConfigurationError`` instead of
+        crashing the daemon record-processor mid-run — which prints a raw
+        multiprocessing traceback and hangs the parent waiting for records
+        that never arrive.
+
+        Default is a no-op: graders with no optional dependencies (the
+        hand-ported ``exact_match`` / ``multiple_choice`` / ``gsm8k`` / ``math``
+        graders) are always available. Graders backed by an optional package
+        override this to check their import flag.
+        """
+        return
+
     async def grade(
         self, response_text: str, ground_truth: str, **kwargs
     ) -> GradingResult:

--- a/src/aiperf/accuracy/graders/code_execution.py
+++ b/src/aiperf/accuracy/graders/code_execution.py
@@ -89,10 +89,15 @@ class CodeExecutionGrader(BaseGrader):
     raised an exception during execution.
     """
 
-    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
-        super().__init__(run=run, **kwargs)
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if lighteval is missing (see ``BaseGrader.check_available``)."""
         if not _HAS_LIGHTEVAL_LCB:
             raise RuntimeError(_MISSING_LIGHTEVAL_HINT)
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(run=run, **kwargs)
+        self.check_available()
 
     def extract_answer(self, response_text: str, **kwargs: Any) -> str:
         """Return the code block lighteval would extract from the response.

--- a/src/aiperf/accuracy/graders/lighteval_grader.py
+++ b/src/aiperf/accuracy/graders/lighteval_grader.py
@@ -108,6 +108,11 @@ class _LightevalBaseGrader(BaseGrader):
 
     _CORRECTNESS_THRESHOLD = 0.5
 
+    @classmethod
+    def check_available(cls) -> None:
+        """Raise if lighteval is missing (see ``BaseGrader.check_available``)."""
+        _require_lighteval()
+
     def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
         super().__init__(run=run, **kwargs)
         _require_lighteval()

--- a/src/aiperf/cli_runner/__init__.py
+++ b/src/aiperf/cli_runner/__init__.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 from aiperf.cli_runner._callbacks import CompletedRun, OnComplete
 from aiperf.cli_runner._multi_run import _run_multi_benchmark
 from aiperf.cli_runner._preflight import (
+    _preflight_accuracy_deps,
     _preflight_artifact_dir,
     _preflight_endpoint_ready,
     _preflight_fd_limit,
@@ -50,6 +51,7 @@ def run_benchmark(plan: BenchmarkPlan) -> None:
         )
 
     _preflight_artifact_dir(plan)
+    _preflight_accuracy_deps(plan)
     _preflight_fd_limit()
     _preflight_endpoint_ready(plan)
 

--- a/src/aiperf/cli_runner/_preflight.py
+++ b/src/aiperf/cli_runner/_preflight.py
@@ -4,9 +4,9 @@
 
 These run before any service bootstrap so misconfiguration surfaces as a
 clean ``ConfigurationError`` instead of a stack trace from deep inside the
-controller. The three checks are: artifact-dir creatable+writable, file
-descriptor soft limit raised (and hard limit large enough), and the target
-endpoint reachable.
+controller. The checks are: artifact-dir creatable+writable, accuracy
+benchmark/grader optional dependencies present, file descriptor soft limit
+raised (and hard limit large enough), and the target endpoint reachable.
 """
 
 from __future__ import annotations
@@ -83,6 +83,74 @@ def _preflight_fd_limit() -> None:
         return
     with contextlib.suppress(ValueError, OSError):
         resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
+
+
+def _preflight_accuracy_deps(plan: BenchmarkPlan) -> None:
+    """Fail fast if a selected accuracy benchmark's or grader's optional
+    dependency (lighteval / deepeval, the ``[accuracy]`` extra) is missing.
+
+    Why: both the benchmark loader (dataset-manager service) and the grader
+    (record-processor daemon) raise at instantiation when their optional
+    package is absent. The grader crash isn't propagated to the controller, so
+    the user sees a raw multiprocessing traceback and the run hangs waiting for
+    records that never arrive; the loader crash surfaces later and less
+    cleanly. Checking here — in the main process, before any service spawns —
+    turns both into a single clean ``ConfigurationError`` panel with a non-zero
+    exit and no hang.
+    """
+    from aiperf.config.loader.errors import ConfigurationError
+    from aiperf.plugin import plugins
+    from aiperf.plugin.enums import PluginType
+    from aiperf.plugin.types import TypeNotFoundError
+
+    checked: set[tuple[str, str]] = set()
+    for config in plan.configs:
+        acc_cfg = getattr(config, "accuracy", None)
+        if acc_cfg is None or not acc_cfg.enabled:
+            continue
+
+        # Keep every preflight failure on the ConfigurationError path: plugin
+        # lookups raise TypeNotFoundError/KeyError/ValueError for an unknown or
+        # malformed benchmark/grader name, ImportError for a broken external
+        # plugin module, and AttributeError when the module imports but the
+        # configured class is missing (PluginEntry.load); check_available raises
+        # RuntimeError for a missing optional dependency. Any of these would
+        # otherwise leak a raw traceback.
+        try:
+            meta = plugins.get_metadata(
+                PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
+            )
+            grader_name = acc_cfg.grader or meta.get(
+                "default_grader", "multiple_choice"
+            )
+
+            key = (str(acc_cfg.benchmark), grader_name)
+            if key in checked:
+                continue
+            checked.add(key)
+
+            # ``check_available`` is an optional hook on both the benchmark
+            # loader and grader: the plugin contracts don't require it, so a
+            # custom plugin need not define it. Built-in graders inherit a
+            # no-op default from ``BaseGrader``; the deepeval-gated benchmark
+            # loaders define it. Treat absence as "no optional deps to verify".
+            benchmark_cls = plugins.get_class(
+                PluginType.ACCURACY_BENCHMARK, acc_cfg.benchmark
+            )
+            grader_cls = plugins.get_class(PluginType.ACCURACY_GRADER, grader_name)
+            for cls in (benchmark_cls, grader_cls):
+                check = getattr(cls, "check_available", None)
+                if callable(check):
+                    check()
+        except (
+            TypeNotFoundError,
+            KeyError,
+            ValueError,
+            ImportError,
+            AttributeError,
+            RuntimeError,
+        ) as exc:
+            raise ConfigurationError(str(exc)) from exc
 
 
 def _preflight_endpoint_ready(plan: BenchmarkPlan) -> None:

--- a/src/aiperf/cli_utils.py
+++ b/src/aiperf/cli_utils.py
@@ -11,6 +11,7 @@ from contextlib import AbstractContextManager
 
 from rich.align import AlignMethod
 from rich.console import Console, RenderableType
+from rich.markup import escape
 from rich.panel import Panel
 from rich.style import StyleType
 from rich.text import Text
@@ -115,8 +116,14 @@ class exit_on_error(AbstractContextManager):
                 )
                 console.file.flush()
 
+            # Escape the exception text before substituting it into the
+            # markup template: exception messages routinely contain square
+            # brackets (e.g. ``list[str]``, ``uv pip install 'aiperf[accuracy]'``)
+            # that Rich would otherwise parse as style tags and silently drop,
+            # corrupting the message. Any intentional markup in the template
+            # itself is preserved.
             message = (
-                self.message.format(e=exc_value)
+                self.message.format(e=escape(str(exc_value)))
                 if isinstance(self.message, str)
                 else self.message
             )

--- a/tests/unit/cli_runner/test_preflight_accuracy_deps.py
+++ b/tests/unit/cli_runner/test_preflight_accuracy_deps.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preflight for accuracy benchmark/grader optional-dependency checks.
+
+The grader (record-processor daemon) and benchmark loader (dataset-manager)
+both raise at instantiation when their optional package (lighteval / deepeval)
+is missing. The grader crash isn't propagated, so the user got a raw
+multiprocessing traceback and a hung run. The preflight moves both checks into
+the main process, before any service spawns, so a missing dependency is a clean
+``ConfigurationError`` with a non-zero exit.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aiperf.cli_runner._preflight import _preflight_accuracy_deps
+from aiperf.config.loader.errors import ConfigurationError
+from aiperf.plugin.enums import PluginType
+
+
+def _plan(accuracy: object) -> SimpleNamespace:
+    return SimpleNamespace(configs=[SimpleNamespace(accuracy=accuracy)])
+
+
+def _acc(enabled: bool, benchmark: str = "math_500", grader: str | None = None):
+    return SimpleNamespace(enabled=enabled, benchmark=benchmark, grader=grader)
+
+
+def _patch_registry(monkeypatch, *, benchmark_cls, grader_cls, default_grader="g"):
+    """Stub the plugin registry: metadata carries default_grader; get_class
+    returns benchmark_cls for ACCURACY_BENCHMARK and grader_cls for ACCURACY_GRADER."""
+    monkeypatch.setattr(
+        "aiperf.plugin.plugins.get_metadata",
+        lambda _type, _name: {"default_grader": default_grader},
+    )
+
+    def _get_class(plugin_type, _name):
+        return (
+            benchmark_cls
+            if plugin_type == PluginType.ACCURACY_BENCHMARK
+            else grader_cls
+        )
+
+    monkeypatch.setattr("aiperf.plugin.plugins.get_class", _get_class)
+
+
+class _Available:
+    @classmethod
+    def check_available(cls) -> None:
+        return None
+
+
+class TestPreflightAccuracyDeps:
+    def test_missing_grader_dep_raises_configuration_error(self, monkeypatch) -> None:
+        """A grader whose check_available raises must surface as a clean
+        ConfigurationError (not a daemon crash / hang)."""
+
+        class _UnavailableGrader:
+            @classmethod
+            def check_available(cls) -> None:
+                raise RuntimeError("lighteval is not installed; ... 'aiperf[accuracy]'")
+
+        _patch_registry(
+            monkeypatch, benchmark_cls=_Available, grader_cls=_UnavailableGrader
+        )
+        with pytest.raises(ConfigurationError, match=r"aiperf\[accuracy\]"):
+            _preflight_accuracy_deps(
+                _plan(_acc(enabled=True, grader="lighteval_latex"))
+            )
+
+    def test_missing_benchmark_loader_dep_raises_configuration_error(
+        self, monkeypatch
+    ) -> None:
+        """A benchmark loader whose check_available raises (e.g. HellaSwag/BigBench
+        without deepeval) must also surface cleanly — its default grader is the
+        dep-free exact_match, so only the loader check catches it."""
+
+        class _UnavailableBenchmark:
+            @classmethod
+            def check_available(cls) -> None:
+                raise RuntimeError("deepeval is not installed; ... 'aiperf[accuracy]'")
+
+        _patch_registry(
+            monkeypatch, benchmark_cls=_UnavailableBenchmark, grader_cls=_Available
+        )
+        with pytest.raises(ConfigurationError, match=r"deepeval"):
+            _preflight_accuracy_deps(_plan(_acc(enabled=True, benchmark="hellaswag")))
+
+    def test_available_deps_do_not_raise(self, monkeypatch) -> None:
+        _patch_registry(monkeypatch, benchmark_cls=_Available, grader_cls=_Available)
+        _preflight_accuracy_deps(_plan(_acc(enabled=True, grader="exact_match")))
+
+    def test_skips_when_accuracy_disabled(self, monkeypatch) -> None:
+        """Non-accuracy runs must not touch the plugin registry at all."""
+
+        def _boom(*_a, **_k):
+            raise AssertionError("registry should not be touched")
+
+        monkeypatch.setattr("aiperf.plugin.plugins.get_class", _boom)
+        monkeypatch.setattr("aiperf.plugin.plugins.get_metadata", _boom)
+        _preflight_accuracy_deps(_plan(_acc(enabled=False)))
+        _preflight_accuracy_deps(_plan(None))
+
+    def test_plugin_without_check_available_is_allowed(self, monkeypatch) -> None:
+        """A custom benchmark/grader satisfying only its protocol (no
+        check_available) must pass preflight, not raise AttributeError."""
+
+        class _ProtocolOnly:
+            pass
+
+        _patch_registry(
+            monkeypatch, benchmark_cls=_ProtocolOnly, grader_cls=_ProtocolOnly
+        )
+        _preflight_accuracy_deps(_plan(_acc(enabled=True, grader="custom")))
+
+    @pytest.mark.parametrize(
+        "exc_type", [KeyError, ValueError, ImportError, AttributeError]
+    )
+    def test_lookup_errors_become_configuration_error(
+        self, monkeypatch, exc_type
+    ) -> None:
+        """Unknown/malformed names (TypeNotFoundError/KeyError/ValueError),
+        broken external plugin modules (ImportError), and a module that imports
+        but is missing its configured class (AttributeError, from
+        PluginEntry.load) must all convert to ConfigurationError, not leak a
+        raw traceback."""
+        monkeypatch.setattr(
+            "aiperf.plugin.plugins.get_metadata",
+            lambda _type, _name: {"default_grader": "g"},
+        )
+
+        def _raise(*_a, **_k):
+            raise exc_type("boom")
+
+        monkeypatch.setattr("aiperf.plugin.plugins.get_class", _raise)
+        with pytest.raises(ConfigurationError):
+            _preflight_accuracy_deps(_plan(_acc(enabled=True, grader="nope")))
+
+    def test_resolves_default_grader_from_benchmark_metadata(self, monkeypatch) -> None:
+        """When grader is unset, the default_grader from benchmark metadata is
+        resolved and checked."""
+        grader_names: list[str] = []
+
+        def _get_class(plugin_type, name):
+            if plugin_type == PluginType.ACCURACY_GRADER:
+                grader_names.append(name)
+            return _Available
+
+        monkeypatch.setattr(
+            "aiperf.plugin.plugins.get_metadata",
+            lambda _type, _name: {"default_grader": "lighteval_latex"},
+        )
+        monkeypatch.setattr("aiperf.plugin.plugins.get_class", _get_class)
+        _preflight_accuracy_deps(_plan(_acc(enabled=True, grader=None)))
+        assert grader_names == ["lighteval_latex"]
+
+    def test_real_accuracy_config_attribute_contract(self) -> None:
+        """Pin the attribute contract against the real AccuracyConfig (not a
+        SimpleNamespace mock): if .enabled/.benchmark/.grader are renamed, this
+        fails loudly here instead of silently no-opping. GSM8K's benchmark and
+        default grader are dependency-free, so a real preflight passes."""
+        from aiperf.config.accuracy import AccuracyConfig
+        from aiperf.plugin.enums import AccuracyBenchmarkType
+
+        acc = AccuracyConfig(benchmark=AccuracyBenchmarkType.GSM8K)
+        # Real registry + real config, no optional deps needed → no raise.
+        _preflight_accuracy_deps(_plan(acc))
+
+
+class TestCheckAvailable:
+    """Benchmark loaders and graders report missing optional deps via check_available."""
+
+    def test_code_execution_grader(self, monkeypatch) -> None:
+        import aiperf.accuracy.graders.code_execution as ce
+
+        monkeypatch.setattr(ce, "_HAS_LIGHTEVAL_LCB", False)
+        with pytest.raises(RuntimeError, match="lighteval is not installed"):
+            ce.CodeExecutionGrader.check_available()
+        monkeypatch.setattr(ce, "_HAS_LIGHTEVAL_LCB", True)
+        ce.CodeExecutionGrader.check_available()
+
+    def test_lighteval_grader(self, monkeypatch) -> None:
+        import aiperf.accuracy.graders.lighteval_grader as le
+
+        monkeypatch.setattr(le, "_HAS_LIGHTEVAL", False)
+        with pytest.raises(RuntimeError, match="lighteval is not installed"):
+            le._LightevalBaseGrader.check_available()
+        monkeypatch.setattr(le, "_HAS_LIGHTEVAL", True)
+        le._LightevalBaseGrader.check_available()
+
+    def test_hellaswag_benchmark(self, monkeypatch) -> None:
+        import aiperf.accuracy.benchmarks.hellaswag as hs
+
+        monkeypatch.setattr(hs, "_HAS_DEEPEVAL", False)
+        with pytest.raises(RuntimeError, match="deepeval is not installed"):
+            hs.HellaSwagBenchmark.check_available()
+        monkeypatch.setattr(hs, "_HAS_DEEPEVAL", True)
+        hs.HellaSwagBenchmark.check_available()
+
+    def test_bigbench_benchmark(self, monkeypatch) -> None:
+        import aiperf.accuracy.benchmarks.bigbench as bb
+
+        monkeypatch.setattr(bb, "_HAS_DEEPEVAL", False)
+        with pytest.raises(RuntimeError, match="deepeval is not installed"):
+            bb.BigBenchBenchmark.check_available()
+        monkeypatch.setattr(bb, "_HAS_DEEPEVAL", True)
+        bb.BigBenchBenchmark.check_available()
+
+    def test_base_grader_check_available_is_noop(self) -> None:
+        """Graders/benchmarks with no optional deps are always available."""
+        from aiperf.accuracy.graders.exact_match import ExactMatchGrader
+
+        ExactMatchGrader.check_available()

--- a/tests/unit/test_cli_utils_escape.py
+++ b/tests/unit/test_cli_utils_escape.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``exit_on_error`` must not let Rich eat square brackets in exception text.
+
+Exception messages routinely contain brackets — ``list[str]``,
+``uv pip install 'aiperf[accuracy]'`` — which Rich parses as style tags and
+silently drops when a raw string is rendered in a Panel. That corrupted the
+missing-lighteval hint (``'aiperf[accuracy]'`` → ``'aiperf'``). The fix escapes
+the exception text before substitution; this test pins it.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+import aiperf.cli_utils as cli_utils
+from aiperf.cli_utils import exit_on_error
+
+
+def test_exit_on_error_preserves_bracketed_exception_text(monkeypatch) -> None:
+    buffer = io.StringIO()
+    # force_terminal=False keeps output plain; the point is the literal text,
+    # not styling.
+    monkeypatch.setattr(
+        cli_utils, "console", Console(file=buffer, force_terminal=False, width=200)
+    )
+
+    with (
+        pytest.raises(SystemExit) as exc_info,
+        exit_on_error(RuntimeError, message="{e}", title="Error", show_traceback=False),
+    ):
+        raise RuntimeError("Install with: uv pip install 'aiperf[accuracy]'.")
+
+    assert exc_info.value.code == 1
+    output = buffer.getvalue()
+    # The bracketed extra must survive verbatim — not be stripped to 'aiperf'.
+    assert "aiperf[accuracy]" in output


### PR DESCRIPTION
## Summary
- Cherry-pick of `314a34b4f` from `main` into `release/0.11.0`
- Original PR: #1083 — fix(accuracy): preflight grader deps so missing lighteval fails cleanly

Running an accuracy benchmark that needs lighteval/deepeval without it installed produced a raw multiprocessing traceback and hung the run (grader/benchmark-loader raised inside a daemon child whose crash wasn't propagated). This preflights the selected benchmark + grader optional deps in the main process before any service spawns, converting a missing dep into a clean ConfigurationError with a non-zero exit. Also escapes exception text in the error panel so `aiperf[accuracy]` isn't mangled by Rich markup.

## Conflicts
None — clean cherry-pick.