### PR TITLE
feat(routing): opt-in X-Dynamo-Session-ID header from correlation ID

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -129,6 +129,7 @@ HTTP client socket and connection configuration. Controls low-level socket optio
 | `AIPERF_HTTP_REQUEST_CANCELLATION_SEND_TIMEOUT` | `300.0` | ≥ 10.0, ≤ 3600.0 | Safety net timeout in seconds for waiting for HTTP request to be fully sent when request cancellation is enabled. Used as fallback when no explicit timeout is configured to prevent hanging indefinitely while waiting for the request to be written to the socket. |
 | `AIPERF_HTTP_IP_VERSION` | `'4'` | — | IP version for HTTP socket connections. Options: '4' (AF_INET, default), '6' (AF_INET6), or 'auto' (AF_UNSPEC, system chooses). |
 | `AIPERF_HTTP_TRUST_ENV` | `False` | — | Trust environment variables for HTTP client configuration. When enabled, aiohttp will read proxy settings from HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables. |
+| `AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID` | `False` | — | Also send X-Dynamo-Session-ID with the stable X-Correlation-ID value, plus X-Dynamo-Parent-Session-ID on subagent children. Use this with a Dynamo frontend running --router-session-affinity-ttl-secs to pin every turn of a session to the replica holding its KV prefix. |
 | `AIPERF_HTTP_VIDEO_POLL_INTERVAL` | `0.1` | ≥ 0.001, ≤ 10.0 | Interval in seconds between status polls for async video generation jobs. Lower values provide faster completion detection but increase server load. Applies to the aiohttp transport. |
 
 ## LOGGING

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -513,6 +513,13 @@ class _HTTPSettings(BaseSettings):
         "When enabled, aiohttp will read proxy settings from HTTP_PROXY, HTTPS_PROXY, "
         "and NO_PROXY environment variables.",
     )
+    X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: bool = Field(
+        default=False,
+        description="Also send X-Dynamo-Session-ID with the stable X-Correlation-ID value, "
+        "plus X-Dynamo-Parent-Session-ID on subagent children. Use this with a Dynamo "
+        "frontend running --router-session-affinity-ttl-secs to pin every turn of a "
+        "session to the replica holding its KV prefix.",
+    )
     VIDEO_POLL_INTERVAL: float = Field(
         ge=0.001,
         le=10.0,

--- a/src/aiperf/transports/base_transports.py
+++ b/src/aiperf/transports/base_transports.py
@@ -121,17 +121,25 @@ class BaseTransport(AIPerfLifecycleMixin, ABC):
                 or "X-Correlation-ID"
             )
             headers[correlation_header] = request_info.x_correlation_id
-            if Environment.HTTP.X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID:
-                headers["X-Dynamo-Session-ID"] = request_info.x_correlation_id
-                if request_info.parent_correlation_id:
-                    headers["X-Dynamo-Parent-Session-ID"] = (
-                        request_info.parent_correlation_id
-                    )
 
         headers.update(request_info.endpoint_headers)
         if request_info.turns and request_info.turns[-1].extra_headers:
             headers.update(request_info.turns[-1].extra_headers)
         headers.update(self.get_transport_headers(request_info))
+
+        # Apply derived Dynamo session headers last so they are authoritative
+        # and cannot be overwritten by endpoint, extra, or transport headers.
+        if (
+            request_info.x_correlation_id
+            and Environment.HTTP.X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID
+        ):
+            headers["X-Dynamo-Session-ID"] = request_info.x_correlation_id
+            if request_info.parent_correlation_id:
+                headers["X-Dynamo-Parent-Session-ID"] = (
+                    request_info.parent_correlation_id
+                )
+            else:
+                headers.pop("X-Dynamo-Parent-Session-ID", None)
 
         return headers
 

--- a/src/aiperf/transports/base_transports.py
+++ b/src/aiperf/transports/base_transports.py
@@ -36,6 +36,15 @@ It is used to release prefill concurrency.
 """
 
 
+def _remove_headers_case_insensitive(
+    headers: dict[str, str], names: tuple[str, ...]
+) -> None:
+    """Remove every key in ``headers`` that case-insensitively matches ``names``."""
+    lowered = {name.lower() for name in names}
+    for key in [k for k in headers if k.lower() in lowered]:
+        del headers[key]
+
+
 @runtime_checkable
 class TransportProtocol(AIPerfLifecycleProtocol, Protocol):
     """Protocol for a transport that sends requests to an inference server."""
@@ -129,17 +138,20 @@ class BaseTransport(AIPerfLifecycleMixin, ABC):
 
         # Apply derived Dynamo session headers last so they are authoritative
         # and cannot be overwritten by endpoint, extra, or transport headers.
+        # Strip any caller-supplied variants case-insensitively first, since HTTP
+        # header names are case-insensitive and these are merged into a plain dict.
         if (
             request_info.x_correlation_id
             and Environment.HTTP.X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID
         ):
+            _remove_headers_case_insensitive(
+                headers, ("X-Dynamo-Session-ID", "X-Dynamo-Parent-Session-ID")
+            )
             headers["X-Dynamo-Session-ID"] = request_info.x_correlation_id
             if request_info.parent_correlation_id:
                 headers["X-Dynamo-Parent-Session-ID"] = (
                     request_info.parent_correlation_id
                 )
-            else:
-                headers.pop("X-Dynamo-Parent-Session-ID", None)
 
         return headers
 

--- a/src/aiperf/transports/base_transports.py
+++ b/src/aiperf/transports/base_transports.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+from aiperf.common.environment import Environment
 from aiperf.common.mixins import AIPerfLifecycleMixin
 from aiperf.common.models import (
     RequestInfo,
@@ -120,6 +121,12 @@ class BaseTransport(AIPerfLifecycleMixin, ABC):
                 or "X-Correlation-ID"
             )
             headers[correlation_header] = request_info.x_correlation_id
+            if Environment.HTTP.X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID:
+                headers["X-Dynamo-Session-ID"] = request_info.x_correlation_id
+                if request_info.parent_correlation_id:
+                    headers["X-Dynamo-Parent-Session-ID"] = (
+                        request_info.parent_correlation_id
+                    )
 
         headers.update(request_info.endpoint_headers)
         if request_info.turns and request_info.turns[-1].extra_headers:

--- a/tests/unit/transports/test_base_transport.py
+++ b/tests/unit/transports/test_base_transport.py
@@ -155,8 +155,11 @@ class TestBaseTransport:
         assert headers["User-Agent"] == AIPERF_USER_AGENT
 
     def test_build_headers_dynamo_session_header_root_has_no_parent(
-        self, transport, request_info, monkeypatch
-    ):
+        self,
+        transport: FakeTransport,
+        request_info: RequestInfo,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Root session emits X-Dynamo-Session-ID but no parent header."""
         monkeypatch.setattr(
             Environment.HTTP, "X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID", True
@@ -168,8 +171,11 @@ class TestBaseTransport:
         assert "X-Dynamo-Parent-Session-ID" not in headers
 
     def test_build_headers_dynamo_session_header_child_adds_parent(
-        self, transport, request_info, monkeypatch
-    ):
+        self,
+        transport: FakeTransport,
+        request_info: RequestInfo,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Subagent child also emits X-Dynamo-Parent-Session-ID."""
         monkeypatch.setattr(
             Environment.HTTP, "X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID", True
@@ -180,6 +186,35 @@ class TestBaseTransport:
 
         assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
         assert headers["X-Dynamo-Parent-Session-ID"] == "parent-correlation-id"
+
+    def test_build_headers_dynamo_session_header_disabled_by_default(
+        self,
+        transport: FakeTransport,
+        request_info: RequestInfo,
+    ) -> None:
+        """With the flag off, neither Dynamo header is emitted, even with a parent."""
+        request_info.parent_correlation_id = "parent-correlation-id"
+
+        headers = transport.build_headers(request_info)
+
+        assert "X-Dynamo-Session-ID" not in headers
+        assert "X-Dynamo-Parent-Session-ID" not in headers
+
+    def test_build_headers_dynamo_session_header_not_overwritten_by_extra_headers(
+        self,
+        transport: FakeTransport,
+        request_info: RequestInfo,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Derived Dynamo headers win over endpoint/extra headers when enabled."""
+        monkeypatch.setattr(
+            Environment.HTTP, "X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID", True
+        )
+        request_info.endpoint_headers = {"X-Dynamo-Session-ID": "override"}
+
+        headers = transport.build_headers(request_info)
+
+        assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
 
     def test_build_headers_transport_headers_override(self, request_info):
         """Test that transport headers can override endpoint headers."""

--- a/tests/unit/transports/test_base_transport.py
+++ b/tests/unit/transports/test_base_transport.py
@@ -6,6 +6,7 @@ import pytest
 
 from aiperf import __version__ as aiperf_version
 from aiperf.common.enums import CreditPhase, ModelSelectionStrategy
+from aiperf.common.environment import Environment
 from aiperf.common.models import Turn
 from aiperf.common.models.model_endpoint_info import (
     EndpointInfo,
@@ -152,6 +153,33 @@ class TestBaseTransport:
         assert headers["Authorization"] == "Bearer token123"
         assert headers["Custom-Header"] == "custom-value"
         assert headers["User-Agent"] == AIPERF_USER_AGENT
+
+    def test_build_headers_dynamo_session_header_root_has_no_parent(
+        self, transport, request_info, monkeypatch
+    ):
+        """Root session emits X-Dynamo-Session-ID but no parent header."""
+        monkeypatch.setattr(
+            Environment.HTTP, "X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID", True
+        )
+
+        headers = transport.build_headers(request_info)
+
+        assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
+        assert "X-Dynamo-Parent-Session-ID" not in headers
+
+    def test_build_headers_dynamo_session_header_child_adds_parent(
+        self, transport, request_info, monkeypatch
+    ):
+        """Subagent child also emits X-Dynamo-Parent-Session-ID."""
+        monkeypatch.setattr(
+            Environment.HTTP, "X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID", True
+        )
+        request_info.parent_correlation_id = "parent-correlation-id"
+
+        headers = transport.build_headers(request_info)
+
+        assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
+        assert headers["X-Dynamo-Parent-Session-ID"] == "parent-correlation-id"
 
     def test_build_headers_transport_headers_override(self, request_info):
         """Test that transport headers can override endpoint headers."""

--- a/tests/unit/transports/test_base_transport.py
+++ b/tests/unit/transports/test_base_transport.py
@@ -191,14 +191,14 @@ class TestBaseTransport:
 
         transport = ConflictingTransport(model_endpoint=request_info.model_endpoint)
         request_info.endpoint_headers = {
-            "X-Dynamo-Session-ID": "endpoint-session",
-            "X-Dynamo-Parent-Session-ID": "endpoint-parent",
+            "x-dynamo-session-id": "endpoint-session",
+            "x-dynamo-parent-session-id": "endpoint-parent",
         }
         request_info.turns = [
             Turn(
                 extra_headers={
-                    "X-Dynamo-Session-ID": "turn-session",
-                    "X-Dynamo-Parent-Session-ID": "turn-parent",
+                    "X-Dynamo-Session-Id": "turn-session",
+                    "X-Dynamo-Parent-Session-Id": "turn-parent",
                 }
             )
         ]
@@ -206,7 +206,8 @@ class TestBaseTransport:
         headers = transport.build_headers(request_info)
 
         assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
-        assert "X-Dynamo-Parent-Session-ID" not in headers
+        assert not any(k.lower() == "x-dynamo-parent-session-id" for k in headers)
+        assert sum(k.lower() == "x-dynamo-session-id" for k in headers) == 1
 
     def test_build_headers_dynamo_session_header_child_wins_over_every_layer(
         self,
@@ -230,14 +231,14 @@ class TestBaseTransport:
         transport = ConflictingTransport(model_endpoint=request_info.model_endpoint)
         request_info.parent_correlation_id = "parent-correlation-id"
         request_info.endpoint_headers = {
-            "X-Dynamo-Session-ID": "endpoint-session",
-            "X-Dynamo-Parent-Session-ID": "endpoint-parent",
+            "x-dynamo-session-id": "endpoint-session",
+            "x-dynamo-parent-session-id": "endpoint-parent",
         }
         request_info.turns = [
             Turn(
                 extra_headers={
-                    "X-Dynamo-Session-ID": "turn-session",
-                    "X-Dynamo-Parent-Session-ID": "turn-parent",
+                    "X-Dynamo-Session-Id": "turn-session",
+                    "X-Dynamo-Parent-Session-Id": "turn-parent",
                 }
             )
         ]
@@ -246,6 +247,8 @@ class TestBaseTransport:
 
         assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
         assert headers["X-Dynamo-Parent-Session-ID"] == "parent-correlation-id"
+        assert sum(k.lower() == "x-dynamo-session-id" for k in headers) == 1
+        assert sum(k.lower() == "x-dynamo-parent-session-id" for k in headers) == 1
 
     def test_build_headers_dynamo_session_header_child_adds_parent(
         self,

--- a/tests/unit/transports/test_base_transport.py
+++ b/tests/unit/transports/test_base_transport.py
@@ -170,6 +170,83 @@ class TestBaseTransport:
         assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
         assert "X-Dynamo-Parent-Session-ID" not in headers
 
+    def test_build_headers_dynamo_session_header_root_strips_parent_from_every_layer(
+        self,
+        request_info: RequestInfo,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A root request removes a parent header injected by any merge layer."""
+        monkeypatch.setattr(
+            Environment.HTTP, "X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID", True
+        )
+
+        class ConflictingTransport(FakeTransport):
+            def get_transport_headers(
+                self, request_info: RequestInfo
+            ) -> dict[str, str]:
+                return {
+                    "X-Dynamo-Session-ID": "transport-session",
+                    "X-Dynamo-Parent-Session-ID": "transport-parent",
+                }
+
+        transport = ConflictingTransport(model_endpoint=request_info.model_endpoint)
+        request_info.endpoint_headers = {
+            "X-Dynamo-Session-ID": "endpoint-session",
+            "X-Dynamo-Parent-Session-ID": "endpoint-parent",
+        }
+        request_info.turns = [
+            Turn(
+                extra_headers={
+                    "X-Dynamo-Session-ID": "turn-session",
+                    "X-Dynamo-Parent-Session-ID": "turn-parent",
+                }
+            )
+        ]
+
+        headers = transport.build_headers(request_info)
+
+        assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
+        assert "X-Dynamo-Parent-Session-ID" not in headers
+
+    def test_build_headers_dynamo_session_header_child_wins_over_every_layer(
+        self,
+        request_info: RequestInfo,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A child request keeps derived session + parent over every merge layer."""
+        monkeypatch.setattr(
+            Environment.HTTP, "X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID", True
+        )
+
+        class ConflictingTransport(FakeTransport):
+            def get_transport_headers(
+                self, request_info: RequestInfo
+            ) -> dict[str, str]:
+                return {
+                    "X-Dynamo-Session-ID": "transport-session",
+                    "X-Dynamo-Parent-Session-ID": "transport-parent",
+                }
+
+        transport = ConflictingTransport(model_endpoint=request_info.model_endpoint)
+        request_info.parent_correlation_id = "parent-correlation-id"
+        request_info.endpoint_headers = {
+            "X-Dynamo-Session-ID": "endpoint-session",
+            "X-Dynamo-Parent-Session-ID": "endpoint-parent",
+        }
+        request_info.turns = [
+            Turn(
+                extra_headers={
+                    "X-Dynamo-Session-ID": "turn-session",
+                    "X-Dynamo-Parent-Session-ID": "turn-parent",
+                }
+            )
+        ]
+
+        headers = transport.build_headers(request_info)
+
+        assert headers["X-Dynamo-Session-ID"] == "test-correlation-id"
+        assert headers["X-Dynamo-Parent-Session-ID"] == "parent-correlation-id"
+
     def test_build_headers_dynamo_session_header_child_adds_parent(
         self,
         transport: FakeTransport,


### PR DESCRIPTION
## Summary

Add an opt-in flag that stamps **Dynamo session-affinity headers** onto every outbound request, so a Dynamo frontend can pin all turns of a session to the replica holding its KV prefix. This is a minimal, header-only addition alongside the existing `session_header` correlation-header logic in `base_transports` — no new plugin machinery.

Set `AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID=true` and every request carries:
- `X-Dynamo-Session-ID` = the stable `x_correlation_id` (same on every turn of a session)
- `X-Dynamo-Parent-Session-ID` = the parent session's ID, **only on subagent children** (omitted for roots)

Pair with a Dynamo frontend running `--router-session-affinity-ttl-secs`.

## Changes
- `environment.py` — new `X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID` bool (default `False`).
- `base_transports.py` — emit the two headers in `build_headers`, parent only when `parent_correlation_id` is set.
- `test_base_transport.py` — two tests (root has no parent header; subagent child adds it).
- `docs/environment-variables.md` — regenerated.

## Verification (over the wire)
Custom spawn `dag_jsonl` (a root that spawns two subagents) run through `aiperf profile` against the in-repo mock server with `--export-level raw`. Raw-export `request_headers` is the exact dict handed to aiohttp `session.post(headers=...)`; every request returned 200.

- **Flag ON:** root carries `X-Dynamo-Session-ID` (own corr) and **no** parent header; children carry both, with `X-Dynamo-Parent-Session-ID` equal to the real root correlation ID.
- **Flag OFF (control):** zero `X-Dynamo-*` headers.
- Unit: `tests/unit/transports/test_base_transport.py` 33/33 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP setting `AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID` to send `X-Dynamo-Session-ID` derived from the stable `X-Correlation-ID`.
  * When enabled, subagent child requests also include `X-Dynamo-Parent-Session-ID`.
  * Derived Dynamo session headers are now protected from being overridden by other provided headers.
* **Documentation**
  * Documented the new environment variable and how it affects HTTP header behavior.
* **Tests**
  * Added unit tests covering root vs. child behavior, default-off behavior, and non-overridable derived headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->