### PR TITLE
chore: bump distroless base image to 3.13-v4.0.8-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -259,7 +259,7 @@ ENTRYPOINT ["/bin/bash", "-c"]
 ############################################
 ############# Runtime Image ################
 ############################################
-FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.5-dev AS runtime
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.8-dev AS runtime
 
 # Include project license and asset attributions
 COPY LICENSE ATTRIBUTIONS.md /legal/


### PR DESCRIPTION
Bumps the runtime distroless Python base image from v4.0.5-dev to v4.0.8-dev to lower the container CVE profile.



(cherry picked from commit a592c1d52d98ae90bb5ff1aa41ca4eb3bcb1d3ac)