### PR TITLE
chore: bump distroless base image to 3.13-v4.0.8-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -259,7 +259,7 @@ ENTRYPOINT ["/bin/bash", "-c"]
 ############################################
 ############# Runtime Image ################
 ############################################
-FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.5-dev AS runtime
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.8-dev AS runtime
 
 # Include project license and asset attributions
 COPY LICENSE ATTRIBUTIONS.md /legal/


### PR DESCRIPTION
Bumps the runtime distroless Python base image from v4.0.5-dev to v4.0.8-dev to lower the container CVE profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s runtime environment to a newer base image. This may improve stability and keep the deployment stack current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->