### PR TITLE
fix: render timeslice latency charts correctly

### DIFF
--- a/src/aiperf/plot/core/data_loader.py
+++ b/src/aiperf/plot/core/data_loader.py
@@ -335,9 +335,18 @@ class DataLoader(AIPerfLoggerMixin):
 
         if "input_config" in aggregated:
             input_config = aggregated["input_config"]
-            if "output" in input_config and "slice_duration" in input_config["output"]:
-                slice_duration = input_config["output"]["slice_duration"]
-                self.info(f"Extracted slice_duration: {slice_duration}s")
+            if isinstance(input_config, dict):
+                output_config = input_config.get("output")
+                artifacts_config = input_config.get("artifacts")
+                output_config = output_config if isinstance(output_config, dict) else {}
+                artifacts_config = (
+                    artifacts_config if isinstance(artifacts_config, dict) else {}
+                )
+                slice_duration = output_config.get("slice_duration")
+                if slice_duration is None:
+                    slice_duration = artifacts_config.get("slice_duration")
+                if slice_duration is not None:
+                    self.info(f"Extracted slice_duration: {slice_duration}s")
 
         metadata = self._extract_metadata(run_path, requests_df, aggregated)
 

--- a/src/aiperf/plot/core/plot_generator.py
+++ b/src/aiperf/plot/core/plot_generator.py
@@ -1451,8 +1451,8 @@ class PlotGenerator:
         if "std" in df.columns and (np.any(normal_mask) or np.any(outlier_mask)):
             fig.add_trace(
                 go.Scatter(
-                    x=[-999999, -999999],
-                    y=[0, 1],
+                    x=[None],
+                    y=[None],
                     mode="lines",
                     line=dict(
                         color=primary_color,

--- a/tests/unit/plot/test_data_loader.py
+++ b/tests/unit/plot/test_data_loader.py
@@ -34,6 +34,32 @@ class TestDataLoaderLoadRun:
         assert "time_to_first_token" in run.requests.columns
         assert "request_latency" in run.requests.columns
 
+    def test_load_run_reads_slice_duration_from_artifacts_config(
+        self,
+        tmp_path: Path,
+        sample_jsonl_data: list[dict[str, Any]],
+        sample_aggregated_data: dict[str, Any],
+    ) -> None:
+        """Test loading slice_duration from the v2 artifacts config shape."""
+        run_dir = tmp_path / "test_run"
+        run_dir.mkdir()
+
+        jsonl_lines = [
+            orjson.dumps(record).decode("utf-8") for record in sample_jsonl_data
+        ]
+        (run_dir / "profile_export.jsonl").write_text("\n".join(jsonl_lines) + "\n")
+
+        input_config = {
+            **sample_aggregated_data["input_config"],
+            "artifacts": {"slice_duration": 60.0},
+        }
+        aggregated = {**sample_aggregated_data, "input_config": input_config}
+        (run_dir / "profile_export_aiperf.json").write_bytes(orjson.dumps(aggregated))
+
+        run = DataLoader().load_run(run_dir)
+
+        assert run.slice_duration == 60.0
+
     def test_load_run_nonexistent_path(self, tmp_path: Path) -> None:
         """Test loading from nonexistent path raises error.
 

--- a/tests/unit/plot/test_plot_generator.py
+++ b/tests/unit/plot/test_plot_generator.py
@@ -569,6 +569,42 @@ class TestTimeSeriesHistogram:
         assert marker.color == LIGHT_MODE_PRIMARY_COLOR
 
 
+class TestTimesliceScatter:
+    """Tests for create_timeslice_scatter method."""
+
+    @pytest.fixture
+    def timeslice_df(self):
+        """Create sample timeslice summary DataFrame for testing."""
+        return pd.DataFrame(
+            {
+                "Timeslice": [0, 1, 2],
+                "avg": [100.0, 120.0, 110.0],
+                "std": [10.0, 12.0, 11.0],
+            }
+        )
+
+    def test_std_legend_trace_does_not_affect_x_axis(
+        self, plot_generator, timeslice_df
+    ):
+        """Test std legend proxy does not add sentinel values to the data range."""
+        fig = plot_generator.create_timeslice_scatter(
+            df=timeslice_df,
+            x_col="Timeslice",
+            y_col="avg",
+            metric_name="Time to First Token",
+            average_value=110.0,
+            average_std=8.0,
+        )
+
+        std_legend_trace = next(
+            trace for trace in fig.data if trace.name == "±1 Timeslice Std"
+        )
+
+        assert list(std_legend_trace.x) == [None]
+        assert list(std_legend_trace.y) == [None]
+        assert -999999 not in list(std_legend_trace.x)
+
+
 class TestDualAxisPlots:
     """Tests for dual-axis plotting functions."""
 


### PR DESCRIPTION
## Summary

Fix the AIPerf dashboard timeslice latency charts when plotting runs whose
`slice_duration` is stored under `input_config.artifacts`.

Before this change, the dashboard could render the `Time to First Token Across
Time Slices` and `Inter Token Latency Across Time Slices` plots as a single
compressed vertical line near `x=0`, even though the exported timeslice data
contained multiple slices.

This PR fixes two issues:

- Load `slice_duration` from the current exported config shape,
  `input_config.artifacts.slice_duration`, while keeping compatibility with the
  older `input_config.output.slice_duration` location.
- Stop using an off-screen numeric sentinel value for the `±1 Timeslice Std`
  legend proxy trace, because Plotly still includes that value in axis
  autorange.

## Motivation

The dashboard is used to inspect latency over time after running `aiperf plot
--dashboard`. For a run with 60-second timeslices, the expected chart should show
one aggregated point per timeslice, for example:

- `0s-60s`
- `60s-120s`
- `120s-180s`
- `180s-240s`
- `240s-300s`
- `300s-360s`

In the affected dashboard, the raw exported timeslice summary was correct, but
the chart x-axis expanded to approximately `-1M..0`. The real timeslice values
were then squeezed into the far right side of the plot and looked like one
vertical line.

## Problem Example

This is a representative affected run generated with 60-second timeslices. The
exported config stores the duration in the current `artifacts` config block
instead of the older `output` block:

```json
{
  "input_config": {
    "output": null,
    "artifacts": {
      "slice_duration": 60.0
    }
  }
}
```

The exported timeslice data contains six distinct buckets, so the dashboard
should render six separate points on the x-axis:

| Slice | Time Window | TTFT Avg | TTFT Std | ITL Avg | ITL Std |
| --- | --- | ---: | ---: | ---: | ---: |
| 0 | `0s-60s` | `5216.10 ms` | `3487.20 ms` | `14.86 ms` | `5.00 ms` |
| 1 | `60s-120s` | `5142.20 ms` | `2172.41 ms` | `12.34 ms` | `1.95 ms` |
| 2 | `120s-180s` | `4372.78 ms` | `2164.27 ms` | `13.36 ms` | `6.07 ms` |
| 3 | `180s-240s` | `6939.54 ms` | `4003.93 ms` | `15.02 ms` | `7.92 ms` |
| 4 | `240s-300s` | `5232.21 ms` | `2840.53 ms` | `13.22 ms` | `3.96 ms` |
| 5 | `300s-360s` | `6059.03 ms` | `3309.16 ms` | `14.06 ms` | `3.96 ms` |

Before this fix, the same run was rendered incorrectly:

- The loader did not read `input_config.artifacts.slice_duration`, so the
  dashboard did not know that each slice represented 60 seconds.
- The hidden legend helper for `±1 Timeslice Std` added this trace:

```python
go.Scatter(
    x=[-999999, -999999],
    y=[0, 1],
    mode="lines",
    name="±1 Timeslice Std",
)
```

Plotly included `-999999` in x-axis autorange. As a result, the chart used an
x-axis similar to `-1M, -0.8M, -0.6M, ..., 0`, and the real timeslice index
points `0..5` were compressed into a narrow strip near `x=0`. To a dashboard
user, the plot looked like a single vertical line instead of six timeslices.

After this fix, the dashboard uses the loaded 60-second duration to place the
points on a `0..360s` x-axis, renders one visible point per bucket, and shows
time-window hover labels. For example, the tooltip for slice 3 becomes:

```text
Time: 180s-240s
Slice: 3
Time to First Token (ms): 6939.54
```

When the chart is rendered correctly, each timeslice shows one average value
because the plot is intentionally displaying aggregated timeslice statistics.
This means that requests in slice 3 were bucketed into the `180s-240s` window
and summarized into one average TTFT point.

The vertical green bar around that point represents `±1 Timeslice Std`, the
gray horizontal line represents the run average, and the brown band represents
run average `±` run std.

## Changes

- Update `DataLoader.load_run()` to read `slice_duration` from both supported
  config shapes:
  - `input_config.output.slice_duration`
  - `input_config.artifacts.slice_duration`
- Keep the existing `output.slice_duration` path as the first lookup so older
  exports continue to behave the same way.
- Make the config access defensive by checking that nested config objects are
  dictionaries before reading from them.
- Change the `±1 Timeslice Std` legend-only trace from an off-screen numeric
  sentinel to `x=[None], y=[None]`, so it still appears in the legend without
  affecting Plotly autorange.
- Add unit coverage for loading `slice_duration` from `input_config.artifacts`.
- Add unit coverage to ensure the std legend proxy trace no longer contributes
  `-999999` to the plotted x-axis data.

## Files Changed

- `src/aiperf/plot/core/data_loader.py`
- `src/aiperf/plot/core/plot_generator.py`
- `tests/unit/plot/test_data_loader.py`
- `tests/unit/plot/test_plot_generator.py`

## Testing

- `uv run --extra test --with-editable ./tests/aiperf_mock_server pytest tests/unit/plot/test_data_loader.py::TestDataLoaderLoadRun::test_load_run_reads_slice_duration_from_artifacts_config tests/unit/plot/test_plot_generator.py::TestTimesliceScatter::test_std_legend_trace_does_not_affect_x_axis`
  - Result: `2 passed`
- `uv run --extra test --with-editable ./tests/aiperf_mock_server pytest tests/unit/plot/test_data_loader.py tests/unit/plot/test_plot_generator.py`
  - Result: `186 passed`
- `uv run ruff check src/aiperf/plot/core/data_loader.py src/aiperf/plot/core/plot_generator.py tests/unit/plot/test_data_loader.py tests/unit/plot/test_plot_generator.py`
  - Result: `All checks passed`

Known local validation note:

- Running the same pytest targets without `--with-editable
  ./tests/aiperf_mock_server` failed during test collection because the local
  test suite expects the editable `aiperf_mock_server` test package to be
  available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made timeslice duration extraction more resilient by reading it from multiple locations within run configuration, improving compatibility across input formats.
  * Updated the “±1 Timeslice Std” legend-only band in timeslice scatter charts to avoid using placeholder coordinates that could interfere with axis scaling.
* **Tests**
  * Added a unit test covering timeslice duration loading from artifact-style configuration.
  * Added plot tests verifying the std legend trace uses `None` coordinates and does not include the previous sentinel value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->