### PR TITLE
test: stop _init_worker tests from leaking a raised root log level

### DIFF
--- a/tests/unit/common/test_tokenizer_validator.py
+++ b/tests/unit/common/test_tokenizer_validator.py
@@ -476,6 +476,19 @@ class TestValidatorFakeModelFallback:
 class TestInitWorker:
     """_init_worker must not raise and must configure the root logger."""
 
+    @pytest.fixture(autouse=True)
+    def _restore_root_logger(self):
+        # _init_worker mutates the process-global root logger (level +
+        # handlers). Snapshot and restore so a raised level (e.g. ERROR) can't
+        # leak into later tests and silently swallow their caplog assertions.
+        root = logging.getLogger()
+        level, handlers = root.level, root.handlers[:]
+        try:
+            yield
+        finally:
+            root.setLevel(level)
+            root.handlers[:] = handlers
+
     @pytest.mark.parametrize(
         "level",
         ["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -486,12 +499,8 @@ class TestInitWorker:
 
     def test_init_worker_configures_root_logger(self) -> None:
         root = logging.getLogger()
-        original_level = root.level
-        try:
-            _init_worker("WARNING")
-            assert root.level == logging.WARNING
-        finally:
-            root.setLevel(original_level)
+        _init_worker("WARNING")
+        assert root.level == logging.WARNING
 
 
 @pytest.mark.network


### PR DESCRIPTION
## What

A logging test was quietly leaving the whole test process louder than it should be, which made an unrelated config test flake under parallel test runs.

## ELI5

Think of the root logger as a volume knob for warnings. `_init_worker` turns that knob, and one parametrized case turns it all the way up to **ERROR** (so warnings go silent) — but never turns it back down when the test finishes.

Later, a different test says *"I expect a WARNING to be logged"* and checks for it with `caplog`. But the knob is still cranked to ERROR, so the warning is filtered before it's ever emitted, `caplog` sees nothing, and that test fails — even though the code it's testing is perfectly fine.

This only shows up sometimes because `pytest-xdist` shuffles which tests share a worker process. When the noisy test happens to run first on the same worker, the victim test fails. That's why it looks like a random flake.

## Root cause

`TestInitWorker.test_init_worker_does_not_raise` is parametrized over `["DEBUG", "INFO", "WARNING", "ERROR"]` and calls `_init_worker(level)`, which mutates the process-global root logger via `logging.root.setLevel(level)`. Unlike its sibling `test_init_worker_configures_root_logger`, it never restored the level, so the `"ERROR"` case pinned the root logger at ERROR for the rest of that worker process. `caplog` only restores levels it changed via `caplog.set_level`, not raw `root.setLevel` calls, so the leak survived across tests and files and silently swallowed later WARNING-level assertions (e.g. `test_flat_models_at_top_auto_migrates_to_envelope`).

## Fix

Add a class-scoped autouse fixture to `TestInitWorker` that snapshots and restores the root logger's level and handlers around every test in the class. This covers all `_init_worker` calls (current and future) and lets the sibling test drop its now-redundant manual `try/finally`. Test-only change — no product code touched.

## Verification

```bash
# Fails on main (noisy test runs first, then the victim); passes with this change:
uv run pytest \
  "tests/unit/common/test_tokenizer_validator.py::TestInitWorker" \
  "tests/unit/config/test_envelope_restructure.py::TestFlatShapeRejection::test_flat_models_at_top_auto_migrates_to_envelope"

# Surfaced while reviewing the pytest auto-worker-count change (#980), which reshuffles xdist sharding and made this latent flake reproducible. This fix addresses only the deterministic log-level leak; the separate parallel-only tokenizer and mlflow-spawn timing flakes are different concerns and are not touched here.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by restoring the root logger after each test, preventing logging changes from affecting later tests.
  * Simplified an existing logger configuration test while keeping the same validation of warning-level setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->