### PR TITLE
fix(video): write synthetic WebM to a seekable file so it carries container duration

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -265,7 +265,6 @@ aiperf profile --model your_model --url localhost:8000 --goodput "request_latenc
 #### `-m`, `--model-names`, `--model` `<list>`
 
 Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
-<br/>_Default: `[]`_
 
 #### `--model-selection-strategy` `<str>`
 
@@ -427,7 +426,6 @@ HuggingFace dataset subset/config name to override the plugin default (e.g. `sha
 #### `--dataset-filter` `<list>`
 
 Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
-<br/>_Default: `[]`_
 
 #### `--custom-dataset-type` `<str>`
 
@@ -1340,7 +1338,6 @@ Deprecated and ignored. The bayesian preset and the optuna expert mode both use 
 #### `--variant`, `--sweep-variant` `<list>`
 
 Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
-<br/>_Default: `[]`_
 
 #### `--search-sla` `<list>`
 
@@ -1691,7 +1688,6 @@ HTTP port for health endpoints (/healthz, /readyz). Required for Kubernetes live
 #### `-m`, `--model-names`, `--model` `<list>`
 
 Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
-<br/>_Default: `[]`_
 
 #### `--model-selection-strategy` `<str>`
 
@@ -1853,7 +1849,6 @@ HuggingFace dataset subset/config name to override the plugin default (e.g. `sha
 #### `--dataset-filter` `<list>`
 
 Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
-<br/>_Default: `[]`_
 
 #### `--custom-dataset-type` `<str>`
 
@@ -2766,7 +2761,6 @@ Deprecated and ignored. The bayesian preset and the optuna expert mode both use 
 #### `--variant`, `--sweep-variant` `<list>`
 
 Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
-<br/>_Default: `[]`_
 
 #### `--search-sla` `<list>`
 

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -265,6 +265,7 @@ aiperf profile --model your_model --url localhost:8000 --goodput "request_latenc
 #### `-m`, `--model-names`, `--model` `<list>`
 
 Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
+<br/>_Default: `[]`_
 
 #### `--model-selection-strategy` `<str>`
 
@@ -426,6 +427,7 @@ HuggingFace dataset subset/config name to override the plugin default (e.g. `sha
 #### `--dataset-filter` `<list>`
 
 Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
+<br/>_Default: `[]`_
 
 #### `--custom-dataset-type` `<str>`
 
@@ -1338,6 +1340,7 @@ Deprecated and ignored. The bayesian preset and the optuna expert mode both use 
 #### `--variant`, `--sweep-variant` `<list>`
 
 Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
+<br/>_Default: `[]`_
 
 #### `--search-sla` `<list>`
 
@@ -1688,6 +1691,7 @@ HTTP port for health endpoints (/healthz, /readyz). Required for Kubernetes live
 #### `-m`, `--model-names`, `--model` `<list>`
 
 Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
+<br/>_Default: `[]`_
 
 #### `--model-selection-strategy` `<str>`
 
@@ -1849,6 +1853,7 @@ HuggingFace dataset subset/config name to override the plugin default (e.g. `sha
 #### `--dataset-filter` `<list>`
 
 Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
+<br/>_Default: `[]`_
 
 #### `--custom-dataset-type` `<str>`
 
@@ -2761,6 +2766,7 @@ Deprecated and ignored. The bayesian preset and the optuna expert mode both use 
 #### `--variant`, `--sweep-variant` `<list>`
 
 Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
+<br/>_Default: `[]`_
 
 #### `--search-sla` `<list>`
 

--- a/src/aiperf/dataset/generator/video.py
+++ b/src/aiperf/dataset/generator/video.py
@@ -390,7 +390,11 @@ class VideoGenerator(BaseGenerator):
         return frame.tobytes()
 
     def _create_video_with_pipes(self, frames: list[Image.Image]) -> str:
-        """Create video using pipes via stdin and either stdout or temp file output."""
+        """Create video by piping raw frames to ffmpeg stdin, writing to a temp file.
+
+        Output goes to a seekable temp file (not ``pipe:``) so container metadata
+        such as the WebM/Matroska duration is written; see the note below.
+        """
         temp_dir = Path(tempfile.mkdtemp(prefix="aiperf_pipes_"))
         try:
             # Gather all frame data first to prevent deadlocks due to pipe input/output synchronization issues
@@ -404,14 +408,15 @@ class VideoGenerator(BaseGenerator):
                 "pix_fmt": "yuv420p",
             }
 
-            # Determine output destination based on format
+            # Always write to a seekable temp file, never a ``pipe:``. Matroska/WebM
+            # only records the segment duration (and thus a derivable frame count)
+            # when the muxer can seek back to the header after writing; a
+            # non-seekable pipe leaves that metadata empty, so frame-sampling
+            # decoders such as vLLM's compute a bad frame count and fail. MP4
+            # already required a file for ``movflags=faststart``.
             if self.config.format == VideoFormat.MP4:
-                # MP4 requires seekable output, use temp file
                 output_options["movflags"] = "faststart"
-                output_dest = str(temp_dir / f"output.{self.config.format}")
-            else:
-                # WebM and other formats can use pipe output
-                output_dest = "pipe:"
+            output_dest = str(temp_dir / f"output.{self.config.format}")
 
             video_stream = ffmpeg.input(
                 "pipe:",
@@ -424,15 +429,9 @@ class VideoGenerator(BaseGenerator):
             pipeline = self._build_ffmpeg_output(
                 video_stream, output_dest, output_options, temp_dir
             )
-            stdout, _ = pipeline.run(
-                input=all_data, capture_stdout=True, capture_stderr=True
-            )
+            pipeline.run(input=all_data, capture_stdout=True, capture_stderr=True)
 
-            # Read output based on destination
-            if output_dest != "pipe:":
-                video_data = Path(output_dest).read_bytes()
-            else:
-                video_data = stdout
+            video_data = Path(output_dest).read_bytes()
 
             if not video_data:
                 raise RuntimeError("FFmpeg produced no output")

--- a/src/aiperf/dataset/generator/video.py
+++ b/src/aiperf/dataset/generator/video.py
@@ -429,7 +429,7 @@ class VideoGenerator(BaseGenerator):
             pipeline = self._build_ffmpeg_output(
                 video_stream, output_dest, output_options, temp_dir
             )
-            pipeline.run(input=all_data, capture_stdout=True, capture_stderr=True)
+            pipeline.run(input=all_data, capture_stderr=True)
 
             video_data = Path(output_dest).read_bytes()
 
@@ -484,7 +484,7 @@ class VideoGenerator(BaseGenerator):
             pipeline = self._build_ffmpeg_output(
                 video_stream, str(output_path), output_options, temp_dir
             )
-            pipeline.run(capture_stdout=True, capture_stderr=True)
+            pipeline.run(capture_stderr=True)
 
             # Read the output file
             video_data = output_path.read_bytes()

--- a/tests/integration/test_video.py
+++ b/tests/integration/test_video.py
@@ -7,6 +7,7 @@ import shutil
 import pytest
 from pytest import approx, param
 
+from aiperf.common import random_generator as rng
 from aiperf.common.enums import VideoFormat, VideoSynthType
 from aiperf.config.dataset.video import VideoConfig
 from aiperf.dataset.generator.video import VideoGenerator
@@ -180,6 +181,19 @@ class TestVideoContainerMetadata:
     frame count and crashed in ``torch.arange`` on every request.
     """
 
+    @pytest.fixture(autouse=True)
+    def _seeded_rng(self):
+        """Seed the shared RNG deterministically, restoring it afterwards.
+
+        The generator needs the module-level RNG initialized, and integration
+        tests have no autouse RNG reset (unlike unit tests), so this also keeps
+        the seed from leaking into later tests.
+        """
+        rng.reset()
+        rng.init(42)
+        yield
+        rng.reset()
+
     @pytest.mark.parametrize(
         "video_format,video_codec",
         [
@@ -191,11 +205,6 @@ class TestVideoContainerMetadata:
         self, video_format: VideoFormat, video_codec: str
     ):
         """Generated clip reports a valid duration without a full-decode fallback."""
-        from aiperf.common import random_generator as rng
-
-        rng.reset()
-        rng.init(42)
-
         width, height, fps, duration = 640, 480, 4, 5.0
         config = VideoConfig(
             width=width,

--- a/tests/integration/test_video.py
+++ b/tests/integration/test_video.py
@@ -5,11 +5,17 @@
 import shutil
 
 import pytest
-from pytest import approx
+from pytest import approx, param
 
+from aiperf.common.enums import VideoFormat, VideoSynthType
+from aiperf.config.dataset.video import VideoConfig
+from aiperf.dataset.generator.video import VideoGenerator
 from tests.harness.utils import AIPerfCLI, AIPerfMockServer
 from tests.integration.conftest import IntegrationTestDefaults as defaults
-from tests.integration.utils import iter_video_details
+from tests.integration.utils import (
+    iter_video_details,
+    probe_container_duration_without_decode,
+)
 
 FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
 
@@ -160,3 +166,52 @@ class TestVideo:
         assert videos, "No video content found in payloads"
         for details in videos:
             assert not details.has_audio, "Video should not have audio when disabled"
+
+
+@pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg not installed")
+@pytest.mark.ffmpeg
+@pytest.mark.integration
+class TestVideoContainerMetadata:
+    """Guards that synthetic clips carry container-level timing metadata.
+
+    Regression for a nightly failure where the synthetic VP9/WebM clip was
+    muxed to a non-seekable pipe, leaving the container duration empty. A
+    metadata-only frame sampler (vLLM's video loader) then derived a zero/garbage
+    frame count and crashed in ``torch.arange`` on every request.
+    """
+
+    @pytest.mark.parametrize(
+        "video_format,video_codec",
+        [
+            param(VideoFormat.WEBM, "libvpx-vp9", id="webm-vp9"),
+            param(VideoFormat.MP4, "libx264", id="mp4-h264"),
+        ],
+    )  # fmt: skip
+    def test_synthetic_video_records_container_duration(
+        self, video_format: VideoFormat, video_codec: str
+    ):
+        """Generated clip reports a valid duration without a full-decode fallback."""
+        from aiperf.common import random_generator as rng
+
+        rng.reset()
+        rng.init(42)
+
+        width, height, fps, duration = 640, 480, 4, 5.0
+        config = VideoConfig(
+            width=width,
+            height=height,
+            duration=duration,
+            fps=fps,
+            format=video_format,
+            codec=video_codec,
+            synth_type=VideoSynthType.MOVING_SHAPES,
+        )
+        data_uri = VideoGenerator(config).generate()
+        base64_data = data_uri.split(",", 1)[1]
+
+        probed = probe_container_duration_without_decode(base64_data)
+        assert probed is not None, (
+            f"{video_format} container carries no duration metadata; a "
+            "metadata-only decoder cannot derive a frame count"
+        )
+        assert probed == approx(duration, abs=0.2)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -188,6 +188,36 @@ def _check_mp4_fragmentation(video_bytes: bytes) -> bool:
     return b"moof" in video_bytes[:header_size]
 
 
+def probe_container_duration_without_decode(base64_data: str) -> float | None:
+    """Return the container-level duration ffprobe reports without decoding frames.
+
+    Mirrors what a metadata-only frame sampler (e.g. vLLM's video loader) sees:
+    it omits ``-count_frames``, so the value comes purely from the muxed
+    container/stream headers rather than a full decode. Returns ``None`` when
+    no duration is recorded (the failure mode this guards against).
+    """
+    video_bytes = base64.b64decode(base64_data)
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration:stream=duration",
+        "-of",
+        "json",
+        "pipe:0",
+    ]
+    result = subprocess.run(cmd, input=video_bytes, capture_output=True, check=True)
+    probe_data = orjson.loads(result.stdout)
+
+    candidates = [probe_data.get("format", {}).get("duration")]
+    candidates += [s.get("duration") for s in probe_data.get("streams", [])]
+    for value in candidates:
+        if value not in (None, "N/A"):
+            return float(value)
+    return None
+
+
 def extract_base64_video_details(base64_data: str) -> VideoDetails:
     """Decode base64 video data and extract file details using ffprobe via stdin.
 

--- a/tests/unit/dataset/generator/test_video_generator.py
+++ b/tests/unit/dataset/generator/test_video_generator.py
@@ -231,7 +231,11 @@ class TestVideoGenerator:
     def test_create_video_with_pipes_format_handling(
         self, video_format, codec, expected_movflags
     ):
-        """Test that MP4 uses temp file output and WebM uses pipe output."""
+        """Both formats write to a seekable temp file; only MP4 sets movflags.
+
+        WebM must also use a seekable file (not ``pipe:``) so the Matroska muxer
+        records the container duration; a pipe leaves that metadata empty.
+        """
         config = VideoConfig(
             width=64,
             height=64,
@@ -245,8 +249,6 @@ class TestVideoGenerator:
         frames = [Image.new("RGB", (64, 64), (255, 0, 0))]
 
         file_data = b"file_video_data"
-        pipe_data = b"pipe_video_data"
-        expected_data = file_data if video_format == VideoFormat.MP4 else pipe_data
         temp_dir = "/tmp/aiperf_pipes_test"
 
         with (
@@ -261,19 +263,16 @@ class TestVideoGenerator:
             mock_ffmpeg.input.return_value = mock_input
             mock_input.output.return_value = mock_output
             mock_output.overwrite_output.return_value = mock_output
-            mock_output.run.return_value = (pipe_data, b"")
+            mock_output.run.return_value = (b"", b"")
 
             result = generator._create_video_with_pipes(frames)
 
-            # Verify output destination
+            # Verify output destination is a temp file for both formats.
+            # Match production's ``str(Path(temp_dir) / "output.<ext>")`` —
+            # on Windows ``WindowsPath`` normalizes ``/`` to ``\\`` for the
+            # entire path, not just the joined separator.
             output_call = mock_input.output.call_args
-            if video_format == VideoFormat.MP4:
-                # Match production's ``str(Path(temp_dir) / "output.mp4")`` —
-                # on Windows ``WindowsPath`` normalizes ``/`` to ``\\`` for
-                # the entire path, not just the joined separator.
-                assert output_call[0][0] == str(Path(temp_dir) / "output.mp4")
-            else:
-                assert output_call[0][0] == "pipe:"
+            assert output_call[0][0] == str(Path(temp_dir) / f"output.{video_format}")
 
             # Verify movflags
             if expected_movflags:
@@ -281,8 +280,8 @@ class TestVideoGenerator:
             else:
                 assert "movflags" not in output_call[1]
 
-            # Verify result contains data from correct source
-            expected_base64 = base64.b64encode(expected_data).decode()
+            # Verify result contains data read back from the temp file
+            expected_base64 = base64.b64encode(file_data).decode()
             assert result.startswith(f"data:video/{video_format};base64,")
             assert expected_base64 in result
 
@@ -437,7 +436,13 @@ class TestVideoGeneratorAudio:
         generator = VideoGenerator(base_config)
         frames = [Image.new("RGB", (64, 64), (255, 0, 0))]
 
-        with patch("aiperf.dataset.generator.video.ffmpeg") as mock_ffmpeg:
+        with (
+            patch("aiperf.dataset.generator.video.ffmpeg") as mock_ffmpeg,
+            patch("tempfile.mkdtemp", return_value="/tmp/aiperf_pipes_test"),
+            patch.object(Path, "read_bytes", return_value=b"video_data"),
+            patch.object(Path, "exists", return_value=True),
+            patch("shutil.rmtree"),
+        ):
             mock_input = Mock()
             mock_output = Mock()
             mock_ffmpeg.input.return_value = mock_input
@@ -460,6 +465,7 @@ class TestVideoGeneratorAudio:
             patch("aiperf.dataset.generator.video.ffmpeg") as mock_ffmpeg,
             patch("tempfile.mkdtemp", return_value="/tmp/aiperf_pipes_test"),
             patch.object(Path, "write_bytes"),
+            patch.object(Path, "read_bytes", return_value=b"video_data"),
             patch.object(Path, "exists", return_value=True),
             patch("shutil.rmtree"),
         ):
@@ -498,6 +504,7 @@ class TestVideoGeneratorAudio:
             patch("aiperf.dataset.generator.video.ffmpeg") as mock_ffmpeg,
             patch("tempfile.mkdtemp", return_value=temp_dir),
             patch.object(Path, "write_bytes"),
+            patch.object(Path, "read_bytes", return_value=b"video_data"),
             patch.object(Path, "exists", return_value=True),
             patch("shutil.rmtree") as mock_rmtree,
         ):


### PR DESCRIPTION
## What's wrong

Our nightly vision test has failed for 10+ days. When AIPerf makes a fake video to benchmark with, vLLM crashes on every request with a 500 error.

## Why

AIPerf builds the WebM video by streaming it through a pipe. But WebM can only record how long the video is when it's written to a real file it can rewind — a pipe can't rewind, so the video ends up with **no duration stamped on it**.

vLLM reads that duration to decide how many frames to sample. With no duration it gets a garbage frame count and crashes here:

RuntimeError: upper bound and lower bound inconsistent with step sign
  indices = torch.arange(0, total_frames_num, total_frames_num / n)

(The real-MP4 vision test passes fine — because MP4 was already written to a file, so it has a duration. Only our piped WebM was broken.)

## The fix

Write the WebM to a temp file instead of a pipe, exactly like MP4 already did. Now the video carries its duration and vLLM can read it.

_(Note: adding ffmpeg `-r`/`-vsync cfr` flags does **nothing** here — verified. Seekable output is the actual fix.)_

## Proof

`ffprobe` on the generated clip, reading only the container metadata (what vLLM sees):

| | container duration | vLLM's frame count | result |
|---|---|---|---|
| **before** | `N/A` | `-36893488147419104` 😱 | crash |
| **after** | `5.000000` | `20` | works |

- ✅ Full unit suite green + new regression test (fails without this fix)
- ✅ Live GPU run: `Qwen2-VL-2B` on vLLM, **5/5 requests succeed, 0 errors** (was 5×500)

## Not included

Pinning `vllm/vllm-openai:latest` — separate hardening, out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFmpeg video generation to always use seekable temporary files for reliable output bytes across formats, improving container metadata population.
  * Preserved MP4 fast-start behavior while ensuring duration/frame-count metadata is recorded when the container supports seekable header updates.

* **Tests**
  * Added ffmpeg-gated integration coverage for container duration metadata using synthetic video clips (without full decode fallback).
  * Updated unit and integration test utilities to probe durations without decoding and to match the new temporary-file workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->