### PR TITLE
fix(records): gate record processing on dataset configuration (cherry-pick to release/0.11.0)

### DIFF
--- a/src/aiperf/records/dataset_gate.py
+++ b/src/aiperf/records/dataset_gate.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared dataset-configuration gate for the record-processing services.
+
+RecordProcessor and RecordsManager receive the DatasetConfiguredNotification on
+the PUB/SUB bus but records on a separate PULL socket, with no ordering guarantee
+between the two. Both must block record processing until the notification has
+configured their processors (e.g. accuracy ground truths / task names).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from aiperf.common.environment import Environment
+from aiperf.common.messages import BaseServiceErrorMessage
+from aiperf.common.models.error_models import ErrorDetails
+
+if TYPE_CHECKING:
+    from aiperf.common.base_component_service import BaseComponentService
+
+
+async def await_dataset_configured(
+    service: BaseComponentService, event: asyncio.Event
+) -> bool:
+    """Block until the dataset-configured ``event`` is set.
+
+    Returns True once configured. On timeout, treats a missing dataset
+    configuration as a fatal misconfiguration: reports it via a
+    BaseServiceErrorMessage (so the run exits non-zero) and kills the service so
+    the run aborts loudly instead of processing records without a configured
+    dataset. Returns False in that case so the caller skips processing (``_kill``
+    force-exits the process, so this return is a safety net if it ever does not).
+    """
+    # Fast path: once configured (the common case), avoid the per-record
+    # wait_for timer allocation on the hot path.
+    if event.is_set():
+        return True
+    try:
+        await asyncio.wait_for(
+            event.wait(), timeout=Environment.DATASET.CONFIGURATION_TIMEOUT
+        )
+        return True
+    except asyncio.TimeoutError:
+        message = (
+            "Dataset configuration not received after "
+            f"{Environment.DATASET.CONFIGURATION_TIMEOUT}s; aborting run."
+        )
+        service.error(message)
+        await service.publish(
+            BaseServiceErrorMessage(
+                service_id=service.service_id,
+                error=ErrorDetails(message=message),
+            )
+        )
+        await service._kill()
+        return False

--- a/src/aiperf/records/inference_result_parser.py
+++ b/src/aiperf/records/inference_result_parser.py
@@ -54,8 +54,10 @@ class InferenceResultParser(CommunicationMixin):
             not endpoint_meta.produces_tokens and not endpoint_meta.tokenizes_input
         )
         self.debug(
-            lambda: f"Created endpoint for {self.model_endpoint.endpoint.type}, "
-            f"class: {self.endpoint.__class__.__name__}",
+            lambda: (
+                f"Created endpoint for {self.model_endpoint.endpoint.type}, "
+                f"class: {self.endpoint.__class__.__name__}"
+            ),
         )
 
     @on_init
@@ -118,9 +120,11 @@ class InferenceResultParser(CommunicationMixin):
         request_info = request_record.request_info
         self.trace_or_debug(
             lambda: f"Received inference results message: {request_record}",
-            lambda: f"Received inference results for credit '{request_info.credit_num}' (id: {request_info.x_request_id})"
-            if request_info
-            else "Received inference results (no request_info)",
+            lambda: (
+                f"Received inference results for credit '{request_info.credit_num}' (id: {request_info.x_request_id})"
+                if request_info
+                else "Received inference results (no request_info)"
+            ),
         )
 
         # Make sure any invalid request records are converted to error records for combined processing.
@@ -167,7 +171,9 @@ class InferenceResultParser(CommunicationMixin):
                 else:
                     # Success path: valid record with no errors
                     self.debug(
-                        lambda: f"Received {raw_response_count} response packet(s), token counts: {record.token_counts}"
+                        lambda: (
+                            f"Received {raw_response_count} response packet(s), token counts: {record.token_counts}"
+                        )
                     )
                     return record
 
@@ -199,7 +205,9 @@ class InferenceResultParser(CommunicationMixin):
         """Process a valid request record."""
         if request_record.model_name is None:
             self.warning(
-                lambda: f"Model name is None, unable to process record: {request_record}"
+                lambda: (
+                    f"Model name is None, unable to process record: {request_record}"
+                )
             )
             return ParsedResponseRecord(
                 request=request_record,

--- a/src/aiperf/records/record_processor_service.py
+++ b/src/aiperf/records/record_processor_service.py
@@ -31,6 +31,7 @@ from aiperf.metrics.metric_dicts import MetricRecordDict
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import PluginType
 from aiperf.post_processors.protocols import RecordProcessorProtocol
+from aiperf.records.dataset_gate import await_dataset_configured
 from aiperf.records.inference_result_parser import InferenceResultParser
 
 if TYPE_CHECKING:
@@ -67,6 +68,12 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
             run=self.run,
         )
 
+        # DatasetConfiguredNotification (SUB) and inference results (PULL) arrive on
+        # independent channels with no ordering guarantee. Gate record processing on
+        # this event so processors are configured (e.g. accuracy ground truths) before
+        # any record is graded.
+        self._dataset_configured_event: asyncio.Event = asyncio.Event()
+
         self.records_processors: list[RecordProcessorProtocol] = []
         for entry in plugins.iter_entries(PluginType.RECORD_PROCESSOR):
             try:
@@ -97,6 +104,7 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
         for processor in self.records_processors:
             if hasattr(processor, "on_dataset_configured"):
                 processor.on_dataset_configured(message.metadata)
+        self._dataset_configured_event.set()
 
     @on_command(CommandType.PROFILE_CONFIGURE)
     async def _profile_configure_command(
@@ -169,6 +177,8 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
     @on_pull_message(MessageType.INFERENCE_RESULTS)
     async def _on_inference_results(self, message: InferenceResultsMessage) -> None:
         """Handle an inference results message."""
+        if not await await_dataset_configured(self, self._dataset_configured_event):
+            return
         record = message.record
 
         # Capture last response timestamp before parsing frees raw SSE data.

--- a/src/aiperf/records/records_manager.py
+++ b/src/aiperf/records/records_manager.py
@@ -82,6 +82,7 @@ from aiperf.post_processors.protocols import (
     FlushableResultsProcessorProtocol,
     ResultsProcessorProtocol,
 )
+from aiperf.records.dataset_gate import await_dataset_configured
 from aiperf.records.error_tracker import ErrorTracker
 from aiperf.records.records_tracker import RecordsTracker
 from aiperf.server_metrics.protocols import (
@@ -148,6 +149,12 @@ class RecordsManager(PullClientMixin, BaseComponentService):
 
         self._records_tracker = RecordsTracker()
         self._error_tracker = ErrorTracker()
+
+        # DatasetConfiguredNotification (SUB) and metric records (PULL) arrive on
+        # independent channels with no ordering guarantee. Gate record processing on
+        # this event so results processors are configured (e.g. accuracy task names)
+        # before any record is accumulated.
+        self._dataset_configured_event: asyncio.Event = asyncio.Event()
 
         self._previous_realtime_records: int | None = None
 
@@ -251,6 +258,8 @@ class RecordsManager(PullClientMixin, BaseComponentService):
     @on_pull_message(MessageType.METRIC_RECORDS)
     async def _on_metric_records(self, message: MetricRecordsMessage) -> None:
         """Handle a metric records message."""
+        if not await await_dataset_configured(self, self._dataset_configured_event):
+            return
         if self.is_trace_enabled:
             self.trace(f"Received metric records: {message}")
 
@@ -585,6 +594,7 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         for processor in self._metric_results_processors:
             if hasattr(processor, "on_dataset_configured"):
                 processor.on_dataset_configured(message.metadata)
+        self._dataset_configured_event.set()
 
     @on_message(MessageType.CREDIT_PHASE_START)
     async def _on_credit_phase_start(

--- a/tests/unit/records/test_record_processor_service.py
+++ b/tests/unit/records/test_record_processor_service.py
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from aiperf.common.enums import CreditPhase
+from aiperf.common.messages import BaseServiceErrorMessage
 from aiperf.common.utils import compute_time_ns
 from aiperf.records.record_processor_service import RecordProcessor
 
@@ -126,3 +128,79 @@ class TestRecordProcessorCreateMetricRecordMetadata:
 
         assert getattr(metadata, expected_metadata_field) is None
         assert metadata.worker_id == worker_id
+
+
+class TestRecordProcessorDatasetConfiguredBarrier:
+    """The record processor must not process inference results until the
+    DatasetConfiguredNotification has been applied to its processors.
+
+    Records (PULL socket) and the notification (SUB socket) arrive on
+    independent channels with no ordering guarantee, so processing must block
+    on an explicit barrier that _on_dataset_configured releases.
+    """
+
+    @pytest.mark.asyncio
+    async def test_on_dataset_configured_sets_event(self):
+        """_on_dataset_configured must release the barrier once processors are configured."""
+        mock_self = MagicMock(spec=RecordProcessor)
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.records_processors = []
+
+        await RecordProcessor._on_dataset_configured(mock_self, MagicMock())
+
+        assert mock_self._dataset_configured_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_on_inference_results_waits_for_dataset_configured(self):
+        """_on_inference_results must block until the dataset is configured, then proceed."""
+        mock_self = MagicMock(spec=RecordProcessor)
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.inference_result_parser = MagicMock()
+        # First downstream step after the barrier; raising proves the barrier was passed.
+        mock_self.inference_result_parser.parse_request_record = AsyncMock(
+            side_effect=RuntimeError("REACHED_PROCESSING")
+        )
+
+        task = asyncio.create_task(
+            RecordProcessor._on_inference_results(mock_self, MagicMock())
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # Barrier not released: processing has not started.
+        assert not task.done()
+        assert not mock_self.inference_result_parser.parse_request_record.called
+
+        # Barrier released: processing proceeds past the wait.
+        mock_self._dataset_configured_event.set()
+        with pytest.raises(RuntimeError, match="REACHED_PROCESSING"):
+            await asyncio.wait_for(task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_on_inference_results_fails_run_on_config_timeout(self, monkeypatch):
+        """On dataset-config timeout, abort the run (report error + kill) rather
+        than process the record without a configured dataset."""
+        mock_self = MagicMock(spec=RecordProcessor)
+        mock_self.service_id = "rp-test"
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.publish = AsyncMock()
+        mock_self._kill = AsyncMock()
+        mock_self.inference_result_parser = MagicMock()
+        mock_self.inference_result_parser.parse_request_record = AsyncMock()
+
+        async def _raise_timeout(coro, *args, **kwargs):
+            coro.close()  # avoid "coroutine was never awaited" warning
+            raise asyncio.TimeoutError
+
+        monkeypatch.setattr(
+            "aiperf.records.dataset_gate.asyncio.wait_for", _raise_timeout
+        )
+
+        await RecordProcessor._on_inference_results(mock_self, MagicMock())
+
+        # Run is failed loudly ...
+        mock_self._kill.assert_awaited_once()
+        published = mock_self.publish.await_args.args[0]
+        assert isinstance(published, BaseServiceErrorMessage)
+        # ... and the record is not processed.
+        mock_self.inference_result_parser.parse_request_record.assert_not_called()

--- a/tests/unit/records/test_records_manager.py
+++ b/tests/unit/records/test_records_manager.py
@@ -9,6 +9,7 @@ import pytest
 
 from aiperf.common.enums import CreditPhase
 from aiperf.common.exceptions import PostProcessorDisabled
+from aiperf.common.messages import BaseServiceErrorMessage
 from aiperf.common.messages.inference_messages import (
     MetricRecordsData,
     MetricRecordsMessage,
@@ -318,6 +319,9 @@ def _create_credit_phase_stats() -> CreditPhaseStats:
 
 def _create_manager_for_timing_dispatch() -> RecordsManager:
     manager = RecordsManager.__new__(RecordsManager)
+    # These tests exercise the post-configuration flow; release the barrier.
+    manager._dataset_configured_event = asyncio.Event()
+    manager._dataset_configured_event.set()
     manager._records_tracker = MagicMock()
     manager._error_tracker = MagicMock()
     manager._complete_credit_phases = set()
@@ -1089,3 +1093,83 @@ class TestMidRunCacheReportingHint:
         record_data = SimpleNamespace(metrics={"output_sequence_length": 32})
         manager._maybe_hint_missing_cache_reporting(record_data)
         manager.warning.assert_not_called()
+
+
+class TestRecordsManagerDatasetConfiguredBarrier:
+    """The records manager must not run metric records through its results
+    processors until the DatasetConfiguredNotification has been applied.
+
+    Metric records (PULL socket) and the notification (SUB socket) arrive on
+    independent channels with no ordering guarantee, so processing must block
+    on an explicit barrier that _on_dataset_configured releases.
+    """
+
+    @pytest.mark.asyncio
+    async def test_on_dataset_configured_sets_event(self):
+        """_on_dataset_configured must release the barrier once processors are configured."""
+        mock_self = MagicMock(spec=RecordsManager)
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self._metric_results_processors = []
+
+        await RecordsManager._on_dataset_configured(mock_self, MagicMock())
+
+        assert mock_self._dataset_configured_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_on_metric_records_waits_for_dataset_configured(self):
+        """_on_metric_records must block until the dataset is configured, then proceed."""
+        mock_self = MagicMock(spec=RecordsManager)
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.is_trace_enabled = False
+        # First downstream step after the barrier; raising proves the barrier was passed.
+        mock_self._send_results_to_results_processors = AsyncMock(
+            side_effect=RuntimeError("REACHED_PROCESSING")
+        )
+        message = MagicMock()
+        message.metadata.benchmark_phase = CreditPhase.PROFILING
+
+        task = asyncio.create_task(
+            RecordsManager._on_metric_records(mock_self, message)
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # Barrier not released: processing has not started.
+        assert not task.done()
+        assert not mock_self._send_results_to_results_processors.called
+
+        # Barrier released: processing proceeds past the wait.
+        mock_self._dataset_configured_event.set()
+        with pytest.raises(RuntimeError, match="REACHED_PROCESSING"):
+            await asyncio.wait_for(task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_on_metric_records_fails_run_on_config_timeout(self, monkeypatch):
+        """On dataset-config timeout, abort the run (report error + kill) rather
+        than process the record without a configured dataset."""
+        mock_self = MagicMock(spec=RecordsManager)
+        mock_self.service_id = "rm-test"
+        mock_self._dataset_configured_event = asyncio.Event()
+        mock_self.is_trace_enabled = False
+        mock_self.publish = AsyncMock()
+        mock_self._kill = AsyncMock()
+        mock_self._send_results_to_results_processors = AsyncMock()
+        message = MagicMock()
+        message.metadata.benchmark_phase = CreditPhase.PROFILING
+
+        async def _raise_timeout(coro, *args, **kwargs):
+            coro.close()  # avoid "coroutine was never awaited" warning
+            raise asyncio.TimeoutError
+
+        monkeypatch.setattr(
+            "aiperf.records.dataset_gate.asyncio.wait_for", _raise_timeout
+        )
+
+        await RecordsManager._on_metric_records(mock_self, message)
+
+        # Run is failed loudly ...
+        mock_self._kill.assert_awaited_once()
+        published = mock_self.publish.await_args.args[0]
+        assert isinstance(published, BaseServiceErrorMessage)
+        # ... and the record is not processed.
+        mock_self._send_results_to_results_processors.assert_not_called()


### PR DESCRIPTION
## Summary
- Cherry-pick of 4450c313 from `main` into `release/0.11.0`
- Original PR: #1079 — fix(records): gate record processing on dataset configuration

## Conflicts
None — clean cherry-pick.