### PR TITLE
chore: hardcode AIPerf team in linear-issue skill

### DIFF
--- a/.agents/skills/linear-issue/SKILL.md
+++ b/.agents/skills/linear-issue/SKILL.md
@@ -27,10 +27,7 @@ Bad titles:
 
 ### Step 1: Determine the team
 
-Call `mcp__linear__list_teams` to retrieve available teams.
-
-- One team: use it silently.
-- Multiple teams: ask the user which team the issue belongs to.
+Use the **AIPerf** team. Do not call `list_teams` or ask the user.
 
 ### Step 2: Confirm the title
 


### PR DESCRIPTION
## Summary
- Removes the dynamic team lookup step from the `linear-issue` skill
- Hardcodes the **AIPerf** team so issues are always created in the correct team without prompting

## Test plan
- [ ] Run `/linear-issue` and confirm it skips team selection and creates the issue under AIPerf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue-creation guidance to consistently select the AIPerf team.
  * Removed the team-selection prompt from the documented workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->