### PR TITLE
chore!: drop Python 3.10 support

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # AIPerf
 
-Python 3.10+ async AI benchmarking tool for measuring LLM inference server performance. 10 services communicate via ZMQ message bus.
+Python 3.11+ async AI benchmarking tool for measuring LLM inference server performance. 10 services communicate via ZMQ message bus.
 
 **Reference documentation:**
 - [`docs/architecture.md`](docs/architecture.md) - Three-plane architecture, core components, credit system, data flow, communication patterns

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # AIPerf
 
-Python 3.10+ async AI benchmarking tool for measuring LLM inference server performance. 10 services communicate via ZMQ message bus.
+Python 3.11+ async AI benchmarking tool for measuring LLM inference server performance. 10 services communicate via ZMQ message bus.
 
 **Reference documentation:**
 - [`docs/architecture.md`](docs/architecture.md) - Three-plane architecture, core components, credit system, data flow, communication patterns

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,11 +20,11 @@ jobs:
 
     - uses: actions/setup-python@v6
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install dependencies
       run: |
-        make first-time-setup PYTHON_VERSION=3.10
+        make first-time-setup PYTHON_VERSION=3.11
 
     - uses: pre-commit/action@v3.0.1
       with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux, macos, windows]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         include:
           - os: linux
             runner: prod-aiperf-builder-amd-v1

--- a/.github/workflows/test-docs-end-to-end.yml
+++ b/.github/workflows/test-docs-end-to-end.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - id: compare
         name: Compare parser-extracted config between base and head

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 # AIPerf
 
-Python 3.10+ async AI benchmarking tool for measuring LLM inference server performance. 10 services communicate via ZMQ message bus.
+Python 3.11+ async AI benchmarking tool for measuring LLM inference server performance. 10 services communicate via ZMQ message bus.
 
 **Reference documentation:**
 - [`docs/architecture.md`](docs/architecture.md) - Three-plane architecture, core components, credit system, data flow, communication patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 -->
 # AIPerf
 
-Python 3.10+ async AI benchmarking tool for measuring LLM inference server performance. 10 services communicate via ZMQ message bus.
+Python 3.11+ async AI benchmarking tool for measuring LLM inference server performance. 10 services communicate via ZMQ message bus.
 
 **Reference documentation:**
 - [`docs/architecture.md`](docs/architecture.md) - Three-plane architecture, core components, credit system, data flow, communication patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ For technical architecture, see [`docs/architecture.md`](docs/architecture.md). 
 
 ### Prerequisites
 
-- **Python 3.10+**
+- **Python 3.11+**
 - **uv**: Package manager (installed automatically by `make first-time-setup`)
 - **pre-commit**: For automated code quality checks
 

--- a/dev/benchmarks/zmq_credit_bench.py
+++ b/dev/benchmarks/zmq_credit_bench.py
@@ -391,7 +391,7 @@ async def _sub(mode, addr, count, result):
             socket=sub, recv_one=recv_one, dispatch=on_msg, batch_limit=YIELD_INTERVAL
         )
         reader.start()
-        with contextlib.suppress(asyncio.TimeoutError):
+        with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(done.wait(), timeout=60)
         reader.stop()
     else:

--- a/dev/benchmarks/zmq_credit_bench.py
+++ b/dev/benchmarks/zmq_credit_bench.py
@@ -403,7 +403,7 @@ async def _sub(mode, addr, count, result):
                 n += 1
                 if n % YIELD_INTERVAL == 0:
                     await asyncio.sleep(0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
     elapsed = (times["last"] - times["first"]) / 1e9
     result["count"] = len(lat)

--- a/docs/plugins/creating-your-first-plugin.md
+++ b/docs/plugins/creating-your-first-plugin.md
@@ -20,7 +20,7 @@ We'll create a plugin for a hypothetical "Echo API" that returns the input text 
 
 ## Prerequisites
 
-- Python 3.10+
+- Python 3.11+
 - AIPerf installed (`uv pip install aiperf`)
 - Basic understanding of Python async/await and Pydantic
 
@@ -102,7 +102,7 @@ build-backend = "hatchling.build"
 name = "my-aiperf-plugins"
 version = "0.1.0"
 description = "Custom AIPerf plugins for my use case"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "aiperf",
 ]

--- a/docs/tutorials/gpu-telemetry.md
+++ b/docs/tutorials/gpu-telemetry.md
@@ -120,7 +120,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 source $HOME/.local/bin/env
 
-uv venv --python 3.10
+uv venv --python 3.11
 
 source .venv/bin/activate
 
@@ -307,7 +307,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 source $HOME/.local/bin/env
 
-uv venv --python 3.10
+uv venv --python 3.11
 
 source .venv/bin/activate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,9 @@ license-files = ["LICENSE", "ATTRIBUTIONS.md"]
 authors = [
     { name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" },
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
   "aiofiles~=24.1.0",
-  "async-timeout>=4.0.0; python_version < '3.11'",
   "aiohttp~=3.13.3",
   "cyclopts>=4,<5",
   "fastapi>=0.115,<1",

--- a/src/aiperf/api/api_service.py
+++ b/src/aiperf/api/api_service.py
@@ -196,7 +196,7 @@ class FastAPIService(BaseComponentService):
                 )
             except TimeoutError:
                 self._server_task.cancel()
-                with suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                with suppress(asyncio.CancelledError, TimeoutError):
                     await asyncio.wait_for(
                         self._server_task,
                         timeout=Environment.SERVICE.TASK_CANCEL_TIMEOUT_SHORT,

--- a/src/aiperf/api/api_service.py
+++ b/src/aiperf/api/api_service.py
@@ -194,7 +194,7 @@ class FastAPIService(BaseComponentService):
                     self._server_task,
                     timeout=Environment.API_SERVER.SHUTDOWN_TIMEOUT,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 self._server_task.cancel()
                 with suppress(asyncio.CancelledError, asyncio.TimeoutError):
                     await asyncio.wait_for(

--- a/src/aiperf/common/enums/base_enums.py
+++ b/src/aiperf/common/enums/base_enums.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 from functools import cached_property
+from typing import Self
 
 from pydantic import BaseModel, Field
-from typing_extensions import Self
 
 
 def _normalize_name(value: str) -> str:

--- a/src/aiperf/common/enums/enums.py
+++ b/src/aiperf/common/enums/enums.py
@@ -1,9 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
-
-from typing_extensions import Self
+from typing import Any, Self
 
 from aiperf.common.enums.base_enums import CaseInsensitiveStrEnum
 

--- a/src/aiperf/common/enums/metric_enums.py
+++ b/src/aiperf/common/enums/metric_enums.py
@@ -4,10 +4,9 @@
 from collections.abc import Callable
 from enum import Flag
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeAlias, TypeVar
 
 from pydantic import Field, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums.base_enums import (
     BasePydanticBackedStrEnum,

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -40,11 +40,10 @@ Examples:
 """
 
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Self
 
 from pydantic import BeforeValidator, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing_extensions import Self
 
 from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.common.constants import IS_WINDOWS

--- a/src/aiperf/common/messages/command_messages.py
+++ b/src/aiperf/common/messages/command_messages.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import uuid
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self
 
 from pydantic import Field, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums import (
     CommandResponseStatus,

--- a/src/aiperf/common/mixins/base_metrics_collector_mixin.py
+++ b/src/aiperf/common/mixins/base_metrics_collector_mixin.py
@@ -451,7 +451,7 @@ class BaseMetricsCollectorMixin(AIPerfLifecycleMixin, ABC, Generic[TRecord]):
             # Fall back to GET if HEAD is not supported
             async with session.get(self._endpoint_url) as response:
                 return response.status == 200
-        except (aiohttp.ClientError, asyncio.TimeoutError):
+        except (TimeoutError, aiohttp.ClientError):
             return False
 
     @background_task(immediate=True, interval=lambda self: self.collection_interval)

--- a/src/aiperf/common/mixins/buffered_jsonl_writer_mixin.py
+++ b/src/aiperf/common/mixins/buffered_jsonl_writer_mixin.py
@@ -148,7 +148,7 @@ class BufferedJSONLWriterMixin(AIPerfLifecycleMixin, Generic[BaseModelT]):
                     self.wait_for_tasks(),
                     timeout=Environment.SERVICE.TASK_CANCEL_TIMEOUT_SHORT,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 self.warning(
                     f"Timeout waiting for {len(self.tasks)} pending flush tasks during shutdown. "
                     "Cancelling tasks and proceeding with cleanup."

--- a/src/aiperf/common/mixins/command_handler_mixin.py
+++ b/src/aiperf/common/mixins/command_handler_mixin.py
@@ -1,13 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
-import sys
 from abc import ABC
-
-if sys.version_info >= (3, 11):
-    from asyncio import timeout as async_timeout
-else:
-    from async_timeout import timeout as async_timeout
 from collections.abc import AsyncIterator, Iterable
 from typing import Any
 
@@ -184,7 +178,7 @@ class CommandHandlerMixin(MessageBusClientMixin, ABC):
         try:
             # Wait for the response future to be set by the command response message handler.
             return await asyncio.wait_for(future, timeout=timeout)
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             return ErrorDetails.from_exception(e)
         finally:
             future.cancel()
@@ -218,7 +212,7 @@ class CommandHandlerMixin(MessageBusClientMixin, ABC):
                 ),
                 timeout=timeout,
             )
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             return [ErrorDetails.from_exception(e) for _ in range(len(service_ids))]
         finally:
             # Clean up the response futures.
@@ -254,18 +248,18 @@ class CommandHandlerMixin(MessageBusClientMixin, ABC):
         seen: set[str] = set()
 
         try:
-            async with async_timeout(timeout):
+            async with asyncio.timeout(timeout):
                 for coro in asyncio.as_completed(futures.values()):
                     response = await coro
                     seen.add(response.service_id)
                     yield (response.service_id, response)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # Yield timeout errors for services that didn't respond
             for service_id in service_ids:
                 if service_id not in seen:
                     yield (
                         service_id,
-                        ErrorDetails.from_exception(asyncio.TimeoutError()),
+                        ErrorDetails.from_exception(TimeoutError()),
                     )
         finally:
             for future in futures.values():

--- a/src/aiperf/common/mixins/message_bus_mixin.py
+++ b/src/aiperf/common/mixins/message_bus_mixin.py
@@ -100,7 +100,7 @@ class MessageBusClientMixin(CommunicationMixin, ABC):
                         f"Connection probe for {self.id} succeeded after {attempt_count} attempts ({elapsed_time:.1f}s)"
                     )
                 return
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Compute from count to avoid floating point accumulation errors
                 elapsed_time = attempt_count * probe_interval
 

--- a/src/aiperf/common/models/auto_routed_model.py
+++ b/src/aiperf/common/models/auto_routed_model.py
@@ -37,11 +37,10 @@ Hierarchical discriminators (same field, multiple levels):
     # Routes directly: Animal.from_json({"type": "poodle"}) -> Poodle instance
 """
 
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
-from typing_extensions import Self
 
 from aiperf.common.utils import load_json_str
 

--- a/src/aiperf/common/models/server_metrics_models.py
+++ b/src/aiperf/common/models/server_metrics_models.py
@@ -3,10 +3,9 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import ClassVar
+from typing import ClassVar, Self
 
 from pydantic import Field, SerializeAsAny, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums import PrometheusMetricType
 from aiperf.common.finite import FiniteFloat

--- a/src/aiperf/common/tokenizer_validator.py
+++ b/src/aiperf/common/tokenizer_validator.py
@@ -514,7 +514,7 @@ async def _run_prefetch_pool(
         ]
         try:
             return await asyncio.wait_for(asyncio.gather(*futures), timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             if logger:
                 logger.warning(
                     f"Tokenizer preload exceeded "

--- a/src/aiperf/config/adaptive_scale_phase.py
+++ b/src/aiperf/config/adaptive_scale_phase.py
@@ -4,10 +4,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, model_validator
-from typing_extensions import Self
 
 from aiperf.config.sweep.adaptive import SLAFilter
 

--- a/src/aiperf/config/comm/dual_bind.py
+++ b/src/aiperf/config/comm/dual_bind.py
@@ -3,10 +3,9 @@
 
 import tempfile
 from pathlib import Path
-from typing import Annotated, ClassVar
+from typing import Annotated, ClassVar, Self
 
 from pydantic import Field, PrivateAttr, model_validator
-from typing_extensions import Self
 
 from aiperf.config.comm.base import BaseZMQCommunicationConfig, BaseZMQProxyConfig
 from aiperf.config.comm.ipc import (

--- a/src/aiperf/config/comm/ipc.py
+++ b/src/aiperf/config/comm/ipc.py
@@ -5,10 +5,9 @@ import hashlib
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Annotated, ClassVar
+from typing import Annotated, ClassVar, Self
 
 from pydantic import Field, PrivateAttr, model_validator
-from typing_extensions import Self
 
 from aiperf.common.constants import IS_WINDOWS
 from aiperf.config.comm.base import BaseZMQCommunicationConfig, BaseZMQProxyConfig

--- a/src/aiperf/config/comm/tcp.py
+++ b/src/aiperf/config/comm/tcp.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Annotated, ClassVar
+from typing import Annotated, ClassVar, Self
 
 from pydantic import Field, model_validator
-from typing_extensions import Self
 
 from aiperf.config.comm.base import BaseZMQCommunicationConfig, BaseZMQProxyConfig
 from aiperf.plugin.enums import CommunicationBackend

--- a/src/aiperf/config/config.py
+++ b/src/aiperf/config/config.py
@@ -32,10 +32,9 @@ Example Usage:
 from __future__ import annotations
 
 import difflib
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import ConfigDict, Field, PrivateAttr, field_validator, model_validator
-from typing_extensions import Self
 
 from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.config.accuracy import (

--- a/src/aiperf/config/dataset/content.py
+++ b/src/aiperf/config/dataset/content.py
@@ -12,7 +12,7 @@ used as building blocks inside dataset variants. Video configs live in
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import (
     BeforeValidator,
@@ -21,7 +21,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing_extensions import Self
 
 from aiperf.common.enums import (
     AudioFormat,

--- a/src/aiperf/config/dataset/video.py
+++ b/src/aiperf/config/dataset/video.py
@@ -9,7 +9,7 @@ Synthetic video and embedded-audio-track configuration.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import (
     BeforeValidator,
@@ -17,7 +17,6 @@ from pydantic import (
     Field,
     model_validator,
 )
-from typing_extensions import Self
 
 from aiperf.common.enums import (
     VideoAudioCodec,

--- a/src/aiperf/config/distributions.py
+++ b/src/aiperf/config/distributions.py
@@ -25,10 +25,9 @@ Discriminator rules (checked in order):
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, Self
 
 from pydantic import ConfigDict, Discriminator, Field, Tag, model_validator
-from typing_extensions import Self
 
 from aiperf.config.base import BaseConfig
 

--- a/src/aiperf/config/endpoint.py
+++ b/src/aiperf/config/endpoint.py
@@ -10,7 +10,7 @@ Endpoint - Server connection and API configuration
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 from urllib.parse import urlparse
 
 from pydantic import (
@@ -20,7 +20,6 @@ from pydantic import (
     field_serializer,
     model_validator,
 )
-from typing_extensions import Self
 
 from aiperf.common.enums import (
     ConnectionReuseStrategy,

--- a/src/aiperf/config/gpu_telemetry.py
+++ b/src/aiperf/config/gpu_telemetry.py
@@ -10,10 +10,9 @@ GPU Telemetry - Live or replayed GPU metrics collection configuration.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Self
 
 from pydantic import ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums import GPUTelemetryMode
 from aiperf.config.base import BaseConfig

--- a/src/aiperf/config/phases.py
+++ b/src/aiperf/config/phases.py
@@ -10,7 +10,7 @@ making invalid states unrepresentable.
 
 from __future__ import annotations
 
-from typing import Annotated, ClassVar, Literal
+from typing import Annotated, ClassVar, Literal, Self
 
 from pydantic import (
     ConfigDict,
@@ -18,7 +18,6 @@ from pydantic import (
     Field,
     model_validator,
 )
-from typing_extensions import Self
 
 from aiperf.config.adaptive_scale_phase import AdaptiveScalePhaseMixin
 from aiperf.config.base import BaseConfig

--- a/src/aiperf/config/plot.py
+++ b/src/aiperf/config/plot.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 
 import difflib
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 from aiperf.config.base import BaseConfig
 from aiperf.plot.core.plot_specs import ExperimentClassificationConfig

--- a/src/aiperf/config/resolution/plan.py
+++ b/src/aiperf/config/resolution/plan.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums import (
     GPUTelemetryMode,

--- a/src/aiperf/config/runtime.py
+++ b/src/aiperf/config/runtime.py
@@ -10,10 +10,9 @@ Re-exported via :mod:`aiperf.config`.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums import AIPerfLogLevel
 from aiperf.config.base import BaseConfig

--- a/src/aiperf/config/sweep/config.py
+++ b/src/aiperf/config/sweep/config.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import math
 import re
 import warnings
-from typing import Annotated, Any, ClassVar, Literal
+from typing import Annotated, Any, ClassVar, Literal, Self
 
 from pydantic import ConfigDict, Discriminator, Field, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums import OptimizationDirection, SweepMode
 from aiperf.common.finite import FiniteFloat

--- a/src/aiperf/config/sweep/multi_run.py
+++ b/src/aiperf/config/sweep/multi_run.py
@@ -11,10 +11,9 @@ on `SweepConfig` (`aiperf.config.sweep`) — not here.
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums import ConvergenceStat
 from aiperf.config.base import BaseConfig

--- a/src/aiperf/config/sweep/sampling.py
+++ b/src/aiperf/config/sweep/sampling.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 
 import math
 import warnings
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import ConfigDict, Field, field_validator, model_validator
-from typing_extensions import Self
 
 from aiperf.common.finite import is_finite_value
 from aiperf.config.base import BaseConfig

--- a/src/aiperf/controller/multiprocess_service_manager.py
+++ b/src/aiperf/controller/multiprocess_service_manager.py
@@ -200,7 +200,7 @@ class MultiProcessServiceManager(BaseServiceManager):
 
         try:
             await asyncio.wait_for(_wait_for_registration(), timeout=timeout_seconds)
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             # Log which services didn't register in time
             registered_types_set = set(
                 service_info.service_type

--- a/src/aiperf/credit/sticky_router.py
+++ b/src/aiperf/credit/sticky_router.py
@@ -321,7 +321,7 @@ class StickyCreditRouter(CommunicationMixin):
             return
         try:
             await asyncio.wait_for(self._worker_available_event.wait(), timeout)
-        except asyncio.TimeoutError as exc:
+        except TimeoutError as exc:
             raise RuntimeError(
                 f"No workers registered with the credit router within {timeout}s "
                 "(tunable via AIPERF_SERVICE_START_TIMEOUT); cannot start credit issuance"

--- a/src/aiperf/credit/structs.py
+++ b/src/aiperf/credit/structs.py
@@ -6,10 +6,9 @@ All over-the-wire structs use tag_field="t" for efficient polymorphic decoding v
 Tag values are short strings for minimal wire overhead.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from msgspec import Struct
-from typing_extensions import Self
 
 from aiperf.common.enums import ConversationBranchMode, CreditPhase
 

--- a/src/aiperf/dataset/agentic_code_gen/cli.py
+++ b/src/aiperf/dataset/agentic_code_gen/cli.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from rich.console import Console
@@ -61,7 +61,7 @@ def synthesize(
 
     dist_config = _apply_cli_overrides(dist_config, max_isl=max_isl, max_osl=max_osl)
 
-    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
+    timestamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
     run_dir_name = f"{config_name}_{num_sessions}s_seed{seed}_{timestamp}"
     run_dir = Path(output) / run_dir_name
 

--- a/src/aiperf/dataset/loader/exgentic.py
+++ b/src/aiperf/dataset/loader/exgentic.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 from collections import Counter
 from collections.abc import Iterable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from math import isfinite
 from typing import Any
 
@@ -55,9 +55,9 @@ def _validated_row_lists(
 
 
 def _timestamp_ms(value: str) -> float:
-    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    parsed = datetime.fromisoformat(value)
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
+        parsed = parsed.replace(tzinfo=UTC)
     return parsed.timestamp() * 1000.0
 
 

--- a/src/aiperf/dataset/loader/sagemaker_data_capture.py
+++ b/src/aiperf/dataset/loader/sagemaker_data_capture.py
@@ -32,7 +32,7 @@ from aiperf.dataset.loader.models import SageMakerDataCaptureTrace
 
 def _parse_iso8601_to_ms(iso_str: str) -> float:
     """Convert ISO 8601 inferenceTime to milliseconds since epoch."""
-    dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+    dt = datetime.fromisoformat(iso_str)
     return dt.timestamp() * 1000.0
 
 

--- a/src/aiperf/dataset/synthesis/models.py
+++ b/src/aiperf/dataset/synthesis/models.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Pydantic models for synthesis and analysis data."""
 
+from typing import Self
+
 from pydantic import Field
-from typing_extensions import Self
 
 from aiperf.common.models import AIPerfBaseModel
 from aiperf.config.dataset.defaults import InputTokensDefaults

--- a/src/aiperf/network_latency/probe.py
+++ b/src/aiperf/network_latency/probe.py
@@ -153,7 +153,7 @@ class NetworkLatencyProbeCollector(AIPerfLifecycleMixin):
                     lambda err=close_error: f"Error closing probe connection to "
                     f"{self._target_host}:{self._target_port}: {err!r}"
                 )
-        except (TimeoutError, OSError) as e:
+        except OSError as e:
             error = ErrorDetails.from_exception(e)
 
         if success:

--- a/src/aiperf/network_latency/probe.py
+++ b/src/aiperf/network_latency/probe.py
@@ -153,7 +153,7 @@ class NetworkLatencyProbeCollector(AIPerfLifecycleMixin):
                     lambda err=close_error: f"Error closing probe connection to "
                     f"{self._target_host}:{self._target_port}: {err!r}"
                 )
-        except (OSError, asyncio.TimeoutError) as e:
+        except (TimeoutError, OSError) as e:
             error = ErrorDetails.from_exception(e)
 
         if success:

--- a/src/aiperf/orchestrator/convergence/base.py
+++ b/src/aiperf/orchestrator/convergence/base.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Self
 
 from aiperf.orchestrator.jsonl_loader import DEFAULT_JSONL_FILENAME, load_single_metric
 from aiperf.orchestrator.models import RunResult

--- a/src/aiperf/plugin/extensible_enums.py
+++ b/src/aiperf/plugin/extensible_enums.py
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterator
 from enum import Enum
-
-from typing_extensions import Self
+from typing import Self
 
 
 def _normalize_name(value: str) -> str:

--- a/src/aiperf/plugin/plugins.py
+++ b/src/aiperf/plugin/plugins.py
@@ -188,7 +188,6 @@ class _PluginRegistry:
         """Discover and load plugin registries via setuptools entry points."""
         _logger.debug(lambda: f"Discovering plugins in {entry_point_group}")
 
-        # Discover entry points (Python 3.10+ API)
         eps = entry_points(group=entry_point_group)
 
         plugin_eps = list(eps)

--- a/src/aiperf/plugin/types.py
+++ b/src/aiperf/plugin/types.py
@@ -3,11 +3,10 @@
 import ast
 import importlib
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import SkipJsonSchema
-from typing_extensions import Self
 
 from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.plugin.schema.schemas import PluginSpec

--- a/src/aiperf/records/dataset_gate.py
+++ b/src/aiperf/records/dataset_gate.py
@@ -42,7 +42,7 @@ async def await_dataset_configured(
             event.wait(), timeout=Environment.DATASET.CONFIGURATION_TIMEOUT
         )
         return True
-    except asyncio.TimeoutError:
+    except TimeoutError:
         message = (
             "Dataset configuration not received after "
             f"{Environment.DATASET.CONFIGURATION_TIMEOUT}s; aborting run."

--- a/src/aiperf/server_metrics/parquet_exporter.py
+++ b/src/aiperf/server_metrics/parquet_exporter.py
@@ -3,7 +3,7 @@
 
 """Parquet exporter for raw server metrics with delta calculations."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -267,7 +267,7 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
             b"aiperf.schema_version": b"1.0",
             b"aiperf.version": aiperf_version.encode("utf-8"),
             b"aiperf.benchmark_id": self.run.benchmark_id.encode("utf-8"),
-            b"aiperf.export_timestamp_utc": datetime.now(timezone.utc)
+            b"aiperf.export_timestamp_utc": datetime.now(UTC)
             .isoformat()
             .encode("utf-8"),
             b"aiperf.exporter": b"ServerMetricsParquetExporter",

--- a/src/aiperf/server_metrics/storage.py
+++ b/src/aiperf/server_metrics/storage.py
@@ -3,11 +3,10 @@
 
 import logging
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import NamedTuple, Self
 
 import numpy as np
 from numpy.typing import NDArray
-from typing_extensions import Self
 
 from aiperf.common.constants import NANOS_PER_SECOND
 from aiperf.common.enums import PrometheusMetricType

--- a/src/aiperf/timing/config.py
+++ b/src/aiperf/timing/config.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 from pydantic import ConfigDict, Field, model_validator
-from typing_extensions import Self
 
 from aiperf.common.enums import CreditPhase
 from aiperf.common.models.base_models import AIPerfBaseModel

--- a/src/aiperf/timing/intervals.py
+++ b/src/aiperf/timing/intervals.py
@@ -9,10 +9,9 @@ Modes for inter-arrival time generation:
 - ConcurrencyBurst: Zero delay, throughput controlled by concurrency semaphore
 """
 
-from typing import Protocol, runtime_checkable
+from typing import Protocol, Self, runtime_checkable
 
 from pydantic import Field
-from typing_extensions import Self
 
 from aiperf.common import random_generator as rng
 from aiperf.common.models import AIPerfBaseModel

--- a/src/aiperf/timing/manager.py
+++ b/src/aiperf/timing/manager.py
@@ -157,7 +157,7 @@ class TimingManager(BaseComponentService):
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if not done:
-                raise asyncio.TimeoutError(
+                raise TimeoutError(
                     f"timed out waiting for dataset configuration after "
                     f"{Environment.DATASET.CONFIGURATION_TIMEOUT}s; check "
                     f"dataset-manager logs and consider raising "

--- a/src/aiperf/timing/phase/runner.py
+++ b/src/aiperf/timing/phase/runner.py
@@ -675,7 +675,7 @@ class PhaseRunner(TaskManagerMixin):
                     self.info(
                         f"All cancelled credits returned for phase {self._config.phase}"
                     )
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     self.error(
                         f"Timeout waiting {drain_timeout}s for cancelled credits to return. "
                         f"Some credits may be stuck. Forcing phase completion."
@@ -755,7 +755,7 @@ class PhaseRunner(TaskManagerMixin):
             self.debug(lambda: f"Event '{name}' set before timeout of {timeout}s")
             return False
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return _on_timeout()
 
         except Exception as e:

--- a/src/aiperf/timing/strategies/adaptive_scale_artifacts.py
+++ b/src/aiperf/timing/strategies/adaptive_scale_artifacts.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from collections.abc import Callable
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -24,7 +24,7 @@ SCHEMA_VERSION = 1
 
 def _iso_utc_from_ns(timestamp_ns: int) -> str:
     """Return an ISO-8601 UTC timestamp with nanosecond input precision."""
-    dt = datetime.fromtimestamp(timestamp_ns / 1_000_000_000, tz=timezone.utc)
+    dt = datetime.fromtimestamp(timestamp_ns / 1_000_000_000, tz=UTC)
     return dt.isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 

--- a/src/aiperf/transports/aiohttp_client.py
+++ b/src/aiperf/transports/aiohttp_client.py
@@ -404,7 +404,7 @@ class AioHttpClient(AIPerfLoggerMixin):
         )
         try:
             await asyncio.wait_for(request_sent.wait(), timeout=send_timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # Request never got sent - cancel and return error
             request_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -427,7 +427,7 @@ class AioHttpClient(AIPerfLoggerMixin):
 
         try:
             return await asyncio.wait_for(request_task, timeout=timeout_s)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             request_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await request_task

--- a/tests/aiperf_mock_server/config.py
+++ b/tests/aiperf_mock_server/config.py
@@ -32,9 +32,10 @@ def _load_cyclopts_parameter() -> type:
     raise ImportError("cyclopts.Parameter is not available in this cyclopts version")
 
 
+from typing import Self  # noqa: E402
+
 from pydantic import Field, model_validator  # noqa: E402
 from pydantic_settings import BaseSettings, SettingsConfigDict  # noqa: E402
-from typing_extensions import Self  # noqa: E402
 
 Parameter = _load_cyclopts_parameter()
 

--- a/tests/aiperf_mock_server/pyproject.toml
+++ b/tests/aiperf_mock_server/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "python-multipart>=0.0.7", # Required for FastAPI Form/File parsing on /v1/images/edits
 ]
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 [tool.setuptools]
 packages = ["aiperf_mock_server"]

--- a/tests/harness/fake_transport.py
+++ b/tests/harness/fake_transport.py
@@ -263,7 +263,7 @@ class FakeTransport(BaseTransport):
             # Wait for cancellation timeout or completion
             try:
                 return await asyncio.wait_for(request_task, timeout=cancel_delay_sec)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Cancel the request
                 request_task.cancel()
                 with suppress(asyncio.CancelledError):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -298,7 +298,7 @@ async def create_server(**kwargs: Any) -> AsyncIterator[AIPerfMockServer]:
                         raise RuntimeError(
                             f"AIPerf Mock Server failed to start (exit code: {process.poll()})"
                         )
-                except (aiohttp.ClientError, asyncio.TimeoutError):
+                except (TimeoutError, aiohttp.ClientError):
                     pass
                 await asyncio.sleep(0.1)
             else:
@@ -312,7 +312,7 @@ async def create_server(**kwargs: Any) -> AsyncIterator[AIPerfMockServer]:
                             asyncio.to_thread(process.join, timeout=5.0),
                             timeout=5.0,
                         )
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         process.kill()
                 raise RuntimeError(
                     f"AIPerf Mock Server failed to become healthy after 100 attempts "
@@ -328,7 +328,7 @@ async def create_server(**kwargs: Any) -> AsyncIterator[AIPerfMockServer]:
                     ) as resp:
                         if resp.status == 200:
                             break
-                except (aiohttp.ClientError, asyncio.TimeoutError):
+                except (TimeoutError, aiohttp.ClientError):
                     pass
                 await asyncio.sleep(0.1)
             else:
@@ -353,7 +353,7 @@ async def create_server(**kwargs: Any) -> AsyncIterator[AIPerfMockServer]:
                     asyncio.to_thread(process.join, timeout=5.0),
                     timeout=5.0,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 process.kill()
 
 
@@ -440,7 +440,7 @@ async def aiperf_runner(
             )
             stdout = stdout_bytes.decode("utf-8", errors="replace")
             stderr = stderr_bytes.decode("utf-8", errors="replace")
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _logger.warning(f"AIPerf timed out after {timeout}s, sending SIGINT")
             _cancel_aiperf_for_timeout(process)
             try:
@@ -449,7 +449,7 @@ async def aiperf_runner(
                 )
                 stdout = stdout_bytes.decode("utf-8", errors="replace")
                 stderr = stderr_bytes.decode("utf-8", errors="replace")
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _logger.warning(
                     "Process did not exit after SIGINT, sending SIGTERM to process group"
                 )
@@ -460,7 +460,7 @@ async def aiperf_runner(
                     )
                     stdout = stdout_bytes.decode("utf-8", errors="replace")
                     stderr = stderr_bytes.decode("utf-8", errors="replace")
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     _logger.warning(
                         "Process did not exit after SIGTERM, sending SIGKILL to process group"
                     )
@@ -567,7 +567,7 @@ class AIPerfSignalCLI:
                             )
                             profiling_started = True
                             break
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         # Timeout reading line, continue checking
                         continue
 
@@ -593,7 +593,7 @@ class AIPerfSignalCLI:
                 # Wait for graceful shutdown
                 try:
                     await asyncio.wait_for(process.wait(), timeout=30.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     _logger.warning(
                         "Process did not exit after SIGINT, sending SIGKILL to process group"
                     )

--- a/tests/unit/api/test_api_service.py
+++ b/tests/unit/api/test_api_service.py
@@ -319,7 +319,7 @@ class TestFastAPIServiceStartStop:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise asyncio.TimeoutError
+                raise TimeoutError
             return await real_wait_for(*args, **kwargs)
 
         with patch(

--- a/tests/unit/network_latency/test_probe_collector.py
+++ b/tests/unit/network_latency/test_probe_collector.py
@@ -10,7 +10,6 @@ socket. Every probe must produce exactly one NetworkLatencySample and never rais
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -88,7 +87,7 @@ class TestProbeOnceFailure:
         "exc",
         [
             ConnectionRefusedError("refused"),
-            asyncio.TimeoutError(),
+            TimeoutError(),
             OSError("network unreachable"),
         ],
     )  # fmt: skip
@@ -136,7 +135,7 @@ class TestProbeOnceFailure:
 
         with patch(
             "aiperf.network_latency.probe.asyncio.wait_for",
-            AsyncMock(side_effect=asyncio.TimeoutError()),
+            AsyncMock(side_effect=TimeoutError()),
         ):
             await collector.probe_once()
 

--- a/tests/unit/records/test_record_processor_service.py
+++ b/tests/unit/records/test_record_processor_service.py
@@ -190,7 +190,7 @@ class TestRecordProcessorDatasetConfiguredBarrier:
 
         async def _raise_timeout(coro, *args, **kwargs):
             coro.close()  # avoid "coroutine was never awaited" warning
-            raise asyncio.TimeoutError
+            raise TimeoutError
 
         monkeypatch.setattr(
             "aiperf.records.dataset_gate.asyncio.wait_for", _raise_timeout

--- a/tests/unit/records/test_records_manager.py
+++ b/tests/unit/records/test_records_manager.py
@@ -1159,7 +1159,7 @@ class TestRecordsManagerDatasetConfiguredBarrier:
 
         async def _raise_timeout(coro, *args, **kwargs):
             coro.close()  # avoid "coroutine was never awaited" warning
-            raise asyncio.TimeoutError
+            raise TimeoutError
 
         monkeypatch.setattr(
             "aiperf.records.dataset_gate.asyncio.wait_for", _raise_timeout

--- a/tools/generate_dpkg_attributions.py
+++ b/tools/generate_dpkg_attributions.py
@@ -23,9 +23,8 @@ import csv
 import re
 import subprocess
 import sys
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 # Maps legacy Debian shorthand to canonical SPDX identifiers.
 # DEP-5 pre-dates SPDX; older packages use forms like "GPL-2+" instead of

--- a/tools/generate_python_attributions.py
+++ b/tools/generate_python_attributions.py
@@ -16,9 +16,8 @@ import csv
 import json
 import re
 import sys
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 _HEADER = """\
 <!--


### PR DESCRIPTION
## Summary

Raises the minimum supported Python from 3.10 to 3.11 (`requires-python >=3.11,<3.14`), removes the 3.10 CI lanes, and deletes every 3.10 compatibility workaround in the codebase.

## Why

**1. Upcoming work needs 3.11.** A new AIPerf-native graph runtime, currently in
progress, is built on `asyncio.TaskGroup` and `ExceptionGroup` — both introduced
in Python 3.11. Raising the floor now clears the path so that work can land
without version guards, rather than shipping a feature the declared minimum
can't run.

**2. Python 3.10 reaches end-of-life this October** (October 2026).
Dropping it ahead of EOL is standard practice; no supported release of AIPerf
should outlive its interpreter's security support.

**3. 3.10 has been a recurring compatibility tax.** Concrete examples we've paid for:
- The `async-timeout` backport dependency plus a `sys.version_info` conditional
  import in `CommandHandlerMixin`, existing solely because `asyncio.timeout` is
  3.11+ (#29 originally had to downgrade `asyncio.timeout` to `asyncio.wait_for`
  for the same reason).
- A CI breakage in May 2026 where the `process_group=0` subprocess kwarg (3.11+)
  forced a version-conditional fallback that couldn't even be reproduced locally —
  no 3.10 interpreter installed — and had to be validated through a simulated
  code path.
- `.replace("Z", "+00:00")` shims before `datetime.fromisoformat()` calls,
  because 3.10 can't parse the `Z` suffix.
- The in-flight Kubernetes operator work pays both taxes again: another
  `Z`-suffix shim for parsing `metadata.creationTimestamp` in the operator
  results layout, and a preflight checker built on `asyncio.timeout` that
  needs the same `async-timeout` backport or `asyncio.wait_for` downgrade
  to run on a 3.10 floor. Every new subsystem re-buys the same workarounds.

**4. CI cost.** 3.10 was a full lane in both the unit-test matrix
(linux/macos/windows) and the integration-test matrix — machine time spent
validating a version on its way out.

**5. Cleaner baseline going forward.** With ruff's inferred target moving to
py311, the pyupgrade sweep auto-fixed 115 violations (`typing_extensions.Self`
→ `typing.Self`, `tomllib` recognized as stdlib), and new code is free to use
`asyncio.timeout`, `TaskGroup`, and `except*` without version guards.

## Changes

- `pyproject.toml` (+ mock server): `requires-python >=3.11,<3.14`; drop `async-timeout`
- CI: remove 3.10 from unit/integration matrices; bump pre-commit and test-docs workflows to 3.11
- Delete all 3.10 shims (conditional imports, `Z`-suffix workarounds)
- ruff py311 pyupgrade sweep (115 auto-fixes across 60+ files)
- Docs and agent files updated (four-file sync kept green)

**Kept:** `typing_extensions.TypedDict` in `accuracy/models.py` — Pydantic requires it over `typing.TypedDict` until the floor reaches 3.12.

## Breaking change

Users on Python 3.10 must upgrade their interpreter to install this and later releases. `pip`/`uv` will refuse to resolve new versions on 3.10 (clear install-time error rather than a runtime crash); the last 3.10-compatible release remains installable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project, setup, and tutorial docs to require Python 3.11+.
* **Bug Fixes**
  * Standardized async timeout handling to use the built-in `TimeoutError` across runtime and tests.
  * Improved timestamp parsing/UTC handling in dataset loading and metrics export.
* **Chores**
  * Updated CI/pre-commit/test workflows to newer Python versions.
  * Modernized type imports to rely on Python 3.11+ (`Self`), removing the extra typing backport usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->