### PR TITLE
perf: serialize messages directly to JSON bytes

### DIFF
--- a/src/aiperf/common/messages/base_messages.py
+++ b/src/aiperf/common/messages/base_messages.py
@@ -3,7 +3,6 @@
 import time
 from typing import ClassVar
 
-import orjson
 from pydantic import Field
 
 from aiperf.common.enums import MessageType
@@ -44,11 +43,11 @@ class Message(AIPerfBaseModel):
         return self.model_dump_json(exclude_none=True)
 
     def to_json_bytes(self) -> bytes:
-        """Serialize message to JSON bytes using orjson for optimal performance.
+        """Serialize a message directly to JSON bytes.
 
-        This method uses orjson for high-performance serialization (6x faster for
-        large records >20KB). It automatically excludes None fields to minimize
-        message size.
+        This method uses Pydantic's compiled serializer to avoid creating an
+        intermediate Python dictionary. It automatically excludes None fields
+        to minimize message size.
 
         Returns:
             bytes: JSON-encoded message as bytes
@@ -61,12 +60,10 @@ class Message(AIPerfBaseModel):
             IPC-only fields like ``MetricResult.console_group`` that are stripped
             from public/exporter dumps but must survive the cross-process bus.
         """
-        return orjson.dumps(
-            self.model_dump(
-                exclude_none=True,
-                mode="json",
-                context={"include_internal": True},
-            )
+        return self.__pydantic_serializer__.to_json(
+            self,
+            exclude_none=True,
+            context={"include_internal": True},
         )
 
 

--- a/tests/unit/common/messages/test_messages.py
+++ b/tests/unit/common/messages/test_messages.py
@@ -5,16 +5,31 @@ import time
 
 import orjson
 import pytest
+from pydantic import Field
 
 from aiperf.common.enums import LifecycleState, MessageType
 from aiperf.common.messages import (
     ErrorMessage,
     HeartbeatMessage,
+    InferenceResultsMessage,
+    Message,
     ShutdownCommand,
     StatusMessage,
 )
-from aiperf.common.models import ErrorDetails
+from aiperf.common.models import (
+    BinaryResponse,
+    ErrorDetails,
+    RequestRecord,
+    SSEField,
+    SSEMessage,
+)
 from aiperf.plugin.enums import ServiceType
+
+
+class CustomRequestRecord(RequestRecord):
+    """Request record used to verify duck-typed IPC serialization."""
+
+    custom_metadata: str = Field(description="Custom metadata carried over IPC")
 
 
 def test_status_message():
@@ -111,6 +126,56 @@ class TestBaseStatusMessageTimestamp:
 
 class TestMessageToJsonBytes:
     """Test suite for Message.to_json_bytes() optimization."""
+
+    def test_to_json_bytes_matches_legacy_pipeline_for_inference_record(self):
+        """Direct serialization preserves the existing inference-record wire shape."""
+        record = CustomRequestRecord(
+            custom_metadata="café",
+            unregistered_extra={"label": "retained"},
+            responses=[
+                *[
+                    SSEMessage(
+                        perf_ns=index,
+                        packets=[
+                            SSEField(
+                                name="data",
+                                value='{"choices":[{"delta":{"content":"é"}}]}',
+                            )
+                        ],
+                    )
+                    for index in range(256)
+                ],
+                BinaryResponse(
+                    perf_ns=256,
+                    raw_bytes=b"binary payload",
+                    content_type="application/octet-stream",
+                ),
+            ],
+        )
+        message = InferenceResultsMessage(
+            service_id="worker-0",
+            request_id="request-0",
+            record=record,
+        )
+
+        legacy_bytes = orjson.dumps(
+            message.model_dump(
+                exclude_none=True,
+                mode="json",
+                context={"include_internal": True},
+            )
+        )
+        direct_bytes = message.to_json_bytes()
+
+        assert orjson.loads(direct_bytes) == orjson.loads(legacy_bytes)
+        restored = Message.from_json(direct_bytes)
+        assert isinstance(restored, InferenceResultsMessage)
+        assert restored.record.model_extra["custom_metadata"] == "café"
+        assert restored.record.model_extra["unregistered_extra"] == {
+            "label": "retained"
+        }
+        assert len(restored.record.responses) == 257
+        assert restored.record.responses[-1].raw_bytes == b"binary payload"
 
     def test_to_json_bytes_returns_bytes(self):
         """Test that to_json_bytes() returns bytes type."""


### PR DESCRIPTION
## Summary

- serialize IPC messages directly with Pydantic's compiled JSON serializer
- avoid the intermediate Python dictionary and second JSON traversal
- preserve `exclude_none`, IPC-only serialization context, `SerializeAsAny`, custom fields, and wire round trips
- add focused parity coverage for a representative 256-frame inference message

This is an internal serialization optimization with no public API, CLI, configuration, schema, or exported-record changes.

## Performance

Measured against pinned `main` at `94ece0ff2` with two maxed request workers, concurrency 1024, deterministic four-turn 32K conversations, and 256 output tokens:

- representative 26 KB serialization throughput: **+37.9%**
- request throughput: **+5.2%**
- request-worker CPU/request: **-4.9%**
- whole-AIPerf CPU/request: **-4.6%**
- p95 latency: **-4.4%**
- estimated serialization CPU/request from matched py-spy profiles: **-31.7%**

Both unprofiled and profiled arms completed with zero request errors, complete server token usage, no affinity violations, and no Dynamo lag, skipped messages, or backend rejection.

## Validation

- focused message, accuracy, ZMQ, and property suites: **438 passed**
- full candidate unit suite: **15,449 passed**; two unrelated console-export tests failed identically on the pinned `main` control
- pre-commit: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message serialization consistency while preserving existing wire-format compatibility.
  * Ensured custom metadata, additional fields, response counts, and binary payloads remain intact when messages are serialized and restored.

* **Performance**
  * Streamlined message-to-JSON serialization for more efficient processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->