### PR TITLE
feat: support session IDs in request bodies

### DIFF
--- a/docs/benchmark-datasets.md
+++ b/docs/benchmark-datasets.md
@@ -86,6 +86,8 @@ aiperf profile \
   --fixed-schedule
 ```
 
+For an endpoint such as SGLang that expects the session identifier in the request body, add `--session-header x-dynamo-session-id --session-body-field session_id`. This copies each recorded Exgentic session ID into the top-level `session_id` field without changing the dataset.
+
 `source_model` selects the model that produced the trace; `--model` selects the target model receiving the replay. `benchmark` selects an Exgentic v2 workload. Invalid filters report the available harness/model combinations. The v1 dataset contains 22 combinations across five harnesses and six canonical source models.
 
 Fixed-schedule mode emits each recorded call as an independently scheduled one-turn request using its start offset from the source session. Calls that overlapped in the trace therefore overlap during replay. Selected source sessions start together at offset zero. Without `--fixed-schedule`, each source session remains a closed-loop multi-turn conversation: AIPerf waits for one live response before applying the recorded residual delay and sending the next request.

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -379,6 +379,10 @@ Content type for request body serialization. By default, requests are sent as 'a
 
 HTTP header name used to carry the per-session affinity identifier. When set, replaces the default `X-Correlation-ID` header with the provided name (e.g., `--session-header X-Session-ID`).
 
+#### `--session-body-field` `<str>`
+
+Optional request body field used to carry the same per-session affinity identifier as `--session-header` (or `X-Correlation-ID` by default). For example, use `--session-body-field session_id` for SGLang session-aware requests.
+
 ### Tokenizer
 
 #### `--tokenizer` `<str>`
@@ -1785,6 +1789,10 @@ Content type for request body serialization. By default, requests are sent as 'a
 #### `--session-header` `<str>`
 
 HTTP header name used to carry the per-session affinity identifier. When set, replaces the default `X-Correlation-ID` header with the provided name (e.g., `--session-header X-Session-ID`).
+
+#### `--session-body-field` `<str>`
+
+Optional request body field used to carry the same per-session affinity identifier as `--session-header` (or `X-Correlation-ID` by default). For example, use `--session-body-field session_id` for SGLang session-aware requests.
 
 ### Tokenizer
 

--- a/src/aiperf/common/models/model_endpoint_info.py
+++ b/src/aiperf/common/models/model_endpoint_info.py
@@ -139,6 +139,11 @@ class EndpointInfo(AIPerfBaseModel):
         description="HTTP header name to use for the per-session affinity identifier. "
         "When set, replaces the default `X-Correlation-ID` header name with this value.",
     )
+    session_body_field: str | None = Field(
+        default=None,
+        description="Optional request body field used to carry the same per-session "
+        "affinity identifier as the configured session header.",
+    )
     collect_trace_chunks: bool = Field(
         default=False,
         description="Collect per-chunk trace data (timestamps and sizes) for HTTP trace export. "
@@ -213,6 +218,7 @@ class ModelEndpointInfo(AIPerfBaseModel):
                 collect_trace_chunks=False,
                 template=getattr(ep, "template", None),
                 session_header=getattr(ep, "session_header", None),
+                session_body_field=getattr(ep, "session_body_field", None),
             ),
             transport=ep.transport,
         )

--- a/src/aiperf/config/endpoint.py
+++ b/src/aiperf/config/endpoint.py
@@ -316,6 +316,17 @@ class EndpointConfig(BaseConfig):
         ),
     ]
 
+    session_body_field: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Optional request body field used to carry the same per-session "
+                "affinity identifier as the configured session header."
+            ),
+        ),
+    ]
+
     wait_for_model_timeout: Annotated[
         float,
         Field(

--- a/src/aiperf/config/flags/_converter_endpoint.py
+++ b/src/aiperf/config/flags/_converter_endpoint.py
@@ -72,6 +72,7 @@ _ENDPOINT_FIELD_MAP: dict[str, str] = {
     "download_video_content": "download_video_content",
     "request_content_type": "request_content_type",
     "session_header": "session_header",
+    "session_body_field": "session_body_field",
 }
 
 

--- a/src/aiperf/config/flags/_section_fields.py
+++ b/src/aiperf/config/flags/_section_fields.py
@@ -23,6 +23,7 @@ ENDPOINT_FIELDS: frozenset[str] = frozenset(
         "model_names",
         "model_selection_strategy",
         "request_content_type",
+        "session_body_field",
         "session_header",
         "streaming",
         "timeout_seconds",

--- a/src/aiperf/config/flags/cli_config.py
+++ b/src/aiperf/config/flags/cli_config.py
@@ -389,6 +389,22 @@ class CLIConfig(BaseConfig):
         ),
     ] = None
 
+    session_body_field: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional request body field used to carry the same per-session "
+                "affinity identifier as `--session-header` (or `X-Correlation-ID` "
+                "by default). For example, use `--session-body-field session_id` "
+                "for SGLang session-aware requests."
+            ),
+        ),
+        CLIParameter(
+            name=("--session-body-field",),
+            group=Groups.ENDPOINT,
+        ),
+    ] = None
+
     @property
     def url(self) -> str:
         """Return the first URL for backward compatibility."""

--- a/src/aiperf/config/schema/aiperf-config.schema.json
+++ b/src/aiperf/config/schema/aiperf-config.schema.json
@@ -7214,6 +7214,19 @@
           "description": "HTTP header name used to carry the per-session affinity identifier. When set, replaces the default `X-Correlation-ID` header. Useful when the inference server expects a custom session-affinity header (e.g. `--session-header X-Session-ID`).",
           "title": "Sessionheader"
         },
+        "sessionBodyField": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional request body field used to carry the same per-session affinity identifier as the configured session header.",
+          "title": "Sessionbodyfield"
+        },
         "waitForModelTimeout": {
           "default": 0.0,
           "description": "Enable a pre-flight readiness probe by setting this to a positive value (seconds). aiperf applies this timeout to each URL/model probe before starting the benchmark, aborting with a non-zero exit if any probe times out. For multiple URLs or models, worst-case wall-clock time can be roughly this timeout multiplied by the number of URL/model probes. The probe strategy is controlled by `--wait-for-model-mode`, which defaults to sending a 1-token inference request. 0 (default) disables the probe. Eliminates the need for external shell-based readiness loops in containers and Kubernetes recipes.",

--- a/src/aiperf/transports/aiohttp_transport.py
+++ b/src/aiperf/transports/aiohttp_transport.py
@@ -319,6 +319,13 @@ class AioHttpTransport(BaseTransport):
         try:
             url = self.build_url(request_info)
             headers = self.build_headers(request_info)
+            session_body_field = request_info.model_endpoint.endpoint.session_body_field
+            if session_body_field:
+                session_header = (
+                    request_info.model_endpoint.endpoint.session_header
+                    or "X-Correlation-ID"
+                )
+                payload[session_body_field] = headers[session_header]
             use_form_data = (
                 request_info.model_endpoint.endpoint.request_content_type
                 == RequestContentType.MULTIPART_FORM_DATA

--- a/tests/unit/config/test_converter_endpoint_session.py
+++ b/tests/unit/config/test_converter_endpoint_session.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from aiperf.config.flags._converter_endpoint import build_endpoint
+from aiperf.config.flags.cli_config import CLIConfig
+
+
+def test_session_affinity_fields_are_added_to_endpoint() -> None:
+    endpoint = build_endpoint(
+        CLIConfig(
+            session_header="x-dynamo-session-id",
+            session_body_field="session_id",
+        )
+    )
+
+    assert endpoint["session_header"] == "x-dynamo-session-id"
+    assert endpoint["session_body_field"] == "session_id"

--- a/tests/unit/transports/test_aiohttp_transport.py
+++ b/tests/unit/transports/test_aiohttp_transport.py
@@ -5,9 +5,11 @@ import asyncio
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import orjson
 import pytest
 
 from aiperf.common.enums import ConnectionReuseStrategy, CreditPhase
+from aiperf.common.models import Turn
 from aiperf.common.models.record_models import RequestInfo, RequestRecord
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import TransportType
@@ -296,6 +298,26 @@ class TestAioHttpTransport:
         assert isinstance(json_bytes, bytes)
         assert b"messages" in json_bytes
         assert b"gpt-4" in json_bytes
+
+    @pytest.mark.asyncio
+    async def test_send_request_copies_resolved_session_header_to_body(self):
+        model_endpoint = create_model_endpoint_info()
+        model_endpoint.endpoint.session_header = "x-dynamo-session-id"
+        model_endpoint.endpoint.session_body_field = "session_id"
+        transport = AioHttpTransport(model_endpoint=model_endpoint)
+        await self._setup_initialized_transport_with_mock(transport)
+
+        request_info = create_request_info(model_endpoint)
+        request_info.turns = [
+            Turn(extra_headers={"x-dynamo-session-id": "source-session-1"})
+        ]
+        payload = {"model": "test-model", "messages": []}
+
+        await transport.send_request(request_info, payload)
+
+        args = self._extract_call_args(transport.aiohttp_client.post_request.call_args)
+        assert args["headers"]["x-dynamo-session-id"] == "source-session-1"
+        assert orjson.loads(args["json_bytes"])["session_id"] == "source-session-1"
 
     @pytest.mark.asyncio
     async def test_send_request_handles_exception(


### PR DESCRIPTION
Exgentic replay added in #1064 carries each recorded session ID in `x-dynamo-session-id`, while SGLang's session-aware cache expects the same ID in the request body's top-level `session_id` field. This adds an opt-in `--session-body-field` that copies the resolved per-request session header value into a configured body field, avoiding a dataset-specific adapter.

### What changed

- Added `--session-body-field` and threaded it through endpoint configuration and generated docs/schema.
- Copied the final resolved session header value into the configured body field immediately before HTTP serialization.
- Documented the SGLang + Exgentic usage and added config/transport coverage.

```mermaid
flowchart LR
    A["Exgentic source session"] --> B["Resolved session header"]
    B --> C["x-dynamo-session-id header"]
    B --> D["session_id request field"]
```

### Usage

```bash
aiperf profile ... \
  --session-header x-dynamo-session-id \
  --session-body-field session_id
```

### Validation

- Full unit suite: 14,454 passed, 96 skipped, 1 expected xfail.
- `pre-commit run --all-files`: passed.
- Live Exgentic fixed-schedule replay against SGLang session-aware HiCache: 9/9 HTTP 200, up to 2,668 cached prefix tokens, and closing the source session dereferenced 18 radix nodes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for copying a session identifier into a request body field during replay or request sending.
  * Introduced a new `--session-body-field` option in the CLI and corresponding configuration support.

* **Documentation**
  * Updated the CLI and replay guides with examples for session-aware requests, including endpoints that require the session ID in the request body.

* **Bug Fixes**
  * Requests now include the expected session value in both headers and the configured body field for supported endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->