### PR TITLE
feat(accuracy): add MMLU-Pro benchmark + fix MMLU for reasoning models

### DIFF
--- a/docs/accuracy/accuracy-benchmarking.md
+++ b/docs/accuracy/accuracy-benchmarking.md
@@ -70,7 +70,8 @@ system message).
 
 | Benchmark | Default grader | Default n-shots | Source |
 |---|---|---|---|
-| `mmlu` | `multiple_choice` | 5 | `lighteval/mmlu` (57 subjects) |
+| `mmlu` | `multiple_choice` | 5 | `lighteval/mmlu` (57 subjects; non-CoT parity, `--accuracy-enable-cot` for reasoning models) |
+| `mmlu_pro` | `mmlu_pro` | 5 | `TIGER-Lab/MMLU-Pro` (14 categories, up to 10 options A-J, CoT-native) |
 | `aime` | `math` | 8 | `Maxwell-Jia/AIME_2024` (trt-llm reference, 8-shot CoT) |
 | `hellaswag` | `exact_match` | 10 | `Rowan/hellaswag` (trt-llm/DeepEval reference; one few-shot per unique activity_label) |
 | `bigbench` | `exact_match` | 3 | `lukaemon/bbh` (trt-llm/DeepEval reference; 27 subtasks, canonical CoT/non-CoT prompt files) |
@@ -128,6 +129,104 @@ uv pip install 'datasets>=3.0,<4'
 The error message names which condition fired (it includes the installed
 `datasets` version when ≥ 4) so operators get an actionable next step
 without reading the source.
+
+## MMLU chain-of-thought and reasoning models
+
+The `mmlu` benchmark has two prompting modes, selected by
+`--accuracy-enable-cot`:
+
+- **Non-CoT (default) — lighteval parity.** The prompt ends in a bare
+  `Answer:` trailer and the generation budget is `generation_size=5`
+  (mapped to the turn's `max_tokens`), with the `["\n"]` stop sequence.
+  This is byte-identical to lighteval's reference MMLU path: the server is
+  expected to emit a single answer letter immediately. Use this for
+  non-reasoning instruct models where you want reference-comparable scores.
+
+- **CoT — `--accuracy-enable-cot`.** The instruction is extended with
+  `Think step by step and then output the answer in the format of "The
+  answer is (X)" at the end.`, the query gets a `Let's think step by step.`
+  primer, and the generation budget is raised to the full
+  `generation_size=4000` so the model has room for a reasoning trace before
+  the final `The answer is (X)` line. The `multiple_choice` grader parses
+  the trailing letter.
+
+  ```bash
+  aiperf profile my-model --url http://localhost:8000 \
+    --endpoint-type chat \
+    --accuracy-benchmark mmlu \
+    --accuracy-enable-cot \
+    --num-requests 15000 \
+    --concurrency 10 \
+    --extra-inputs '{"temperature": 0}'
+  ```
+
+For reasoning models whose traces are long enough to exhaust the 4000-token
+budget before reaching the answer line, raise the budget with
+`--extra-inputs '{"max_completion_tokens": 16000}'`. The `--extra-inputs`
+value overrides the benchmark's `generation_size` (which is what the
+benchmark maps into the turn `max_tokens`), so the model can finish its
+reasoning:
+
+```bash
+aiperf profile my-model --url http://localhost:8000 \
+  --endpoint-type chat \
+  --accuracy-benchmark mmlu \
+  --accuracy-enable-cot \
+  --num-requests 15000 \
+  --concurrency 10 \
+  --extra-inputs '{"temperature": 0, "max_completion_tokens": 16000}'
+```
+
+### Troubleshooting: 0% / all-unparsed against a reasoning model
+
+An MMLU run that scores near 0% with (almost) every response flagged
+`unparsed` against a **reasoning** model is expected in **non-CoT** mode.
+The non-CoT prompt asks for a single answer letter under a 5-token budget,
+but a reasoning model emits chain-of-thought that never reaches (or is
+truncated before) a parseable letter, so extraction falls through every
+tier. This is not a grader bug. Fix it by giving the model room to reason:
+
+- add `--accuracy-enable-cot` (MMLU's CoT mode, full 4000-token budget), or
+- switch to the CoT-native `mmlu_pro` benchmark (below).
+
+## MMLU-Pro
+
+The `mmlu_pro` benchmark ports TIGER-AI-Lab's MMLU-Pro
+(`evaluate_from_api.py`) at parity:
+
+- **Dataset:** `TIGER-Lab/MMLU-Pro`. Test split provides the graded
+  questions; the validation split provides the per-category CoT few-shots.
+- **Categories (14):** `biology`, `business`, `chemistry`,
+  `computer science`, `economics`, `engineering`, `health`, `history`,
+  `law`, `math`, `philosophy`, `physics`, `psychology`, `other`. Restrict
+  with `--accuracy-tasks` (e.g. `--accuracy-tasks math,physics`); omit for
+  all 14.
+- **Options:** up to 10 per question, labeled `A`-`J` (`N/A` placeholder
+  options are filtered out before lettering).
+- **Defaults:** `default_n_shots: 5`, `default_enable_cot: true`,
+  `default_grader: mmlu_pro`. MMLU-Pro is **CoT-native** — the per-category
+  instruction always requests the `"The answer is (X)"` format and the
+  generation budget is `generation_size=4000`.
+- **Grader (`mmlu_pro`):** extracts the final `A`-`J` letter via the
+  upstream 3-tier cascade — `answer is (X)` -> `Answer: X` -> the last lone
+  in-range letter. A response parsed by a fallback tier (or not at all) is
+  flagged `unparsed`. No optional dependencies are required.
+
+Because MMLU-Pro defaults to CoT, it works with reasoning models out of the
+box; as with MMLU CoT, raise the budget via
+`--extra-inputs '{"max_completion_tokens": 16000}'` if long reasoning
+traces get truncated before the answer line.
+
+A **non-CoT** variant is available via `--accuracy-no-enable-cot`, which
+switches the few-shots and the query to a bare `Answer:` trailer. This is an
+AIPerf extension for quick low-latency runs and is **not** part of upstream
+MMLU-Pro parity — use the default CoT mode for reference-comparable scores.
+
+```bash
+aiperf profile --model <model> --url <url>/v1 --endpoint-type chat --streaming \
+  --tokenizer <model> --accuracy-benchmark mmlu_pro --num-requests 200 --concurrency 10 \
+  --extra-inputs '{"temperature": 0}'
+```
 
 ## CLI Flags
 
@@ -206,7 +305,8 @@ aiperf profile my-model --url http://localhost:8000 \
 
 | Grader | Selection rule | Coverage |
 |---|---|---|
-| `multiple_choice` | A/B/C/D match against gold letter (lighteval `ExactMatches`). | MMLU |
+| `multiple_choice` | A/B/C/D match against gold letter (lighteval `ExactMatches`). Under `--accuracy-enable-cot` the model emits a reasoning trace ending in `The answer is (X)`. | MMLU |
+| `mmlu_pro` | Extract the final `A`-`J` letter via the upstream 3-tier cascade: `answer is (X)` → `Answer: X` → last lone in-range letter. Fallback-tier or no-match responses are flagged `unparsed`. No optional dependencies. | MMLU-Pro |
 | `math` | Extract last `\boxed{...}`, fall back to "answer is X" / last number. Apply trt-llm `strip_string` normalization, then compare via `math_equal` (lowercase string → numeric `isclose` → symbolic equivalence via sympy + latex2sympy2-extended). | AIME |
 | `exact_match` | Stub. | (unused) |
 | `code_execution` | Stub. | (unused) |

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -265,7 +265,6 @@ aiperf profile --model your_model --url localhost:8000 --goodput "request_latenc
 #### `-m`, `--model-names`, `--model` `<list>`
 
 Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
-<br/>_Default: `[]`_
 
 #### `--model-selection-strategy` `<str>`
 
@@ -427,7 +426,6 @@ HuggingFace dataset subset/config name to override the plugin default (e.g. `sha
 #### `--dataset-filter` `<list>`
 
 Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
-<br/>_Default: `[]`_
 
 #### `--custom-dataset-type` `<str>`
 
@@ -1375,7 +1373,6 @@ Deprecated and ignored. The bayesian preset and the optuna expert mode both use 
 #### `--variant`, `--sweep-variant` `<list>`
 
 Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
-<br/>_Default: `[]`_
 
 #### `--search-sla` `<list>`
 
@@ -1726,7 +1723,6 @@ HTTP port for health endpoints (/healthz, /readyz). Required for Kubernetes live
 #### `-m`, `--model-names`, `--model` `<list>`
 
 Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
-<br/>_Default: `[]`_
 
 #### `--model-selection-strategy` `<str>`
 
@@ -1888,7 +1884,6 @@ HuggingFace dataset subset/config name to override the plugin default (e.g. `sha
 #### `--dataset-filter` `<list>`
 
 Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
-<br/>_Default: `[]`_
 
 #### `--custom-dataset-type` `<str>`
 
@@ -2836,7 +2831,6 @@ Deprecated and ignored. The bayesian preset and the optuna expert mode both use 
 #### `--variant`, `--sweep-variant` `<list>`
 
 Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
-<br/>_Default: `[]`_
 
 #### `--search-sla` `<list>`
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -265,6 +265,7 @@ aiperf profile --model your_model --url localhost:8000 --goodput "request_latenc
 #### `-m`, `--model-names`, `--model` `<list>`
 
 Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
+<br/>_Default: `[]`_
 
 #### `--model-selection-strategy` `<str>`
 
@@ -428,6 +429,7 @@ HuggingFace dataset subset/config name to override the plugin default (e.g. `sha
 #### `--dataset-filter` `<list>`
 
 Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
+<br/>_Default: `[]`_
 
 #### `--custom-dataset-type` `<str>`
 
@@ -1322,6 +1324,7 @@ Deprecated and ignored. The bayesian preset and the optuna expert mode both use 
 #### `--variant`, `--sweep-variant` `<list>`
 
 Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
+<br/>_Default: `[]`_
 
 #### `--search-sla` `<list>`
 
@@ -1436,7 +1439,7 @@ Number of log-spaced steps for the decode-itl-curve recipe's OSL grid (default 4
 #### `--accuracy-benchmark` `<str>`
 
 Accuracy benchmark to run (e.g., mmlu, aime, hellaswag). When set, enables accuracy benchmarking mode alongside performance profiling.
-<br/>_Choices: [`mmlu`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
+<br/>_Choices: [`mmlu`, `mmlu_pro`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
 
 #### `--accuracy-tasks` `<list>`
 
@@ -1447,7 +1450,7 @@ Specific tasks or subtasks within the benchmark to evaluate (e.g., specific MMLU
 Number of few-shot examples to include in the prompt. 0 means zero-shot evaluation, None uses the benchmark default (e.g. MMLU=5). Maximum 32.
 <br/>_Constraints: ≥ 0, ≤ 32_
 
-#### `--accuracy-enable-cot`
+#### `--accuracy-enable-cot`, `--accuracy-no-enable-cot`
 
 Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instructions to the prompt. Defaults to the benchmark's ``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).
 <br/>_Flag (no value required)_
@@ -1455,7 +1458,7 @@ Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instru
 #### `--accuracy-grader` `<str>`
 
 Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
-<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`]_
+<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`, `mmlu_pro`]_
 
 #### `--accuracy-system-prompt` `<str>`
 
@@ -1672,6 +1675,7 @@ HTTP port for health endpoints (/healthz, /readyz). Required for Kubernetes live
 #### `-m`, `--model-names`, `--model` `<list>`
 
 Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
+<br/>_Default: `[]`_
 
 #### `--model-selection-strategy` `<str>`
 
@@ -1835,6 +1839,7 @@ HuggingFace dataset subset/config name to override the plugin default (e.g. `sha
 #### `--dataset-filter` `<list>`
 
 Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
+<br/>_Default: `[]`_
 
 #### `--custom-dataset-type` `<str>`
 
@@ -2729,6 +2734,7 @@ Deprecated and ignored. The bayesian preset and the optuna expert mode both use 
 #### `--variant`, `--sweep-variant` `<list>`
 
 Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
+<br/>_Default: `[]`_
 
 #### `--search-sla` `<list>`
 
@@ -2843,7 +2849,7 @@ Number of log-spaced steps for the decode-itl-curve recipe's OSL grid (default 4
 #### `--accuracy-benchmark` `<str>`
 
 Accuracy benchmark to run (e.g., mmlu, aime, hellaswag). When set, enables accuracy benchmarking mode alongside performance profiling.
-<br/>_Choices: [`mmlu`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
+<br/>_Choices: [`mmlu`, `mmlu_pro`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
 
 #### `--accuracy-tasks` `<list>`
 
@@ -2854,7 +2860,7 @@ Specific tasks or subtasks within the benchmark to evaluate (e.g., specific MMLU
 Number of few-shot examples to include in the prompt. 0 means zero-shot evaluation, None uses the benchmark default (e.g. MMLU=5). Maximum 32.
 <br/>_Constraints: ≥ 0, ≤ 32_
 
-#### `--accuracy-enable-cot`
+#### `--accuracy-enable-cot`, `--accuracy-no-enable-cot`
 
 Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instructions to the prompt. Defaults to the benchmark's ``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).
 <br/>_Flag (no value required)_
@@ -2862,7 +2868,7 @@ Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instru
 #### `--accuracy-grader` `<str>`
 
 Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
-<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`]_
+<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`, `mmlu_pro`]_
 
 #### `--accuracy-system-prompt` `<str>`
 

--- a/src/aiperf/accuracy/accuracy_record_processor.py
+++ b/src/aiperf/accuracy/accuracy_record_processor.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from aiperf.accuracy.models import GradingResult
+from aiperf.accuracy.models import (
+    ACCURACY_RECORD_CORRECT_KEY,
+    ACCURACY_RECORD_UNPARSED_KEY,
+    GradingResult,
+)
 from aiperf.common.exceptions import PostProcessorDisabled
 from aiperf.common.mixins import AIPerfLifecycleMixin
 from aiperf.common.models import MetricRecordMetadata, ParsedResponseRecord
@@ -77,7 +81,9 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
 
         Maps ``metadata.session_num % len(_ground_truths)`` to the ground-truth
         answer, runs the configured grader, and returns a MetricRecordDict
-        containing ``accuracy.correct`` and ``accuracy.unparsed``.
+        containing the per-record transport keys ``accuracy_correct`` and
+        ``accuracy_unparsed`` (underscore-namespaced so they never collide with
+        the ``accuracy.`` summary tags).
 
         Raises:
             RuntimeError: if on_dataset_configured was not called before processing.
@@ -96,8 +102,8 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
 
         result: GradingResult = await self.grader.grade(response_text, ground_truth)
 
-        record_metrics["accuracy.correct"] = 1.0 if result.correct else 0.0
-        record_metrics["accuracy.unparsed"] = 1.0 if result.unparsed else 0.0
+        record_metrics[ACCURACY_RECORD_CORRECT_KEY] = 1.0 if result.correct else 0.0
+        record_metrics[ACCURACY_RECORD_UNPARSED_KEY] = 1.0 if result.unparsed else 0.0
 
         self._log_grading_detail(metadata.session_num, response_text, result)
 

--- a/src/aiperf/accuracy/accuracy_results_processor.py
+++ b/src/aiperf/accuracy/accuracy_results_processor.py
@@ -8,10 +8,13 @@ from typing import TYPE_CHECKING, Any
 
 from aiperf.accuracy.models import (
     ACCURACY_OVERALL_TAG,
+    ACCURACY_RECORD_CORRECT_KEY,
+    ACCURACY_RECORD_UNPARSED_KEY,
     ACCURACY_UNPARSED_TAG,
     accuracy_task_tag,
     accuracy_unparsed_task_tag,
 )
+from aiperf.common.enums import MetricConsoleGroup
 from aiperf.common.exceptions import PostProcessorDisabled
 from aiperf.common.mixins import AIPerfLifecycleMixin
 from aiperf.common.models import MetricResult
@@ -78,13 +81,13 @@ class AccuracyResultsProcessor(AIPerfLifecycleMixin):
                 "on_dataset_configured must be called before process_result"
             )
         metrics = record_data.metrics
-        correct = metrics.get("accuracy.correct")
+        correct = metrics.get(ACCURACY_RECORD_CORRECT_KEY)
         if correct is None:
             return
 
         task = self._tasks[record_data.metadata.session_num % len(self._tasks)]
         is_correct = float(correct) >= 0.5
-        is_unparsed = float(metrics.get("accuracy.unparsed", 0.0)) >= 0.5
+        is_unparsed = float(metrics.get(ACCURACY_RECORD_UNPARSED_KEY, 0.0)) >= 0.5
 
         self._overall_total += 1
         if is_correct:
@@ -121,6 +124,10 @@ class AccuracyResultsProcessor(AIPerfLifecycleMixin):
                     count=self._overall_total,
                     current=overall_acc,
                     sum=self._overall_correct,
+                    # Rendered by the dedicated Accuracy Benchmark Results table,
+                    # not the main LLM metrics table (a ratio has no avg/p99/etc,
+                    # so it would show as a row of N/A there).
+                    console_group=MetricConsoleGroup.NONE,
                 )
             )
 
@@ -136,6 +143,7 @@ class AccuracyResultsProcessor(AIPerfLifecycleMixin):
                     count=total,
                     current=acc,
                     sum=correct,
+                    console_group=MetricConsoleGroup.NONE,
                 )
             )
 
@@ -148,6 +156,7 @@ class AccuracyResultsProcessor(AIPerfLifecycleMixin):
                     count=self._overall_total,
                     current=self._overall_unparsed / self._overall_total,
                     sum=self._overall_unparsed,
+                    console_group=MetricConsoleGroup.NONE,
                 )
             )
 
@@ -162,6 +171,7 @@ class AccuracyResultsProcessor(AIPerfLifecycleMixin):
                     count=total,
                     current=unparsed / total if total > 0 else 0.0,
                     sum=unparsed,
+                    console_group=MetricConsoleGroup.NONE,
                 )
             )
 

--- a/src/aiperf/accuracy/benchmarks/mmlu.py
+++ b/src/aiperf/accuracy/benchmarks/mmlu.py
@@ -35,6 +35,10 @@ CHOICES = [f" {c}" for c in ascii_uppercase[:4]]
 GENERATION_SIZE = 5
 STOP_SEQUENCE = ["\n"]
 
+# Non-CoT (lighteval parity) budget. CoT needs room for a full reasoning
+# trace before the "The answer is (X)" line, matching MMLU-Pro's budget.
+COT_GENERATION_SIZE = 4000
+
 MMLU_SUBJECTS = [
     "abstract_algebra",
     "anatomy",
@@ -132,6 +136,7 @@ class MMLUBenchmark(AIPerfLoggerMixin):
         enable_cot: bool,
     ) -> list[BenchmarkProblem]:
         few_shots = self._build_few_shots(ds, n_shots)
+        gen_size = COT_GENERATION_SIZE if enable_cot else GENERATION_SIZE
         problems: list[BenchmarkProblem] = []
         for row in ds["test"]:
             prompt = self._format_prompt(row, subject, few_shots, enable_cot)
@@ -150,8 +155,8 @@ class MMLUBenchmark(AIPerfLoggerMixin):
                     task=subject,
                     metadata={
                         "subject": subject,
-                        "generation_size": GENERATION_SIZE,
-                        "stop_sequence": STOP_SEQUENCE,
+                        "generation_size": gen_size,
+                        "stop_sequence": [] if enable_cot else STOP_SEQUENCE,
                     },
                     raw_messages=raw_messages,
                 )
@@ -265,8 +270,14 @@ class MMLUBenchmark(AIPerfLoggerMixin):
         """
         instruction = (
             "The following are multiple choice questions (with answers) "
-            f"about {subject.replace('_', ' ')}.\n\n"
+            f"about {subject.replace('_', ' ')}."
         )
+        if enable_cot:
+            instruction += (
+                " Think step by step and then output the answer in the format of "
+                '"The answer is (X)" at the end.'
+            )
+        instruction += "\n\n"
 
         few_shot_text = "\n\n".join(ex["formatted"] for ex in few_shots)
         if few_shot_text:
@@ -303,8 +314,14 @@ class MMLUBenchmark(AIPerfLoggerMixin):
         """
         instruction = (
             "The following are multiple choice questions (with answers) "
-            f"about {subject.replace('_', ' ')}.\n\n"
+            f"about {subject.replace('_', ' ')}."
         )
+        if enable_cot:
+            instruction += (
+                " Think step by step and then output the answer in the format of "
+                '"The answer is (X)" at the end.'
+            )
+        instruction += "\n\n"
 
         messages: list[AccuracyChatMessage] = []
 

--- a/src/aiperf/accuracy/benchmarks/mmlu_pro.py
+++ b/src/aiperf/accuracy/benchmarks/mmlu_pro.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Portions of this file are derived from TIGER-AI-Lab/MMLU-Pro
+# (https://github.com/TIGER-AI-Lab/MMLU-Pro), licensed under Apache-2.0.
+
+"""MMLU-Pro benchmark loader, ported from TIGER-AI-Lab MMLU-Pro.
+
+Byte-equal to evaluate_from_api.py: dataset TIGER-Lab/MMLU-Pro, per-category
+instruction, N/A-filtered A-J options, validation-split CoT few-shots, and the
+"Let's think step by step." query primer. Pairs with MMLUProGrader.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from aiperf.accuracy.benchmarks._datasets_compat import load_dataset
+from aiperf.accuracy.models import AccuracyChatMessage, BenchmarkProblem
+from aiperf.common.mixins import AIPerfLoggerMixin
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
+
+DATASET_NAME = "TIGER-Lab/MMLU-Pro"
+CHOICE_MAP = "ABCDEFGHIJ"
+GENERATION_SIZE = 4000
+
+MMLU_PRO_CATEGORIES = [
+    "biology",
+    "business",
+    "chemistry",
+    "computer science",
+    "economics",
+    "engineering",
+    "health",
+    "history",
+    "law",
+    "math",
+    "philosophy",
+    "physics",
+    "psychology",
+    "other",
+]
+
+
+class MMLUProBenchmark(AIPerfLoggerMixin):
+    """MMLU-Pro benchmark loader (14 categories, up to 10 options, CoT-native)."""
+
+    def __init__(self, run: BenchmarkRun, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.run = run
+
+    async def load_problems(
+        self, tasks: list[str] | None, n_shots: int, enable_cot: bool
+    ) -> list[BenchmarkProblem]:
+        categories = self._resolve_categories(tasks)
+        dd = await asyncio.to_thread(load_dataset, DATASET_NAME)
+        return await asyncio.to_thread(self._build, dd, categories, n_shots, enable_cot)
+
+    def _resolve_categories(self, tasks: list[str] | None) -> list[str]:
+        if not tasks or "all" in tasks:
+            return MMLU_PRO_CATEGORIES
+        resolved: list[str] = []
+        for t in tasks:
+            if t not in MMLU_PRO_CATEGORIES:
+                raise ValueError(
+                    f"Unknown MMLU-Pro category '{t}'. Valid categories: "
+                    f"{', '.join(MMLU_PRO_CATEGORIES)}."
+                )
+            resolved.append(t)
+        return resolved
+
+    def _build(
+        self, dd: Any, categories: list[str], n_shots: int, enable_cot: bool
+    ) -> list[BenchmarkProblem]:
+        cot_by_cat: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in dd["validation"]:
+            cot_by_cat[row["category"]].append(row)
+
+        wanted = set(categories)
+        problems: list[BenchmarkProblem] = []
+        for row in dd["test"]:
+            category = row["category"]
+            if category not in wanted:
+                continue
+            few_shots = cot_by_cat.get(category, [])[:n_shots]
+            prompt = self._build_prompt(row, category, few_shots, enable_cot)
+            messages: list[AccuracyChatMessage] = [{"role": "user", "content": prompt}]
+            problems.append(
+                BenchmarkProblem(
+                    prompt=prompt,
+                    ground_truth=str(row["answer"]),
+                    task=category,
+                    metadata={
+                        "category": category,
+                        "generation_size": GENERATION_SIZE,
+                    },
+                    raw_messages=messages,
+                )
+            )
+        return problems
+
+    @staticmethod
+    def _options(options: list[str]) -> list[str]:
+        return [opt for opt in options if opt != "N/A"]
+
+    def _format_example(
+        self, question: str, options: list[str], cot_content: str
+    ) -> str:
+        if cot_content == "":
+            cot_content = "Let's think step by step."
+        if cot_content.startswith("A: "):
+            cot_content = cot_content[3:]
+        example = f"Question: {question}\nOptions: "
+        for i, opt in enumerate(self._options(options)):
+            example += f"{CHOICE_MAP[i]}. {opt}\n"
+        example += f"Answer: {cot_content}\n\n"
+        return example
+
+    def _build_prompt(
+        self,
+        row: dict[str, Any],
+        category: str,
+        few_shots: list[dict[str, Any]],
+        enable_cot: bool,
+    ) -> str:
+        if enable_cot:
+            # Upstream-parity CoT instruction: reason, then "The answer is (X)".
+            instruction = (
+                "The following are multiple choice questions (with answers) about "
+                f"{category}. Think step by step and then output the answer in the "
+                'format of "The answer is (X)" at the end.\n\n'
+            )
+        else:
+            # Non-CoT (AIPerf extension): request a bare letter, no CoT directive.
+            instruction = (
+                "The following are multiple choice questions (with answers) about "
+                f"{category}.\n\n"
+            )
+        prompt = instruction
+        for ex in few_shots:
+            # CoT few-shots carry the reference reasoning; non-CoT few-shots show
+            # only the bare gold letter so the model learns to answer directly.
+            ex_answer = ex["cot_content"] if enable_cot else str(ex["answer"])
+            prompt += self._format_example(ex["question"], ex["options"], ex_answer)
+
+        if enable_cot:
+            prompt += self._format_example(row["question"], row["options"], "")
+        else:
+            # Bare Answer: trailer, no "Let's think step by step." primer.
+            example = f"Question: {row['question']}\nOptions: "
+            for i, opt in enumerate(self._options(row["options"])):
+                example += f"{CHOICE_MAP[i]}. {opt}\n"
+            example += "Answer: \n\n"
+            prompt += example
+        return prompt

--- a/src/aiperf/accuracy/graders/_choice_extract.py
+++ b/src/aiperf/accuracy/graders/_choice_extract.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Portions of this file are derived from TIGER-AI-Lab/MMLU-Pro
+# (https://github.com/TIGER-AI-Lab/MMLU-Pro), licensed under Apache-2.0.
+
+"""Shared multiple-choice answer extraction.
+
+Adapts the TIGER-AI-Lab MMLU-Pro 3-tier extraction cascade
+(evaluate_from_api.py: extract_answer / extract_again / extract_final),
+parameterized on the letter range so MMLU (A-D) and MMLU-Pro (A-J) share it.
+
+Tiers 1 and 2 reproduce upstream verbatim. Tier 3 refines upstream's
+``[A-J](?=[^A-J]*$)`` (the last in-range char anywhere, including mid-word) to
+the last *standalone* in-range letter, avoiding spurious matches inside words
+like "FLAG". Tier 3 is always flagged as an unparsed fallback, so this refinement
+never affects a cleanly parsed score.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import cache
+
+
+@cache
+def _compiled(letters: str) -> tuple[re.Pattern[str], re.Pattern[str], re.Pattern[str]]:
+    cls = f"[{letters}]"
+    return (
+        re.compile(rf"answer is \(?({cls})\)?"),
+        re.compile(rf".*[aA]nswer:\s*({cls})", re.DOTALL),
+        re.compile(rf"\b{cls}\b(?!.*\b{cls}\b)", re.DOTALL),
+    )
+
+
+def extract_choice_letter(text: str, letters: str = "ABCDEFGHIJ") -> tuple[str, int]:
+    """Extract a choice letter from model output.
+
+    Returns (letter, tier): tier 1 = clean "answer is (X)", 2 = "Answer: X"
+    fallback, 3 = last lone in-range letter, 0 = no match (letter "").
+
+    Tier 1 returns the LAST "answer is (X)" match: chain-of-thought traces may
+    mention an intermediate answer ("maybe the answer is A ... actually the
+    answer is B") before the final one, and the model is instructed to put the
+    final answer last. Tiers 2 and 3 are already last-oriented.
+    """
+    tier1, tier2, tier3 = _compiled(letters)
+    matches = list(tier1.finditer(text))
+    if matches:
+        return matches[-1].group(1), 1
+    if (m := tier2.search(text)) is not None:
+        return m.group(1), 2
+    if (m := tier3.search(text)) is not None:
+        return m.group(0), 3
+    return "", 0

--- a/src/aiperf/accuracy/graders/mmlu_pro.py
+++ b/src/aiperf/accuracy/graders/mmlu_pro.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Portions of this file are derived from TIGER-AI-Lab/MMLU-Pro
+# (https://github.com/TIGER-AI-Lab/MMLU-Pro), licensed under Apache-2.0.
+
+"""MMLU-Pro grader.
+
+Ports TIGER-AI-Lab MMLU-Pro's answer extraction (A-J, whole-text
+"answer is (X)" cascade) via the shared extract_choice_letter helper.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aiperf.accuracy.graders._choice_extract import extract_choice_letter
+from aiperf.accuracy.graders.base import BaseGrader
+from aiperf.accuracy.models import GradingResult
+
+LETTERS = "ABCDEFGHIJ"
+
+
+class MMLUProGrader(BaseGrader):
+    """Grades MMLU-Pro CoT responses by extracting the final A-J letter."""
+
+    def _extract(self, response_text: str) -> tuple[str, bool]:
+        # Non-CoT output is a bare letter on the first line; treat that as a
+        # clean parse before falling to the whole-text "answer is (X)" cascade.
+        first_line = response_text.split("\n", 1)[0].strip()
+        if len(first_line) == 1 and first_line in LETTERS:
+            return first_line, False
+        letter, tier = extract_choice_letter(response_text, LETTERS)
+        return letter, tier != 1  # unparsed when a fallback tier (or no match) used
+
+    def extract_answer(self, response_text: str, **kwargs: Any) -> str:
+        letter, _ = self._extract(response_text)
+        return letter
+
+    async def grade(
+        self, response_text: str, ground_truth: str, **kwargs: Any
+    ) -> GradingResult:
+        pred, unparsed = self._extract(response_text)
+        gold = ground_truth.strip()
+        correct = pred == gold and pred != ""
+        return GradingResult(
+            correct=correct,
+            unparsed=unparsed,
+            confidence=1.0 if correct else 0.0,
+            reasoning=(
+                f"extracted '{pred}'"
+                + (" (fallback)" if unparsed else "")
+                + f"; ground_truth '{gold}'; match={correct}"
+            ),
+            extracted_answer=pred,
+            ground_truth=gold,
+        )

--- a/src/aiperf/accuracy/graders/multiple_choice.py
+++ b/src/aiperf/accuracy/graders/multiple_choice.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+from aiperf.accuracy.graders._choice_extract import extract_choice_letter
 from aiperf.accuracy.graders.base import BaseGrader
 from aiperf.accuracy.models import GradingResult
 
@@ -43,13 +44,37 @@ class MultipleChoiceGrader(BaseGrader):
         super().__init__(run=run, **kwargs)
 
     def _extract_with_flag(self, response_text: str) -> tuple[str, bool]:
-        """Return (answer, unparsed). unparsed=True when regex fallback was used."""
+        """Return (answer, unparsed). unparsed=True when a fallback past the
+        clean bare-letter first line was used.
+
+        Order matters for chain-of-thought output. A bare-letter first line
+        (non-CoT lighteval parity) wins first. Otherwise the explicit
+        ``"The answer is (X)"`` signal (tier 1 of the shared cascade) is tried
+        BEFORE the first-line lone-letter regex: CoT reasoning routinely echoes
+        the option list (e.g. ``"A. 0, B. 4, C. 2, D. 6"``) on its first line,
+        and the old first-line-regex-first order grabbed that echoed option
+        label instead of the model's actual answer.
+        """
         first_line = response_text.split("\n", 1)[0].strip()
         if first_line in _VALID_CHOICES:
             return first_line, False
+        letter, tier = extract_choice_letter(response_text, "ABCD")
+        # Explicit CoT answer statement anywhere in the response. This IS the
+        # requested answer format, so it is a clean parse (not unparsed).
+        if letter and tier == 1:
+            return letter, False
+        # An explicit "Answer: X" anywhere (tier 2) also beats the first-line
+        # lone-letter regex, which would otherwise grab an option label echoed
+        # in the reasoning (e.g. "A. 0, B. 4, ..." then a final "Answer: B").
+        if letter and tier == 2:
+            return letter, True
+        # Legacy first-line lone-letter fallback (messy non-CoT output).
         m = _LETTER_RE.search(first_line)
         if m:
             return m.group(1), True
+        # Whole-text last-lone-letter (tier 3, last resort).
+        if letter:
+            return letter, True
         return first_line, True
 
     def extract_answer(self, response_text: str, **kwargs: Any) -> str:

--- a/src/aiperf/accuracy/models.py
+++ b/src/aiperf/accuracy/models.py
@@ -8,11 +8,23 @@ from typing_extensions import TypedDict
 
 from aiperf.common.models.base_models import AIPerfBaseModel
 
+# Summary/metric tags (the ``accuracy.`` dot namespace) emitted by
+# AccuracyResultsProcessor.summarize() and read by the accuracy exporters.
 ACCURACY_OVERALL_TAG = "accuracy.overall"
 ACCURACY_TASK_TAG_PREFIX = "accuracy.task."
 ACCURACY_UNPARSED_TAG = "accuracy.unparsed"
 ACCURACY_UNPARSED_TASK_TAG_PREFIX = "accuracy.unparsed.task."
 ACCURACY_METRIC_PREFIX = "accuracy."
+
+# Per-record TRANSPORT keys (NOT metric tags): AccuracyRecordProcessor writes
+# these into each record's MetricRecordDict to hand the grade to
+# AccuracyResultsProcessor.process_result. They use an ``accuracy_`` (underscore)
+# prefix so they live outside the ``accuracy.`` (dot) summary namespace and can
+# never be mistaken for — or collide with — a summary/metric tag. Keeping them
+# in the dot namespace is what let a registered ``accuracy.unparsed`` metric
+# shadow the summary tag historically; the underscore keeps the two separate.
+ACCURACY_RECORD_CORRECT_KEY = "accuracy_correct"
+ACCURACY_RECORD_UNPARSED_KEY = "accuracy_unparsed"
 
 
 def accuracy_task_tag(task: str) -> str:

--- a/src/aiperf/common/enums/metric_enums.py
+++ b/src/aiperf/common/enums/metric_enums.py
@@ -787,6 +787,13 @@ class MetricFlags(Flag):
     Surfaces honest tail latency under non-trivial error rates — see
     https://github.com/ai-dynamo/aiperf/issues/688."""
 
+    DISABLE_ON_ACCURACY = 1 << 18
+    """Metrics that should not be computed when accuracy benchmarking mode is
+    enabled. Accuracy benchmarks set ``max_tokens`` as a generation ceiling that
+    the model is expected to stop well under (chain-of-thought answers finish
+    early), so metrics that assume ``max_tokens`` is a target — notably the
+    OSL-mismatch family — are meaningless there and only produce noise."""
+
     def has_flags(self, flags: "MetricFlags") -> bool:
         """Return True if the metric has ALL of the given flag(s) (regardless of other flags)."""
         # Bitwise AND will return the input flags only if all of the given flags are present.

--- a/src/aiperf/config/flags/cli_config.py
+++ b/src/aiperf/config/flags/cli_config.py
@@ -3530,6 +3530,7 @@ class CLIConfig(BaseConfig):
         CLIParameter(
             name=("--accuracy-enable-cot",),
             group=Groups.ACCURACY,
+            negative="--accuracy-no-enable-cot",
         ),
     ] = None
 

--- a/src/aiperf/config/schema/aiperf-config.schema.json
+++ b/src/aiperf/config/schema/aiperf-config.schema.json
@@ -20,6 +20,7 @@
     "AccuracyBenchmarkType": {
       "enum": [
         "mmlu",
+        "mmlu_pro",
         "aime",
         "hellaswag",
         "bigbench",
@@ -151,7 +152,8 @@
         "lighteval_expr",
         "lighteval_latex",
         "lighteval_gpqa",
-        "lighteval_gsm8k"
+        "lighteval_gsm8k",
+        "mmlu_pro"
       ],
       "title": "AccuracyGraderType",
       "type": "string"

--- a/src/aiperf/dataset/loader/accuracy_dataset_loader.py
+++ b/src/aiperf/dataset/loader/accuracy_dataset_loader.py
@@ -124,6 +124,14 @@ class AccuracyDatasetLoader:
                 if problem.metadata
                 else DEFAULT_GENERATION_SIZE
             )
+            # Benchmarks that need a server-side stop (e.g. MMLU non-CoT uses
+            # ``["\n"]`` for lighteval parity) declare it in metadata; ride it
+            # through the OpenAI-style ``extra_body["stop"]``. Empty/absent =>
+            # no stop (e.g. CoT, which must not truncate the reasoning).
+            stop_sequence = (
+                problem.metadata.get("stop_sequence") if problem.metadata else None
+            )
+            extra_body = {"stop": stop_sequence} if stop_sequence else None
 
             prompt_text = (
                 f"{system_prompt}\n\n{problem.prompt}"
@@ -135,6 +143,7 @@ class AccuracyDatasetLoader:
                 role="user",
                 raw_messages=messages,
                 max_tokens=gen_size,
+                extra_body=extra_body,
                 texts=[Text(contents=[prompt_text])],
             )
 

--- a/src/aiperf/metrics/types/accuracy_metrics.py
+++ b/src/aiperf/metrics/types/accuracy_metrics.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from aiperf.accuracy.models import (
+    ACCURACY_RECORD_CORRECT_KEY,
+    ACCURACY_RECORD_UNPARSED_KEY,
+)
 from aiperf.common.enums import GenericMetricUnit, MetricConsoleGroup, MetricFlags
 from aiperf.common.exceptions import NoMetricValue
 from aiperf.common.models import ParsedResponseRecord
@@ -9,15 +13,22 @@ from aiperf.metrics.metric_dicts import MetricRecordDict
 
 
 class AccuracyCorrectSumMetric(BaseAggregateMetric[float]):
-    """Running sum of per-record accuracy.correct values (1.0 correct, 0.0 incorrect).
+    """Registration for the per-record ``accuracy_correct`` transport key.
 
-    AccuracyRecordProcessor writes this tag to MetricRecordDict for every record.
-    Registered here so MetricResultsProcessor can aggregate it without warnings.
-    AccuracyAccumulator and AccuracyConsoleExporter own display; this metric
-    uses console_group=NONE | INTERNAL so it does not appear in the standard table.
+    AccuracyRecordProcessor writes ``accuracy_correct`` (1.0 correct / 0.0
+    incorrect) into every record's MetricRecordDict to hand the grade to
+    AccuracyResultsProcessor. The dict only accepts registered tags (it warns
+    and drops anything else), so this exists purely to register that key.
+
+    It is a transport key, NOT the accuracy display: ``INTERNAL`` +
+    ``console_group=NONE`` keep it out of the console table and file exports.
+    The user-facing accuracy summary is produced separately by
+    AccuracyResultsProcessor.summarize() under the ``accuracy.`` (dot) namespace,
+    which this ``accuracy_`` (underscore) tag deliberately stays out of so the
+    two can never collide.
     """
 
-    tag = "accuracy.correct"
+    tag = ACCURACY_RECORD_CORRECT_KEY
     header = "Accuracy Correct"
     unit = GenericMetricUnit.RATIO
     flags = MetricFlags.INTERNAL
@@ -27,9 +38,9 @@ class AccuracyCorrectSumMetric(BaseAggregateMetric[float]):
     def _parse_record(
         self, record: ParsedResponseRecord, record_metrics: MetricRecordDict
     ) -> float:
-        value = record_metrics.get("accuracy.correct")
+        value = record_metrics.get(ACCURACY_RECORD_CORRECT_KEY)
         if value is None:
-            raise NoMetricValue("accuracy.correct not in record_metrics")
+            raise NoMetricValue(f"{ACCURACY_RECORD_CORRECT_KEY} not in record_metrics")
         return float(value)
 
     def _aggregate_value(self, value: float) -> None:
@@ -37,14 +48,16 @@ class AccuracyCorrectSumMetric(BaseAggregateMetric[float]):
 
 
 class AccuracyUnparsedSumMetric(BaseAggregateMetric[float]):
-    """Running sum of per-record accuracy.unparsed values (1.0 unparsed, 0.0 conforming).
+    """Registration for the per-record ``accuracy_unparsed`` transport key.
 
-    AccuracyRecordProcessor writes this tag when the model output required the
-    regex fallback (e.g. 'The answer is B.' instead of 'B').
-    Uses console_group=NONE | INTERNAL so it does not appear in the standard table.
+    Same role as AccuracyCorrectSumMetric: registers the per-record
+    ``accuracy_unparsed`` (1.0 when the grader could not cleanly extract the
+    answer) transport key so the MetricRecordDict accepts it. Transport only —
+    ``INTERNAL`` + ``console_group=NONE``; the displayed unparsed counts come
+    from AccuracyResultsProcessor.summarize() in the ``accuracy.`` namespace.
     """
 
-    tag = "accuracy.unparsed"
+    tag = ACCURACY_RECORD_UNPARSED_KEY
     header = "Accuracy Unparsed"
     unit = GenericMetricUnit.RATIO
     flags = MetricFlags.INTERNAL
@@ -54,9 +67,9 @@ class AccuracyUnparsedSumMetric(BaseAggregateMetric[float]):
     def _parse_record(
         self, record: ParsedResponseRecord, record_metrics: MetricRecordDict
     ) -> float:
-        value = record_metrics.get("accuracy.unparsed")
+        value = record_metrics.get(ACCURACY_RECORD_UNPARSED_KEY)
         if value is None:
-            raise NoMetricValue("accuracy.unparsed not in record_metrics")
+            raise NoMetricValue(f"{ACCURACY_RECORD_UNPARSED_KEY} not in record_metrics")
         return float(value)
 
     def _aggregate_value(self, value: float) -> None:

--- a/src/aiperf/metrics/types/osl_mismatch_metrics.py
+++ b/src/aiperf/metrics/types/osl_mismatch_metrics.py
@@ -91,7 +91,7 @@ class OSLMismatchDiffMetric(BaseRecordMetric[float]):
     short_header = "OSL Diff"
     short_header_hide_unit = True
     unit = GenericMetricUnit.PERCENT
-    flags = MetricFlags.PRODUCES_TOKENS_ONLY
+    flags = MetricFlags.PRODUCES_TOKENS_ONLY | MetricFlags.DISABLE_ON_ACCURACY
     console_group = MetricConsoleGroup.NONE
     required_metrics: ClassVar[set[str]] = {
         RequestedOSLMetric.tag,
@@ -155,7 +155,11 @@ class OSLMismatchCountMetric(BaseAggregateCounterMetric[int]):
     short_header = "OSL Mismatches"
     short_header_hide_unit = True
     unit = GenericMetricUnit.REQUESTS
-    flags = MetricFlags.PRODUCES_TOKENS_ONLY | MetricFlags.NO_INDIVIDUAL_RECORDS
+    flags = (
+        MetricFlags.PRODUCES_TOKENS_ONLY
+        | MetricFlags.NO_INDIVIDUAL_RECORDS
+        | MetricFlags.DISABLE_ON_ACCURACY
+    )
     console_group = MetricConsoleGroup.NONE
     required_metrics: ClassVar[set[str]] = {
         OSLMismatchDiffMetric.tag,

--- a/src/aiperf/plugin/enums.py
+++ b/src/aiperf/plugin/enums.py
@@ -103,7 +103,7 @@ AccuracyGraderType = plugins.create_enum(PluginType.ACCURACY_GRADER, "AccuracyGr
 
 AccuracyBenchmarkTypeStr: TypeAlias = str
 AccuracyBenchmarkType = plugins.create_enum(PluginType.ACCURACY_BENCHMARK, "AccuracyBenchmarkType", module=__name__)
-"""Dynamic enum for accuracy benchmark. Example: AccuracyBenchmarkType.AIME, AccuracyBenchmarkType.GSM8K, AccuracyBenchmarkType.MMLU"""
+"""Dynamic enum for accuracy benchmark. Example: AccuracyBenchmarkType.AIME, AccuracyBenchmarkType.GSM8K, AccuracyBenchmarkType.MMLU_PRO"""
 
 DataExporterTypeStr: TypeAlias = str
 DataExporterType = plugins.create_enum(PluginType.DATA_EXPORTER, "DataExporterType", module=__name__)

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1501,6 +1501,13 @@ accuracy_grader:
       "####" marker when present). Compares numerically so "24" and "24.0"
       match. Pure-regex; no lighteval install required.
 
+  mmlu_pro:
+    class: aiperf.accuracy.graders.mmlu_pro:MMLUProGrader
+    description: |
+      MMLU-Pro grader. Extracts the final A-J letter from chain-of-thought
+      output via the upstream 3-tier cascade ("answer is (X)" ->
+      "Answer: X" -> last lone A-J letter). No optional dependencies.
+
 # =============================================================================
 # Accuracy Benchmarks
 # =============================================================================
@@ -1516,6 +1523,18 @@ accuracy_benchmark:
     metadata:
       default_grader: multiple_choice
       default_n_shots: 5
+
+  mmlu_pro:
+    class: aiperf.accuracy.benchmarks.mmlu_pro:MMLUProBenchmark
+    description: |
+      MMLU-Pro benchmark (TIGER-Lab/MMLU-Pro): 14 categories, up to 10 options
+      (A-J), chain-of-thought prompting at parity with the TIGER-AI-Lab
+      evaluate_from_api.py reference. Answer extracted via the "The answer is
+      (X)" cascade.
+    metadata:
+      default_grader: mmlu_pro
+      default_n_shots: 5
+      default_enable_cot: true
 
   aime:
     class: aiperf.accuracy.benchmarks.aime:AIMEBenchmark

--- a/src/aiperf/post_processors/base_metrics_processor.py
+++ b/src/aiperf/post_processors/base_metrics_processor.py
@@ -104,6 +104,12 @@ class BaseMetricsProcessor(AIPerfLifecycleMixin, ABC):
         if not self.run.cfg.slos:
             disallowed_flags |= MetricFlags.GOODPUT
 
+        accuracy_cfg = self.run.cfg.accuracy
+        if accuracy_cfg is not None and accuracy_cfg.enabled:
+            # In accuracy mode max_tokens is a generation ceiling, not a target,
+            # so metrics that assume otherwise (OSL-mismatch) are just noise.
+            disallowed_flags |= MetricFlags.DISABLE_ON_ACCURACY
+
         metrics: list[BaseMetric] = []
         applicable_tags = MetricRegistry.tags_applicable_to(
             required_flags,

--- a/src/aiperf/records/records_manager.py
+++ b/src/aiperf/records/records_manager.py
@@ -1472,6 +1472,36 @@ class RecordsManager(PullClientMixin, BaseComponentService):
                 timeslices = ts
         return records_results, timeslices, error_results
 
+    async def _summarize_accuracy_results_processors(self) -> list[MetricResult]:
+        """Summarize accuracy results processors orphaned by the accumulator engine.
+
+        AccuracyResultsProcessor lives in ``_metric_results_processors`` and
+        accumulates per-task correct/total/unparsed counts via ``process_result``
+        as records arrive, but emits its ``accuracy.*`` MetricResult rows only
+        from ``summarize()`` — which the accumulator refactor (#1102) no longer
+        calls. Run it here so the rows reach ProfileResults.records and the
+        accuracy exporters. Best-effort: a summarize failure is logged, never
+        fatal to the run.
+        """
+        from aiperf.accuracy.accuracy_results_processor import (
+            AccuracyResultsProcessor,
+        )
+
+        results: list[MetricResult] = []
+        for processor in self._metric_results_processors:
+            if not isinstance(processor, AccuracyResultsProcessor):
+                continue
+            try:
+                summary = await processor.summarize()
+            except Exception as e:  # noqa: BLE001
+                self.error(
+                    f"Accuracy summarize() failed for "
+                    f"{processor.__class__.__name__}: {e!r}"
+                )
+                continue
+            results.extend(r for r in summary if isinstance(r, MetricResult))
+        return results
+
     def _has_records_for_phase(self, phase: CreditPhase) -> bool:
         phase_trackers = getattr(self._records_tracker, "_phase_trackers", {})
         if not isinstance(phase_trackers, dict):
@@ -1629,11 +1659,24 @@ class RecordsManager(PullClientMixin, BaseComponentService):
         await self._finalize_stream_exporters()
 
         phase_stats = self._records_tracker.create_stats_for_phase(phase)
-        # Snapshot count BEFORE extending with efficiency metrics — `completed`
-        # reports the number of request-derived records, not derived aggregates.
+        # Snapshot count BEFORE extending with efficiency/accuracy aggregates —
+        # `completed` reports the number of request-derived records, not derived
+        # aggregates.
         records_completed = len(records_results)
 
         self._apply_gpu_efficiency_metrics(records_results, phase_stats, phase)
+
+        # The accumulator engine (#1102) became the sole summary producer, which
+        # orphaned results-processors that emit their summary via summarize() —
+        # notably AccuracyResultsProcessor, whose per-task accuracy rows are
+        # produced ONLY in summarize(). process_result() still accumulates its
+        # counters per-record, but summarize() is no longer called on the
+        # _metric_results_processors list, so its accuracy.* MetricResults never
+        # reached ProfileResults.records (empty accuracy table/CSV). Merge them
+        # back in (after the completed snapshot, since they are derived
+        # aggregates, not request records) so the accuracy exporters see them.
+        if phase == CreditPhase.PROFILING:
+            records_results.extend(await self._summarize_accuracy_results_processors())
 
         result = ProcessRecordsResult(
             results=ProfileResults(

--- a/tests/unit/accuracy/test_accuracy_record_processor.py
+++ b/tests/unit/accuracy/test_accuracy_record_processor.py
@@ -72,7 +72,7 @@ def _make_record_data(
 ) -> MetricRecordsData:
     return MetricRecordsData(
         metadata=create_metric_metadata(session_num=session_num),
-        metrics={"accuracy.correct": correct, "accuracy.unparsed": unparsed},
+        metrics={"accuracy_correct": correct, "accuracy_unparsed": unparsed},
     )
 
 
@@ -127,8 +127,8 @@ class TestAccuracyRecordProcessorSessionBounds:
         metadata = create_metric_metadata(session_num=1)
         result = await processor.process_record(sample_parsed_record, metadata)
 
-        assert result["accuracy.correct"] == 1.0
-        assert result["accuracy.unparsed"] == 0.0
+        assert result["accuracy_correct"] == 1.0
+        assert result["accuracy_unparsed"] == 0.0
         processor.grader.grade.assert_awaited_once_with("Hello world", "A")
 
     async def test_process_record_wraps_to_correct_problem(
@@ -152,8 +152,8 @@ class TestAccuracyRecordProcessorSessionBounds:
         metadata = create_metric_metadata(session_num=4)
         result = await processor.process_record(sample_parsed_record, metadata)
 
-        assert result["accuracy.correct"] == 0.0
-        assert result["accuracy.unparsed"] == 1.0
+        assert result["accuracy_correct"] == 0.0
+        assert result["accuracy_unparsed"] == 1.0
         processor.grader.grade.assert_awaited_once_with("Hello world", "B")
 
     async def test_process_record_last_valid_session_num_succeeds(
@@ -174,8 +174,8 @@ class TestAccuracyRecordProcessorSessionBounds:
         metadata = create_metric_metadata(session_num=1)
         result = await processor.process_record(sample_parsed_record, metadata)
 
-        assert result["accuracy.correct"] == 1.0
-        assert result["accuracy.unparsed"] == 0.0
+        assert result["accuracy_correct"] == 1.0
+        assert result["accuracy_unparsed"] == 0.0
 
     async def test_process_record_raises_if_not_configured(
         self, monkeypatch, sample_parsed_record
@@ -351,12 +351,12 @@ class TestAccuracyResultsProcessorSessionBounds:
     async def test_process_result_missing_unparsed_key_treated_as_conforming(
         self,
     ) -> None:
-        """Records without accuracy.unparsed (e.g. from older graders) count as conforming."""
+        """Records without accuracy_unparsed (e.g. from older graders) count as conforming."""
         processor = _make_results_processor()
         processor._tasks = ["algebra"]
         data = MetricRecordsData(
             metadata=create_metric_metadata(session_num=0),
-            metrics={"accuracy.correct": 1.0},  # no accuracy.unparsed key
+            metrics={"accuracy_correct": 1.0},  # no accuracy_unparsed key
         )
 
         await processor.process_result(data)

--- a/tests/unit/accuracy/test_choice_extract.py
+++ b/tests/unit/accuracy/test_choice_extract.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pytest import param
+
+from aiperf.accuracy.graders._choice_extract import extract_choice_letter
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        param("The answer is (D).", ("D", 1), id="tier1_parens"),
+        param("The answer is B", ("B", 1), id="tier1_no_parens"),
+        param("Reasoning...\nAnswer: F", ("F", 2), id="tier2_answer_colon"),
+        param("blah C blah then finally H", ("H", 3), id="tier3_last_lone"),
+        param("no letters here", ("", 0), id="no_match"),
+    ],
+)  # fmt: skip
+def test_extract_cascade_tiers(text, expected):
+    assert extract_choice_letter(text, "ABCDEFGHIJ") == expected
+
+
+def test_range_limits_to_abcd() -> None:
+    # 'H' is out of A-D range; tier-1 pattern must not match it.
+    assert extract_choice_letter("The answer is (H).", "ABCD") == ("", 0)
+
+
+def test_range_abcd_matches_in_range() -> None:
+    assert extract_choice_letter("The answer is (C).", "ABCD") == ("C", 1)
+
+
+def test_tier1_returns_last_answer_is_match() -> None:
+    # Intermediate musing before the final answer -> take the last one.
+    text = "Maybe the answer is (A). Let me reconsider. The answer is (C)."
+    assert extract_choice_letter(text, "ABCDEFGHIJ") == ("C", 1)

--- a/tests/unit/accuracy/test_hf_benchmark_datasets.py
+++ b/tests/unit/accuracy/test_hf_benchmark_datasets.py
@@ -75,6 +75,14 @@ _BENCHMARK_DATASETS = [
         id="mmlu",
     ),
     param(
+        "TIGER-Lab/MMLU-Pro",
+        None,
+        "test",
+        ["question", "options", "answer", "category"],
+        False,
+        id="mmlu_pro",
+    ),
+    param(
         "Rowan/hellaswag",
         None,
         "train",

--- a/tests/unit/accuracy/test_mmlu_cot.py
+++ b/tests/unit/accuracy/test_mmlu_cot.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aiperf.accuracy.benchmarks import mmlu as mmlu_mod
+from aiperf.accuracy.benchmarks.mmlu import MMLUBenchmark
+from aiperf.plugin.enums import AccuracyBenchmarkType, EndpointType
+from tests.unit.conftest import make_benchmark_run
+
+
+def _run():
+    return make_benchmark_run(
+        model_names=["m"],
+        endpoint_type=EndpointType.COMPLETIONS,
+        streaming=False,
+        accuracy={"benchmark": AccuracyBenchmarkType.MMLU},
+    )
+
+
+def _row():
+    return {"question": "2+2?", "choices": ["3", "4", "5", "6"], "answer": "B"}
+
+
+def _split(rows):
+    ds = MagicMock()
+    ds.__iter__ = MagicMock(side_effect=lambda: iter(rows))
+    ds.__len__ = MagicMock(return_value=len(rows))
+    ds.__getitem__ = MagicMock(side_effect=lambda i: rows[i])
+    return ds
+
+
+async def _load(enable_cot: bool):
+    dd = {"test": _split([_row()]), "dev": _split([])}
+    with patch("aiperf.accuracy.benchmarks.mmlu.load_dataset", return_value=dd):
+        return await MMLUBenchmark(run=_run()).load_problems(
+            tasks=["abstract_algebra"], n_shots=0, enable_cot=enable_cot
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_cot_generation_size_unchanged():
+    problems = await _load(enable_cot=False)
+    assert problems[0].metadata["generation_size"] == 5
+
+
+@pytest.mark.asyncio
+async def test_cot_generation_size_is_large():
+    problems = await _load(enable_cot=True)
+    assert problems[0].metadata["generation_size"] == mmlu_mod.COT_GENERATION_SIZE
+    assert mmlu_mod.COT_GENERATION_SIZE == 4000
+
+
+@pytest.mark.asyncio
+async def test_cot_prompt_requests_answer_format():
+    problems = await _load(enable_cot=True)
+    assert "The answer is (X)" in problems[0].prompt
+
+
+@pytest.mark.asyncio
+async def test_non_cot_prompt_has_no_answer_format_instruction():
+    problems = await _load(enable_cot=False)
+    assert "The answer is (X)" not in problems[0].prompt
+
+
+@pytest.mark.asyncio
+async def test_cot_chat_messages_also_request_answer_format():
+    # Chat-endpoint parity: the instruction must be added to raw_messages too,
+    # not just the flat completions prompt (mmlu.py::_build_chat_messages).
+    problems = await _load(enable_cot=True)
+    msgs = problems[0].raw_messages
+    assert msgs is not None
+    joined = "".join(m["content"] for m in msgs)
+    assert "The answer is (X)" in joined
+
+
+@pytest.mark.asyncio
+async def test_non_cot_chat_messages_have_no_answer_format():
+    problems = await _load(enable_cot=False)
+    msgs = problems[0].raw_messages
+    assert msgs is not None
+    joined = "".join(m["content"] for m in msgs)
+    assert "The answer is (X)" not in joined

--- a/tests/unit/accuracy/test_mmlu_pro_benchmark.py
+++ b/tests/unit/accuracy/test_mmlu_pro_benchmark.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aiperf.accuracy.benchmarks.mmlu_pro import (
+    GENERATION_SIZE,
+    MMLUProBenchmark,
+)
+from aiperf.accuracy.models import BenchmarkProblem
+from aiperf.plugin.enums import AccuracyBenchmarkType, EndpointType
+from tests.unit.conftest import make_benchmark_run
+
+if TYPE_CHECKING:
+    from aiperf.config.resolution.plan import BenchmarkRun
+
+
+def _run() -> BenchmarkRun:
+    return make_benchmark_run(
+        model_names=["test-model"],
+        endpoint_type=EndpointType.CHAT,
+        streaming=False,
+        accuracy={"benchmark": AccuracyBenchmarkType.MMLU_PRO},
+    )
+
+
+def _test_row(
+    qid: int = 1,
+    category: str = "math",
+    question: str = "What is 2+2?",
+    options: list[str] | None = None,
+    answer: str = "B",
+    cot: str = "",
+) -> dict[str, Any]:
+    return {
+        "question_id": qid,
+        "question": question,
+        "options": options if options is not None else ["3", "4", "5", "N/A"],
+        "answer": answer,
+        "answer_index": 1,
+        "category": category,
+        "cot_content": cot,
+    }
+
+
+def _val_row(category: str = "math") -> dict[str, Any]:
+    return _test_row(
+        qid=99,
+        category=category,
+        question="1+1?",
+        options=["1", "2"],
+        answer="B",
+        cot="We add one and one to get two. The answer is (B).",
+    )
+
+
+def _fake_split(rows: list[dict[str, Any]]) -> MagicMock:
+    ds = MagicMock()
+    ds.__iter__ = MagicMock(side_effect=lambda: iter(rows))
+    ds.__len__ = MagicMock(return_value=len(rows))
+    ds.__getitem__ = MagicMock(side_effect=lambda i: rows[i])
+    return ds
+
+
+def _fake_dataset(
+    test_rows: list[dict[str, Any]], val_rows: list[dict[str, Any]]
+) -> dict[str, MagicMock]:
+    # load_dataset(DATASET_NAME) returns a DatasetDict-like mapping.
+    dd = {"test": _fake_split(test_rows), "validation": _fake_split(val_rows)}
+    return dd
+
+
+async def _load(
+    test_rows: list[dict[str, Any]],
+    val_rows: list[dict[str, Any]],
+    **kw: Any,
+) -> list[BenchmarkProblem]:
+    with patch(
+        "aiperf.accuracy.benchmarks.mmlu_pro.load_dataset",
+        return_value=_fake_dataset(test_rows, val_rows),
+    ):
+        bench = MMLUProBenchmark(run=_run())
+        return await bench.load_problems(
+            tasks=kw.get("tasks"),
+            n_shots=kw.get("n_shots", 0),
+            enable_cot=kw.get("enable_cot", True),
+        )
+
+
+@pytest.mark.asyncio
+class TestMMLUProBenchmark:
+    async def test_cot_zero_shot_prompt_byte_equal(self) -> None:
+        problems = await _load([_test_row()], [_val_row()], n_shots=0, enable_cot=True)
+        expected = (
+            "The following are multiple choice questions (with answers) about "
+            "math. Think step by step and then output the answer in the format "
+            'of "The answer is (X)" at the end.\n\n'
+            "Question: What is 2+2?\nOptions: A. 3\nB. 4\nC. 5\n"
+            "Answer: Let's think step by step.\n\n"
+        )
+        assert problems[0].prompt == expected
+
+    async def test_na_options_filtered(self) -> None:
+        problems = await _load(
+            [_test_row(options=["3", "4", "5", "N/A"])], [_val_row()], n_shots=0
+        )
+        assert "N/A" not in problems[0].prompt
+        assert "D." not in problems[0].prompt  # only A,B,C survive
+
+    async def test_few_shot_uses_validation_cot(self) -> None:
+        problems = await _load([_test_row()], [_val_row()], n_shots=1, enable_cot=True)
+        assert "The answer is (B)." in problems[0].prompt  # few-shot cot present
+
+    async def test_non_cot_query_has_bare_answer_trailer(self) -> None:
+        problems = await _load([_test_row()], [_val_row()], n_shots=0, enable_cot=False)
+        assert problems[0].prompt.endswith("Answer: \n\n")
+        assert "Let's think step by step." not in problems[0].prompt
+
+    async def test_non_cot_instruction_drops_cot_directive(self) -> None:
+        # --accuracy-no-enable-cot must not request chain-of-thought.
+        problems = await _load([_test_row()], [_val_row()], n_shots=1, enable_cot=False)
+        p = problems[0].prompt
+        assert "Think step by step" not in p
+        assert "The answer is (X)" not in p
+        # Non-CoT few-shot answer is the bare gold letter, not "The answer is (B)."
+        assert "The answer is (B)." not in p
+        assert "Answer: B\n\n" in p
+
+    async def test_ground_truth_is_gold_letter(self) -> None:
+        problems = await _load([_test_row(answer="B")], [_val_row()])
+        assert problems[0].ground_truth == "B"
+
+    async def test_single_user_message(self) -> None:
+        problems = await _load([_test_row()], [_val_row()])
+        msgs = problems[0].raw_messages
+        assert msgs and len(msgs) == 1 and msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == problems[0].prompt
+
+    async def test_metadata_generation_size(self) -> None:
+        problems = await _load([_test_row()], [_val_row()])
+        assert problems[0].metadata["generation_size"] == GENERATION_SIZE
+        assert GENERATION_SIZE == 4000
+
+    async def test_task_is_category(self) -> None:
+        problems = await _load(
+            [_test_row(category="physics")], [_val_row(category="physics")]
+        )
+        assert problems[0].task == "physics"
+
+    async def test_category_filter(self) -> None:
+        rows = [_test_row(category="math"), _test_row(category="physics")]
+        vals = [_val_row("math"), _val_row("physics")]
+        problems = await _load(rows, vals, tasks=["math"])
+        assert {p.task for p in problems} == {"math"}
+
+    async def test_unknown_category_raises(self) -> None:
+        with pytest.raises(ValueError, match="nonsense"):
+            await _load([_test_row()], [_val_row()], tasks=["nonsense"])

--- a/tests/unit/accuracy/test_mmlu_pro_grader.py
+++ b/tests/unit/accuracy/test_mmlu_pro_grader.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from aiperf.accuracy.graders.mmlu_pro import MMLUProGrader
+from aiperf.plugin.enums import AccuracyBenchmarkType, EndpointType
+from tests.unit.conftest import make_benchmark_run
+
+
+def _make_grader() -> MMLUProGrader:
+    return MMLUProGrader(
+        run=make_benchmark_run(
+            model_names=["test-model"],
+            endpoint_type=EndpointType.CHAT,
+            streaming=False,
+            accuracy={"benchmark": AccuracyBenchmarkType.MMLU_PRO},
+        )
+    )
+
+
+@pytest.mark.asyncio
+class TestMMLUProGrade:
+    async def test_tier1_clean(self) -> None:
+        r = await _make_grader().grade("... The answer is (F).", "F")
+        assert r.correct and not r.unparsed and r.extracted_answer == "F"
+
+    async def test_tier2_flags_unparsed(self) -> None:
+        r = await _make_grader().grade("Reasoning.\nAnswer: F", "F")
+        assert r.correct and r.unparsed
+
+    async def test_tier3_flags_unparsed(self) -> None:
+        r = await _make_grader().grade("I weigh options; ultimately G", "G")
+        assert r.correct and r.unparsed
+
+    async def test_full_range_j(self) -> None:
+        r = await _make_grader().grade("The answer is (J).", "J")
+        assert r.correct
+
+    async def test_wrong_letter(self) -> None:
+        r = await _make_grader().grade("The answer is (A).", "B")
+        assert not r.correct and not r.unparsed
+
+    async def test_no_match_unparsed(self) -> None:
+        r = await _make_grader().grade("no idea", "C")
+        assert not r.correct and r.unparsed and r.extracted_answer == ""
+
+    async def test_reasoning_plus_content_concatenated(self) -> None:
+        # Simulates ReasoningResponseData.get_text() == reasoning + content:
+        # a long reasoning trace precedes the final answer. This is the exact
+        # shape that produced the 0/200 MMLU incident; MMLU-Pro must handle it.
+        text = "We need to compute the product of roots. " * 50 + "The answer is (D)."
+        r = await _make_grader().grade(text, "D")
+        assert r.correct and not r.unparsed
+
+    async def test_bare_letter_non_cot_is_clean(self) -> None:
+        # --accuracy-no-enable-cot yields a bare first-line letter; clean parse.
+        r = await _make_grader().grade("B", "B")
+        assert r.correct and not r.unparsed and r.extracted_answer == "B"
+
+    async def test_bare_letter_j_non_cot(self) -> None:
+        r = await _make_grader().grade("J\n", "J")
+        assert r.correct and not r.unparsed

--- a/tests/unit/accuracy/test_multiple_choice_grader.py
+++ b/tests/unit/accuracy/test_multiple_choice_grader.py
@@ -65,10 +65,11 @@ class TestMultipleChoiceGraderGrade:
         assert not result.correct
         assert result.unparsed
 
-    async def test_regex_fallback_sentence(self) -> None:
+    async def test_answer_is_sentence_is_clean(self) -> None:
+        # "The answer is (X)" is the requested CoT format -> clean parse.
         result = await _make_grader().grade("The answer is B.", "B")
         assert result.correct
-        assert result.unparsed
+        assert not result.unparsed
         assert result.extracted_answer == "B"
 
     async def test_regex_fallback_bold_markdown(self) -> None:
@@ -83,10 +84,10 @@ class TestMultipleChoiceGraderGrade:
         assert result.unparsed
         assert result.extracted_answer == "D"
 
-    async def test_regex_fallback_wrong_letter(self) -> None:
+    async def test_answer_is_wrong_letter(self) -> None:
         result = await _make_grader().grade("The answer is B.", "A")
         assert not result.correct
-        assert result.unparsed
+        assert not result.unparsed
         assert result.extracted_answer == "B"
 
     async def test_no_regex_match_is_unparsed(self) -> None:
@@ -119,3 +120,35 @@ class TestMultipleChoiceGraderExtractAnswer:
 
     def test_no_match_returns_stripped_first_line(self) -> None:
         assert _make_grader().extract_answer("I don't know") == "I don't know"
+
+
+@pytest.mark.asyncio
+class TestMultipleChoiceCoTFallback:
+    async def test_cot_reasoning_then_answer_is_x(self) -> None:
+        text = "We eliminate options one by one. The answer is (C)."
+        result = await _make_grader().grade(text, "C")
+        assert result.correct
+        assert not result.unparsed  # "answer is (X)" is a clean parse
+        assert result.extracted_answer == "C"
+
+    async def test_reasoning_plus_content_first_line_not_letter(self) -> None:
+        # Simulates reasoning+content concatenation defeating first-line-only.
+        text = "We need to answer the question.\nThe answer is (A)."
+        result = await _make_grader().grade(text, "A")
+        assert result.correct
+        assert result.extracted_answer == "A"
+
+    async def test_bare_letter_first_line_still_wins_unchanged(self) -> None:
+        # Parity: a clean first-line letter is parsed WITHOUT the fallback.
+        result = await _make_grader().grade("B\n\nQuestion: unrelated D E F", "B")
+        assert result.correct
+        assert not result.unparsed
+        assert result.extracted_answer == "B"
+
+    async def test_answer_colon_beats_echoed_first_line_option(self) -> None:
+        # Reasoning echoes the option list on the first line, then ends with
+        # "Answer: B". Tier-2 must win over the echoed first-line "A".
+        text = "Options: A. 0, B. 4, C. 2, D. 6. We compute.\nAnswer: B"
+        result = await _make_grader().grade(text, "B")
+        assert result.correct
+        assert result.extracted_answer == "B"

--- a/tests/unit/config/test_accuracy_enable_cot_flag.py
+++ b/tests/unit/config/test_accuracy_enable_cot_flag.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``--accuracy-enable-cot`` / ``--accuracy-no-enable-cot`` CLI tri-state.
+
+``accuracy_enable_cot`` is ``bool | None``: unset defers to the benchmark's
+``default_enable_cot`` metadata, ``--accuracy-enable-cot`` forces CoT on, and
+``--accuracy-no-enable-cot`` forces it off. The negative flag is what makes the
+non-CoT path reachable for CoT-default benchmarks (e.g. ``mmlu_pro``), so it is
+covered here at the cyclopts-parse boundary rather than only at the field level.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest import param
+
+from aiperf.cli_commands.profile import app
+
+_BASE_ARGV = [
+    "--model",
+    "m",
+    "--url",
+    "http://localhost:1/v1",
+    "--accuracy-benchmark",
+    "mmlu",
+]
+
+
+def _parse_enable_cot(extra_argv: list[str]) -> bool | None:
+    _cmd, bound, _ignored = app.parse_args(
+        _BASE_ARGV + extra_argv, exit_on_error=False, verbose=False
+    )
+    return bound.arguments["cli_config"].accuracy_enable_cot
+
+
+@pytest.mark.parametrize(
+    "extra_argv,expected",
+    [
+        param([], None, id="unset_defers_to_metadata"),
+        param(["--accuracy-enable-cot"], True, id="enable_forces_cot_on"),
+        param(["--accuracy-no-enable-cot"], False, id="no_enable_forces_cot_off"),
+    ],
+)  # fmt: skip
+def test_accuracy_enable_cot_tristate(
+    extra_argv: list[str], expected: bool | None
+) -> None:
+    assert _parse_enable_cot(extra_argv) is expected

--- a/tests/unit/records/test_records_manager.py
+++ b/tests/unit/records/test_records_manager.py
@@ -893,6 +893,9 @@ class TestRecordsManagerEfficiencyMetricsSnapshot:
         manager.service_id = "records-manager-test"
         manager._latest_branch_stats = None
         manager._flush_metric_results_processors = AsyncMock()
+        # No accuracy processors in this fixture: the orphaned-summarize re-run
+        # iterates an empty list and contributes nothing.
+        manager._metric_results_processors = []
         manager.publish = AsyncMock()
 
         manager.run = MagicMock()
@@ -984,6 +987,9 @@ class TestRecordsManagerEfficiencyMetricsDegeneratePhase:
         manager.service_id = "records-manager-test"
         manager._latest_branch_stats = None
         manager._flush_metric_results_processors = AsyncMock()
+        # No accuracy processors in this fixture: the orphaned-summarize re-run
+        # iterates an empty list and contributes nothing.
+        manager._metric_results_processors = []
         manager.publish = AsyncMock()
 
         manager.run = MagicMock()
@@ -1047,6 +1053,9 @@ class TestRecordsManagerEfficiencyMetricsDegeneratePhase:
         manager.service_id = "records-manager-test"
         manager._latest_branch_stats = None
         manager._flush_metric_results_processors = AsyncMock()
+        # No accuracy processors in this fixture: the orphaned-summarize re-run
+        # iterates an empty list and contributes nothing.
+        manager._metric_results_processors = []
         manager.publish = AsyncMock()
 
         manager.run = MagicMock()

--- a/tests/unit/records/test_records_manager_process_results.py
+++ b/tests/unit/records/test_records_manager_process_results.py
@@ -132,6 +132,10 @@ def _make_manager_mock(
     # the summary numbers — stub it out.
     mgr._flush_metric_results_processors = AsyncMock()
 
+    # Accuracy summary merge (orphaned-summarize re-run) — no accuracy processors
+    # in these unit fixtures, so it contributes nothing.
+    mgr._summarize_accuracy_results_processors = AsyncMock(return_value=[])
+
     # Records tracker — drives the time window via PROFILING phase stats.
     phase_stats = PhaseRecordsStats(
         phase=CreditPhase.PROFILING,


### PR DESCRIPTION
## Summary

Adds **MMLU-Pro** as a new accuracy benchmark at parity with the upstream [TIGER-AI-Lab MMLU-Pro](https://github.com/TIGER-AI-Lab/MMLU-Pro) reference, and **fixes the existing MMLU accuracy path for reasoning models**.

### Motivation

A production MMLU run against a reasoning model (Nemotron via Dynamo) scored **0/200, all unparsed**. Root cause traced through the code:

- **`generation_size` → `max_tokens` is live wiring** (`accuracy_dataset_loader.py`). MMLU hard-codes `generation_size=5`, so a reasoning model spends its entire 5-token budget on preamble (`"We need to answer the"`) and is cut off before emitting any letter. The token budget — not the stop sequence — was the bug.
- **`stop_sequence` metadata is a silent no-op** for every accuracy benchmark (the loader never wires it into the request).
- **The grader reads `reasoning + content` concatenated** and takes the *first line* — i.e. the first line of the reasoning trace.

MMLU-Pro (CoT-native, 4000-token budget, whole-text `"The answer is (X)"` extraction) is immune to all three by construction.

## What's included

**MMLU-Pro (upstream parity)**
- `benchmarks/mmlu_pro.py`: dataset `TIGER-Lab/MMLU-Pro`, 14 categories, up to 10 options (A–J, N/A filtered), byte-equal instruction/prompt, 5-shot CoT from the validation split, single-user-message chat wire, `generation_size=4000`.
- `graders/mmlu_pro.py`: A–J grader using the upstream 3-tier `"answer is (X)"` cascade.

**MMLU reasoning-model fix (non-CoT default unchanged)**
- `--accuracy-enable-cot` now uses a full generation budget (4000) and a prompt that requests the `"The answer is (X)"` format, in both the completions and chat code paths.
- `MultipleChoiceGrader` gains a CoT fallback: first-line bare letter still wins (lighteval parity preserved byte-for-byte); otherwise it falls through to the shared whole-text A–D cascade.
- **The non-CoT default is byte-identical to before** (generation_size=5, unchanged instruction/primer) — guarded by tests.

**Shared + wiring**
- `graders/_choice_extract.py`: one extraction cascade shared by both graders (parameterized on letter range).
- New `--accuracy-no-enable-cot` negation flag so the non-CoT path is CLI-reachable for CoT-default benchmarks (it was unreachable before).
- Plugin registration + regenerated enums, HF network-smoke-test coverage for the new dataset, docs.

## Testing

- `tests/unit/accuracy/`: **430 passed, 9 skipped**, including a regression test that feeds the grader the exact `reasoning + content` shape that produced the original 0/200.
- Byte-equality tests lock the MMLU-Pro prompt and the MMLU non-CoT parity guarantee.
- Tri-state CLI test for `--accuracy-enable-cot` / `--accuracy-no-enable-cot`.

## Docs

`docs/accuracy/accuracy-benchmarking.md` documents MMLU-Pro, the working MMLU CoT path, the reasoning-model token-budget knob, and a troubleshooting note; `docs/cli-options.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the MMLU-Pro accuracy benchmark with category selection and CoT or direct-answer modes.
  - Registered a new MMLU-Pro grader for final A–J answer scoring.
- **Bug Fixes**
  - Improved multiple-choice answer extraction and clearer “unparsed” handling for reasoning-heavy outputs.
  - Accuracy summary rows now reliably appear in profiling results.
- **Documentation**
  - Expanded accuracy benchmarking/grader and CLI option documentation (including MMLU-Pro and related graders).
- **New Features**
  - Added `--accuracy-no-enable-cot` to explicitly disable chain-of-thought prompting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->