### PR TITLE
ci: raise unit workflow timeout

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    # Windows x64 runners can finish the component tier just past 30 minutes.
+    timeout-minutes: 45
     # Force CPython UTF-8 mode so file reads default to UTF-8 instead of the
     # Windows cp1252 code page (no-op on POSIX). Without it, reading a UTF-8
     # file on Windows raises UnicodeDecodeError on bytes like 0x8f.


### PR DESCRIPTION
Windows x64 runners can finish the component tier just past the old 30-minute job budget, so restore the 45-minute cap and document the reason inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the unit test workflow timeout to allow slower runs more time to complete, helping reduce timeouts on Windows builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->