### PR TITLE
perf: send parsed responses to record processors

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,7 @@ At end of the profiling phase, `RecordsManager._publish_accuracy_results(phase)`
 
 ```mermaid
 flowchart TD
-    W[Worker] -->|raw response| RP[AccuracyRecordProcessor<br/>grade vs ground truth]
+    W[Worker] -->|parsed inference result| RP[AccuracyRecordProcessor<br/>grade vs ground truth]
     RP -->|AccuracyRecordsData<br/>record_type=accuracy| RM[RecordsManager<br/>routing table]
     RM -->|process_record| ACC[AccuracyAccumulator<br/>AccuracySummary]
     RM -->|process_record| JW[AccuracyJSONLWriter<br/>accuracy_export.jsonl]
@@ -219,7 +219,8 @@ This section describes the end-to-end message flow during a benchmark run, showi
 **Key Data Structures:**
 - **Timing Credit**: Grants permission to send one request
 - **Dataset Entry**: Prompt and conversation context
-- **Raw Result**: Request timing, tokens, response text
+- **Inference Result**: Request timing plus worker-parsed response data; raw
+  responses are retained when required for raw export or compatibility
 - **Metric Record**: Per-request computed metrics plus trace data
 - **Aggregated Results**: Final performance summary and per-request details
 
@@ -228,7 +229,9 @@ This section describes the end-to-end message flow during a benchmark run, showi
 2. Workers access dataset entries via memory-mapped files
 3. Workers send requests to Inference Server (external HTTP)
 4. Workers return completed credits to the Timing Manager over a dedicated PUSH/PULL fan-in channel
-5. Workers push raw results to Record Processors
+5. Workers push parsed inference results to Record Processors. For valid
+   non-raw records using built-in response types, the internal envelope omits
+   raw responses; raw export, errors, and custom response types retain them.
 6. Record Processors push metric records to Records Manager
 7. Records Manager aggregates and exports final results
 
@@ -371,7 +374,7 @@ sequenceDiagram
     participant C as OTel Collector
     participant M as MLflow Tracking
 
-    W->>RP: raw response
+    W->>RP: parsed inference result
     RP->>RM: MetricRecordsData
     RM->>OP: process_result(MetricRecordsData)
     OP->>OP: MetricResultsStrategy.supports -> True

--- a/src/aiperf/common/messages/inference_messages.py
+++ b/src/aiperf/common/messages/inference_messages.py
@@ -1,16 +1,133 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from pydantic import Field, SerializeAsAny, field_validator
+from pydantic import ConfigDict, Field, SerializeAsAny, TypeAdapter, field_validator
 
 from aiperf.common.enums import MessageType, MetricValueTypeT
 from aiperf.common.messages.service_messages import BaseServiceMessage
-from aiperf.common.models import ErrorDetails, RecordData, RequestRecord
+from aiperf.common.models import (
+    BaseResponseData,
+    EmbeddingResponseData,
+    ErrorDetails,
+    ImageResponseData,
+    ImageRetrievalResponseData,
+    ParsedResponse,
+    RAGSources,
+    RankingsResponseData,
+    ReasoningResponseData,
+    RecordData,
+    RequestRecord,
+    TextResponseData,
+    ToolCallResponseData,
+    VideoResponseData,
+)
 from aiperf.common.models.record_models import MetricRecordMetadata, MetricResult
 from aiperf.common.models.trace_models import BaseTraceData
 from aiperf.common.types import MessageTypeT, MetricTagT
+
+ParsedResponseDataType = Literal[
+    "base",
+    "embedding",
+    "image",
+    "image_retrieval",
+    "rankings",
+    "reasoning",
+    "text",
+    "tool_call",
+    "video",
+]
+_RESPONSE_DATA_TYPE_BY_CLASS: dict[type[BaseResponseData], ParsedResponseDataType] = {
+    BaseResponseData: "base",
+    EmbeddingResponseData: "embedding",
+    ImageResponseData: "image",
+    ImageRetrievalResponseData: "image_retrieval",
+    RankingsResponseData: "rankings",
+    ReasoningResponseData: "reasoning",
+    TextResponseData: "text",
+    ToolCallResponseData: "tool_call",
+    VideoResponseData: "video",
+}
+_RESPONSE_DATA_ADAPTER_BY_TYPE = {
+    data_type: TypeAdapter(data_class)
+    for data_class, data_type in _RESPONSE_DATA_TYPE_BY_CLASS.items()
+}
+
+
+@dataclass(slots=True)
+class ParsedResponsePayload:
+    """Compact built-in parsed response representation for internal IPC."""
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    perf_ns: int
+    """Performance timestamp of the parsed response in nanoseconds."""
+
+    data_type: ParsedResponseDataType | None = None
+    """Built-in response data discriminator, or None for usage-only responses."""
+
+    data: Any | None = None
+    """Built-in parsed response data."""
+
+    usage: dict[str, Any] | None = None
+    """Server-reported usage associated with this response."""
+
+    sources: RAGSources | None = None
+    """RAG sources associated with this response."""
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    """Additional response metadata."""
+
+    @classmethod
+    def from_parsed_response(
+        cls, response: ParsedResponse
+    ) -> ParsedResponsePayload | None:
+        """Encode a parsed response when its concrete data type is built in."""
+        data = response.data
+        data_type = None
+        if data is not None:
+            data_type = _RESPONSE_DATA_TYPE_BY_CLASS.get(type(data))
+            if data_type is None:
+                return None
+
+        return cls(
+            perf_ns=response.perf_ns,
+            data_type=data_type,
+            data=data,
+            usage=dict(response.usage) if response.usage is not None else None,
+            sources=response.sources,
+            metadata=response.metadata,
+        )
+
+    def to_parsed_response(self) -> ParsedResponse:
+        """Reconstruct the worker-produced parsed response."""
+        data = self.data
+        if self.data_type is not None and isinstance(data, dict):
+            data = _RESPONSE_DATA_ADAPTER_BY_TYPE[self.data_type].validate_python(data)
+        return ParsedResponse(
+            perf_ns=self.perf_ns,
+            data=data,
+            usage=self.usage,
+            sources=self.sources,
+            metadata=self.metadata,
+        )
+
+
+def encode_parsed_responses(
+    responses: list[ParsedResponse],
+) -> list[ParsedResponsePayload] | None:
+    """Encode built-in responses atomically, falling back on any custom type."""
+    payloads: list[ParsedResponsePayload] = []
+    for response in responses:
+        payload = ParsedResponsePayload.from_parsed_response(response)
+        if payload is None:
+            return None
+        payloads.append(payload)
+    return payloads
 
 
 class InferenceResultsMessage(BaseServiceMessage):
@@ -20,6 +137,24 @@ class InferenceResultsMessage(BaseServiceMessage):
 
     record: SerializeAsAny[RequestRecord] = Field(
         ..., description="The inference results record"
+    )
+    parsed_responses: list[ParsedResponsePayload] | None = Field(
+        default=None,
+        description="Worker-produced parsed responses for compact internal processing.",
+    )
+    last_response_perf_ns: int | None = Field(
+        default=None,
+        gt=0,
+        description="Performance timestamp of the final raw response.",
+    )
+    raw_response_count: int | None = Field(
+        default=None,
+        ge=0,
+        description="Number of raw responses received before optional compaction.",
+    )
+    responses_validated: bool = Field(
+        default=False,
+        description="Whether the worker validated the raw responses before compaction.",
     )
 
 

--- a/src/aiperf/common/messages/inference_messages.py
+++ b/src/aiperf/common/messages/inference_messages.py
@@ -94,11 +94,13 @@ class ParsedResponsePayload:
             if data_type is None:
                 return None
 
+        # Encoding is terminal: the worker does not mutate parsed responses after
+        # publication, so sharing these references avoids hot-path defensive copies.
         return cls(
             perf_ns=response.perf_ns,
             data_type=data_type,
             data=data,
-            usage=dict(response.usage) if response.usage is not None else None,
+            usage=response.usage,
             sources=response.sources,
             metadata=response.metadata,
         )
@@ -152,9 +154,9 @@ class InferenceResultsMessage(BaseServiceMessage):
         ge=0,
         description="Number of raw responses received before optional compaction.",
     )
-    responses_validated: bool = Field(
+    responses_compacted: bool = Field(
         default=False,
-        description="Whether the worker validated the raw responses before compaction.",
+        description="Whether the worker validated and compacted the raw responses.",
     )
 
 

--- a/src/aiperf/records/inference_result_parser.py
+++ b/src/aiperf/records/inference_result_parser.py
@@ -126,7 +126,7 @@ class InferenceResultParser(CommunicationMixin):
         *,
         parsed_responses: list[ParsedResponse] | None = None,
         raw_response_count: int | None = None,
-        responses_validated: bool = False,
+        responses_compacted: bool = False,
     ) -> ParsedResponseRecord:
         """Handle an inference results message.
 
@@ -149,7 +149,7 @@ class InferenceResultParser(CommunicationMixin):
         )
 
         # Make sure any invalid request records are converted to error records for combined processing.
-        if not responses_validated:
+        if not responses_compacted:
             request_record.create_error_from_invalid()
 
         # One payload decode + walk per record, shared by the ISL tokeniser and

--- a/src/aiperf/records/inference_result_parser.py
+++ b/src/aiperf/records/inference_result_parser.py
@@ -121,7 +121,12 @@ class InferenceResultParser(CommunicationMixin):
             return self.tokenizers[model]
 
     async def parse_request_record(
-        self, request_record: RequestRecord
+        self,
+        request_record: RequestRecord,
+        *,
+        parsed_responses: list[ParsedResponse] | None = None,
+        raw_response_count: int | None = None,
+        responses_validated: bool = False,
     ) -> ParsedResponseRecord:
         """Handle an inference results message.
 
@@ -144,7 +149,8 @@ class InferenceResultParser(CommunicationMixin):
         )
 
         # Make sure any invalid request records are converted to error records for combined processing.
-        request_record.create_error_from_invalid()
+        if not responses_validated:
+            request_record.create_error_from_invalid()
 
         # One payload decode + walk per record, shared by the ISL tokeniser and
         # the MediaCounts builder. Both valid and error records go through this.
@@ -181,9 +187,13 @@ class InferenceResultParser(CommunicationMixin):
 
         else:
             try:
-                raw_response_count = len(request_record.responses)
+                if raw_response_count is None:
+                    raw_response_count = len(request_record.responses)
                 record = await self.process_valid_record(
-                    request_record, inputs=inputs, media_counts=media_counts
+                    request_record,
+                    inputs=inputs,
+                    media_counts=media_counts,
+                    parsed_responses=parsed_responses,
                 )
 
                 # Check if the parsed record is actually valid (e.g., has content responses)
@@ -263,6 +273,7 @@ class InferenceResultParser(CommunicationMixin):
         *,
         inputs: ExtractedPayload | None = None,
         media_counts: MediaCounts | None = None,
+        parsed_responses: list[ParsedResponse] | None = None,
     ) -> ParsedResponseRecord:
         """Process a valid request record.
 
@@ -270,6 +281,8 @@ class InferenceResultParser(CommunicationMixin):
         ``parse_request_record`` (single payload decode shared with the token
         counter). When called directly (tests, other entry points) both default
         to ``None`` and the tokeniser falls back to a per-call decode.
+        ``parsed_responses`` bypasses endpoint extraction when the worker
+        supplied an internal IPC representation.
         """
         if request_record.model_name is None:
             self.warning(
@@ -283,7 +296,11 @@ class InferenceResultParser(CommunicationMixin):
                 media_counts=media_counts or MediaCounts(),
             )
 
-        resp = self.endpoint.extract_response_data(request_record)
+        resp = (
+            parsed_responses
+            if parsed_responses is not None
+            else self.endpoint.extract_response_data(request_record)
+        )
 
         # Free the raw responses list after extraction.
         # Skip when RAW export needs the original responses for serialization.

--- a/src/aiperf/records/record_processor_service.py
+++ b/src/aiperf/records/record_processor_service.py
@@ -268,14 +268,12 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
         record = message.record
 
         # Capture last response timestamp before parsing frees raw SSE data.
-        last_response_perf_ns = (
-            message.last_response_perf_ns
-            if isinstance(message, InferenceResultsMessage)
-            and message.last_response_perf_ns is not None
-            else record.responses[-1].perf_ns
-            if record.responses
-            else None
-        )
+        if message.last_response_perf_ns is not None:
+            last_response_perf_ns = message.last_response_perf_ns
+        elif record.responses:
+            last_response_perf_ns = record.responses[-1].perf_ns
+        else:
+            last_response_perf_ns = None
 
         try:
             await self._process_and_forward_record(
@@ -312,19 +310,14 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
                 response_payload.to_parsed_response()
                 for response_payload in message.parsed_responses
             ]
-            if isinstance(message, InferenceResultsMessage)
-            and message.parsed_responses is not None
+            if message.parsed_responses is not None
             else None
         )
         parsed_record = await self.inference_result_parser.parse_request_record(
             record,
             parsed_responses=parsed_responses,
-            raw_response_count=message.raw_response_count
-            if isinstance(message, InferenceResultsMessage)
-            else None,
-            responses_validated=message.responses_validated
-            if isinstance(message, InferenceResultsMessage)
-            else False,
+            raw_response_count=message.raw_response_count,
+            responses_compacted=message.responses_compacted,
         )
 
         # Free raw SSE messages now that parsing extracted what it needs.

--- a/src/aiperf/records/record_processor_service.py
+++ b/src/aiperf/records/record_processor_service.py
@@ -269,7 +269,12 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
 
         # Capture last response timestamp before parsing frees raw SSE data.
         last_response_perf_ns = (
-            record.responses[-1].perf_ns if record.responses else None
+            message.last_response_perf_ns
+            if isinstance(message, InferenceResultsMessage)
+            and message.last_response_perf_ns is not None
+            else record.responses[-1].perf_ns
+            if record.responses
+            else None
         )
 
         try:
@@ -302,7 +307,25 @@ class RecordProcessor(PullClientMixin, BaseComponentService):
         last_response_perf_ns: int | None,
     ) -> None:
         """Parse, produce, observe, and forward the records for a single request."""
-        parsed_record = await self.inference_result_parser.parse_request_record(record)
+        parsed_responses = (
+            [
+                response_payload.to_parsed_response()
+                for response_payload in message.parsed_responses
+            ]
+            if isinstance(message, InferenceResultsMessage)
+            and message.parsed_responses is not None
+            else None
+        )
+        parsed_record = await self.inference_result_parser.parse_request_record(
+            record,
+            parsed_responses=parsed_responses,
+            raw_response_count=message.raw_response_count
+            if isinstance(message, InferenceResultsMessage)
+            else None,
+            responses_validated=message.responses_validated
+            if isinstance(message, InferenceResultsMessage)
+            else False,
+        )
 
         # Free raw SSE messages now that parsing extracted what it needs.
         # Skip when RAW export is active -- the raw writer needs them.

--- a/src/aiperf/workers/worker.py
+++ b/src/aiperf/workers/worker.py
@@ -993,23 +993,23 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         Note: Uses execute_async() to avoid blocking on network I/O.
         """
         # All records will flow through here to be sent to the inference results push client.
-        responses_validated = record.valid
-        self.task_stats.task_finished(responses_validated)
+        record_valid = record.valid
+        self.task_stats.task_finished(record_valid)
 
         raw_response_count = len(record.responses) if record.responses else 0
         last_response_perf_ns = (
-            record.responses[-1].perf_ns
-            if responses_validated and record.responses
-            else None
+            record.responses[-1].perf_ns if record_valid and record.responses else None
         )
         parsed_response_payloads = None
         if (
-            responses_validated
+            record_valid
             and parsed_responses is not None
             and self.run.cfg.artifacts.export_level != ExportLevel.RAW
         ):
             parsed_response_payloads = encode_parsed_responses(parsed_responses)
             if parsed_response_payloads is not None:
+                # Only RAW export consumes RequestRecord.responses; non-RAW
+                # pipeline consumers use the parsed response payloads.
                 record.responses = None
 
         msg = InferenceResultsMessage(
@@ -1018,7 +1018,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
             parsed_responses=parsed_response_payloads,
             last_response_perf_ns=last_response_perf_ns,
             raw_response_count=raw_response_count,
-            responses_validated=parsed_response_payloads is not None,
+            responses_compacted=parsed_response_payloads is not None,
         )
         self.execute_async(self.inference_results_push_client.push(msg))
 

--- a/src/aiperf/workers/worker.py
+++ b/src/aiperf/workers/worker.py
@@ -14,6 +14,7 @@ from aiperf.common.enums import (
     CommandType,
     ConversationBranchMode,
     CreditPhase,
+    ExportLevel,
     MemoryMapFormat,
     MessageType,
 )
@@ -38,6 +39,7 @@ from aiperf.common.messages.dataset_messages import (
     ConversationRequestMessage,
     ConversationResponseMessage,
 )
+from aiperf.common.messages.inference_messages import encode_parsed_responses
 from aiperf.common.mixins import ProcessHealthMixin
 from aiperf.common.models import (
     Conversation,
@@ -536,13 +538,18 @@ class Worker(BaseComponentService, ProcessHealthMixin):
             record: RequestRecord = await self.inference_client.send_request(
                 request_info, first_token_callback=first_token_callback
             )
-            await self._send_inference_result_message(record)
 
             # Copy request-level errors to credit context for CreditReturn tracking
             if record.error is not None:
                 credit_context.error = record.error
 
-            self._finalize_session_response(session, credit_context, record)
+            parsed_responses = None
+            try:
+                parsed_responses = self._finalize_session_response(
+                    session, credit_context, record
+                )
+            finally:
+                await self._send_inference_result_message(record, parsed_responses)
 
         except asyncio.CancelledError:
             # Mark cancelled before re-raising so finally can evict session
@@ -596,8 +603,8 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         record = await self.inference_client.send_request(
             request_info, first_token_callback=first_token_callback
         )
-        self._populate_response_metrics(credit_context, record)
-        await self._send_inference_result_message(record)
+        parsed_responses = self._populate_response_metrics(credit_context, record)
+        await self._send_inference_result_message(record, parsed_responses)
         if record.error is not None:
             credit_context.error = record.error
         return True
@@ -634,7 +641,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         session: UserSession,
         credit_context: CreditContext,
         record: RequestRecord,
-    ) -> None:
+    ) -> list[ParsedResponse]:
         """Capture replay state and metrics from one response-processing pass."""
         parsed_responses, assistant_turn = self._process_responses_for_record(
             record,
@@ -643,13 +650,14 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         if assistant_turn is not None:
             session.store_response(assistant_turn)
         self._populate_response_metrics(credit_context, record, parsed_responses)
+        return parsed_responses
 
     def _populate_response_metrics(
         self,
         credit_context: CreditContext,
         record: RequestRecord,
         parsed_responses: list[ParsedResponse] | None = None,
-    ) -> None:
+    ) -> list[ParsedResponse]:
         """Derive latency/OSL/ITL from ``record`` onto ``credit_context``.
 
         Shared by the normal session path and the payload-bytes fast path so
@@ -674,6 +682,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
             parsed_responses,
             credit_context.output_sequence_length,
         )
+        return parsed_responses
 
     def _content_response_perf_ns_for_record(
         self,
@@ -966,7 +975,11 @@ class Worker(BaseComponentService, ProcessHealthMixin):
 
         return conversation_response.conversation
 
-    async def _send_inference_result_message(self, record: RequestRecord) -> None:
+    async def _send_inference_result_message(
+        self,
+        record: RequestRecord,
+        parsed_responses: list[ParsedResponse] | None = None,
+    ) -> None:
         """Send RequestRecord to RecordProcessor for metric calculation.
 
         All records (success and error) flow through this method to ensure consistent
@@ -980,11 +993,32 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         Note: Uses execute_async() to avoid blocking on network I/O.
         """
         # All records will flow through here to be sent to the inference results push client.
-        self.task_stats.task_finished(record.valid)
+        responses_validated = record.valid
+        self.task_stats.task_finished(responses_validated)
+
+        raw_response_count = len(record.responses) if record.responses else 0
+        last_response_perf_ns = (
+            record.responses[-1].perf_ns
+            if responses_validated and record.responses
+            else None
+        )
+        parsed_response_payloads = None
+        if (
+            responses_validated
+            and parsed_responses is not None
+            and self.run.cfg.artifacts.export_level != ExportLevel.RAW
+        ):
+            parsed_response_payloads = encode_parsed_responses(parsed_responses)
+            if parsed_response_payloads is not None:
+                record.responses = None
 
         msg = InferenceResultsMessage(
             service_id=self.service_id,
             record=record,
+            parsed_responses=parsed_response_payloads,
+            last_response_perf_ns=last_response_perf_ns,
+            raw_response_count=raw_response_count,
+            responses_validated=parsed_response_payloads is not None,
         )
         self.execute_async(self.inference_results_push_client.push(msg))
 

--- a/tests/unit/common/messages/test_inference_messages.py
+++ b/tests/unit/common/messages/test_inference_messages.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
-
 from aiperf.common.messages import InferenceResultsMessage
 from aiperf.common.messages.inference_messages import encode_parsed_responses
 from aiperf.common.models import (
@@ -67,26 +65,10 @@ def test_inference_results_parsed_responses_round_trip_builtin_types():
         payload.to_parsed_response() for payload in restored.parsed_responses or []
     ]
 
-    assert [type(response.data) for response in restored_responses] == [
-        type(response.data) for response in responses
-    ]
     assert restored_responses == responses
     assert restored.last_response_perf_ns == 10
     assert restored.raw_response_count == 11
     assert restored.responses_compacted is True
-
-
-def test_encode_parsed_responses_custom_data_returns_none():
-    @dataclass(slots=True)
-    class CustomResponseData(BaseResponseData):
-        value: str
-
-    responses = [
-        ParsedResponse(perf_ns=1, data=TextResponseData("built-in")),
-        ParsedResponse(perf_ns=2, data=CustomResponseData("custom")),
-    ]
-
-    assert encode_parsed_responses(responses) is None
 
 
 def test_inference_results_legacy_message_defaults_to_raw_path():
@@ -95,7 +77,16 @@ def test_inference_results_legacy_message_defaults_to_raw_path():
         record=RequestRecord(start_perf_ns=1, end_perf_ns=2),
     )
 
-    restored = InferenceResultsMessage.from_json(message.to_json_bytes())
+    legacy_data = message.model_dump(
+        mode="json",
+        exclude={
+            "parsed_responses",
+            "last_response_perf_ns",
+            "raw_response_count",
+            "responses_compacted",
+        },
+    )
+    restored = InferenceResultsMessage.from_json(legacy_data)
 
     assert restored.parsed_responses is None
     assert restored.last_response_perf_ns is None

--- a/tests/unit/common/messages/test_inference_messages.py
+++ b/tests/unit/common/messages/test_inference_messages.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+from aiperf.common.messages import InferenceResultsMessage
+from aiperf.common.messages.inference_messages import encode_parsed_responses
+from aiperf.common.models import (
+    BaseResponseData,
+    EmbeddingResponseData,
+    ImageDataItem,
+    ImageResponseData,
+    ImageRetrievalResponseData,
+    ParsedResponse,
+    RAGSources,
+    RankingsResponseData,
+    ReasoningResponseData,
+    RequestRecord,
+    TextResponseData,
+    ToolCallResponseData,
+    VideoResponseData,
+)
+
+
+def test_inference_results_parsed_responses_round_trip_builtin_types():
+    responses = [
+        ParsedResponse(perf_ns=1, data=BaseResponseData()),
+        ParsedResponse(perf_ns=2, data=EmbeddingResponseData([[1.0, 2.0]])),
+        ParsedResponse(
+            perf_ns=3,
+            data=ImageResponseData(
+                images=[ImageDataItem(url="https://example.test/image.png")],
+                size="1024x1024",
+            ),
+        ),
+        ParsedResponse(perf_ns=4, data=ImageRetrievalResponseData([{"id": "image-1"}])),
+        ParsedResponse(perf_ns=5, data=RankingsResponseData([{"index": 0}])),
+        ParsedResponse(
+            perf_ns=6,
+            data=ReasoningResponseData(content="answer", reasoning="thought"),
+        ),
+        ParsedResponse(
+            perf_ns=7,
+            data=TextResponseData("hello"),
+            usage={"prompt_tokens": 11, "completion_tokens": 7},
+            sources=RAGSources({"document": "source"}),
+            metadata={"finish_reason": "stop"},
+        ),
+        ParsedResponse(perf_ns=8, data=ToolCallResponseData("tool()")),
+        ParsedResponse(perf_ns=9, data=VideoResponseData(video_id="video-1")),
+        ParsedResponse(perf_ns=10, usage={"completion_tokens": 7}),
+    ]
+    payloads = encode_parsed_responses(responses)
+    assert payloads is not None
+
+    message = InferenceResultsMessage(
+        service_id="worker-1",
+        record=RequestRecord(start_perf_ns=1, end_perf_ns=11),
+        parsed_responses=payloads,
+        last_response_perf_ns=10,
+        raw_response_count=11,
+        responses_validated=True,
+    )
+
+    restored = InferenceResultsMessage.from_json(message.to_json_bytes())
+    restored_responses = [
+        payload.to_parsed_response() for payload in restored.parsed_responses or []
+    ]
+
+    assert [type(response.data) for response in restored_responses] == [
+        type(response.data) for response in responses
+    ]
+    assert restored_responses == responses
+    assert restored.last_response_perf_ns == 10
+    assert restored.raw_response_count == 11
+    assert restored.responses_validated is True
+
+
+def test_encode_parsed_responses_custom_data_returns_none():
+    @dataclass(slots=True)
+    class CustomResponseData(BaseResponseData):
+        value: str
+
+    responses = [
+        ParsedResponse(perf_ns=1, data=TextResponseData("built-in")),
+        ParsedResponse(perf_ns=2, data=CustomResponseData("custom")),
+    ]
+
+    assert encode_parsed_responses(responses) is None
+
+
+def test_inference_results_legacy_message_defaults_to_raw_path():
+    message = InferenceResultsMessage(
+        service_id="worker-1",
+        record=RequestRecord(start_perf_ns=1, end_perf_ns=2),
+    )
+
+    restored = InferenceResultsMessage.from_json(message.to_json_bytes())
+
+    assert restored.parsed_responses is None
+    assert restored.last_response_perf_ns is None
+    assert restored.raw_response_count is None
+    assert restored.responses_validated is False

--- a/tests/unit/common/messages/test_inference_messages.py
+++ b/tests/unit/common/messages/test_inference_messages.py
@@ -59,7 +59,7 @@ def test_inference_results_parsed_responses_round_trip_builtin_types():
         parsed_responses=payloads,
         last_response_perf_ns=10,
         raw_response_count=11,
-        responses_validated=True,
+        responses_compacted=True,
     )
 
     restored = InferenceResultsMessage.from_json(message.to_json_bytes())
@@ -73,7 +73,7 @@ def test_inference_results_parsed_responses_round_trip_builtin_types():
     assert restored_responses == responses
     assert restored.last_response_perf_ns == 10
     assert restored.raw_response_count == 11
-    assert restored.responses_validated is True
+    assert restored.responses_compacted is True
 
 
 def test_encode_parsed_responses_custom_data_returns_none():
@@ -100,4 +100,4 @@ def test_inference_results_legacy_message_defaults_to_raw_path():
     assert restored.parsed_responses is None
     assert restored.last_response_perf_ns is None
     assert restored.raw_response_count is None
-    assert restored.responses_validated is False
+    assert restored.responses_compacted is False

--- a/tests/unit/records/test_inference_result_parser.py
+++ b/tests/unit/records/test_inference_result_parser.py
@@ -208,6 +208,38 @@ class TestInvalidRecords:
 
 
 @pytest.mark.asyncio
+async def test_parse_request_record_uses_worker_parsed_responses(
+    server_token_parser, request_record
+):
+    parsed_responses = [
+        make_parsed_response(
+            text="worker parsed",
+            perf_ns=1_000,
+            prompt_tokens=32,
+            completion_tokens=4,
+        )
+    ]
+    request_record.start_perf_ns = 1
+    request_record.end_perf_ns = 2_000
+    request_record.responses = None
+    server_token_parser.endpoint.extract_response_data = MagicMock(
+        side_effect=AssertionError("response must not be parsed again")
+    )
+
+    result = await server_token_parser.parse_request_record(
+        request_record,
+        parsed_responses=parsed_responses,
+        raw_response_count=2,
+        responses_validated=True,
+    )
+
+    assert result.responses == parsed_responses
+    assert result.token_counts.input == 32
+    assert result.token_counts.output == 4
+    server_token_parser.endpoint.extract_response_data.assert_not_called()
+
+
+@pytest.mark.asyncio
 class TestAsyncTokenizerEncode:
     """Tests for async _compute_token_count using asyncio.to_thread."""
 

--- a/tests/unit/records/test_inference_result_parser.py
+++ b/tests/unit/records/test_inference_result_parser.py
@@ -230,7 +230,7 @@ async def test_parse_request_record_uses_worker_parsed_responses(
         request_record,
         parsed_responses=parsed_responses,
         raw_response_count=2,
-        responses_validated=True,
+        responses_compacted=True,
     )
 
     assert result.responses == parsed_responses

--- a/tests/unit/records/test_record_processor_service.py
+++ b/tests/unit/records/test_record_processor_service.py
@@ -168,7 +168,7 @@ class TestRecordProcessorGenericShip:
             parsed_responses=payloads,
             last_response_perf_ns=2,
             raw_response_count=3,
-            responses_validated=True,
+            responses_compacted=True,
         )
 
         await RecordProcessor._process_and_forward_record(
@@ -179,7 +179,7 @@ class TestRecordProcessorGenericShip:
             message.record,
             parsed_responses=parsed_responses,
             raw_response_count=3,
-            responses_validated=True,
+            responses_compacted=True,
         )
 
 

--- a/tests/unit/records/test_record_processor_service.py
+++ b/tests/unit/records/test_record_processor_service.py
@@ -10,9 +10,12 @@ from aiperf.accuracy.models import AccuracyRecordsData
 from aiperf.common.enums import CreditPhase, ExportLevel
 from aiperf.common.messages import (
     BaseServiceErrorMessage,
+    InferenceResultsMessage,
     MetricRecordsData,
     RecordsMessage,
 )
+from aiperf.common.messages.inference_messages import encode_parsed_responses
+from aiperf.common.models import ParsedResponse, RequestRecord, TextResponseData
 from aiperf.common.utils import compute_time_ns
 from aiperf.records.record_processor_service import RecordProcessor
 from tests.unit.post_processors.conftest import create_metric_metadata
@@ -152,6 +155,32 @@ class TestRecordProcessorGenericShip:
         mock_self.records_push_client.push.assert_awaited_once()
         msg = mock_self.records_push_client.push.await_args.args[0]
         assert msg.records == [accuracy_record]
+
+    @pytest.mark.asyncio
+    async def test_compact_message_passes_worker_parsed_responses_to_parser(self):
+        mock_self = _make_processor_mock(producers=[])
+        parsed_responses = [ParsedResponse(perf_ns=2, data=TextResponseData("hello"))]
+        payloads = encode_parsed_responses(parsed_responses)
+        assert payloads is not None
+        message = InferenceResultsMessage(
+            service_id="w1",
+            record=RequestRecord(start_perf_ns=1, end_perf_ns=3),
+            parsed_responses=payloads,
+            last_response_perf_ns=2,
+            raw_response_count=3,
+            responses_validated=True,
+        )
+
+        await RecordProcessor._process_and_forward_record(
+            mock_self, message, message.record, message.last_response_perf_ns
+        )
+
+        mock_self.inference_result_parser.parse_request_record.assert_awaited_once_with(
+            message.record,
+            parsed_responses=parsed_responses,
+            raw_response_count=3,
+            responses_validated=True,
+        )
 
 
 class TestRecordProcessorCreateMetricRecordMetadata:

--- a/tests/unit/workers/test_worker.py
+++ b/tests/unit/workers/test_worker.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -9,6 +10,7 @@ from pytest import param
 
 from aiperf.common.enums import CreditPhase
 from aiperf.common.models import (
+    BaseResponseData,
     Conversation,
     ErrorDetails,
     ParsedResponse,
@@ -647,7 +649,100 @@ class TestPayloadBytesFastPath:
         assert handled is True
         assert sample_credit_context.error == error_record.error
         mock_worker._send_inference_result_message.assert_awaited_once_with(
-            error_record
+            error_record, []
         )
         sent_request_info = mock_worker.inference_client.send_request.call_args.args[0]
         assert sent_request_info.payload_bytes == b'{"p": 1}'
+
+
+@pytest.mark.asyncio
+class TestInferenceResultIPC:
+    @staticmethod
+    def _capture_push(mock_worker):
+        mock_worker.inference_results_push_client.push = Mock(return_value=Mock())
+        mock_worker.execute_async = Mock()
+        return mock_worker.inference_results_push_client.push
+
+    async def test_summary_export_sends_parsed_responses_without_raw(self, mock_worker):
+        push = self._capture_push(mock_worker)
+        record = RequestRecord(
+            model_name="test-model",
+            start_perf_ns=1,
+            end_perf_ns=3,
+            responses=[SSEMessage(perf_ns=2)],
+        )
+        parsed_responses = [ParsedResponse(perf_ns=2, data=TextResponseData("hello"))]
+
+        await mock_worker._send_inference_result_message(record, parsed_responses)
+
+        message = push.call_args.args[0]
+        assert record.responses is None
+        assert message.parsed_responses is not None
+        assert message.last_response_perf_ns == 2
+        assert message.raw_response_count == 1
+        assert message.responses_validated is True
+        assert "responses" not in message.model_dump(exclude_none=True)["record"]
+
+    async def test_raw_export_retains_raw_responses(self, mock_worker):
+        push = self._capture_push(mock_worker)
+        mock_worker.run.cfg.artifacts.raw = True
+        response = SSEMessage(perf_ns=2)
+        record = RequestRecord(
+            model_name="test-model",
+            start_perf_ns=1,
+            end_perf_ns=3,
+            responses=[response],
+        )
+
+        await mock_worker._send_inference_result_message(
+            record, [ParsedResponse(perf_ns=2, data=TextResponseData("hello"))]
+        )
+
+        message = push.call_args.args[0]
+        assert record.responses == [response]
+        assert message.parsed_responses is None
+        assert message.responses_validated is False
+
+    async def test_custom_response_data_retains_raw_responses(self, mock_worker):
+        @dataclass(slots=True)
+        class CustomResponseData(BaseResponseData):
+            value: str
+
+        push = self._capture_push(mock_worker)
+        response = SSEMessage(perf_ns=2)
+        record = RequestRecord(
+            model_name="test-model",
+            start_perf_ns=1,
+            end_perf_ns=3,
+            responses=[response],
+        )
+
+        await mock_worker._send_inference_result_message(
+            record,
+            [ParsedResponse(perf_ns=2, data=CustomResponseData(value="custom"))],
+        )
+
+        message = push.call_args.args[0]
+        assert record.responses == [response]
+        assert message.parsed_responses is None
+        assert message.responses_validated is False
+
+    async def test_invalid_response_timestamp_retains_raw_response(self, mock_worker):
+        push = self._capture_push(mock_worker)
+        response = SSEMessage(perf_ns=-1)
+        record = RequestRecord(
+            model_name="test-model",
+            start_perf_ns=1,
+            end_perf_ns=3,
+            responses=[response],
+        )
+
+        await mock_worker._send_inference_result_message(
+            record, [ParsedResponse(perf_ns=-1, data=TextResponseData("invalid"))]
+        )
+
+        message = push.call_args.args[0]
+        assert record.responses == [response]
+        assert message.parsed_responses is None
+        assert message.last_response_perf_ns is None
+        assert message.responses_validated is False

--- a/tests/unit/workers/test_worker.py
+++ b/tests/unit/workers/test_worker.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from pytest import param
 
-from aiperf.common.enums import CreditPhase
+from aiperf.common.enums import CreditPhase, ExportLevel
 from aiperf.common.models import (
     BaseResponseData,
     Conversation,
@@ -656,6 +656,42 @@ class TestPayloadBytesFastPath:
 
 
 @pytest.mark.asyncio
+async def test_process_credit_finalize_failure_still_sends_raw_record(
+    mock_worker: Worker, sample_credit_context: CreditContext
+) -> None:
+    session = SimpleNamespace(
+        conversation=SimpleNamespace(
+            system_message=None,
+            user_context_message=None,
+        ),
+        advance_turn=Mock(),
+    )
+    record = RequestRecord(
+        model_name="test-model",
+        start_perf_ns=1,
+        end_perf_ns=3,
+        responses=[SSEMessage(perf_ns=2)],
+    )
+    mock_worker._try_payload_bytes_fast_path = AsyncMock(return_value=False)
+    mock_worker.session_manager.get = Mock(return_value=session)
+    mock_worker._create_request_info = Mock(return_value=Mock())
+    mock_worker.inference_client.send_request = AsyncMock(return_value=record)
+    mock_worker._finalize_session_response = Mock(
+        side_effect=RuntimeError("finalize failed")
+    )
+    mock_worker._send_inference_result_message = AsyncMock()
+    mock_worker._release_and_evict_for_terminal = Mock()
+
+    await mock_worker._process_credit(sample_credit_context)
+
+    mock_worker._send_inference_result_message.assert_awaited_once_with(record, None)
+    assert record.responses == [SSEMessage(perf_ns=2)]
+    assert sample_credit_context.error is not None
+    assert sample_credit_context.error.type == "RuntimeError"
+    assert "finalize failed" in sample_credit_context.error.message
+
+
+@pytest.mark.asyncio
 class TestInferenceResultIPC:
     @staticmethod
     def _capture_push(mock_worker):
@@ -663,8 +699,21 @@ class TestInferenceResultIPC:
         mock_worker.execute_async = Mock()
         return mock_worker.inference_results_push_client.push
 
-    async def test_summary_export_sends_parsed_responses_without_raw(self, mock_worker):
+    @pytest.mark.parametrize(
+        "export_level",
+        [
+            param(ExportLevel.SUMMARY, id="summary"),
+            param(ExportLevel.RECORDS, id="records"),
+        ],
+    )
+    async def test_non_raw_export_sends_parsed_responses_without_raw(
+        self, mock_worker: Worker, export_level: ExportLevel
+    ) -> None:
         push = self._capture_push(mock_worker)
+        mock_worker.run.cfg.artifacts.records = (
+            False if export_level == ExportLevel.SUMMARY else ["jsonl"]
+        )
+        assert mock_worker.run.cfg.artifacts.export_level == export_level
         record = RequestRecord(
             model_name="test-model",
             start_perf_ns=1,
@@ -680,7 +729,7 @@ class TestInferenceResultIPC:
         assert message.parsed_responses is not None
         assert message.last_response_perf_ns == 2
         assert message.raw_response_count == 1
-        assert message.responses_validated is True
+        assert message.responses_compacted is True
         assert "responses" not in message.model_dump(exclude_none=True)["record"]
 
     async def test_raw_export_retains_raw_responses(self, mock_worker):
@@ -701,7 +750,7 @@ class TestInferenceResultIPC:
         message = push.call_args.args[0]
         assert record.responses == [response]
         assert message.parsed_responses is None
-        assert message.responses_validated is False
+        assert message.responses_compacted is False
 
     async def test_custom_response_data_retains_raw_responses(self, mock_worker):
         @dataclass(slots=True)
@@ -725,7 +774,7 @@ class TestInferenceResultIPC:
         message = push.call_args.args[0]
         assert record.responses == [response]
         assert message.parsed_responses is None
-        assert message.responses_validated is False
+        assert message.responses_compacted is False
 
     async def test_invalid_response_timestamp_retains_raw_response(self, mock_worker):
         push = self._capture_push(mock_worker)
@@ -745,4 +794,4 @@ class TestInferenceResultIPC:
         assert record.responses == [response]
         assert message.parsed_responses is None
         assert message.last_response_perf_ns is None
-        assert message.responses_validated is False
+        assert message.responses_compacted is False

--- a/tests/unit/workers/test_worker.py
+++ b/tests/unit/workers/test_worker.py
@@ -28,6 +28,11 @@ from tests.harness.fake_tokenizer import FakeTokenizer
 from tests.harness.fake_transport import FakeTransport as FakeTransport
 
 
+@dataclass(slots=True)
+class CustomResponseData(BaseResponseData):
+    value: str
+
+
 @pytest.mark.parametrize(
     ("phase_data", "expected"),
     [
@@ -667,9 +672,6 @@ async def test_process_credit_finalize_failure_still_sends_raw_record(
         advance_turn=Mock(),
     )
     record = RequestRecord(
-        model_name="test-model",
-        start_perf_ns=1,
-        end_perf_ns=3,
         responses=[SSEMessage(perf_ns=2)],
     )
     mock_worker._try_payload_bytes_fast_path = AsyncMock(return_value=False)
@@ -686,7 +688,6 @@ async def test_process_credit_finalize_failure_still_sends_raw_record(
 
     mock_worker._send_inference_result_message.assert_awaited_once_with(record, None)
     assert record.responses == [SSEMessage(perf_ns=2)]
-    assert sample_credit_context.error is not None
     assert sample_credit_context.error.type == "RuntimeError"
     assert "finalize failed" in sample_credit_context.error.message
 
@@ -713,11 +714,8 @@ class TestInferenceResultIPC:
         mock_worker.run.cfg.artifacts.records = (
             False if export_level == ExportLevel.SUMMARY else ["jsonl"]
         )
-        assert mock_worker.run.cfg.artifacts.export_level == export_level
         record = RequestRecord(
-            model_name="test-model",
             start_perf_ns=1,
-            end_perf_ns=3,
             responses=[SSEMessage(perf_ns=2)],
         )
         parsed_responses = [ParsedResponse(perf_ns=2, data=TextResponseData("hello"))]
@@ -732,66 +730,64 @@ class TestInferenceResultIPC:
         assert message.responses_compacted is True
         assert "responses" not in message.model_dump(exclude_none=True)["record"]
 
-    async def test_raw_export_retains_raw_responses(self, mock_worker):
+    @pytest.mark.parametrize(
+        (
+            "raw_export",
+            "response_perf_ns",
+            "parsed_responses",
+            "expected_last_response_perf_ns",
+        ),
+        [
+            param(
+                True,
+                2,
+                [ParsedResponse(perf_ns=2, data=TextResponseData("hello"))],
+                2,
+                id="raw-export",
+            ),
+            param(
+                False,
+                2,
+                [
+                    ParsedResponse(perf_ns=1, data=TextResponseData("built-in")),
+                    ParsedResponse(
+                        perf_ns=2,
+                        data=CustomResponseData(value="custom"),
+                    ),
+                ],
+                2,
+                id="custom-data",
+            ),
+            param(
+                False,
+                -1,
+                [ParsedResponse(perf_ns=-1, data=TextResponseData("invalid"))],
+                None,
+                id="invalid-timestamp",
+            ),
+        ],
+    )  # fmt: skip
+    async def test_uncompacted_responses_retain_raw(
+        self,
+        mock_worker: Worker,
+        raw_export: bool,
+        response_perf_ns: int,
+        parsed_responses: list[ParsedResponse],
+        expected_last_response_perf_ns: int | None,
+    ) -> None:
         push = self._capture_push(mock_worker)
-        mock_worker.run.cfg.artifacts.raw = True
-        response = SSEMessage(perf_ns=2)
+        mock_worker.run.cfg.artifacts.raw = raw_export
+        response = SSEMessage(perf_ns=response_perf_ns)
         record = RequestRecord(
-            model_name="test-model",
             start_perf_ns=1,
-            end_perf_ns=3,
             responses=[response],
         )
 
-        await mock_worker._send_inference_result_message(
-            record, [ParsedResponse(perf_ns=2, data=TextResponseData("hello"))]
-        )
+        await mock_worker._send_inference_result_message(record, parsed_responses)
 
         message = push.call_args.args[0]
         assert record.responses == [response]
         assert message.parsed_responses is None
-        assert message.responses_compacted is False
-
-    async def test_custom_response_data_retains_raw_responses(self, mock_worker):
-        @dataclass(slots=True)
-        class CustomResponseData(BaseResponseData):
-            value: str
-
-        push = self._capture_push(mock_worker)
-        response = SSEMessage(perf_ns=2)
-        record = RequestRecord(
-            model_name="test-model",
-            start_perf_ns=1,
-            end_perf_ns=3,
-            responses=[response],
-        )
-
-        await mock_worker._send_inference_result_message(
-            record,
-            [ParsedResponse(perf_ns=2, data=CustomResponseData(value="custom"))],
-        )
-
-        message = push.call_args.args[0]
-        assert record.responses == [response]
-        assert message.parsed_responses is None
-        assert message.responses_compacted is False
-
-    async def test_invalid_response_timestamp_retains_raw_response(self, mock_worker):
-        push = self._capture_push(mock_worker)
-        response = SSEMessage(perf_ns=-1)
-        record = RequestRecord(
-            model_name="test-model",
-            start_perf_ns=1,
-            end_perf_ns=3,
-            responses=[response],
-        )
-
-        await mock_worker._send_inference_result_message(
-            record, [ParsedResponse(perf_ns=-1, data=TextResponseData("invalid"))]
-        )
-
-        message = push.call_args.args[0]
-        assert record.responses == [response]
-        assert message.parsed_responses is None
-        assert message.last_response_perf_ns is None
+        assert message.last_response_perf_ns == expected_last_response_perf_ns
+        assert message.raw_response_count == 1
         assert message.responses_compacted is False


### PR DESCRIPTION
## Summary

- carry the parsed responses already produced by request workers through the internal `InferenceResultsMessage`
- compact valid non-RAW built-in responses before worker-to-RecordProcessor serialization
- retain the existing raw-response path for RAW export, invalid/error records, custom response subclasses, and older messages
- consume supplied parsed responses in the RecordProcessor without repeating endpoint extraction
- document the updated internal data flow

## Why

After #1172, request workers already parsed completed responses for replay and metrics, but the worker still serialized every raw SSE response and the RecordProcessor parsed the same response stream again. This change reuses the worker-produced result while preserving all fallback and compatibility paths.

## Performance

Matched 32K-context, four-turn runs used server token counts, summary export, two request workers and one RecordProcessor on CPUs 0-4, plus Dynamo and four accelerated mock workers on CPUs 5-23. Each selected run used concurrency 1024, a 20-second warmup, and a 60-second measurement.

| Metric | main | candidate | Change |
|---|---:|---:|---:|
| Request throughput | 916.45 req/s | 969.03 req/s | +5.7% |
| Whole-AIPerf CPU/request | 4.542 ms | 4.170 ms | -8.2% |
| Request-worker CPU/request | 2.211 ms | 2.090 ms | -5.5% |
| RecordProcessor CPU/request | 1.120 ms | 0.902 ms | -19.5% |
| p95 latency | 155.12 ms | 147.04 ms | -5.2% |
| Peak RSS | 7.29 GiB | 4.43 GiB | -39.2% |

Saturation probes at concurrency 512, 1024, and 2048 plateaued at 4.16 aggregate AIPerf cores. At 1024 the TimingManager, RecordProcessor, and both request workers were each individually CPU-bound; 2048 consumed no additional CPU and slightly reduced throughput, so 1024 was used instead of chasing an unfillable fifth-core topology gap.

Separate 49 Hz py-spy runs attributed a 52.6% reduction in the combined targeted serialization and duplicate-parsing CPU/request. RecordProcessor parsing/reconstruction fell 81.1%; worker envelope serialization fell 32.4% after accounting for the compact-payload encoding cost.

Both arms completed with zero request errors, cancellations, missing usage, affinity violations, Dynamo lag, skipped messages, or backend rejection.

## Validation

- `99 passed` in focused worker, message, endpoint/parser, and RecordProcessor tests
- `59 passed` in property tests
- pre-commit passed, including Ruff, generated-doc, schema, import, and ergonomics checks
- full unit run: `15457 passed, 94 skipped, 1 xfailed`; the two remaining TTY console failures reproduce unchanged on the pinned main control

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Inference result artifacts can now preserve supported parsed response details in IPC for non-raw export modes.
  - Workers now send additional inference metadata (timing, raw response counts, and compaction status).
  - Record processing can reuse pre-parsed responses to avoid redundant extraction.
- **Documentation**
  - Updated architecture diagrams and messaging descriptions to clearly separate parsed vs raw end-to-end flows.
- **Tests**
  - Added coverage for parsed-response encoding/round-tripping, legacy defaults, compact-message forwarding, and parser reuse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->