### PR TITLE
fix(docs): stabilize generated cli-options across cyclopts default rendering

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -405,12 +405,10 @@ Apply the HuggingFace tokenizer's chat template when counting input tokens. When
 #### `--extra-inputs` `<list>`
 
 Additional input parameters to include in every API request payload. Specify as `key:value` pairs (e.g., `--extra-inputs temperature:0.7 top_p:0.9`) or as JSON string (e.g., `'{"temperature": 0.7}'`). These parameters are merged with request-specific inputs and sent directly to the endpoint API.
-<br/>_Default: `[]`_
 
 #### `-H`, `--header` `<list>`
 
 Custom HTTP headers to include with every request. Specify as `Header:Value` pairs (e.g., `--header X-Custom-Header:value`) or as JSON string. Can be specified multiple times. Useful for custom authentication, tracking, or API-specific requirements. Combined with auto-generated headers (e.g., `Authorization` from `--api-key`).
-<br/>_Default: `[]`_
 
 #### `--input-file` `<str>`
 
@@ -1830,12 +1828,10 @@ Apply the HuggingFace tokenizer's chat template when counting input tokens. When
 #### `--extra-inputs` `<list>`
 
 Additional input parameters to include in every API request payload. Specify as `key:value` pairs (e.g., `--extra-inputs temperature:0.7 top_p:0.9`) or as JSON string (e.g., `'{"temperature": 0.7}'`). These parameters are merged with request-specific inputs and sent directly to the endpoint API.
-<br/>_Default: `[]`_
 
 #### `-H`, `--header` `<list>`
 
 Custom HTTP headers to include with every request. Specify as `Header:Value` pairs (e.g., `--header X-Custom-Header:value`) or as JSON string. Can be specified multiple times. Useful for custom authentication, tracking, or API-specific requirements. Combined with auto-generated headers (e.g., `Authorization` from `--api-key`).
-<br/>_Default: `[]`_
 
 #### `--input-file` `<str>`
 

--- a/tools/generate_cli_docs.py
+++ b/tools/generate_cli_docs.py
@@ -197,11 +197,16 @@ def _extract_param(arg: Any, constraints: dict[str, list[str]]) -> Param:
     long_opts = [n for n in arg.names if n.startswith("--")]
     short_opts = [n for n in arg.names if n.startswith("-") and n not in long_opts]
 
-    # Default value
+    # Default value. Skip sentinels, None, and empty collections: an empty
+    # ``[]`` / ``{}`` default documents nothing useful, and rendering it couples
+    # the output to cyclopts' default-rendering (4.21 began emitting "[]" for
+    # empty-list params where 4.20 emitted nothing, drifting the committed docs).
+    # Suppressing it here keeps generated docs stable across cyclopts versions.
     default = ""
     if arg.show_default:
         val = arg.field_info.default
-        if val is not FieldInfo.empty and val is not None:
+        is_empty_collection = isinstance(val, (list, dict, tuple, set)) and not val
+        if val is not FieldInfo.empty and val is not None and not is_empty_collection:
             default = (
                 str(arg.show_default(val)) if callable(arg.show_default) else str(val)
             )


### PR DESCRIPTION
## Problem

The nightly's `generate-cli-docs` pre-commit check has failed since 2026-07-10. cyclopts **4.21.0** (released 2026-07-09) changed how it renders defaults: `<list>` flags with an empty default now emit a `Default: []` line where 4.20 emitted nothing. The nightly fresh-installs latest deps, so regenerating `docs/cli-options.md` drifts from what's committed → *"files were modified by this hook."*

## Fix

Suppress empty-collection (`[]`/`{}`) defaults in the generator itself. An empty-list default documents nothing useful, and this decouples the output from cyclopts' rendering choices — so a cyclopts default-rendering change can't drift the committed docs.

## Verification

Generator output is now identical on cyclopts **4.20.0 and 4.21.0** (idempotent; `generate-cli-docs` and all sibling generate/validate hooks pass on both). Doc change is exactly 4 now-suppressed `Default: []` lines.

Note: this resolves the `generate-cli-docs` nightly failure only. The separate vllm 0.24.0 / Qwen2-VL vision failure is not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line documentation for the `--header` option.
  * Removed the displayed empty default value while retaining usage instructions, formatting, and repeatable-option details.
  * Improved generated documentation consistency for options with empty collection defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->