### PR TITLE
chore: bump Fern version from 5.57.0 to 5.75.8

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.57.0"
+  "version": "5.75.8"
 }


### PR DESCRIPTION
## Summary
- Bumps Fern CLI version from `5.57.0` to `5.75.8` in `fern/fern.config.json`

## Test plan
- [ ] Verify Fern docs build successfully with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the displayed product version from 5.57.0 to 5.75.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->