### PR TITLE
test: whitelist OutputFragment.metrics in numeric-bounds invariant

### DIFF
--- a/tests/unit/property/test_finite_invariants.py
+++ b/tests/unit/property/test_finite_invariants.py
@@ -360,6 +360,11 @@ NUMERIC_BOUNDS_WHITELIST: set[str] = {
     # RateSeriesConfig.points: list[RateSeriesPoint], not a numeric field. The
     # substring-based heuristic sees "int" inside "Point".
     "RateSeriesConfig.points",
+    # OutputFragment.metrics: dict[str, MetricValueTypeT] of allowlisted
+    # per-request metrics in display units, not a numeric leaf. Values are
+    # already scrubbed/typed upstream by the metric pipeline; no useful
+    # field-level bound applies to the free-form dict.
+    "OutputFragment.metrics",
 }
 
 


### PR DESCRIPTION
## What

`OutputFragment.metrics` (added in #1138) is a `dict[str, MetricValueTypeT]` of allowlisted per-request metrics in display units — not a numeric leaf field. The substring-based numeric heuristic in `test_every_numeric_field_has_bounds` sees a numeric type inside the dict value annotation and flags it as an unbounded numeric field.

Because the field landed on `main` without a whitelist entry, `test_every_numeric_field_has_bounds` is currently **failing on main** (and on every branch that rebases onto it, e.g. #1097).

## Fix

Add `OutputFragment.metrics` to `NUMERIC_BOUNDS_WHITELIST` alongside the existing container false-positives (`RateSeriesConfig.points`, `ServerMetricsResults.warmup_endpoint_summaries`, `AdaptiveSearchSweep.outcome_constraints`). The dict values are already scrubbed/typed upstream by the metric pipeline; no useful field-level bound applies to the free-form dict.

## Test

```
uv run pytest tests/unit/property/test_finite_invariants.py -n auto
# 5 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated numeric validation coverage to allow free-form per-request metrics that are already validated upstream.
  * Expanded the validation test exclusions to reflect the metrics field’s intended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->