### PR TITLE
chore: bump aiperf version to 0.12.0

### DIFF
--- a/docs/plugins/creating-your-first-plugin.md
+++ b/docs/plugins/creating-your-first-plugin.md
@@ -234,7 +234,7 @@ You should see both packages listed in the same environment:
 
 ```text
 Name: aiperf
-Version: 0.11.0
+Version: 0.12.0
 Location: ...
 Requires: ...
 Required-by: my-aiperf-plugins

--- a/docs/server-metrics/server-metrics-json-schema.md
+++ b/docs/server-metrics/server-metrics-json-schema.md
@@ -60,7 +60,7 @@ data["metrics"]["metric_name"]["series"][0]["stats"]["p99"]
 ```json
 {
   "schema_version": "1.1",
-  "aiperf_version": "0.11.0",
+  "aiperf_version": "0.12.0",
   "benchmark_id": "550e8400-e29b-41d4-a716-446655440000",
   "summary": { ... },
   "metrics_phase": "profiling",
@@ -73,7 +73,7 @@ data["metrics"]["metric_name"]["series"][0]["stats"]["p99"]
 | Field | Type | Description |
 |-------|------|-------------|
 | `schema_version` | string | Schema version for this export format (e.g., `"1.1"`) |
-| `aiperf_version` | string or null | AIPerf version that generated this export (e.g., `"0.11.0"`). `null` if version unavailable. |
+| `aiperf_version` | string or null | AIPerf version that generated this export (e.g., `"0.12.0"`). `null` if version unavailable. |
 | `benchmark_id` | string or null | Unique UUID identifying this benchmark run. `null` if not available. |
 | [`summary`](#summary-section) | object | Collection metadata and endpoint information. `phase_time_ranges` is present with at least a `profiling` entry when the profiling window is non-degenerate; `warmup` is the optional second key. |
 | `metrics_phase` | string | Benchmark phase represented by the top-level `metrics` field. Always `"profiling"` (kept for backward compatibility). |
@@ -883,7 +883,7 @@ for series in metric["series"]:
 ```json
 {
   "schema_version": "1.1",
-  "aiperf_version": "0.11.0",
+  "aiperf_version": "0.12.0",
   "benchmark_id": "550e8400-e29b-41d4-a716-446655440000",
   "metrics_phase": "profiling",
   "summary": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ allow-direct-references = true
 
 [project]
 name = "aiperf"
-version = "0.11.0"
+version = "0.12.0"
 description = "AIPerf is a package for performance testing of AI models"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/aiperf_mock_server/pyproject.toml
+++ b/tests/aiperf_mock_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiperf-mock-server"
-version = "0.11.0"
+version = "0.12.0"
 description = "AIPerf FastAPI-based OpenAI mock server for AI performance testing"
 authors = []
 dependencies = [


### PR DESCRIPTION
Updates the package and mock-server pyproject.toml versions and refreshes the version strings shown in the plugin tutorial example and the server-metrics JSON schema example output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package and mock server versions to **0.12.0**.

* **Documentation**
  * Updated installation verification examples to reference version **0.12.0**.
  * Updated server metrics schema examples and version field documentation to reflect **0.12.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->