### PR TITLE
chore: replace --tokenizer gpt2 with --tokenizer builtin in docs and tests

### DIFF
--- a/docs/plugins/creating-your-first-plugin.md
+++ b/docs/plugins/creating-your-first-plugin.md
@@ -372,7 +372,7 @@ aiperf profile \
   --model echo-model \
   --url http://localhost:8000 \
   --endpoint-type echo \
-  --tokenizer gpt2 \
+  --tokenizer builtin \
   --synthetic-input-tokens-mean 100 \
   --request-count 10
 
@@ -381,7 +381,7 @@ aiperf profile \
   --model echo-model \
   --url http://localhost:8000 \
   --endpoint-type echo \
-  --tokenizer gpt2 \
+  --tokenizer builtin \
   --synthetic-input-tokens-mean 100 \
   --concurrency 4 \
   --request-count 100

--- a/docs/tutorials/image-generation.md
+++ b/docs/tutorials/image-generation.md
@@ -88,7 +88,7 @@ EOF
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.1-dev \
-  --tokenizer gpt2 \
+  --tokenizer builtin \
   --url http://localhost:30000 \
   --endpoint-type image_generation \
   --input-file image_prompts.jsonl \
@@ -119,7 +119,7 @@ aiperf profile \
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.1-dev \
-  --tokenizer gpt2 \
+  --tokenizer builtin \
   --url http://localhost:30000 \
   --endpoint-type image_generation \
   --extra-inputs size:512x512 \
@@ -179,7 +179,7 @@ EOF
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.1-dev \
-  --tokenizer gpt2 \
+  --tokenizer builtin \
   --url http://localhost:30000 \
   --endpoint-type image_generation \
   --input-file image_prompts.jsonl \

--- a/docs/tutorials/sglang-image-edit.md
+++ b/docs/tutorials/sglang-image-edit.md
@@ -76,7 +76,7 @@ The simplest path: AIPerf generates a synthetic reference image for every reques
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.2-klein-4B \
-  --tokenizer gpt2 \
+  --tokenizer builtin \
   --url http://localhost:30000 \
   --endpoint-type image_edit \
   --image-batch-size 1 \
@@ -123,7 +123,7 @@ EOF
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.2-klein-4B \
-  --tokenizer gpt2 \
+  --tokenizer builtin \
   --url http://localhost:30000 \
   --endpoint-type image_edit \
   --input-file edit_prompts.jsonl \
@@ -157,7 +157,7 @@ Use `--export-level raw` to capture the raw input/output payloads, which lets yo
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.2-klein-4B \
-  --tokenizer gpt2 \
+  --tokenizer builtin \
   --url http://localhost:30000 \
   --endpoint-type image_edit \
   --input-file edit_prompts.jsonl \

--- a/docs/tutorials/sglang-video-generation.md
+++ b/docs/tutorials/sglang-video-generation.md
@@ -147,7 +147,7 @@ EOF
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --input-file video_prompts.jsonl \
@@ -180,7 +180,7 @@ Generate videos using synthetic prompts with configurable token lengths:
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --extra-inputs "size:1280x720" \
@@ -213,7 +213,7 @@ Use `--download-video-content` to include video content download in the benchmar
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --input-file video_prompts.jsonl \
@@ -229,7 +229,7 @@ aiperf profile \
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --input-file video_prompts.jsonl \
@@ -257,7 +257,7 @@ AIPerf automatically handles polling for video generation. Configure polling beh
 # Set slower polling (0.5s) with 20 minute timeout
 AIPERF_HTTP_VIDEO_POLL_INTERVAL=0.5 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --input-file video_prompts.jsonl \
@@ -277,7 +277,7 @@ To extract and save the generated videos, use `--export-level raw` to capture th
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --input-file video_prompts.jsonl \
@@ -366,7 +366,7 @@ Test maximum throughput with multiple concurrent requests:
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --extra-inputs "size:720x480" \
@@ -384,7 +384,7 @@ Test single-request latency for different video sizes:
 # Short 4-second video
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --extra-inputs "size:1280x720" \
@@ -396,7 +396,7 @@ aiperf profile \
 # Longer 8-second video
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --extra-inputs "size:1280x720" \
@@ -414,7 +414,7 @@ Compare generation quality at different inference step counts:
 # Fast generation (fewer steps)
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --extra-inputs "size:1280x720" \
@@ -427,7 +427,7 @@ aiperf profile \
 # High quality (more steps)
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
-    --tokenizer gpt2 \
+    --tokenizer builtin \
     --url http://localhost:30010 \
     --endpoint-type video_generation \
     --extra-inputs "size:1280x720" \

--- a/src/aiperf/common/tokenizer_display.py
+++ b/src/aiperf/common/tokenizer_display.py
@@ -236,7 +236,7 @@ def _detect_error(
                 "Check [cyan]huggingface.co/<model>/tree/main[/cyan] for a tokenizer_config.json",
             ],
             fixes=[
-                "Pass a compatible text tokenizer: [green]--tokenizer gpt2[/green]",
+                "Pass a compatible text tokenizer: [green]--tokenizer builtin[/green]",
                 "Pass the tokenizer subdirectory: [green]--tokenizer ./model/tokenizer[/green]",
             ],
         )

--- a/tests/component_integration/endpoints/test_embeddings_endpoint.py
+++ b/tests/component_integration/endpoints/test_embeddings_endpoint.py
@@ -20,7 +20,7 @@ class TestEmbeddingsEndpoint:
             f"""
             aiperf profile \
                 --model nomic-ai/nomic-embed-text-v1.5 \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type embeddings \
                 --request-count {defaults.request_count} \
                 --concurrency {defaults.concurrency} \

--- a/tests/component_integration/endpoints/test_image_edit_endpoint.py
+++ b/tests/component_integration/endpoints/test_image_edit_endpoint.py
@@ -20,7 +20,7 @@ class TestImageEditEndpoint:
             f"""
             aiperf profile \
                 --model black-forest-labs/FLUX.2-klein-4B \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type image_edit \
                 --image-batch-size 1 \
                 --image-width-mean 64 \
@@ -45,7 +45,7 @@ class TestImageEditEndpoint:
             f"""
             aiperf profile \
                 --model black-forest-labs/FLUX.2-klein-4B \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type image_edit \
                 --image-batch-size 1 \
                 --image-width-mean 64 \

--- a/tests/component_integration/endpoints/test_image_generation_endpoint.py
+++ b/tests/component_integration/endpoints/test_image_generation_endpoint.py
@@ -34,7 +34,7 @@ class TestImageGenerationEndpoint:
             f"""
             aiperf profile \
                 --model black-forest-labs/FLUX.1-dev \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type image_generation \
                 --synthetic-input-tokens-mean 150 \
                 --synthetic-input-tokens-stddev 30 \
@@ -64,7 +64,7 @@ class TestImageGenerationEndpoint:
             f"""
             aiperf profile \
                 --model black-forest-labs/FLUX.1-dev \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type image_generation \
                 --extra-inputs size:512x512 quality:standard \
                 --request-count {defaults.request_count} \

--- a/tests/component_integration/endpoints/test_rankings_endpoint.py
+++ b/tests/component_integration/endpoints/test_rankings_endpoint.py
@@ -25,7 +25,7 @@ class TestRankingsEndpoint:
             f"""
             aiperf profile \
                 --model nvidia/nv-rerank-qa-mistral-4b \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type nim_rankings \
                 --input-file {dataset_path} \
                 --custom-dataset-type single_turn \
@@ -85,7 +85,7 @@ class TestRankingsEndpoint:
             f"""
             aiperf profile \
                 --model nvidia/nv-rerank-qa-mistral-4b \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type nim_rankings \
                 --request-count {defaults.request_count} \
                 --concurrency {defaults.concurrency} \

--- a/tests/integration/test_custom_gpu_metrics.py
+++ b/tests/integration/test_custom_gpu_metrics.py
@@ -97,7 +97,7 @@ DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz)
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --gpu-telemetry {custom_gpu_metrics_csv} {" ".join(aiperf_mock_server.dcgm_urls)} \
                 --benchmark-duration 2 \
@@ -185,7 +185,7 @@ DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz)
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --gpu-telemetry {custom_gpu_metrics_csv_with_defaults} {" ".join(aiperf_mock_server.dcgm_urls)} \
                 --benchmark-duration 2 \
@@ -231,7 +231,7 @@ DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz)
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --gpu-telemetry {custom_gpu_metrics_csv_invalid} {" ".join(aiperf_mock_server.dcgm_urls)} \
                 --benchmark-duration 2 \
@@ -263,7 +263,7 @@ DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz)
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --gpu-telemetry {nonexistent_csv} {" ".join(aiperf_mock_server.dcgm_urls)} \
                 --request-count 10 \

--- a/tests/integration/test_dashboard_ui.py
+++ b/tests/integration/test_dashboard_ui.py
@@ -30,7 +30,7 @@ class TestDashboardUI:
                 aiperf profile \
                     --model {defaults.model} \
                     --url {aiperf_mock_server.url} \
-                    --tokenizer gpt2 \
+                    --tokenizer builtin \
                     --endpoint-type chat \
                     --ui dashboard \
                     --benchmark-duration 5 \

--- a/tests/integration/test_embeddings_endpoint.py
+++ b/tests/integration/test_embeddings_endpoint.py
@@ -21,7 +21,7 @@ class TestEmbeddingsEndpoint:
             f"""
             aiperf profile \
                 --model nomic-ai/nomic-embed-text-v1.5 \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --url {aiperf_mock_server.url} \
                 --endpoint-type embeddings \
                 --request-count {defaults.request_count} \

--- a/tests/integration/test_gpu_telemetry.py
+++ b/tests/integration/test_gpu_telemetry.py
@@ -29,7 +29,7 @@ class TestGpuTelemetry:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --gpu-telemetry {" ".join(aiperf_mock_server.dcgm_urls)} \
                 --streaming \
@@ -78,7 +78,7 @@ class TestGpuTelemetry:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --gpu-telemetry {" ".join(aiperf_mock_server.dcgm_urls)} \
                 --streaming \
@@ -135,7 +135,7 @@ class TestGpuTelemetry:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --gpu-telemetry {" ".join(aiperf_mock_server.dcgm_urls)} \
                 --streaming \
@@ -173,7 +173,7 @@ class TestGpuTelemetry:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --streaming \
                 --request-count 25 \

--- a/tests/integration/test_image_edit_endpoint.py
+++ b/tests/integration/test_image_edit_endpoint.py
@@ -29,7 +29,7 @@ class TestImageEditEndpoint:
             f"""
             aiperf profile \
                 --model black-forest-labs/FLUX.2-klein-4B \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --url {aiperf_mock_server.url} \
                 --endpoint-type image_edit \
                 --image-batch-size 1 \
@@ -62,7 +62,7 @@ class TestImageEditEndpoint:
             f"""
             aiperf profile \
                 --model black-forest-labs/FLUX.2-klein-4B \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --url {aiperf_mock_server.url} \
                 --endpoint-type image_edit \
                 --image-batch-size 1 \

--- a/tests/integration/test_image_generation_endpoint.py
+++ b/tests/integration/test_image_generation_endpoint.py
@@ -29,7 +29,7 @@ class TestImageGenerationEndpoint:
             f"""
             aiperf profile \
                 --model black-forest-labs/FLUX.1-dev \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --url {aiperf_mock_server.url} \
                 --endpoint-type image_generation \
                 --synthetic-input-tokens-mean 150 \

--- a/tests/integration/test_rankings_endpoint.py
+++ b/tests/integration/test_rankings_endpoint.py
@@ -35,7 +35,7 @@ class TestRankingsEndpoint:
             aiperf profile \
                 --model test-reranker \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type {endpoint_type} \
                 --input-file {dataset_path} \
                 --custom-dataset-type single_turn \
@@ -57,7 +57,7 @@ class TestRankingsEndpoint:
             aiperf profile \
                 --model test-reranker \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type nim_rankings \
                 --request-count {defaults.request_count} \
                 --concurrency {defaults.concurrency} \

--- a/tests/integration/test_server_metrics.py
+++ b/tests/integration/test_server_metrics.py
@@ -45,7 +45,7 @@ class TestServerMetrics:
                 aiperf profile \
                     --model nvidia/llama-3.1-nemotron-70b-instruct \
                     --url {aiperf_mock_server.url} \
-                    --tokenizer gpt2 \
+                    --tokenizer builtin \
                     --endpoint-type chat \
                     --streaming \
                     --request-count 50 \
@@ -92,7 +92,7 @@ class TestServerMetrics:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --streaming \
                 --request-count 50 \
@@ -161,7 +161,7 @@ class TestServerMetrics:
                 aiperf profile \
                     --model nvidia/llama-3.1-nemotron-70b-instruct \
                     --url {aiperf_mock_server.url} \
-                    --tokenizer gpt2 \
+                    --tokenizer builtin \
                     --endpoint-type chat \
                     --streaming \
                     --request-count 100 \
@@ -227,7 +227,7 @@ class TestServerMetrics:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --streaming \
                 --request-count 50 \
@@ -335,7 +335,7 @@ class TestServerMetrics:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --streaming \
                 --request-count 50 \
@@ -386,7 +386,7 @@ class TestServerMetrics:
                 aiperf profile \
                     --model nvidia/llama-3.1-nemotron-70b-instruct \
                     --url {aiperf_mock_server.url} \
-                    --tokenizer gpt2 \
+                    --tokenizer builtin \
                     --endpoint-type chat \
                     --streaming \
                     --request-count 50 \
@@ -431,7 +431,7 @@ class TestServerMetrics:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --request-count 50 \
                 --concurrency 2 \
@@ -458,7 +458,7 @@ class TestServerMetrics:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --streaming \
                 --request-count 25 \
@@ -501,7 +501,7 @@ class TestServerMetrics:
             aiperf profile \
                 --model nvidia/llama-3.1-nemotron-70b-instruct \
                 --url {aiperf_mock_server.url} \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --endpoint-type chat \
                 --streaming \
                 --request-count 25 \
@@ -541,7 +541,7 @@ class TestServerMetrics:
                 aiperf profile \
                     --model nvidia/llama-3.1-nemotron-70b-instruct \
                     --url {aiperf_mock_server.url} \
-                    --tokenizer gpt2 \
+                    --tokenizer builtin \
                     --endpoint-type chat \
                     --streaming \
                     --request-count 50 \

--- a/tests/integration/test_solido_rag_endpoint.py
+++ b/tests/integration/test_solido_rag_endpoint.py
@@ -21,7 +21,7 @@ class TestSolidoRAGEndpoint:
             f"""
             aiperf profile \
                 --model rag-model \
-                --tokenizer gpt2 \
+                --tokenizer builtin \
                 --url {aiperf_mock_server.url} \
                 --endpoint-type solido_rag \
                 --request-count {defaults.request_count} \

--- a/tests/unit/common/test_tokenizer_display.py
+++ b/tests/unit/common/test_tokenizer_display.py
@@ -197,7 +197,7 @@ class TestDisplayTokenizerValidationError:
                 ["TokenizerError", "ValueError"],
                 "Couldn't instantiate the backend tokenizer from one of: (1) a `tokenizers` library serialization file",
                 "No Standard Tokenizer",
-                ["--tokenizer gpt2", "tokenizer_config.json"],
+                ["--tokenizer builtin", "tokenizer_config.json"],
             ),
             # tokenizer_class not registered in installed transformers (issue #960)
             (


### PR DESCRIPTION
## Summary
- Replace all remaining `--tokenizer gpt2` examples/fixtures with `--tokenizer builtin` across docs and tests

## Test plan
- [x] `pre-commit` hooks passed on commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin and image, video, and image-edit tutorials to recommend the built-in tokenizer option in command examples.
* **Bug Fixes**
  * Updated tokenizer guidance shown when standard tokenizer setup fails, directing users to the built-in tokenizer.
* **Tests**
  * Aligned integration and unit test scenarios with the built-in tokenizer option across supported endpoints, telemetry, metrics, dashboards, and ranking workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->