### PR TITLE
test(ci): fix two windows/CI flake families in tests

### DIFF
--- a/tests/aiperf_mock_server/tokens.py
+++ b/tests/aiperf_mock_server/tokens.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import time
+import zlib
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -431,11 +432,18 @@ def _calculate_variable_token_count(
 
 
 def _generate_seed(prompt_tokens: list[str]) -> int:
-    """Generate deterministic seed from prompt tokens."""
+    """Generate a deterministic seed from prompt tokens.
+
+    Uses crc32 rather than ``hash()``: string hashing is salted per-process
+    via PYTHONHASHSEED, so ``hash()`` made mock-server output lengths vary
+    across CI jobs. When the salted seed landed exactly on the max_tokens
+    budget (~1/1000 jobs), tests asserting ``finish_reason == "stop"`` flaked
+    with ``"length"``. crc32 is stable across processes and platforms.
+    """
     if not prompt_tokens:
         return 0
     sample = prompt_tokens[:5]
-    return hash(tuple(sample)) % 1000
+    return zlib.crc32("\x1f".join(sample).encode()) % 1000
 
 
 def _cycle_tokens(

--- a/tests/component_integration/timing/test_advanced_scenarios.py
+++ b/tests/component_integration/timing/test_advanced_scenarios.py
@@ -20,6 +20,7 @@ from tests.component_integration.timing.conftest import (
     TimingTestConfig,
     build_timing_command,
     defaults,
+    skip_on_cloud_windows_timing,
 )
 from tests.harness.analyzers import (
     ConcurrencyAnalyzer,
@@ -207,6 +208,7 @@ class TestBenchmarkDurationAndGracePeriod:
     - Grace period timeout triggers forced cancellation
     """
 
+    @skip_on_cloud_windows_timing
     def test_benchmark_duration_stops_new_credits(self, cli: AIPerfCLI):
         """Test that benchmark duration stops issuing new credits.
 
@@ -240,6 +242,7 @@ class TestBenchmarkDurationAndGracePeriod:
             f"Duration should issue at least 2 requests, got {result.request_count}"
         )
 
+    @skip_on_cloud_windows_timing
     def test_zero_grace_period_immediate_cutoff(self, cli: AIPerfCLI):
         """Test zero grace period cancels in-flight requests immediately.
 
@@ -278,6 +281,7 @@ class TestBenchmarkDurationAndGracePeriod:
         credit_analyzer = CreditFlowAnalyzer(runner)
         assert credit_analyzer.total_credits == len(return_payloads)
 
+    @skip_on_cloud_windows_timing
     def test_multi_turn_with_duration_and_grace(self, cli: AIPerfCLI):
         """Test multi-turn conversations with duration and grace period.
 

--- a/tests/component_integration/timing/test_session_turn_delays.py
+++ b/tests/component_integration/timing/test_session_turn_delays.py
@@ -26,7 +26,10 @@ import pytest
 
 from aiperf.common.enums import CreditPhase
 from aiperf.credit.structs import Credit
-from tests.component_integration.timing.conftest import defaults
+from tests.component_integration.timing.conftest import (
+    defaults,
+    skip_on_cloud_windows_timing,
+)
 from tests.harness.analyzers import CreditFlowAnalyzer
 from tests.harness.utils import AIPerfCLI
 
@@ -158,6 +161,7 @@ class TestTurnDelayInteractions:
 
         assert credit_analyzer.credits_balanced()
 
+    @skip_on_cloud_windows_timing
     def test_turn_delay_with_duration_grace_period(self, cli: AIPerfCLI):
         """Test turn delays + duration + grace period interaction.
 

--- a/tests/unit/server/test_tokens.py
+++ b/tests/unit/server/test_tokens.py
@@ -10,6 +10,7 @@ from aiperf_mock_server.models import (
 )
 from aiperf_mock_server.tokens import (
     TokenizedText,
+    _generate_seed,
     _tokenize,
     count_tokens,
     tokenize,
@@ -383,3 +384,25 @@ class TestMinTokens:
         )
         result = tokenize_request(req)
         assert min_tokens <= result.count <= max_tokens
+
+
+class TestSeedDeterminism:
+    """_generate_seed must be stable across processes and platforms.
+
+    The previous hash()-based seed was salted per-process via PYTHONHASHSEED,
+    so output lengths varied per CI job; when the salted seed landed exactly
+    on the max_tokens budget (~1/1000 jobs), finish_reason flipped from
+    "stop" to "length" and count assertions flaked (reproducible with
+    PYTHONHASHSEED=960 on the old implementation). The pinned constants
+    below fail under any per-process-salted implementation.
+    """
+
+    def test_generate_seed_is_salt_independent(self):
+        assert _generate_seed(["Shor", "t"]) == 390
+
+    def test_generate_seed_empty_prompt_is_zero(self):
+        assert _generate_seed([]) == 0
+
+    def test_generate_seed_uses_first_five_tokens_only(self):
+        base = ["a", "b", "c", "d", "e"]
+        assert _generate_seed(base) == _generate_seed(base + ["f", "g"])


### PR DESCRIPTION
## Summary

Two unrelated sources of recurring CI flakes, both test-only changes:

### 1. Mock-server output lengths were `PYTHONHASHSEED`-dependent
`_generate_seed` in `tests/aiperf_mock_server/tokens.py` used `hash()`, which is salted per process — so generated token counts varied per CI job despite the docstring claiming determinism. When the salted seed landed exactly on the `max_tokens` budget (~1/1000 jobs), `finish_reason` flipped from `stop` to `length` and count assertions failed (deterministically reproducible with `PYTHONHASHSEED=960` on the old implementation). Now uses `zlib.crc32` — stable across processes and platforms — with salt-independence pin tests that fail under any per-process-salted implementation.

### 2. Sub-second wall-clock count floors on cloud windows runners
Four component-integration timing tests assert absolute request-count floors inside sub-second real windows (e.g. "dispatch ≥5 requests in 0.4s"). Cloud windows runners add hypervisor-level timer jitter that `timeBeginPeriod(1)` can't absorb, so slow runs dispatch fewer requests and trip the floor — a different test each time (observed across three PRs this week, e.g. `assert 3 >= 5`). Applied the repo's existing `skip_on_cloud_windows_timing` mark — the same policy and rationale the scheduler-precision tests already use — to:
- `test_turn_delay_with_duration_grace_period`
- `test_benchmark_duration_stops_new_credits`
- `test_zero_grace_period_immediate_cutoff`
- `test_multi_turn_with_duration_and_grace`

The logic remains covered on linux/macOS and windows correctness stays covered by the basic completion tests.

## Testing

- `pytest tests/unit/ -n auto` — 13,773 passed (includes all mock-server `server_unit` tests).
- `make integration-tests-ci` — 141/142 locally (the stragglers were unrelated single-xdist-worker load flakes on a busy dev box, different tests per run).
- New `TestSeedDeterminism` pins: known-input seed constant, empty-prompt zero, first-five-tokens-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in token-based behavior so results are more stable across runs and environments.
  * Reduced timing-related test flakiness by skipping certain benchmark delay scenarios on affected cloud Windows environments.

* **Tests**
  * Added coverage for deterministic token-seed behavior, including empty inputs and limited token influence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->