### PR TITLE
fix(readiness): add /v1/messages inference probe template

### DIFF
--- a/src/aiperf/common/readiness_probe.py
+++ b/src/aiperf/common/readiness_probe.py
@@ -47,6 +47,12 @@ _CANNED_PAYLOADS: dict[str, dict] = {
         "messages": [{"role": "user", "content": _READINESS_PROMPT}],
         "max_tokens": 1,
     },
+    "messages": {
+        # Anthropic Messages API: same message array as chat, but max_tokens
+        # is required (the API rejects requests without it).
+        "messages": [{"role": "user", "content": _READINESS_PROMPT}],
+        "max_tokens": 1,
+    },
     "completions": {
         "prompt": _READINESS_PROMPT,
         "max_tokens": 1,
@@ -58,6 +64,7 @@ _CANNED_PAYLOADS: dict[str, dict] = {
 
 _DEFAULT_PATHS: dict[str, str] = {
     "chat": "/v1/chat/completions",
+    "messages": "/v1/messages",
     "completions": "/v1/completions",
     "embeddings": "/v1/embeddings",
 }

--- a/tests/unit/common/test_readiness_probe.py
+++ b/tests/unit/common/test_readiness_probe.py
@@ -88,6 +88,39 @@ def test_wait_inference_dedicated_template_does_not_warn(
     assert client.payloads == [{"input": "Lo", "model": "embedder"}]
 
 
+def test_wait_inference_messages_uses_dedicated_template(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="aiperf.common.readiness_probe")
+    client = _FakeClient()
+
+    asyncio.run(
+        readiness_probe._wait_inference(
+            client=cast(Any, client),
+            url="http://server",
+            model_name="claude-sonnet-4-20250514",
+            endpoint_type="messages",
+            custom_endpoint=None,
+            timeout_s=1.0,
+            interval_s=0.1,
+            headers={},
+        )
+    )
+
+    # The Messages endpoint has a dedicated template, so no chat fallback
+    # warning and the probe hits /v1/messages with a Messages-shaped body
+    # (max_tokens is required by the Anthropic API).
+    assert "no dedicated request template" not in caplog.text
+    assert client.posted_urls == ["http://server/v1/messages"]
+    assert client.payloads == [
+        {
+            "messages": [{"role": "user", "content": "Lo"}],
+            "max_tokens": 1,
+            "model": "claude-sonnet-4-20250514",
+        }
+    ]
+
+
 class _FakeReadyRecord:
     """A get_request response that the probe treats as 'server live'."""
 


### PR DESCRIPTION
Addresses the open readiness-probe review thread on #731 (@ilana-n).

## Problem

`_CANNED_PAYLOADS` and `_DEFAULT_PATHS` in `src/aiperf/common/readiness_probe.py` only cover `chat`, `completions`, and `embeddings`. So `--endpoint-type messages --wait-for-model-mode inference` falls through to the chat-compatible fallback (logs the "no dedicated request template" warning and posts a `/v1/chat/completions`-shaped body to a Messages-only server), which checks liveness but doesn't prove Messages-endpoint readiness.

## Fix

Add a dedicated `messages` entry to both maps:
- `_CANNED_PAYLOADS["messages"] = {messages: [{role: user, content: "Lo"}], max_tokens: 1}` — same message array as chat, but `max_tokens` is required by the Anthropic Messages API.
- `_DEFAULT_PATHS["messages"] = "/v1/messages"`.

The probe adds `model` automatically, so the emitted body is a valid minimal Messages request.

## Test

TDD (red→green). New `test_wait_inference_messages_uses_dedicated_template` asserts:
- no chat-fallback warning,
- probe hits `/v1/messages`,
- body is `{messages, max_tokens: 1, model}`.

Full `test_readiness_probe.py` green; ruff clean.

Base is `ajc/anthropic-messages` so this lands directly on #731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)