### PR TITLE
fix(config): use readable per-run dir names for nested scenario sweeps (cherry-pick to release/0.11.0)

### DIFF
--- a/src/aiperf/cli_runner/_sweep_aggregate.py
+++ b/src/aiperf/cli_runner/_sweep_aggregate.py
@@ -113,16 +113,21 @@ def _variation_dir_name(
         >>> # nested override -> label
         >>> # scalar override  -> "concurrency_10"
     """
-    from aiperf.config.sweep import _format_dir_name
-
-    has_nested = any(
-        isinstance(value, (dict, list))
-        for result in group
-        for value in result.variation_values.values()
+    from aiperf.config.sweep import (
+        _format_dir_name,
+        _is_nested_override,
+        _label_dir_segment,
     )
-    if has_nested:
-        return variation_label
-    return _format_dir_name(dict(_key_values(key))) or variation_label
+
+    # Sanitize the label identically to `SweepVariation.dir_name` so per-run
+    # and aggregate directories match even for sanitizable labels (e.g.
+    # `qps:100` -> `qps100` on both). `variation_index` mirrors the per-run
+    # variation index for the empty-label fallback.
+    index = group[0].variation_index if group else 0
+    fallback = _label_dir_segment(variation_label, index)
+    if any(_is_nested_override(result.variation_values) for result in group):
+        return fallback
+    return _format_dir_name(dict(_key_values(key))) or fallback
 
 
 def _group_results_by_variation(

--- a/src/aiperf/config/sweep/__init__.py
+++ b/src/aiperf/config/sweep/__init__.py
@@ -23,6 +23,8 @@ from aiperf.config.sweep.config import (
     SweepVariation,
     ZipSweep,
     _format_dir_name,
+    _is_nested_override,
+    _label_dir_segment,
     _set_nested_value,
     expand_sweep,
 )
@@ -51,6 +53,8 @@ __all__ = [
     "_GridSweepBase",
     "_SamplingSweepBase",
     "_format_dir_name",
+    "_is_nested_override",
+    "_label_dir_segment",
     "_set_nested_value",
     "expand_qmc_sweep",
     "expand_sweep",

--- a/src/aiperf/config/sweep/config.py
+++ b/src/aiperf/config/sweep/config.py
@@ -11,6 +11,7 @@ Supports the following sweep strategies:
 from __future__ import annotations
 
 import math
+import re
 import warnings
 from typing import Annotated, Any, ClassVar, Literal
 
@@ -230,6 +231,25 @@ class ScenarioSweep(_GridSweepBase):
             raise ValueError(
                 f"scenario sweep runs must have unique names; duplicates: {dups!r}."
             )
+        return self
+
+    @model_validator(mode="after")
+    def _check_run_name_path_safety(self) -> Self:
+        # `name` becomes a filesystem path segment via `variation.dir_name`
+        # (`base_dir / dir_name`). Reject path separators and `..` up front so
+        # a name like `../outside` can't escape the artifact directory.
+        # `dir_name` sanitizes the label as a backstop; rejecting here makes
+        # the failure explicit instead of silently rewriting the user's name.
+        for run in self.runs:
+            name = run.get("name") if isinstance(run, dict) else None
+            if isinstance(name, str) and (
+                re.search(r"[/\\]|\.\.", name) or re.fullmatch(r"\.+", name)
+            ):
+                raise ValueError(
+                    f"scenario sweep run name {name!r} is path-unsafe (contains "
+                    f"a path separator or '..', or is only dots); choose a name "
+                    f"usable as a directory."
+                )
         return self
 
 
@@ -665,9 +685,11 @@ class SweepVariation(BaseConfig):
 
         Naming convention is
         ``{last_segment_of_dotted_key}_{value}``. Multi-dim variations
-        join components with ``__``. Falls back to ``label`` when
-        ``values`` is empty (e.g. ``"base"`` for non-sweep runs, or
-        named scenarios like ``"scenario_a"``).
+        join components with ``__``. Falls back to the sanitized ``label``
+        when ``values`` is empty (e.g. ``"base"`` for non-sweep runs, or
+        named scenarios like ``"scenario_a"``) or nested (scenario sweeps
+        without an explicit ``values:`` block). The label is sanitized so a
+        user-supplied scenario name cannot inject path segments.
 
         Examples:
 
@@ -676,7 +698,34 @@ class SweepVariation(BaseConfig):
         >>> # values={"a.b": 1, "c.d": 2}                    -> "b_1__d_2"
         >>> # values={}                                      -> self.label
         """
-        return _format_dir_name(self.values) or self.label
+        return _format_dir_name(self.values) or _label_dir_segment(
+            self.label, self.index
+        )
+
+
+def _is_nested_override(values: dict[str, Any]) -> bool:
+    """True if any value is a nested dict/list (a scenario override subtree).
+
+    Such values can't form a readable ``{leaf}_{value}`` segment, so callers
+    fall back to the variation label. Shared by the per-run (`dir_name`),
+    aggregate (`_variation_dir_name`), and expansion-warning paths so their
+    nested-detection can't drift.
+    """
+    return any(isinstance(value, (dict, list)) for value in values.values())
+
+
+def _label_dir_segment(label: str, index: int) -> str:
+    """Canonical, sanitized, always-non-empty dir segment from a variation label.
+
+    Shared by the per-run and aggregate paths so a sanitizable label
+    (e.g. ``qps:100`` -> ``qps100``) yields the *same* directory name on both,
+    keeping per-run and aggregate artifacts matched. ``variation_{index}`` is
+    the last resort for a label that sanitizes to empty (e.g. ``../..`` -> "");
+    without it `dir_name` would be "" and `base_dir / ""` collapses to
+    `base_dir`, so runs would clobber each other. The index is always present
+    and unique.
+    """
+    return _sanitize_dir_segment(label) or f"variation_{index}"
 
 
 def _format_dir_name(values: dict[str, Any]) -> str:
@@ -685,8 +734,16 @@ def _format_dir_name(values: dict[str, Any]) -> str:
     Returns ``""`` when ``values`` is empty so callers can fall back to a
     user-provided label. Single-dim sweeps produce ``{last_seg}_{value}``
     (e.g. ``concurrency_10``); multi-dim joins components with ``__``.
+
+    Also returns ``""`` when any value is a nested dict/list: scenario
+    sweeps without an explicit ``values:`` block carry the whole override
+    subtree here, which would stringify into an unreadable path
+    (``benchmark_{'phases': [...]}``). Falling back to the label yields the
+    human-authored name (e.g. ``aa-1k``).
     """
     if not values:
+        return ""
+    if _is_nested_override(values):
         return ""
     parts = []
     for dotted_key, value in values.items():
@@ -697,10 +754,12 @@ def _format_dir_name(values: dict[str, Any]) -> str:
 
 def _sanitize_dir_segment(segment: str) -> str:
     """Strip filesystem-unsafe characters from a single path segment."""
-    import re as _re
-
-    sanitized = _re.sub(r"[/\\]|\.\.", "", segment)
-    return _re.sub(r'[<>:"|?*]', "", sanitized)
+    sanitized = re.sub(r"[/\\]|\.\.", "", segment)
+    sanitized = re.sub(r'[<>:"|?*]', "", sanitized)
+    # An all-dots result (e.g. "." or "...") resolves to the current directory,
+    # so `base_dir / segment` collapses to `base_dir`; treat it as empty so
+    # callers fall back to a real segment.
+    return "" if set(sanitized) <= {"."} else sanitized
 
 
 # Resolve the forward ref on `SearchRecipeOutput.adaptive_search` once

--- a/src/aiperf/config/sweep/expand.py
+++ b/src/aiperf/config/sweep/expand.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+import warnings
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -410,7 +411,7 @@ def _expand_scenario_sweep(
     hashable groupings (e.g. pareto-sweep crossing paired ISL/OSL with a
     concurrency list) set ``values`` explicitly.
     """
-    from aiperf.config.sweep import SweepVariation
+    from aiperf.config.sweep import SweepVariation, _is_nested_override
 
     results = []
     for idx, scenario in enumerate(runs):
@@ -446,6 +447,15 @@ def _expand_scenario_sweep(
         variant = {k: v for k, v in variant.items() if k != "sweep"}
         label = scenario.get("name", f"scenario_{idx}")
         values = dict(explicit_values) if explicit_values is not None else scenario_data
+        if scenario.get("name") is None and _is_nested_override(values):
+            warnings.warn(
+                f"sweep run [{idx}]: no 'name:' set and its overrides are "
+                f"nested, so per-run and aggregate artifact directories fall "
+                f"back to the positional name '{label}'. Add a 'name:' "
+                f"(e.g. 'aa-1k') for readable directory names.",
+                UserWarning,
+                stacklevel=2,
+            )
         results.append((variant, SweepVariation(index=idx, label=label, values=values)))
     return results
 

--- a/src/aiperf/orchestrator/models.py
+++ b/src/aiperf/orchestrator/models.py
@@ -35,6 +35,11 @@ class RunResult(AIPerfBaseModel):
         default_factory=dict,
         description="Parameter values for this run's variation; mirror of variation.values.",
     )
+    variation_index: int = Field(
+        default=0,
+        ge=0,
+        description="Zero-based variation index; mirror of variation.index. Used to derive a unique fallback directory name.",
+    )
     trial_index: int = Field(
         default=0, description="Zero-based trial index within the variation."
     )

--- a/src/aiperf/orchestrator/orchestrator.py
+++ b/src/aiperf/orchestrator/orchestrator.py
@@ -717,4 +717,5 @@ class MultiRunOrchestrator:
         if run.variation is not None:
             result.variation_label = run.variation.label
             result.variation_values = dict(run.variation.values)
+            result.variation_index = run.variation.index
         result.trial_index = trial_index

--- a/tests/unit/config/test_sweep.py
+++ b/tests/unit/config/test_sweep.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for sweep configuration models and expansion."""
 
+import warnings
+
 import pytest
 from pydantic import ValidationError
 from pytest import param
@@ -65,6 +67,29 @@ class TestSweepModels:
     def test_scenario_sweep_forbids_extra(self):
         with pytest.raises(ValidationError):
             ScenarioSweep(runs=[{"x": 1}], unknown="bad")
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            param("../outside", id="parent_traversal"),
+            param("a/b", id="forward_slash"),
+            param("a\\b", id="backslash"),
+            param("..", id="dot_dot"),
+            param(".", id="single_dot"),
+            param("...", id="triple_dot"),
+        ],
+    )  # fmt: skip
+    def test_scenario_sweep_rejects_path_unsafe_names(self, bad_name):
+        """A scenario `name:` becomes a directory segment; path separators or
+        `..` could write artifacts outside the run dir, so reject them up
+        front with a clear error rather than silently sanitizing."""
+        with pytest.raises(ValidationError, match="path-unsafe"):
+            ScenarioSweep(runs=[{"name": bad_name, "phases": {"concurrency": 8}}])
+
+    def test_scenario_sweep_allows_safe_names(self):
+        """Readable names with dots/hyphens are accepted unchanged."""
+        sweep = ScenarioSweep(runs=[{"name": "aa-1k", "phases": {"concurrency": 8}}])
+        assert sweep.runs[0]["name"] == "aa-1k"
 
 
 class TestExpandSweep:
@@ -186,6 +211,67 @@ class TestExpandSweep:
         # Other fields preserved (deep-merge by name keeps base requests=10)
         assert self._phase(result[0][0], "profiling")["requests"] == 10
         assert self._phase(result[1][0], "profiling")["requests"] == 10
+
+    def test_scenario_unnamed_nested_overrides_warns_and_uses_positional_label(self):
+        """Nested overrides can't produce a readable dir name; without a
+        `name:` the dir falls back to `scenario_N`. Warn so the user can add
+        one, and confirm the positional fallback still yields a safe name."""
+        data = self._base_config(
+            sweep={
+                "type": "scenarios",
+                "runs": [
+                    {"benchmark": {"phases": [{"name": "profiling", "requests": 20}]}},
+                ],
+            }
+        )
+        with pytest.warns(UserWarning, match=r"no 'name:'"):
+            result = expand_sweep(data)
+        assert result[0][1].label == "scenario_0"
+        assert result[0][1].dir_name == "scenario_0"
+
+    def test_scenario_named_nested_overrides_does_not_warn(self):
+        """An explicit `name:` produces a readable dir name, so no nudge."""
+        data = self._base_config(
+            sweep={
+                "type": "scenarios",
+                "runs": [
+                    {
+                        "name": "aa-1k",
+                        "benchmark": {
+                            "phases": [{"name": "profiling", "requests": 20}]
+                        },
+                    },
+                ],
+            }
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = expand_sweep(data)
+        assert not any("no 'name:'" in str(w.message) for w in caught)
+        assert result[0][1].dir_name == "aa-1k"
+
+    def test_scenario_unnamed_flat_values_does_not_warn(self):
+        """Flat scalar overrides yield a readable `{leaf}_{value}` dir name,
+        so there is no positional fallback and no nudge even without a
+        `name:`."""
+        data = self._base_config(
+            sweep={
+                "type": "scenarios",
+                "runs": [
+                    {
+                        "values": {"phases.profiling.concurrency": 8},
+                        "benchmark": {
+                            "phases": [{"name": "profiling", "concurrency": 8}]
+                        },
+                    },
+                ],
+            }
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = expand_sweep(data)
+        assert not any("no 'name:'" in str(w.message) for w in caught)
+        assert result[0][1].dir_name == "concurrency_8"
 
     def test_magic_list_detection(self):
         data = self._base_config()
@@ -1260,11 +1346,58 @@ class TestSweepVariationDirName:
         # Format is `{last_seg}_{value}` => "rate_5.0-rps_v2".
         assert v.dir_name == "rate_5.0-rps_v2"
 
-    def test_label_fallback_path_is_not_sanitized(self):
-        """Fallback to `label` skips the sanitizer (label is user-controlled
-        but already validated upstream by sweep-name uniqueness checks).
-        Pin this so a refactor that double-sanitizes the label doesn't
-        silently strip user-meaningful characters from named scenarios.
-        """
+    def test_label_fallback_preserves_safe_chars(self):
+        """The label fallback is sanitized (a user-supplied scenario name
+        reaches `dir_name` and must not inject path segments), but safe
+        characters -- dots, hyphens -- survive so readable names are kept."""
         v = SweepVariation(index=0, label="scenario.with.dots", values={})
         assert v.dir_name == "scenario.with.dots"
+
+    def test_label_fallback_sanitizes_path_traversal(self):
+        """An unsafe label reaching the fallback is stripped of traversal
+        characters so artifacts stay inside the run directory. The
+        scenario-sweep model also rejects such names upstream; this is the
+        point-of-use backstop for any label from another source."""
+        v = SweepVariation(index=0, label="../../etc", values={})
+        assert "/" not in v.dir_name
+        assert ".." not in v.dir_name
+
+    def test_label_that_sanitizes_to_empty_falls_back_to_index(self):
+        """A label made entirely of separators/`..` sanitizes to "". Without a
+        final fallback `dir_name` would be "" and `base_dir / ""` collapses to
+        `base_dir`, so runs would overwrite each other. The index-based
+        segment keeps it non-empty and unique."""
+        v = SweepVariation(index=3, label="../..", values={})
+        assert v.dir_name == "variation_3"
+
+    def test_label_that_is_all_dots_falls_back_to_index(self):
+        """A dot-only label sanitizes to "" (it would resolve to the current
+        dir, collapsing `base_dir / dir_name` to `base_dir`); the index
+        fallback keeps dir_name non-empty and unique."""
+        assert SweepVariation(index=2, label=".", values={}).dir_name == "variation_2"
+        assert SweepVariation(index=5, label="...", values={}).dir_name == "variation_5"
+
+    def test_nested_dict_value_falls_back_to_label(self):
+        """Scenario sweeps without an explicit `values:` block carry the whole
+        override subtree in `values`; stringifying a nested dict produced
+        unreadable per-run dirs like `benchmark_{'phases': [...]}`. Fall back
+        to the human-authored label instead."""
+        v = SweepVariation(
+            index=0,
+            label="aa-1k",
+            values={
+                "benchmark": {
+                    "phases": [{"name": "profiling", "requests": 10}],
+                    "datasets": [{"name": "default"}],
+                }
+            },
+        )
+        assert v.dir_name == "aa-1k"
+
+    def test_nested_list_value_falls_back_to_label(self):
+        v = SweepVariation(
+            index=0,
+            label="aa-10k",
+            values={"phases": [{"name": "profiling", "requests": 20}]},
+        )
+        assert v.dir_name == "aa-10k"

--- a/tests/unit/test_cli_runner_sweep_helpers.py
+++ b/tests/unit/test_cli_runner_sweep_helpers.py
@@ -21,6 +21,7 @@ from aiperf.cli_runner._sweep_table import SweepTableLogger
 from aiperf.common.enums import SweepMode
 from aiperf.common.models.export_models import JsonMetricResult
 from aiperf.config.resolution.plan import BenchmarkConfig, BenchmarkPlan
+from aiperf.config.sweep import SweepVariation
 from aiperf.orchestrator.models import RunResult
 
 _MINIMAL_CONFIG_KWARGS = {
@@ -231,6 +232,46 @@ def test_variation_dir_name_nested_dict_values_uses_label():
         )
     ]
     assert _variation_dir_name(key, "aa-1k", group) == "aa-1k"
+
+
+def test_variation_dir_name_matches_per_run_for_sanitizable_label():
+    """Per-run (`SweepVariation.dir_name`) and aggregate (`_variation_dir_name`)
+    must produce the same directory for a sanitizable-but-allowed label such as
+    ``qps:100`` (valid on Linux/macOS, `:` stripped for portability), so a
+    variation's raw runs and its aggregate stay matched."""
+    label = "qps:100"
+    nested = {"benchmark": {"phases": [{"name": "profiling"}]}}
+    variation = SweepVariation(index=1, label=label, values=nested)
+    key = _variation_key(label, nested)
+    group = [
+        RunResult(
+            label="q",
+            success=True,
+            variation_label=label,
+            variation_values=nested,
+            variation_index=1,
+        )
+    ]
+    assert variation.dir_name == _variation_dir_name(key, label, group) == "qps100"
+
+
+def test_variation_dir_name_empty_label_falls_back_to_index():
+    """An all-consumed label sanitizes to "" on both paths; the shared
+    index-based fallback keeps per-run and aggregate matched and non-empty."""
+    label = ".."
+    nested = {"benchmark": {"phases": [{"name": "profiling"}]}}
+    variation = SweepVariation(index=4, label=label, values=nested)
+    key = _variation_key(label, nested)
+    group = [
+        RunResult(
+            label="x",
+            success=True,
+            variation_label=label,
+            variation_values=nested,
+            variation_index=4,
+        )
+    ]
+    assert variation.dir_name == _variation_dir_name(key, label, group) == "variation_4"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Cherry-pick of a71fa7a5 from `main` into `release/0.11.0`
- Original PR: #1080 — fix(config): use readable per-run dir names for nested scenario sweeps

## Conflicts
None — clean cherry-pick.