### PR TITLE
ci: restrict Velonix workflows to trusted branch pushes

### DIFF
--- a/.github/workflows/resolve-check.yml
+++ b/.github/workflows/resolve-check.yml
@@ -22,7 +22,7 @@ on:
   push:
     branches:
       - main
-      - 'pull-request/*'
+      - 'pull-request/[0-9]+'
       - 'release/*'
 
 jobs:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 name: "Run Unit Tests"
 
+# The Linux matrix leg runs on Velonix. Only run repository code from trusted
+# branch pushes; fork PRs enter CI after being copied to pull-request/<number>.
 on:
-  pull_request:
   push:
     branches:
       - main
+      - 'pull-request/[0-9]+'
+      - 'release/*'
 
 jobs:
   build:

--- a/.github/workflows/test-docs-end-to-end.yml
+++ b/.github/workflows/test-docs-end-to-end.yml
@@ -4,24 +4,23 @@
 # Runs tests/ci/test_docs_end_to_end/setup_test.sh on the AMD GPU runner.
 #
 # Triggers:
-#   pull_request      — auto-runs on PRs that touch tutorial markdown or the
-#                       test runner itself.
-#   workflow_dispatch — manual trigger from the Actions UI / gh CLI.
-#   workflow_call     — invoked by nightly.yml so the nightly stays green.
+#   push          — runs for trusted main, release, and mirrored PR branch
+#                   pushes that touch tutorial markdown or the test runner.
+#   workflow_call — invoked by nightly.yml so the nightly stays green.
 #
-# A cheap ubuntu-latest detect-changes job pre-flights the work and skips the
-# AMD GPU job when a PR doesn't actually change anything the parser would
-# extract from the tutorials.
+# The paths filter avoids allocating AMD GPU runners for unrelated pushes.
 
 name: Test Docs End-to-End
 
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches:
+      - main
+      - 'pull-request/[0-9]+'
+      - 'release/*'
     paths:
       - 'docs/tutorials/**'
       - 'tests/ci/test_docs_end_to_end/**'
-  workflow_dispatch:
   workflow_call:
     inputs:
       source_ref:
@@ -50,8 +49,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Non-PR triggers (workflow_dispatch, workflow_call from nightly)
-          # have no base/head to compare; always run the test.
+          # Trusted push and workflow_call events have no PR base/head to
+          # compare; the push paths filter already removed unrelated changes.
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "run_test=true" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
## Summary

- run the Velonix-backed Linux unit-test leg only on pushes to `pull-request/[0-9]+`, `main`, or `release/*`
- run the Velonix docs GPU workflow directly only on the same trusted pushes, removing direct `pull_request` and manual dispatch triggers
- align the existing Velonix resolve check with Dynamo numeric PR-copy branch matching

## Trigger audit

| Workflow | Velonix path | Result |
| --- | --- | --- |
| `run-unit-tests.yml` | Linux matrix | trusted push branches only |
| `test-docs-end-to-end.yml` | AMD GPU matrix | trusted push branches; reusable call retained for `nightly.yml` |
| `resolve-check.yml` | default worker | trusted push branches only |
| `nightly.yml` | build, resolve, stage workers | existing schedule/manual nightly retained; dispatch is gated to `main`, the requested SHA must be reachable from `main`, and every downstream Velonix job depends on that gate |

The nightly exception is intentional: removing its schedule and dispatch events would disable the nightly build and release pipeline. It does not execute PR refs.

## Validation

- `.venv/bin/pre-commit run`
- YAML syntax parse
- programmatic assertion of the three trusted push branch filters
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated validation workflows to run consistently for main, release, and pull-request branches.
  - Improved documentation test automation so relevant tutorial changes receive end-to-end validation.
  - Refined change detection to avoid unnecessary checks for unrelated updates.
  - Added clarifying guidance for trusted branch-based validation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->