### PR TITLE
fix: uncaught valueerror in sagemaker loader

### DIFF
--- a/src/aiperf/dataset/loader/sagemaker_data_capture.py
+++ b/src/aiperf/dataset/loader/sagemaker_data_capture.py
@@ -128,6 +128,10 @@ class SageMakerDataCaptureLoader(
             raise DatasetLoaderError(
                 f"Capture record {event_id} missing required field: {e}"
             ) from e
+        except ValueError as e:
+            raise DatasetLoaderError(
+                f"Capture record {event_id} has malformed inferenceTime: {e}"
+            ) from e
 
         try:
             input_data = _decode_payload(

--- a/src/aiperf/dataset/loader/sagemaker_data_capture.py
+++ b/src/aiperf/dataset/loader/sagemaker_data_capture.py
@@ -128,7 +128,7 @@ class SageMakerDataCaptureLoader(
             raise DatasetLoaderError(
                 f"Capture record {event_id} missing required field: {e}"
             ) from e
-        except ValueError as e:
+        except (TypeError, ValueError) as e:
             raise DatasetLoaderError(
                 f"Capture record {event_id} has malformed inferenceTime: {e}"
             ) from e

--- a/tests/unit/dataset/loader/test_sagemaker_data_capture.py
+++ b/tests/unit/dataset/loader/test_sagemaker_data_capture.py
@@ -832,7 +832,9 @@ class TestParseTraceErrorPaths:
                 "inferenceTime": "not-a-timestamp",
             },
         }
-        with pytest.raises(DatasetLoaderError, match="bad-ts.*malformed inferenceTime"):
+        with pytest.raises(
+            DatasetLoaderError, match=r"bad-ts.*malformed inferenceTime"
+        ):
             loader._parse_trace(record)
 
     def test_load_dataset_empty_file_returns_empty(self, tmp_path: Path) -> None:

--- a/tests/unit/dataset/loader/test_sagemaker_data_capture.py
+++ b/tests/unit/dataset/loader/test_sagemaker_data_capture.py
@@ -813,6 +813,28 @@ class TestParseTraceErrorPaths:
         with pytest.raises(DatasetLoaderError, match="bad-json payload decode failed"):
             loader._parse_trace(record)
 
+    def test_parse_trace_malformed_inference_time_raises_dataset_loader_error(
+        self, tmp_path: Path
+    ) -> None:
+        """A present-but-non-ISO8601 inferenceTime must raise DatasetLoaderError, not ValueError."""
+        loader = self._make_loader(tmp_path)
+        record = {
+            "captureData": {
+                "endpointInput": {
+                    "data": orjson.dumps(
+                        {"messages": [{"role": "user", "content": "hi"}]}
+                    ).decode(),
+                    "encoding": "JSON",
+                },
+            },
+            "eventMetadata": {
+                "eventId": "bad-ts",
+                "inferenceTime": "not-a-timestamp",
+            },
+        }
+        with pytest.raises(DatasetLoaderError, match="bad-ts.*malformed inferenceTime"):
+            loader._parse_trace(record)
+
     def test_load_dataset_empty_file_returns_empty(self, tmp_path: Path) -> None:
         f = tmp_path / "empty.jsonl"
         f.write_text("")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed `inferenceTime` values in SageMaker data captures.
  * Invalid timestamps now produce a clear dataset loading error message rather than leaking raw parsing exceptions.
* **Tests**
  * Added coverage to verify malformed `inferenceTime` is reported as a `DatasetLoaderError` with the expected event-scoped message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->