### PR TITLE
fix: grade reasoning models on answer content only, not CoT preamble

### DIFF
--- a/src/aiperf/accuracy/accuracy_record_processor.py
+++ b/src/aiperf/accuracy/accuracy_record_processor.py
@@ -100,7 +100,8 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
         ground_truth = self._ground_truths[
             metadata.session_num % len(self._ground_truths)
         ]
-        response_text = self._extract_response_text(record)
+        model_output, model_thinking = self._extract_output_and_thinking(record)
+        response_text = model_output
 
         result: GradingResult = await self.grader.grade(response_text, ground_truth)
 
@@ -111,8 +112,6 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
         )
 
         self._log_grading_detail(metadata.session_num, response_text, result)
-
-        model_output, model_thinking = self._extract_output_and_thinking(record)
 
         return AccuracyRecordsData(
             session_num=metadata.session_num,
@@ -167,16 +166,6 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
             self.debug(_detail)
 
     @staticmethod
-    def _extract_response_text(record: ParsedResponseRecord) -> str:
-        parts: list[str] = []
-        for resp in record.content_responses:
-            if resp.data:
-                text = resp.data.get_text()
-                if text:
-                    parts.append(text)
-        return "".join(parts)
-
-    @staticmethod
     def _extract_output_and_thinking(
         record: ParsedResponseRecord,
     ) -> tuple[str, str | None]:
@@ -187,9 +176,9 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
         ``tool_call_text``); ``model_thinking`` is the concatenated
         ``reasoning_content`` from any ``ReasoningResponseData`` chunks, or None
         when the model emitted no separate reasoning channel. For reasoning models
-        this deliberately splits the two channels: grading scores the full
-        ``get_text()`` (reasoning + content), while the export keeps ``model_output``
-        to the answer content and routes reasoning to ``model_thinking``.
+        this splits the two channels: grading scores only ``model_output``
+        (the final answer content) so that CoT preamble does not poison
+        exact-match and similar graders; ``model_thinking`` is exported separately.
         """
         output_parts: list[str] = []
         thinking_parts: list[str] = []

--- a/src/aiperf/accuracy/accuracy_record_processor.py
+++ b/src/aiperf/accuracy/accuracy_record_processor.py
@@ -182,6 +182,7 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
         """
         output_parts: list[str] = []
         thinking_parts: list[str] = []
+        fallback_parts: list[str] = []
         for resp in record.content_responses:
             data = resp.data
             if data is None:
@@ -189,15 +190,17 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
             reasoning = getattr(data, "reasoning", None)
             if reasoning:
                 thinking_parts.append(reasoning)
+                fallback_parts.append(reasoning)
             content = getattr(data, "content", None)
             tool_call_text = getattr(data, "tool_call_text", None)
-            if content is not None:
+            if content:
                 output_parts.append(content)
             if tool_call_text:
                 # Tool-call responses grade on content + tool_call_text; keep both.
                 output_parts.append(tool_call_text)
-            elif content is None and reasoning is None:
+            elif not content and reasoning is None:
                 # Plain text data with no reasoning/tool-call channel.
                 output_parts.append(data.get_text())
         thinking = "".join(thinking_parts) if thinking_parts else None
-        return "".join(output_parts), thinking
+        model_output = "".join(output_parts) or "".join(fallback_parts)
+        return model_output, thinking

--- a/src/aiperf/accuracy/accuracy_record_processor.py
+++ b/src/aiperf/accuracy/accuracy_record_processor.py
@@ -12,6 +12,10 @@ from aiperf.accuracy.models import (
 from aiperf.common.exceptions import PostProcessorDisabled
 from aiperf.common.mixins import AIPerfLifecycleMixin
 from aiperf.common.models import MetricRecordMetadata, ParsedResponseRecord
+from aiperf.common.models.record_models import (
+    ReasoningResponseData,
+    ToolCallResponseData,
+)
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import PluginType
 
@@ -187,19 +191,17 @@ class AccuracyRecordProcessor(AIPerfLifecycleMixin):
             data = resp.data
             if data is None:
                 continue
-            reasoning = getattr(data, "reasoning", None)
-            if reasoning:
-                thinking_parts.append(reasoning)
-                fallback_parts.append(reasoning)
-            content = getattr(data, "content", None)
-            tool_call_text = getattr(data, "tool_call_text", None)
-            if content:
-                output_parts.append(content)
-            if tool_call_text:
-                # Tool-call responses grade on content + tool_call_text; keep both.
-                output_parts.append(tool_call_text)
-            elif not content and reasoning is None:
-                # Plain text data with no reasoning/tool-call channel.
+            if isinstance(data, ReasoningResponseData):
+                if data.reasoning:
+                    thinking_parts.append(data.reasoning)
+                    fallback_parts.append(data.reasoning)
+                if data.content:
+                    output_parts.append(data.content)
+            elif isinstance(data, ToolCallResponseData):
+                if data.content:
+                    output_parts.append(data.content)
+                output_parts.append(data.tool_call_text)
+            else:
                 output_parts.append(data.get_text())
         thinking = "".join(thinking_parts) if thinking_parts else None
         model_output = "".join(output_parts) or "".join(fallback_parts)

--- a/tests/unit/accuracy/test_accuracy_record_processor.py
+++ b/tests/unit/accuracy/test_accuracy_record_processor.py
@@ -222,6 +222,52 @@ class TestAccuracyRecordProcessorSessionBounds:
         assert result.task is None
         assert result.passed is True
 
+    async def test_process_record_grades_reasoning_model_on_content_only(
+        self, monkeypatch
+    ) -> None:
+        """Grader receives only the answer content, not reasoning + content.
+
+        Regression test for https://github.com/ai-dynamo/aiperf/issues/1136:
+        reasoning models returned 0% because the CoT preamble was concatenated
+        with the final answer before exact-match comparison.
+        """
+        from aiperf.common.models.record_models import ReasoningResponseData
+
+        processor = _make_processor(monkeypatch)
+        processor._ground_truths = ["True"]
+
+        grading_result = GradingResult(
+            correct=True,
+            confidence=1.0,
+            reasoning="Correct",
+            extracted_answer="True",
+            ground_truth="True",
+        )
+        processor.grader.grade = AsyncMock(return_value=grading_result)
+
+        reasoning_record = MagicMock(spec=ParsedResponseRecord)
+        reasoning_record.content_responses = [
+            ParsedResponse(
+                perf_ns=0,
+                data=ReasoningResponseData(
+                    reasoning="Thinking Process:\n\n1. Analyze the request... True",
+                    content="\n\nTrue",
+                ),
+            ),
+        ]
+
+        metadata = create_metric_metadata(session_num=0)
+        result = await processor.process_record(reasoning_record, metadata)
+
+        assert result.passed is True
+        # Grader must have received only the answer content, not the CoT preamble.
+        processor.grader.grade.assert_awaited_once_with("\n\nTrue", "True")
+        assert result.model_output == "\n\nTrue"
+        assert (
+            result.model_thinking
+            == "Thinking Process:\n\n1. Analyze the request... True"
+        )
+
     async def test_process_record_raises_if_not_configured(
         self, monkeypatch, sample_parsed_record
     ) -> None:

--- a/tests/unit/accuracy/test_accuracy_record_processor.py
+++ b/tests/unit/accuracy/test_accuracy_record_processor.py
@@ -376,3 +376,25 @@ class TestExtractOutputAndThinking:
         output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
         assert output == ""
         assert thinking is None
+
+    def test_reasoning_only_content_none_falls_back_to_reasoning(self) -> None:
+        """content=None with reasoning present → reasoning used as model_output fallback."""
+        from aiperf.common.models.record_models import ReasoningResponseData
+
+        record = self._record(
+            [ReasoningResponseData(content=None, reasoning="Thinking... True")]
+        )
+        output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
+        assert output == "Thinking... True"
+        assert thinking == "Thinking... True"
+
+    def test_reasoning_only_content_empty_falls_back_to_reasoning(self) -> None:
+        """content='' is treated as missing; reasoning used as model_output fallback."""
+        from aiperf.common.models.record_models import ReasoningResponseData
+
+        record = self._record(
+            [ReasoningResponseData(content="", reasoning="Thinking... True")]
+        )
+        output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
+        assert output == "Thinking... True"
+        assert thinking == "Thinking... True"

--- a/tests/unit/accuracy/test_accuracy_record_processor.py
+++ b/tests/unit/accuracy/test_accuracy_record_processor.py
@@ -398,3 +398,26 @@ class TestExtractOutputAndThinking:
         output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
         assert output == "Thinking... True"
         assert thinking == "Thinking... True"
+
+    def test_unknown_subclass_uses_get_text_not_content_attr(self) -> None:
+        """Non-Reasoning/ToolCall subclasses go through get_text(), not .content.
+
+        Regression: the old getattr-based implementation would have read the
+        .content attribute directly, returning the wrong value for any
+        BaseResponseData subclass whose .content differs from .get_text().
+        """
+        from dataclasses import dataclass
+
+        from aiperf.common.models.record_models import BaseResponseData
+
+        @dataclass(slots=True)
+        class CustomResponseData(BaseResponseData):
+            content: str = "wrong"
+
+            def get_text(self) -> str:
+                return "correct"
+
+        record = self._record([CustomResponseData()])
+        output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
+        assert output == "correct"
+        assert thinking is None

--- a/tests/unit/accuracy/test_accuracy_record_processor.py
+++ b/tests/unit/accuracy/test_accuracy_record_processor.py
@@ -63,6 +63,20 @@ def _make_dataset_metadata(
     )
 
 
+class TestAccuracyRecordProcessorInit:
+    def test_raises_when_accuracy_not_enabled(self, monkeypatch) -> None:
+        """PostProcessorDisabled raised when accuracy mode is off."""
+        from aiperf.common.exceptions import PostProcessorDisabled
+
+        run = make_benchmark_run(
+            model_names=["m"],
+            endpoint_type=EndpointType.COMPLETIONS,
+            streaming=False,
+        )
+        with pytest.raises(PostProcessorDisabled):
+            AccuracyRecordProcessor(run=run, service_id="test")
+
+
 class TestAccuracyRecordProcessorOnDatasetConfigured:
     def test_populates_ground_truths_from_metadata(self, monkeypatch) -> None:
         processor = _make_processor(monkeypatch)
@@ -420,4 +434,43 @@ class TestExtractOutputAndThinking:
         record = self._record([CustomResponseData()])
         output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
         assert output == "correct"
+        assert thinking is None
+
+    def test_none_data_in_response_is_skipped(self) -> None:
+        """resp.data=None entries are skipped without error."""
+        from aiperf.common.models.record_models import TextResponseData
+
+        record = MagicMock(spec=ParsedResponseRecord)
+        record.content_responses = [
+            ParsedResponse(perf_ns=0, data=None),
+            ParsedResponse(perf_ns=1, data=TextResponseData(text="hello")),
+        ]
+        output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
+        assert output == "hello"
+        assert thinking is None
+
+    def test_tool_call_response_includes_content_and_tool_call_text(self) -> None:
+        """ToolCallResponseData appends content then tool_call_text to model_output."""
+        from aiperf.common.models.record_models import ToolCallResponseData
+
+        record = self._record(
+            [
+                ToolCallResponseData(
+                    tool_call_text='{"name":"fn"}', content="Sure, calling:"
+                )
+            ]
+        )
+        output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
+        assert output == 'Sure, calling:{"name":"fn"}'
+        assert thinking is None
+
+    def test_tool_call_response_no_content_uses_tool_call_text_only(self) -> None:
+        """ToolCallResponseData with content=None only adds tool_call_text."""
+        from aiperf.common.models.record_models import ToolCallResponseData
+
+        record = self._record(
+            [ToolCallResponseData(tool_call_text='{"name":"fn"}', content=None)]
+        )
+        output, thinking = AccuracyRecordProcessor._extract_output_and_thinking(record)
+        assert output == '{"name":"fn"}'
         assert thinking is None


### PR DESCRIPTION
## Summary

- `AccuracyRecordProcessor` was concatenating `reasoning + content` and passing the full CoT blob to graders, causing `ExactMatchGrader` (and others) to always score 0% against reasoning models
- Replace the separate `_extract_response_text()` call with `_extract_output_and_thinking()`, which already correctly separates the two channels — graders now receive content-only `model_output`
- Delete the now-unused `_extract_response_text()` method

Fixes https://github.com/ai-dynamo/aiperf/issues/1136
Tracks AIP-1018

## Test plan

- [ ] New regression test `test_process_record_grades_reasoning_model_on_content_only` reproduces the exact scenario from the issue (CoT preamble + `\n\nTrue` content vs gold `"True"`) and asserts the grader receives content only
- [ ] All 14 existing tests in `test_accuracy_record_processor.py` pass
- [ ] Full unit suite: 14,948 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Accuracy grading now evaluates only the model’s final answer (visible output), excluding separate reasoning/chain-of-thought from the exact-match input.
  * Accuracy records now reliably capture `model_output` from the evaluated answer while preserving `model_thinking` from the full reasoning (including fallback for reasoning-only responses).
* **Tests**
  * Added unit tests covering grading/extraction for reasoning-capable records, including cases with empty or missing content.
  * Added an initialization test to confirm accuracy mode disables the post-processor when not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->