### PR TITLE
fix(dataset): sample ISL/OSL from typed distribution per turn

### DIFF
--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -244,6 +244,7 @@ A: None measurable. Network I/O dominates by 1000×.
 ```python
 "composer.turn.model_selection"    # Model selection per turn
 "composer.turn.max_tokens"         # max_tokens sampling
+"composer.turn.sequence_length"    # Per-turn ISL/OSL sequence-length sampling
 "composer.conversation.turn_count" # Number of turns per conversation
 "composer.conversation.turn_delay" # Delay between turns
 ```

--- a/src/aiperf/dataset/composer/base.py
+++ b/src/aiperf/dataset/composer/base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import bisect
 import inspect
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
@@ -10,10 +11,6 @@ from aiperf.common import random_generator as rng
 from aiperf.common.enums import ConversationContextMode, ModelSelectionStrategy
 from aiperf.common.mixins import AIPerfLoggerMixin
 from aiperf.common.models import Conversation, Turn
-from aiperf.common.models.sequence_distribution import (
-    SequenceLengthDistribution,
-    SequenceLengthPair,
-)
 from aiperf.common.tokenizer import Tokenizer
 from aiperf.config.dataset import SyntheticDataset
 from aiperf.dataset.generator.audio import AudioGenerator
@@ -24,6 +21,7 @@ from aiperf.dataset.generator.prompt import PromptGenerator
 from aiperf.dataset.generator.video import VideoGenerator
 
 if TYPE_CHECKING:
+    from aiperf.common.random_generator import RandomGenerator
     from aiperf.config.dataset import VideoConfig
     from aiperf.config.dataset.content import (
         AudioConfig,
@@ -33,6 +31,47 @@ if TYPE_CHECKING:
     )
     from aiperf.config.distributions import SamplingDistribution
     from aiperf.config.resolution.plan import BenchmarkRun
+    from aiperf.config.types import SequenceDistributionEntry
+
+
+class TypedSequenceDistribution:
+    """Runtime (ISL, OSL) distribution that preserves the typed sub-distributions.
+
+    Each ``SequenceDistributionEntry`` carries a typed ``SamplingDistribution``
+    for ISL and OSL (Fixed/Normal/LogNormal/Multimodal/Empirical). Selection
+    picks one entry by its probability weight; the chosen entry's ISL and OSL
+    are then drawn from their own distribution via ``sample_int`` using the
+    caller-supplied RNG.
+    """
+
+    def __init__(self, entries: list[SequenceDistributionEntry]) -> None:
+        if not entries:
+            raise ValueError(
+                "Distribution must contain at least one sequence length entry"
+            )
+        self._entries = tuple(entries)
+        self._cumulative = self.cumulative(self._entries)
+
+    @property
+    def entries(self) -> tuple[SequenceDistributionEntry, ...]:
+        return self._entries
+
+    def cumulative(self, entries: tuple[SequenceDistributionEntry, ...]) -> list[float]:
+        """Calculate cumulative probability"""
+        total = sum(entry.probability for entry in entries)
+        cumulative: list[float] = []
+        running = 0.0
+        for entry in entries:
+            running += entry.probability / total
+            cumulative.append(running)
+        return cumulative
+
+    def sample(self, rng: RandomGenerator) -> tuple[int, int]:
+        """Select an entry by weight, then sample its typed ISL/OSL with ``rng``."""
+        idx = bisect.bisect_right(self._cumulative, rng.random())
+        idx = min(idx, len(self._entries) - 1)
+        entry = self._entries[idx]
+        return entry.isl.sample_int(rng), entry.osl.sample_int(rng)
 
 
 _CHAT_TEMPLATE_PROBE_SAMPLES: tuple[str, ...] = (
@@ -164,15 +203,15 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
 
         self._model_selector_rng = rng.derive("composer.turn.model_selection")
         self._max_tokens_rng = rng.derive("composer.turn.max_tokens")
+        self._length_rng = rng.derive("composer.turn.sequence_length")
 
         self.turn_count = 0
 
         # ``PromptConfig.sequence_distribution`` is a
         # ``list[SequenceDistributionEntry]`` of typed ``SamplingDistribution``
-        # objects. Convert each entry directly to a ``SequenceLengthPair``
-        # (extracting mean + stddev from the underlying distribution) and
-        # build the runtime distribution without re-serializing through
-        # ``DistributionParser.parse``, which only accepts strings.
+        # objects. Keep those typed distributions at runtime so each selected
+        # entry's ISL/OSL sample from their own shape per turn, rather than
+        # collapsing to mean + normal-only stddev.
         self._seq_distribution = self._build_sequence_distribution()
 
         # Cache for turn-level sequence lengths to ensure ISL/OSL pairing consistency
@@ -301,15 +340,15 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
         """
         ...
 
-    def _build_sequence_distribution(self) -> SequenceLengthDistribution | None:
+    def _build_sequence_distribution(self) -> TypedSequenceDistribution | None:
         """Build a runtime sequence-length distribution from config entries.
 
         ``PromptConfig.sequence_distribution`` is a list of
         ``SequenceDistributionEntry`` carrying typed ``SamplingDistribution``
-        ISL/OSL fields (Fixed/Normal/LogNormal/...). Pull the mean and the
-        normal-distribution stddev (0 for non-normal types) off each entry to
-        construct ``SequenceLengthPair`` directly. ``DistributionParser.parse``
-        only accepts strings and would reject this list shape.
+        ISL/OSL fields (Fixed/Normal/LogNormal/Multimodal/Empirical). The typed
+        distributions are preserved as-is so each selected entry samples its own
+        shape per turn; flattening to mean + normal-only stddev would collapse
+        LogNormal/Multimodal/Empirical entries to a constant.
         """
         if self._synthetic_prompts is None:
             return None
@@ -317,17 +356,7 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
         if not entries:
             return None
 
-        pairs = [
-            SequenceLengthPair(
-                input_seq_len=int(entry.isl.expected_value),
-                output_seq_len=int(entry.osl.expected_value),
-                probability=float(entry.probability),
-                input_seq_len_stddev=float(getattr(entry.isl, "stddev", 0.0) or 0.0),
-                output_seq_len_stddev=float(getattr(entry.osl, "stddev", 0.0) or 0.0),
-            )
-            for entry in entries
-        ]
-        return SequenceLengthDistribution(pairs)
+        return TypedSequenceDistribution(entries)
 
     def _osl_distribution(self) -> SamplingDistribution | None:
         """Resolve the OSL distribution to use as a fallback for max_tokens.
@@ -379,24 +408,27 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
             return self._turn_sequence_cache[turn_id]
 
         if self._seq_distribution is None:
-            isl_mean = (
-                int(self._synthetic_prompts.isl.expected_value)
+            isl_dist = (
+                self._synthetic_prompts.isl
                 if self._synthetic_prompts is not None
-                and self._synthetic_prompts.isl is not None
-                else 0
-            )
-            osl_mean = (
-                int(self._synthetic_prompts.osl.expected_value)
-                if self._synthetic_prompts is not None
-                and self._synthetic_prompts.osl is not None
                 else None
             )
+            osl_dist = (
+                self._synthetic_prompts.osl
+                if self._synthetic_prompts is not None
+                else None
+            )
+            # Draw from the typed distribution itself (Fixed/Normal/LogNormal/
+            # Multimodal/Empirical) so non-Normal shapes actually vary per
+            # request.
+            isl_val = isl_dist.sample_int(self._length_rng) if isl_dist else 0
+            osl_val = osl_dist.sample_int(self._length_rng) if osl_dist else None
             seq_lengths = (
-                isl_mean,
-                osl_mean or max(128, isl_mean // 2),
+                isl_val,
+                osl_val or max(128, isl_val // 2),
             )
         else:
-            seq_lengths = self._seq_distribution.sample()
+            seq_lengths = self._seq_distribution.sample(self._length_rng)
 
         self._turn_sequence_cache[turn_id] = seq_lengths
         return seq_lengths
@@ -442,13 +474,14 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
         else:
             osl_dist = self._osl_distribution()
             if osl_dist is not None:
-                osl_mean = int(osl_dist.expected_value)
-                if osl_mean <= 0:
+                if osl_dist.expected_value <= 0:
                     return
-                osl_stddev = int(getattr(osl_dist, "stddev", 0.0) or 0.0)
-                turn.max_tokens = self._max_tokens_rng.sample_positive_normal_integer(
-                    osl_mean, osl_stddev
-                )
+                # Draw from the typed distribution itself (Fixed/Normal/
+                # LogNormal/Multimodal/Empirical) so non-Normal OSL shapes vary
+                # per request, mirroring the ISL path.
+                # ``sample_positive_normal_integer`` only reads mean+stddev, so
+                # every non-Normal shape collapsed to its mean.
+                turn.max_tokens = osl_dist.sample_int(self._max_tokens_rng)
 
         if turn.max_tokens is not None and turn.max_tokens <= 0:
             self.warning(
@@ -541,7 +574,9 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
             if shared_system_prompt:
                 conversation.system_message = shared_system_prompt
                 self.trace(
-                    lambda conv=conversation: f"Set system_message on conversation {conv.session_id}"
+                    lambda conv=conversation: (
+                        f"Set system_message on conversation {conv.session_id}"
+                    )
                 )
 
             # Set user context prompt (unique per session)
@@ -551,9 +586,10 @@ class BaseDatasetComposer(AIPerfLoggerMixin, ABC):
                 )
                 conversation.user_context_message = user_context
                 self.trace(
-                    lambda idx=session_index,
-                    conv=conversation: f"Set user_context_message for session {idx} "
-                    f"(conversation {conv.session_id})"
+                    lambda idx=session_index, conv=conversation: (
+                        f"Set user_context_message for session {idx} "
+                        f"(conversation {conv.session_id})"
+                    )
                 )
 
     @staticmethod

--- a/src/aiperf/dataset/composer/synthetic.py
+++ b/src/aiperf/dataset/composer/synthetic.py
@@ -66,9 +66,6 @@ class SyntheticDatasetComposer(BaseDatasetComposer):
         self._video_batch_size = (
             dataset.video.batch_size if dataset.video is not None else 1
         )
-        self._isl_stddev = _stddev_int(
-            dataset.prompts.isl if dataset.prompts is not None else None
-        )
 
         # Inclusion flags (computed once at init).
         self._include_prompt = (
@@ -204,12 +201,8 @@ class SyntheticDatasetComposer(BaseDatasetComposer):
         if adjustment > 0:
             isl = max(1, isl - adjustment)
 
-        # Preserve original variance unless sequence distribution is active
-        stddev = 0 if self._seq_distribution is not None else self._isl_stddev
-
         for _ in range(self._prompt_batch_size):
-            # Generate prompt content using the sampled input sequence length
-            content = self.prompt_generator.generate(mean=isl, stddev=stddev)
+            content = self.prompt_generator.generate(mean=isl, stddev=0)
 
             # Add prefix prompt if this is the first turn and prefix is enabled
             if is_first and self.prefix_prompt_enabled:

--- a/tests/integration/assets/canary_reference_inputs.json
+++ b/tests/integration/assets/canary_reference_inputs.json
@@ -10,7 +10,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " ever but slenderly known himself GONERIL The best and soundest of his time hath been but rash then must we look from his age to receive not alone the imperfections of longengrafted condition but therewithal the unruly waywardness that infirm and choleric years bring with them REGAN Such unconstant starts are we like to have from him as this of Kents banishment GONERIL There is further compliment of leavetaking between France and him Pray you let us hit together if our father carry authority with such disposition as"
+                  "text": " ever but slenderly known himself GONERIL The best and soundest of his time hath been but rash then must we look from his age to receive not alone the imperfections of longengrafted condition but therewithal the unruly waywardness that infirm and choleric years bring with them REGAN Such unconstant starts are we like to have from him as this of Kents banishment GONERIL There is further compliment of leavetaking between France and him Pray you let us hit together if our father carry authority with such"
                 },
                 {
                   "type": "input_audio",
@@ -38,7 +38,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " it to my wife and fetch your money ANGELO Come come you know I gave it you even now Either send the chain or send by me some token ANTIPHOLUS OF EPHESUS Fie now you run this humour out of breath Come wheres the chain I pray you let me see it MERCHANT My business cannot brook this dalliance Good sir say wheer youll answer me or no If not Ill leave him to the officer ANTIPHOLUS OF EPHESUS I answer you What should"
+                  "text": " it to my wife and fetch your money ANGELO Come come you know I gave it you even now Either send the chain or send by me some token ANTIPHOLUS OF EPHESUS Fie now you run this humour out of breath Come wheres the chain I pray you let me see it MERCHANT My business cannot brook this dalliance Good sir say wheer youll answer me or no If not Ill leave him to the officer ANTIPHOLUS"
                 },
                 {
                   "type": "input_audio",
@@ -66,7 +66,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " the judges clerk Would he were gelt that had it for my part Since you do take it love so much at heart PORTIA A quarrel ho already Whats the matter GRATIANO About a hoop of gold a paltry ring That she did give me whose posy was For all the world like cutlers poetry Upon a knife Love me and leave me not NERISSA What talk you of the posy or the value You swore to me when I did give it you That you would wear"
+                  "text": " the judges clerk Would he were gelt that had it for my part Since you do take it love so much at heart PORTIA A quarrel ho already Whats the matter GRATIANO About a hoop of gold a paltry ring That she did give me whose posy was For all the world like cutlers poetry Upon a knife Love me and leave me not NERISSA What talk you of the posy or the value You sw"
                 },
                 {
                   "type": "input_audio",
@@ -94,7 +94,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " his wife Exeunt SCENE V A Room in Olivias House Enter Maria and Clown MARIA Nay either tell me where thou hast been or I will not open my lips so wide as a bristle may enter in way of thy excuse my lady will hang thee for thy absenceCLOWN Let her hang me he that is well hanged in this world needs to fear no colours MARIA Make that good CLOWN He shall see none to fear MARIA A good lenten answer I can tell thee where that saying was born of I fear no colours CLOWN Where"
+                  "text": " his wife Exeunt SCENE V A Room in Olivias House Enter Maria and Clown MARIA Nay either tell me where thou hast been or I will not open my lips so wide as a bristle may enter in way of thy excuse my lady will hang thee for thy absenceCLOWN Let her hang me he that is well hanged in this world needs to fear no colours MARIA Make that good CLOWN He shall see none to fear MARIA A good lenten answer I can tell thee where that saying"
                 },
                 {
                   "type": "input_audio",
@@ -122,7 +122,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " Officers Soldiers c EDMUND Some officers take them away good guard Until their greater pleasures first be known That are to censure them CORDELIA We are not the first Who with best meaning have incurrd the worst For thee oppressed King I am cast down Myself could else outfrown false fortunes frown Shall we not see these daughters and these sisters LEAR No no no no Come lets away to prison"
+                  "text": " Officers Soldiers c EDMUND Some officers take them away good guard Until their greater pleasures first be known That are to censure them CORDELIA We are not the first Who with best meaning have incurrd the worst For thee oppressed King I am cast down Myself could else outfrown false fortunes frown Shall we not see these daughters and these sisters LEAR No no no no Come lets away to prison We two alone will sing like birds i the cage When thou dost ask me blessing Ill kneel"
                 },
                 {
                   "type": "input_audio",
@@ -150,7 +150,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " Enter Diomedes and a Servant DIOMEDES Go go my servant take thou Troilus horse Present the fair steed to my lady Cressid Fellow commend my service to her beauty Tell her I have chastisd the amorous Trojan And am her knight by proof SERVANT I go my lord Exit Enter Agamemnon AGAMEMNON Renew renew The fierce Polydamas Hath beat down Menon bastard Margarelon Hath D"
+                  "text": " Enter Diomedes and a Servant DIOMEDES Go go my servant take thou Troilus horse Present the fair steed to my lady Cressid Fellow commend my service to her beauty Tell her I have chastisd the amorous Trojan And am her knight by proof SERVANT I go my lord Exit Enter Agamemnon AGAMEMNON Renew renew The fierce Polydamas Hath beat down Menon bastard Margarelon Hath Doreus prisoner And stands colossuswise waving his beam Upon the pashed"
                 },
                 {
                   "type": "input_audio",
@@ -178,7 +178,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " in love shall not deny me this BASSANIO This ring good sir Alas it is a trifle I will not shame myself to give you this PORTIA I will have nothing else but only this And now methinks I have a mind to it BASSANIO Theres more depends on this than on the value The dearest ring in Venice will I give you And find it out by proclamation Only for this I pray you pardon me PORTIA I see sir you"
+                  "text": " in love shall not deny me this BASSANIO This ring good sir Alas it is a trifle I will not shame myself to give you this PORTIA I will have nothing else but only this And now methinks I have a mind to it BASSANIO Theres more depends on this than on the value The dearest ring in Venice will I give you And find it out by proclamation Only for this I pray you pardon me PORTIA I see sir you are liberal in offers You taught me first to beg and now methinks You teach me how a beggar"
                 },
                 {
                   "type": "input_audio",
@@ -206,7 +206,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " damns himself to do and dares better be damnd than to dot SECOND LORD You do not know him my lord as we do certain it is that he will steal himself into a mans favour and for a week escape a great deal of discoveries but when you find him out you have him ever after BERTRAM Why do you think he will make no deed at all of this that so seriously he does address himself unto FIRST LORD None in the world but return with an invention and clap upon you two or three probable lies but we have almost"
+                  "text": " damns himself to do and dares better be damnd than to dot SECOND LORD You do not know him my lord as we do certain it is that he will steal himself into a mans favour and for a week escape a great deal of discoveries but when you find him out you have him ever after BERTRAM Why do you think he will make no deed at all of this that so seriously he does address himself unto FIRST LORD None in the world but return with an invention and clap"
                 },
                 {
                   "type": "input_audio",
@@ -234,7 +234,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " the author thou the instrument Therefore that I may conquer Fortunes spite By living low where Fortune cannot hurt me And that the people of this blessed land May not be punished with my thwarting stars Warwick although my head still wear the crown I here resign my government to thee For thou art fortunate in all thy deeds WARWICK Your Grace hath still been famed for virtuous And now may seem as wise as virtuous By spying and avoiding Fortunes malice For few men rightly temper with the stars Yet in this one thing let me blame"
+                  "text": " the author thou the instrument Therefore that I may conquer Fortunes spite By living low where Fortune cannot hurt me And that the people of this blessed land May not be punished with my thwarting stars Warwick although my head still wear the crown I here resign my government to thee For thou art fortunate in all thy deeds WARWICK Your Grace hath still been famed for virtuous And now may seem as wise as virtuous By spying and avoiding Fortunes malice For few"
                 },
                 {
                   "type": "input_audio",
@@ -262,7 +262,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " Theres a fearful point Shall I not then be stifled in the vault To whose foul mouth no healthsome air breathes in And there die strangled ere my Romeo comes Or if I live is it not very like The horrible conceit of death and night Together with the terror of the place As in a vault an ancient receptacle Where for this many hundred years the bones Of all my buried ancestors are packd Where bloody Tybalt yet but green in earth Lies festering in his shroud where as they say"
+                  "text": " Theres a fearful point Shall I not then be stifled in the vault To whose foul mouth no healthsome air breathes in And there die strangled ere my Romeo comes Or if I live is it not very like The horrible conceit of death and night Together with the terror of the place As in a vault an ancient receptacle Where for this many hundred years the bones Of all my buried ancestors are packd Where bloody Tybalt yet but green in earth"
                 },
                 {
                   "type": "input_audio",
@@ -290,7 +290,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " happy being feard Than they in fearing What drinkst thou oft instead of homage sweet But poisond flattery O be sick great greatness And bid thy Ceremony give thee cure Thinkst thou the fiery fever will go out With titles blown from adulation Will it give place to flexure and low bending Canst thou when thou commandst the beggars knee Command the health of it No thou proud dream That playst so subtly with a kings repose I am a king that find thee and I"
+                  "text": " happy being feard Than they in fearing What drinkst thou oft instead of homage sweet But poisond flattery O be sick great greatness And bid thy Ceremony give thee cure Thinkst thou the fiery fever will go out With titles blown from adulation Will it give place to flexure and low bending Canst thou when thou commandst the beggars knee Command the health of it No thou proud dream That playst so subtly with a kings repose I am a king that find thee and"
                 },
                 {
                   "type": "input_audio",
@@ -318,7 +318,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " never with more care Read to her sons than she hath read to thee Sweet poetry and Tullys Orator MARCUS Canst thou not guess wherefore she plies thee thus YOUNG LUCIUS My lord I know not I nor can I guess Unless some fit or frenzy do possess her For I have heard my grandsire say full oft Extremity of griefs would make men mad And I have read that Hecuba"
+                  "text": " never with more care Read to her sons than she hath read to thee Sweet poetry and Tullys Orator MARCUS Canst thou not guess wherefore she plies thee thus YOUNG LUCIUS My lord I know not I nor can I guess Unless some fit or frenzy do possess her For I have heard my grandsire say full oft Extremity of griefs would make men mad"
                 },
                 {
                   "type": "input_audio",
@@ -346,7 +346,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " look you there look how it steals away My father in his habit as he livd Look where he goes even now out at the portal Exit Ghost QUEEN This is the very coinage of your brain This bodiless creation ecstasy Is very cunning in HAMLET Ecstasy My pulse as yours doth temperately keep time And makes as healthful music It is not madness That I have utterd Bring me to the test And I the matter will reword which madness Would gambol from"
+                  "text": " look you there look how it steals away My father in his habit as he livd Look where he goes even now out at the portal Exit Ghost QUEEN This is the very coinage of your brain This bodiless creation ecstasy Is very cunning in HAMLET Ecstasy My pulse as yours doth temperately keep time And makes as healthful music It is not madness That I have utterd Bring me to the test And I the matter will reword which madness Would gambol from Mother for love of grace Lay not that flattering"
                 },
                 {
                   "type": "input_audio",
@@ -374,7 +374,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " eyes of man ALCIBIADES What is thy name Is man so hateful to thee That art thyself a man TIMON I am Misanthropos and hate mankind For thy part I do wish thou wert a dog That I might love thee something ALCIBIADES I know thee well But in thy fortunes am unlearned and strange TIMON I know thee too and more than that I know thee I not desire to know Follow thy drum With mans blood paint the ground gules gules Religious canons"
+                  "text": " eyes of man ALCIBIADES What is thy name Is man so hateful to thee That art thyself a man TIMON I am Misanthropos and hate mankind For thy part I do wish thou wert a dog That I might love thee something ALCIBIADES I know thee well But in thy fortunes am unlearned and strange TIMON I know thee too and more than that I know thee I not desire to know Follow thy drum With mans blood paint the ground gules gules Religious canons civil laws"
                 },
                 {
                   "type": "input_audio",
@@ -402,7 +402,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " fool Was not a man my father Hadst thou foxship To banish him that struck more blows for Rome Than thou hast spoken words SICINIUS O blessed heavens VOLUMNIA More noble blows than ever thou wise words And for Romes good Ill tell thee whatyet go Nay but thou shalt stay too I would my son Were in Arabia and thy tribe before him His good sword in his hand SICINIUS What then VIRGILIA What then Hed make an end of thy poster"
+                  "text": " fool Was not a man my father Hadst thou foxship To banish him that struck more blows for Rome Than thou hast spoken words SICINIUS O blessed heavens VOLUMNIA More noble blows than ever thou wise words And for Romes good Ill tell thee whatyet go Nay but thou shalt stay too I would my son Were in Arabia and thy tribe before him His good sword in his hand SICINIUS What then VIRGILIA What then Hed"
                 },
                 {
                   "type": "input_audio",
@@ -430,7 +430,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " barren ground Long heath brown furze anything The wills above be done but I would fain die a dry death Exit SCENE II The Island Before the cell of Prospero Enter Prospero and Miranda MIRANDA If by your art my dearest father you have Put the wild waters in this roar allay them The sky it seems would pour down stinking pitch But that the sea mounting to th welkins cheek Dashes the fire out O I have suffered With those that I saw suffer A"
+                  "text": " barren ground Long heath brown furze anything The wills above be done but I would fain die a dry death Exit SCENE II The Island Before the cell of Prospero Enter Prospero and Miranda MIRANDA If by your art my dearest father you have Put the wild waters in this roar allay them The sky it seems would pour down stinking pitch But that the sea mounting to th welkins cheek Dashes the fire out O I have suffered With those that I saw suffer A brave vessel Who had"
                 },
                 {
                   "type": "input_audio",
@@ -458,7 +458,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " climb The generals disdaind By him one step below he by the next That next by him beneath so every step Exampld by the first pace that is sick Of his superior grows to an envious fever Of pale and bloodless emulation And tis this fever that keeps Troy on foot Not her own sinews To end a tale of length Troy in our weakness stands not in her strength NESTOR Most wisely hath Ulysses here discoverd The fever whereof all our power is sick AGAMEMNON The nature of the"
+                  "text": " climb The generals disdaind By him one step below he by the next That next by him beneath so every step Exampld by the first pace that is sick Of his superior grows to an envious fever Of pale and bloodless emulation And tis this fever that keeps Troy on foot Not her own sinews To end a tale of length Troy in our weakness stands not in her strength NESTOR Most wisely hath Ulysses here discoverd The fever where"
                 },
                 {
                   "type": "input_audio",
@@ -486,7 +486,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " that knows it O thou thinkest To serve me last that I may longest keep Thy sorrow in my breast Come ladies go To meet at London Londons king in woe What was I born to this that my sad look Should grace the triumph of great Bolingbroke Gardner for telling me these news of woe Pray God the plants thou graftst may never grow Exeunt Queen and Ladies GARDENER Poor Queen so that thy state might be no worse I"
+                  "text": " that knows it O thou thinkest To serve me last that I may longest keep Thy sorrow in my breast Come ladies go To meet at London Londons king in woe What was I born to this that my sad look Should grace the triumph of great Bolingbroke Gardner for telling me these news of woe Pray God the plants thou graftst may never grow Exeunt Queen and Ladies GARDENER Poor"
                 },
                 {
                   "type": "input_audio",
@@ -514,7 +514,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " Shall cumber all the parts of Italy Blood and destruction shall be so in use And dreadful objects so familiar That mothers shall but smile when they behold Their infants quartered with the hands of war All pity chokd with custom of fell deeds And Caesars spirit ranging for revenge With Ate by his side come hot from Hell Shall in these confines with a monarchs voice Cry havoc and let slip the dogs of war That this foul deed shall smell above the earth With carrion men groaning"
+                  "text": " Shall cumber all the parts of Italy Blood and destruction shall be so in use And dreadful objects so familiar That mothers shall but smile when they behold Their infants quartered with the hands of war All pity chokd with custom of fell deeds And Caesars spirit ranging for revenge With Ate by his side come hot from Hell Shall in these confines with a monarchs voice Cry havoc and let slip the dogs of war That this foul deed shall smell above the earth With carrion men groaning for burial Enter a Servant"
                 },
                 {
                   "type": "input_audio",
@@ -542,7 +542,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": " the subjects to his hate And he to yours and all of you to Gods Exit BUCKINGHAM My hair doth stand on end to hear her curses RIVERS And so doth mine I muse why shes at liberty RICHARD I cannot blame her By Gods holy mother She hath had too much wrong and I repent My part thereof that I have done to her QUEEN ELIZABETH I never did her any to my knowledge RICHARD Yet you have all the vantage of her wrong"
+                  "text": " the subjects to his hate And he to yours and all of you to Gods Exit BUCKINGHAM My hair doth stand on end to hear her curses RIVERS And so doth mine I muse why shes at liberty RICHARD I cannot blame her By Gods holy mother She hath had too much wrong and I repent My part thereof that I have done to her QUEEN ELIZABETH I never did her any to"
                 },
                 {
                   "type": "input_audio",

--- a/tests/unit/common/models/test_sequence_distribution.py
+++ b/tests/unit/common/models/test_sequence_distribution.py
@@ -23,6 +23,8 @@ from aiperf.common.models.sequence_distribution import (
     create_balanced_distribution,
     create_uniform_distribution,
 )
+from aiperf.config.types import SequenceDistributionEntry
+from aiperf.dataset.composer.base import TypedSequenceDistribution
 
 
 class TestSequenceLengthPair:
@@ -673,11 +675,14 @@ class TestSequenceCaching:
 
         # Set up composer with distribution
         composer = MockComposer.__new__(MockComposer)
-        dist = DistributionParser.parse("128,64:50;256,128:50")
-        composer._seq_distribution = dist
+        composer._seq_distribution = TypedSequenceDistribution(
+            [
+                SequenceDistributionEntry(isl=128, osl=64, probability=50),
+                SequenceDistributionEntry(isl=256, osl=128, probability=50),
+            ]
+        )
         composer._turn_sequence_cache = {}
-        # Use the global RNG instead of _seq_rng
-        composer._rng = rng.derive("test_composer")
+        composer._length_rng = rng.derive("test_composer")
 
         # Create a turn and get its ID
         turn = Turn()
@@ -716,13 +721,12 @@ class TestSequenceCaching:
 
         # Set up composer with distribution
         composer = MockComposer.__new__(MockComposer)
-        dist = DistributionParser.parse(
-            "100,50:100"
-        )  # Single pair for predictable results
-        composer._seq_distribution = dist
+        # Single entry for predictable results
+        composer._seq_distribution = TypedSequenceDistribution(
+            [SequenceDistributionEntry(isl=100, osl=50, probability=100)]
+        )
         composer._turn_sequence_cache = {}
-        # Use the global RNG instead of _seq_rng
-        composer._rng = rng.derive("test_composer2")
+        composer._length_rng = rng.derive("test_composer2")
 
         # Create two different turns
         turn1 = Turn()

--- a/tests/unit/dataset/composer/test_base_composer.py
+++ b/tests/unit/dataset/composer/test_base_composer.py
@@ -6,9 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pytest import param
 
+from aiperf.common import random_generator as rng
 from aiperf.common.enums import ModelSelectionStrategy
 from aiperf.common.models import Turn
+from aiperf.config.distributions import LogNormalDistribution
 from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.config.types import SequenceDistributionEntry
 from aiperf.dataset.composer.base import BaseDatasetComposer
 from tests.unit.dataset.composer.conftest import make_run
 
@@ -71,17 +74,60 @@ class TestBaseDatasetComposer:
             run=make_run(sequence_dist_config), tokenizer=mock_tokenizer
         )
 
-        # Distribution was built directly from the v2 entries (not via
-        # DistributionParser.parse, which only accepts strings).
+        # Distribution preserves the typed v2 entries at runtime (typed ISL/OSL
+        # distributions kept intact, not flattened to mean + stddev).
         assert composer._seq_distribution is not None
-        pairs = composer._seq_distribution.pairs
-        assert len(pairs) == 2
-        assert pairs[0].input_seq_len == 100
-        assert pairs[0].output_seq_len == 25
-        assert pairs[0].probability == 50.0
-        assert pairs[1].input_seq_len == 200
-        assert pairs[1].output_seq_len == 50
-        assert pairs[1].probability == 50.0
+        entries = composer._seq_distribution.entries
+        assert len(entries) == 2
+        assert entries[0].isl.expected_value == 100
+        assert entries[0].osl.expected_value == 25
+        assert entries[0].probability == 50.0
+        assert entries[1].isl.expected_value == 200
+        assert entries[1].osl.expected_value == 50
+        assert entries[1].probability == 50.0
+
+    def test_sequence_distribution_non_normal_entry_varies_per_turn(
+        self, sequence_dist_config, mock_tokenizer
+    ):
+        """Regression: a sequence_distribution entry with a non-Normal (log-normal)
+        ISL/OSL must vary per turn instead of collapsing to the entry mean."""
+        composer = ConcreteBaseComposer(
+            run=make_run(sequence_dist_config), tokenizer=mock_tokenizer
+        )
+        # Single 100%-weight entry whose ISL and OSL are log-normal.
+        composer._synthetic_prompts.sequence_distribution = [
+            SequenceDistributionEntry(
+                isl={"mean": 6000, "median": 2000, "min": 50, "max": 50000},
+                osl={"mean": 6000, "median": 2000, "min": 50, "max": 50000},
+                probability=100,
+            )
+        ]
+        composer._seq_distribution = composer._build_sequence_distribution()
+
+        pairs = [composer._get_turn_sequence_lengths(t) for t in range(200)]
+        isls = [p[0] for p in pairs]
+        osls = [p[1] for p in pairs]
+
+        assert len(set(isls)) > 50, "seq-dist ISL collapsed to (near-)constant"
+        assert len(set(osls)) > 50, "seq-dist OSL collapsed to (near-)constant"
+        assert min(isls) >= 50 and max(isls) <= 50000
+        assert min(osls) >= 50 and max(osls) <= 50000
+        assert max(isls) > 3 * (sum(isls) / len(isls))
+
+    def test_sequence_distribution_deterministic_across_composers(
+        self, sequence_dist_config, mock_tokenizer
+    ):
+        """Same seed -> identical per-turn seq-dist samples."""
+        runs = []
+        for _ in range(2):
+            rng.reset()
+            rng.init(42)
+            composer = ConcreteBaseComposer(
+                run=make_run(sequence_dist_config), tokenizer=mock_tokenizer
+            )
+            runs.append([composer._get_turn_sequence_lengths(t) for t in range(20)])
+
+        assert runs[0] == runs[1]
 
     def test_model_selection_round_robin(self, base_config, mock_tokenizer):
         """Test round robin model selection."""
@@ -136,24 +182,47 @@ class TestBaseDatasetComposer:
     def test_get_turn_sequence_lengths_without_distribution(
         self, base_config, mock_tokenizer
     ):
-        """Test getting sequence lengths without distribution (fallback)."""
+        """Without a sequence_distribution, ISL/OSL are sampled per turn from
+        the typed ISL/OSL distributions (here Normal), not pinned to the mean."""
         composer = ConcreteBaseComposer(
             run=make_run(base_config), tokenizer=mock_tokenizer
         )
 
         turn_id = 12345
-        result = composer._get_turn_sequence_lengths(turn_id)
+        isl, osl = composer._get_turn_sequence_lengths(turn_id)
 
-        # Should use fallback values from config
-        expected = (
-            base_config.prompt_input_tokens_mean,
-            base_config.prompt_output_tokens_mean,
+        # Drawn from Normal(mean, stddev): positive and within a wide band
+        assert 0 < isl < base_config.prompt_input_tokens_mean * 3
+        assert 0 < osl < base_config.prompt_output_tokens_mean * 3
+
+        # Cached so repeated calls in the same turn are consistent.
+        assert composer._turn_sequence_cache[turn_id] == (isl, osl)
+        assert composer._get_turn_sequence_lengths(turn_id) == (isl, osl)
+
+    def test_get_turn_sequence_lengths_varies_across_turns(
+        self, base_config, mock_tokenizer
+    ):
+        """Regression: per-turn sampling vary."""
+        composer = ConcreteBaseComposer(
+            run=make_run(base_config), tokenizer=mock_tokenizer
         )
-        assert result == expected
+        isls = [composer._get_turn_sequence_lengths(t)[0] for t in range(50)]
+        assert len(set(isls)) > 1
 
-        # Should be cached
-        assert turn_id in composer._turn_sequence_cache
-        assert composer._turn_sequence_cache[turn_id] == expected
+    def test_get_turn_sequence_lengths_deterministic_across_composers(
+        self, base_config, mock_tokenizer
+    ):
+        """Same seed -> identical per-turn ISL/OSL."""
+        runs = []
+        for _ in range(2):
+            rng.reset()
+            rng.init(42)
+            composer = ConcreteBaseComposer(
+                run=make_run(base_config), tokenizer=mock_tokenizer
+            )
+            runs.append([composer._get_turn_sequence_lengths(t) for t in range(20)])
+
+        assert runs[0] == runs[1]
 
     def test_clear_turn_cache(self, sequence_dist_config, mock_tokenizer):
         """Test clearing turn cache."""
@@ -245,6 +314,28 @@ class TestBaseDatasetComposer:
         composer._set_max_tokens(turn)
 
         assert turn.max_tokens == 42
+
+    def test_set_max_tokens_non_normal_osl_varies_per_turn(
+        self, base_config, mock_tokenizer
+    ):
+        """Non-Normal OSL (here log-normal) must vary max_tokens per turn."""
+        composer = ConcreteBaseComposer(
+            run=make_run(base_config), tokenizer=mock_tokenizer
+        )
+        composer._synthetic_prompts.osl = LogNormalDistribution(
+            mean=6000, median=2000, min=50, max=50000
+        )
+
+        max_tokens = []
+        for _ in range(200):
+            turn = Turn()
+            composer._set_max_tokens(turn)
+            max_tokens.append(turn.max_tokens)
+
+        assert len(set(max_tokens)) > 50, "OSL collapsed to (near-)constant"
+        assert min(max_tokens) >= 50 and max(max_tokens) <= 50000
+        # A heavy right tail must actually appear, not just jitter around a point.
+        assert max(max_tokens) > 3 * (sum(max_tokens) / len(max_tokens))
 
     def test_finalize_turn(self, sequence_dist_config, mock_tokenizer):
         """Test turn finalization."""

--- a/tests/unit/dataset/composer/test_synthetic_composer.py
+++ b/tests/unit/dataset/composer/test_synthetic_composer.py
@@ -7,6 +7,10 @@ import pytest
 
 from aiperf.common import random_generator as rng
 from aiperf.common.models import Audio, Conversation, Image, Text, Turn
+from aiperf.config.distributions import (
+    LogNormalDistribution,
+    MultimodalDistribution,
+)
 from aiperf.config.flags.cli_config import CLIConfig
 from aiperf.dataset.composer.synthetic import SyntheticDatasetComposer
 from tests.harness.optional_deps import HAS_SOUNDFILE
@@ -90,6 +94,47 @@ class TestSyntheticDatasetComposer:
     # ============================================================================
     # Create Dataset Method Tests
     # ============================================================================
+
+    @pytest.mark.parametrize(
+        "isl_dist",
+        [
+            LogNormalDistribution(mean=6000, median=2000, min=50, max=50000),
+            MultimodalDistribution(
+                peaks=[
+                    {
+                        "mean": 1500,
+                        "stddev": 300,
+                        "weight": 70,
+                        "min": 50,
+                        "max": 50000,
+                    },
+                    {
+                        "mean": 12000,
+                        "median": 6000,
+                        "weight": 30,
+                        "min": 50,
+                        "max": 50000,
+                    },
+                ]
+            ),
+        ],
+        ids=["lognormal", "multimodal"],
+    )
+    def test_non_normal_isl_varies_per_turn(
+        self, synthetic_config, mock_tokenizer, isl_dist
+    ):
+        """Regression: log-normal / multimodal ISL must vary per turn."""
+        composer = SyntheticDatasetComposer(
+            run=make_run(synthetic_config), tokenizer=mock_tokenizer
+        )
+        composer._synthetic_prompts.isl = isl_dist
+
+        isls = [composer._get_turn_sequence_lengths(t)[0] for t in range(200)]
+
+        assert len(set(isls)) > 50, "ISL collapsed to (near-)constant"
+        assert min(isls) >= 50 and max(isls) <= 50000, "clamp [50,50000] violated"
+        # A heavy right tail must actually appear, not just jitter around a point.
+        assert max(isls) > 3 * (sum(isls) / len(isls))
 
     def test_create_dataset_basic(self, synthetic_config, mock_tokenizer):
         """Test basic dataset creation with text-only conversations."""


### PR DESCRIPTION
## Summary
  For batch testing, the synthetic composer effectively pinned every request's
  input sequence length to the distribution's analytic **mean**, so a single
  batch could not exercise short-tail vs. long-tail length variance. Any
  non-Normal ISL shape (log-normal, multimodal, empirical) collapsed to one
  value, making it impossible to benchmark how an inference server normalizes
  across a realistic spread of sequence lengths within one run.

  ## Testing
  - `uv run pytest tests/unit/dataset/composer/` — 121 passed, 1 skipped
  - `uv run pytest tests/unit/property/` — 59 passed
  - Added regression tests: per-turn variation for log-normal/multimodal ISL,
    and same-seed determinism of the new RNG stream

  ## Docs
  - `docs/reproducibility.md`: documented the new
    `composer.turn.sequence_length` RNG identifier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Synthetic workloads now generate more realistic per-turn input and output sequence lengths, including varied distribution patterns.
  * Sequence lengths remain consistent within a turn while varying appropriately across turns.
  * Output token limits now honor configured distributions and enforce valid minimum values.
  * Prompt lengths account for cache-busting markers and chat-template overhead.
  * Fixed random seeds produce reproducible sequence-length sampling across runs.

* **Documentation**
  * Added the Composer turn sequence-length sampling RNG identifier to the reproducibility reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->