### PR TITLE
perf: increase TimingManager credit throughput

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,6 +204,7 @@ The Timing Manager uses a **credit-based flow control system** to control when r
 **Credit Distribution:**
 - Credits are dispatched to workers via a ROUTER/DEALER pattern (the Timing Manager's sticky ROUTER to each worker's DEALER)
 - Router selects workers based on sticky sessions (multi-turn conversations) or least-loaded worker selection
+- Request-rate strategies validate stop conditions once before non-blocking slot acquisition; the prevalidated acquisition remains synchronous in the same event-loop turn. Blocking acquisition continues to revalidate after waits.
 - Credit returns travel back on a dedicated PUSH/PULL fan-in channel: each worker PUSHes its `CreditReturn`/`FirstToken` to the Timing Manager's single PULL, separating the high-volume return path from credit dispatch
 - The return channel carries no ZMQ envelope identity, so the returning worker id travels inside the message
 - No coordination required between workers

--- a/src/aiperf/credit/issuer.py
+++ b/src/aiperf/credit/issuer.py
@@ -189,15 +189,33 @@ class CreditIssuer:
         if not can_proceed_fn():
             return False
 
+        return await self.try_issue_credit_prechecked(turn)
+
+    async def try_issue_credit_prechecked(self, turn: TurnToSend) -> bool | None:
+        """Try to issue credit after the caller has checked stop conditions.
+
+        The caller must invoke this method in the same event-loop turn as the
+        successful stop-condition check.
+
+        Args:
+            turn: The turn to send.
+
+        Returns:
+            True: Credit issued, more credits can be sent.
+            False: Credit issued but this was final.
+            None: No slots available, credit not issued.
+        """
+        is_first_turn = turn.turn_index == 0
+
         if is_first_turn:
-            acquired = self._concurrency_manager.try_acquire_session_slot(
-                self._phase_key, can_proceed_fn
+            acquired = self._concurrency_manager.try_acquire_session_slot_prechecked(
+                self._phase_key
             )
             if not acquired:
                 return None  # No slot - credit not issued
 
-        acquired = self._concurrency_manager.try_acquire_prefill_slot(
-            self._phase_key, can_proceed_fn
+        acquired = self._concurrency_manager.try_acquire_prefill_slot_prechecked(
+            self._phase_key
         )
         if not acquired:
             # CRITICAL: Release session slot if we acquired it to maintain symmetry

--- a/src/aiperf/timing/concurrency.py
+++ b/src/aiperf/timing/concurrency.py
@@ -307,9 +307,26 @@ class GlobalPhaseConcurrencyLimiter:
         if phase not in self._phase_limits:
             raise ValueError(f"Phase {phase} not configured in limiter")
 
-        # Check stop conditions first to avoid unnecessary slot attempts
         if not can_proceed_fn():
             return False
+
+        return self.try_acquire_prechecked(phase)
+
+    def try_acquire_prechecked(self, phase: PhaseRuntimeKey) -> bool:
+        """Try to acquire a slot after the caller has checked stop conditions.
+
+        Args:
+            phase: The phase to acquire for.
+
+        Returns:
+            True if both global and phase slots were acquired, False if no slots
+            are available.
+
+        Raises:
+            ValueError: If phase not configured via configure_for_phase().
+        """
+        if phase not in self._phase_limits:
+            raise ValueError(f"Phase {phase} not configured in limiter")
 
         phase_limit = self._phase_limits[phase]
 
@@ -483,6 +500,12 @@ class ConcurrencyManager:
             return can_proceed_fn()
         return self._session_limiter.try_acquire(phase, can_proceed_fn)
 
+    def try_acquire_session_slot_prechecked(self, phase: PhaseRuntimeKey) -> bool:
+        """Try to acquire a session slot after stop conditions were checked."""
+        if not self._session_limiter.enabled:
+            return True
+        return self._session_limiter.try_acquire_prechecked(phase)
+
     def release_session_slot(self, phase: PhaseRuntimeKey) -> None:
         """Release a session concurrency slot.
 
@@ -539,6 +562,12 @@ class ConcurrencyManager:
         if not self._prefill_limiter.enabled:
             return can_proceed_fn()
         return self._prefill_limiter.try_acquire(phase, can_proceed_fn)
+
+    def try_acquire_prefill_slot_prechecked(self, phase: PhaseRuntimeKey) -> bool:
+        """Try to acquire a prefill slot after stop conditions were checked."""
+        if not self._prefill_limiter.enabled:
+            return True
+        return self._prefill_limiter.try_acquire_prechecked(phase)
 
     def release_prefill_slot(self, phase: PhaseRuntimeKey) -> None:
         """Release a prefill concurrency slot.

--- a/src/aiperf/timing/phase/stop_conditions.py
+++ b/src/aiperf/timing/phase/stop_conditions.py
@@ -289,7 +289,10 @@ class StopConditionChecker:
         - Request count limit reached
         - All sessions complete (session-based mode)
         """
-        return all(func() for func in self._can_send_any_turn_funcs)
+        for func in self._can_send_any_turn_funcs:  # noqa: SIM110 - avoid allocation
+            if not func():
+                return False
+        return True
 
     def can_send_dag_child_turn(self) -> bool:
         """True if a DAG child turn can still dispatch.
@@ -301,7 +304,10 @@ class StopConditionChecker:
         to their parent's session and shouldn't be truncated by
         ``--num-conversations``.
         """
-        return all(func() for func in self._can_send_dag_child_turn_funcs)
+        for func in self._can_send_dag_child_turn_funcs:  # noqa: SIM110 - avoid allocation
+            if not func():
+                return False
+        return True
 
     def can_start_new_session(self) -> bool:
         """True if phase can start a NEW session (more restrictive).
@@ -316,4 +322,7 @@ class StopConditionChecker:
         if not self.can_send_any_turn():
             return False
 
-        return all(func() for func in self._can_start_new_session_funcs)
+        for func in self._can_start_new_session_funcs:  # noqa: SIM110 - avoid allocation
+            if not func():
+                return False
+        return True

--- a/src/aiperf/timing/strategies/request_rate.py
+++ b/src/aiperf/timing/strategies/request_rate.py
@@ -197,10 +197,10 @@ class RequestRateStrategy(AIPerfLoggerMixin):
                     return
 
             # Priority 2: Start new session if allowed and slots available.
-            # try_issue_credit returns None if no slot (skip interval), False if
-            # stop condition reached (exit loop), True if issued successfully.
+            # The prechecked issuer returns None if no slot (skip interval),
+            # False if the final credit was issued, or True otherwise.
             elif self._stop_checker.can_start_new_session():
-                result = await self._credit_issuer.try_issue_credit(
+                result = await self._credit_issuer.try_issue_credit_prechecked(
                     next_new_session_turn
                 )
                 match result:
@@ -209,10 +209,8 @@ class RequestRateStrategy(AIPerfLoggerMixin):
                         next_new_session_turn = (
                             self._conversation_source.next().build_first_turn()
                         )
-                    case False:  # Stop condition reached
-                        self.debug(
-                            "Exiting: stop condition reached after try_issue_credit"
-                        )
+                    case False:  # Final credit issued
+                        self.debug("Exiting: final credit issued")
                         return
                     case None:  # No slot available, retry later
                         # Always yield to event loop to allow callbacks to run.

--- a/tests/unit/credit/test_issuer.py
+++ b/tests/unit/credit/test_issuer.py
@@ -45,6 +45,8 @@ def mock_concurrency():
     mock = MagicMock()
     mock.acquire_session_slot = AsyncMock(return_value=True)
     mock.acquire_prefill_slot = AsyncMock(return_value=True)
+    mock.try_acquire_session_slot_prechecked = MagicMock(return_value=True)
+    mock.try_acquire_prefill_slot_prechecked = MagicMock(return_value=True)
     mock.release_session_slot = MagicMock()
     return mock
 
@@ -272,6 +274,69 @@ class TestStopConditionChecking:
         call_args = mock_concurrency.acquire_prefill_slot.call_args
         check_fn = call_args[0][1]  # Second positional arg is the check function
         assert check_fn == mock_stop_checker.can_send_any_turn
+
+
+# =============================================================================
+# Test: Non-Blocking Credit Issuance
+# =============================================================================
+
+
+class TestNonBlockingCreditIssuance:
+    """Tests for checked and prechecked non-blocking issuance."""
+
+    async def test_checked_first_turn_evaluates_stop_condition_once(
+        self, credit_issuer, mock_stop_checker, mock_concurrency, mock_router
+    ) -> None:
+        result = await credit_issuer.try_issue_credit(make_turn())
+
+        assert result is True
+        mock_stop_checker.can_start_new_session.assert_called_once_with()
+        mock_concurrency.try_acquire_session_slot_prechecked.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
+        mock_concurrency.try_acquire_prefill_slot_prechecked.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
+        mock_router.send_credit.assert_awaited_once()
+
+    async def test_checked_first_turn_stopped_skips_slot_acquisition(
+        self, credit_issuer, mock_stop_checker, mock_concurrency, mock_router
+    ) -> None:
+        mock_stop_checker.can_start_new_session.return_value = False
+
+        result = await credit_issuer.try_issue_credit(make_turn())
+
+        assert result is False
+        mock_stop_checker.can_start_new_session.assert_called_once_with()
+        mock_concurrency.try_acquire_session_slot_prechecked.assert_not_called()
+        mock_concurrency.try_acquire_prefill_slot_prechecked.assert_not_called()
+        mock_router.send_credit.assert_not_awaited()
+
+    async def test_prechecked_session_slot_unavailable_returns_none(
+        self, credit_issuer, mock_stop_checker, mock_concurrency, mock_router
+    ) -> None:
+        mock_concurrency.try_acquire_session_slot_prechecked.return_value = False
+
+        result = await credit_issuer.try_issue_credit_prechecked(make_turn())
+
+        assert result is None
+        mock_stop_checker.can_start_new_session.assert_not_called()
+        mock_concurrency.try_acquire_prefill_slot_prechecked.assert_not_called()
+        mock_router.send_credit.assert_not_awaited()
+
+    async def test_prechecked_prefill_failure_releases_session_slot(
+        self, credit_issuer, mock_stop_checker, mock_concurrency, mock_router
+    ) -> None:
+        mock_concurrency.try_acquire_prefill_slot_prechecked.return_value = False
+
+        result = await credit_issuer.try_issue_credit_prechecked(make_turn())
+
+        assert result is None
+        mock_stop_checker.can_start_new_session.assert_not_called()
+        mock_concurrency.release_session_slot.assert_called_once_with(
+            CreditPhase.PROFILING
+        )
+        mock_router.send_credit.assert_not_awaited()
 
 
 # =============================================================================

--- a/tests/unit/timing/conftest.py
+++ b/tests/unit/timing/conftest.py
@@ -567,6 +567,9 @@ def mock_concurrency_manager() -> MagicMock:
     )
     m.set_session_limit = m.set_prefill_limit = MagicMock()
     m.acquire_session_slot = m.acquire_prefill_slot = _async_true
+    m.try_acquire_session_slot_prechecked = m.try_acquire_prefill_slot_prechecked = (
+        MagicMock(return_value=True)
+    )
     m.release_stuck_slots = MagicMock(return_value=(0, 0))
     m.get_session_stats = m.get_prefill_stats = MagicMock(return_value=None)
     return m

--- a/tests/unit/timing/strategies/test_request_rate.py
+++ b/tests/unit/timing/strategies/test_request_rate.py
@@ -209,7 +209,7 @@ async def test_request_rate_update_wakes_pending_sleep() -> None:
     conversation_source = MagicMock()
     conversation_source.next.return_value.build_first_turn.return_value = object()
     credit_issuer = MagicMock()
-    credit_issuer.try_issue_credit = AsyncMock(return_value=False)
+    credit_issuer.try_issue_credit_prechecked = AsyncMock(return_value=False)
     stop_checker = MagicMock()
     stop_checker.can_start_new_session.return_value = True
 
@@ -238,7 +238,8 @@ async def test_request_rate_update_wakes_pending_sleep() -> None:
     strategy.set_request_rate(100.0)
     await asyncio.wait_for(task, timeout=1.0)
 
-    credit_issuer.try_issue_credit.assert_awaited_once()
+    stop_checker.can_start_new_session.assert_called_once_with()
+    credit_issuer.try_issue_credit_prechecked.assert_awaited_once()
 
 
 class TestConcurrencyBurstGenerator:

--- a/tests/unit/timing/test_concurrency.py
+++ b/tests/unit/timing/test_concurrency.py
@@ -305,6 +305,13 @@ class TestGlobalPhaseConcurrencyLimiter:
         lim.configure_for_phase(P, 5)
         assert await lim.acquire(P, lambda: can_proceed) == expected
 
+    def test_try_acquire_prechecked_acquires_available_slots(self) -> None:
+        lim = GlobalPhaseConcurrencyLimiter()
+        lim.configure_for_phase(P, 1)
+
+        assert lim.try_acquire_prechecked(P) is True
+        assert lim.try_acquire_prechecked(P) is False
+
     def test_release_requires_configured_phase(self) -> None:
         lim = GlobalPhaseConcurrencyLimiter()
         lim.configure_for_phase(P, 10)
@@ -389,6 +396,15 @@ class TestConcurrencyManager:
         m.configure_for_phase(P, 5, None)
         assert await m.acquire_session_slot(P, lambda: can_proceed) == expected
 
+    @pytest.mark.parametrize("concurrency", [None, 1])
+    def test_try_acquire_session_slot_prechecked(self, concurrency: int | None) -> None:
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, concurrency, None)
+
+        assert m.try_acquire_session_slot_prechecked(P) is True
+        if concurrency is not None:
+            assert m.try_acquire_session_slot_prechecked(P) is False
+
     def test_release_session_slot_disabled_noop(self) -> None:
         m = ConcurrencyManager()
         m.configure_for_phase(P, None, None)
@@ -425,6 +441,15 @@ class TestConcurrencyManager:
         m = ConcurrencyManager()
         m.configure_for_phase(P, None, 5)
         assert await m.acquire_prefill_slot(P, lambda: True) is True
+
+    @pytest.mark.parametrize("concurrency", [None, 1])
+    def test_try_acquire_prefill_slot_prechecked(self, concurrency: int | None) -> None:
+        m = ConcurrencyManager()
+        m.configure_for_phase(P, None, concurrency)
+
+        assert m.try_acquire_prefill_slot_prechecked(P) is True
+        if concurrency is not None:
+            assert m.try_acquire_prefill_slot_prechecked(P) is False
 
     def test_release_prefill_slot_disabled_noop(self) -> None:
         m = ConcurrencyManager()


### PR DESCRIPTION
## Summary

- evaluate request-rate stop conditions once per non-blocking new-session attempt
- add an explicitly prechecked synchronous slot-acquisition path while preserving the existing checked API for other callers
- replace generator-based stop-condition evaluation with allocation-free ordered loops
- document the same-event-loop validity invariant

## Why

A concurrency-burst request-rate attempt previously evaluated the same stop conditions three or four times: in `RequestRateStrategy`, `CreditIssuer`, and the session/prefill limiters. These callbacks normalize and hash enum values and re-read phase state on every evaluation, limiting a single TimingManager's credit throughput at large worker counts.

The optimized path performs the authoritative check once, then acquires slots synchronously without yielding before progress is incremented. Blocking acquisition remains unchanged because it must revalidate after waits. Slot rollback, continuation priority, final-credit handling, and the checked `try_issue_credit()` contract are preserved.

## Performance

Pinned control and candidate: `94ece0ff2` (`main`, including #1172).

One-core scheduler microbenchmark, three matched repetitions per arm:

| Mode | Control | Candidate | Change |
|---|---:|---:|---:|
| First-turn credit issuance | 126.3k credits/s | 200.2k credits/s | +58.5% |
| In-memory credit/return loop | 98.5k credits/s | 139.4k credits/s | +41.6% |
| Issuance CPU cost | 7.90 us/credit | 4.97 us/credit | -37.0% |
| Closed-loop CPU cost | 10.13 us/credit | 7.17 us/credit | -29.2% |

Matched TimingManager-only py-spy profiles showed stop-condition self time falling 70.0% and the combined stop-condition plus enum normalization/hash path falling 66.0%.

## Validation

- `174 passed, 7 deselected` in the focused issuer/concurrency/request-rate/stop-condition suite
- `992 passed, 7 deselected` across credit and timing unit tests
- `298 passed, 2 skipped` in TimingManager component integration tests
- `59 passed` in unit property tests
- `pre-commit run --all-files`
- `pre-commit run` on the final staged diff
- LLM ergonomics review: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-rate scheduling by validating stop conditions before attempting non-blocking capacity allocation.
  * Preserved reliable session and prefill slot handling when capacity is unavailable.
  * Clarified final-credit behavior and prevented unnecessary scheduling attempts.

* **Documentation**
  * Updated architecture documentation to reflect request timing and stop-condition validation behavior.

* **Tests**
  * Added coverage for prevalidated capacity acquisition, credit issuance outcomes, and request-rate wake-up behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->