### PR TITLE
perf(dataset): batch-encode ShareGPT to fix 300s configuration timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ test = [
   "pytest-asyncio",
   "pytest-cov",
   "pytest-rerunfailures>=15.0",
+  "pytest-timeout>=2.0.0",
   "pytest-xdist>=3.8.0",
   # trustme pulls cryptography, which has no Windows-on-ARM wheel and
   # source-builds against openssl-sys (fails on win-arm). Only the TLS

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -58,6 +58,9 @@ class _TiktokenAdapter:
     def decode(self, token_ids: list[int], **kwargs) -> str:
         return self._encoding.decode(token_ids)
 
+    def encode_batch(self, texts: list[str]) -> list[list[int]]:
+        return self._encoding.encode_batch(texts, allowed_special="all")
+
     def __call__(self, text: str, **kwargs) -> dict:
         return {"input_ids": self.encode(text)}
 
@@ -733,6 +736,25 @@ class Tokenizer:
         """
         self._require_init()
         return self._tokenizer.decode(token_ids, **{**self._decode_args, **kwargs})
+
+    def encode_lengths_batch(self, texts: list[str]) -> list[int]:
+        """Return the token count for each text using a single batch call.
+
+        Uses tiktoken's native parallel encode_batch or the HuggingFace tokenizer's
+        batch __call__, both of which are significantly faster than sequential encode()
+        calls for large input lists.
+
+        Args:
+            texts: List of strings to tokenize.
+
+        Returns:
+            List of token counts, one per input text.
+        """
+        self._require_init()
+        if isinstance(self._tokenizer, _TiktokenAdapter):
+            return [len(ids) for ids in self._tokenizer.encode_batch(texts)]
+        result = self._tokenizer(texts, **{**self._call_args, "padding": False})
+        return [len(ids) for ids in result["input_ids"]]
 
     @property
     def resolved_name(self) -> str | None:

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -753,6 +753,8 @@ class Tokenizer:
         Returns:
             List of token counts, one per input text.
         """
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
         self._require_init()
         lengths: list[int] = []
         for i in range(0, len(texts), chunk_size):

--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -737,24 +737,32 @@ class Tokenizer:
         self._require_init()
         return self._tokenizer.decode(token_ids, **{**self._decode_args, **kwargs})
 
-    def encode_lengths_batch(self, texts: list[str]) -> list[int]:
-        """Return the token count for each text using a single batch call.
+    def encode_lengths_batch(
+        self, texts: list[str], chunk_size: int = 4096
+    ) -> list[int]:
+        """Return the token count for each text using chunked batch calls.
 
-        Uses tiktoken's native parallel encode_batch or the HuggingFace tokenizer's
-        batch __call__, both of which are significantly faster than sequential encode()
-        calls for large input lists.
+        Processes texts in bounded chunks to avoid materialising the full token
+        corpus in memory at once. Uses tiktoken's native parallel encode_batch or
+        the HuggingFace tokenizer's batch __call__.
 
         Args:
             texts: List of strings to tokenize.
+            chunk_size: Maximum number of texts per batch call.
 
         Returns:
             List of token counts, one per input text.
         """
         self._require_init()
-        if isinstance(self._tokenizer, _TiktokenAdapter):
-            return [len(ids) for ids in self._tokenizer.encode_batch(texts)]
-        result = self._tokenizer(texts, **{**self._call_args, "padding": False})
-        return [len(ids) for ids in result["input_ids"]]
+        lengths: list[int] = []
+        for i in range(0, len(texts), chunk_size):
+            chunk = texts[i : i + chunk_size]
+            if isinstance(self._tokenizer, _TiktokenAdapter):
+                lengths.extend(len(ids) for ids in self._tokenizer.encode_batch(chunk))
+            else:
+                result = self._tokenizer(chunk, **self._call_args)
+                lengths.extend(len(ids) for ids in result["input_ids"])
+        return lengths
 
     @property
     def resolved_name(self) -> str | None:

--- a/src/aiperf/dataset/loader/sharegpt.py
+++ b/src/aiperf/dataset/loader/sharegpt.py
@@ -83,7 +83,6 @@ class ShareGPTLoader(BasePublicDatasetLoader):
         )
         return load_json_str(loaded_dataset)
 
-    # TODO: distribute this work across the processors
     async def convert_to_conversations(
         self, dataset: dict[str, Any]
     ) -> list[Conversation]:
@@ -102,24 +101,48 @@ class ShareGPTLoader(BasePublicDatasetLoader):
         self.info(
             f"Validating {self.tag} dataset and constructing conversation dataset"
         )
-        filtered_dataset = []
-        skipped_entries = 0
+
+        # Pass 1: extract all (prompt, completion) pairs per entry without tokenizing.
+        all_entry_pairs: list[list[tuple[str, str]]] = []
         for entry in dataset:
             conversations = entry.get("conversations", [])
             if not conversations or len(conversations) < 2:
-                skipped_entries += 1
+                all_entry_pairs.append([])
                 continue
+            all_entry_pairs.append(
+                self._sharegpt_prompt_completion_pairs(conversations)
+            )
 
-            pairs = self._sharegpt_prompt_completion_pairs(conversations)
+        # Build a flat text list interleaved as [prompt0, completion0, prompt1, ...].
+        # flat_pair_offset[e] is the pair index (not text index) where entry e starts.
+        flat_texts: list[str] = []
+        flat_pair_offset: list[int] = []
+        for pairs in all_entry_pairs:
+            flat_pair_offset.append(len(flat_texts) // 2)
+            for prompt, completion in pairs:
+                flat_texts.append(prompt)
+                flat_texts.append(completion)
+
+        # Pass 2: single batch-encode call for all texts.
+        all_lengths = (
+            self.tokenizer.encode_lengths_batch(flat_texts) if flat_texts else []
+        )
+
+        # Pass 3: validate lengths and build Conversation objects.
+        filtered_dataset = []
+        skipped_entries = 0
+        for entry_idx, pairs in enumerate(all_entry_pairs):
             if not pairs:
                 skipped_entries += 1
                 continue
 
+            pair_start = flat_pair_offset[entry_idx]
             validated: list[tuple[str, int]] = []
             rejected = False
-            for prompt, completion in pairs:
-                prompt_length = len(self.tokenizer.encode(prompt))
-                completion_length = len(self.tokenizer.encode(completion))
+            for i, (prompt, _) in enumerate(pairs):
+                pi = (pair_start + i) * 2
+                prompt_length = all_lengths[pi]
+                completion_length = all_lengths[pi + 1]
                 if not self.is_valid_sequence(
                     prompt_len=prompt_length,
                     output_len=completion_length,
@@ -128,22 +151,22 @@ class ShareGPTLoader(BasePublicDatasetLoader):
                     rejected = True
                     break
                 validated.append((prompt, completion_length))
+
             if rejected or not validated:
                 skipped_entries += 1
                 continue
 
-            turns = [
-                Turn(
-                    model=self._select_model_name(),
-                    texts=[Text(contents=[prompt])],
-                    max_tokens=completion_length,
-                )
-                for prompt, completion_length in validated
-            ]
             filtered_dataset.append(
                 Conversation(
                     session_id=self.session_id_generator.next(),
-                    turns=turns,
+                    turns=[
+                        Turn(
+                            model=self._select_model_name(),
+                            texts=[Text(contents=[prompt])],
+                            max_tokens=completion_length,
+                        )
+                        for prompt, completion_length in validated
+                    ],
                 )
             )
 

--- a/src/aiperf/dataset/loader/sharegpt.py
+++ b/src/aiperf/dataset/loader/sharegpt.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from aiperf.common import random_generator as rng
@@ -102,7 +103,6 @@ class ShareGPTLoader(BasePublicDatasetLoader):
             f"Validating {self.tag} dataset and constructing conversation dataset"
         )
 
-        # Pass 1: extract all (prompt, completion) pairs per entry without tokenizing.
         all_entry_pairs: list[list[tuple[str, str]]] = []
         for entry in dataset:
             conversations = entry.get("conversations", [])
@@ -113,7 +113,6 @@ class ShareGPTLoader(BasePublicDatasetLoader):
                 self._sharegpt_prompt_completion_pairs(conversations)
             )
 
-        # Build a flat text list interleaved as [prompt0, completion0, prompt1, ...].
         # flat_pair_offset[e] is the pair index (not text index) where entry e starts.
         flat_texts: list[str] = []
         flat_pair_offset: list[int] = []
@@ -123,12 +122,11 @@ class ShareGPTLoader(BasePublicDatasetLoader):
                 flat_texts.append(prompt)
                 flat_texts.append(completion)
 
-        # Pass 2: single batch-encode call for all texts.
         all_lengths = (
-            self.tokenizer.encode_lengths_batch(flat_texts) if flat_texts else []
+            await asyncio.to_thread(self.tokenizer.encode_lengths_batch, flat_texts)
+            if flat_texts
+            else []
         )
-
-        # Pass 3: validate lengths and build Conversation objects.
         filtered_dataset = []
         skipped_entries = 0
         for entry_idx, pairs in enumerate(all_entry_pairs):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -410,6 +410,9 @@ def mock_tokenizer_cls() -> type[Tokenizer]:
             # Create MagicMock methods that you can assert on
             self.encode = MagicMock(side_effect=self._mock_encode)
             self.decode = MagicMock(side_effect=self._mock_decode)
+            self.encode_lengths_batch = MagicMock(
+                side_effect=self._mock_encode_lengths_batch
+            )
 
         @classmethod
         def from_pretrained(
@@ -434,7 +437,7 @@ def mock_tokenizer_cls() -> type[Tokenizer]:
         def _mock_decode(self, token_ids, **kwargs):
             return " ".join([f"token_{t}" for t in token_ids])
 
-        def encode_lengths_batch(self, texts: list[str]) -> list[int]:
+        def _mock_encode_lengths_batch(self, texts: list[str]) -> list[int]:
             return [len(self._mock_encode(t)) for t in texts]
 
     return MockTokenizer

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -434,6 +434,9 @@ def mock_tokenizer_cls() -> type[Tokenizer]:
         def _mock_decode(self, token_ids, **kwargs):
             return " ".join([f"token_{t}" for t in token_ids])
 
+        def encode_lengths_batch(self, texts: list[str]) -> list[int]:
+            return [len(self._mock_encode(t)) for t in texts]
+
     return MockTokenizer
 
 

--- a/tests/unit/dataset/loader/test_sharegpt.py
+++ b/tests/unit/dataset/loader/test_sharegpt.py
@@ -167,7 +167,7 @@ class TestShareGPTLoader:
     @pytest.mark.timeout(5)
     async def test_convert_to_conversations_uses_batch_encoding_not_sequential(
         self, sharegpt_loader: ShareGPTLoader
-    ):
+    ) -> None:
         """convert_to_conversations must call encode_lengths_batch, never per-entry encode().
 
         The ShareGPT dataset has ~90K entries. Sequential encode() calls for every
@@ -196,3 +196,4 @@ class TestShareGPTLoader:
         conversations = await sharegpt_loader.convert_to_conversations(dataset)
         assert len(conversations) == 5_000
         assert sharegpt_loader.tokenizer.encode.call_count == 0
+        assert sharegpt_loader.tokenizer.encode_lengths_batch.call_count == 1

--- a/tests/unit/dataset/loader/test_sharegpt.py
+++ b/tests/unit/dataset/loader/test_sharegpt.py
@@ -163,3 +163,36 @@ class TestShareGPTLoader:
             conversations[0].turns[0].texts[0].contents[0]
             == "Hello can you help me with a question"
         )
+
+    @pytest.mark.timeout(5)
+    async def test_convert_to_conversations_uses_batch_encoding_not_sequential(
+        self, sharegpt_loader: ShareGPTLoader
+    ):
+        """convert_to_conversations must call encode_lengths_batch, never per-entry encode().
+
+        The ShareGPT dataset has ~90K entries. Sequential encode() calls for every
+        prompt and completion took 5+ minutes, exceeding the default 300s timeout.
+        Batch encoding collapses this to a single call regardless of dataset size.
+        """
+        short_prompt = "what is the capital city"
+        short_completion = "it is a large coastal city"
+        medium_prompt = " ".join(["word"] * 150)
+        medium_completion = " ".join(["response"] * 100)
+        long_prompt = " ".join(["word"] * 700)
+        long_completion = " ".join(["response"] * 500)
+
+        prompts = [short_prompt, medium_prompt, long_prompt]
+        completions = [short_completion, medium_completion, long_completion]
+
+        dataset = [
+            {
+                "conversations": [
+                    {"from": "human", "value": prompts[i % 3]},
+                    {"from": "gpt", "value": completions[i % 3]},
+                ]
+            }
+            for i in range(5_000)
+        ]
+        conversations = await sharegpt_loader.convert_to_conversations(dataset)
+        assert len(conversations) == 5_000
+        assert sharegpt_loader.tokenizer.encode.call_count == 0


### PR DESCRIPTION
## Summary

- The ShareGPT loader iterated all ~90K entries and called `tokenizer.encode()` individually for every prompt and completion, resulting in up to 540K sequential encode calls that routinely exceeded the default 300s `AIPERF_DATASET_CONFIGURATION_TIMEOUT`
- Replaced the per-entry encode loop with a 3-pass approach: extract all pairs, batch-encode all texts in a single `encode_lengths_batch()` call, then validate lengths and build `Conversation` objects
- Added `Tokenizer.encode_lengths_batch()` backed by tiktoken's native parallel `encode_batch()` and HuggingFace's batch `__call__()`

## Test plan

- [ ] Existing 7 ShareGPT unit tests still pass (output unchanged)
- [ ] New regression test `test_convert_to_conversations_uses_batch_encoding_not_sequential` asserts `encode.call_count == 0` with 5K mixed-length entries and enforces a 5s `pytest.mark.timeout` guard
- [ ] Full unit suite green (17447 passed)
- [ ] Reproduce fix: run `aiperf profile --public-dataset sharegpt --request-count 10` — dataset configuration should complete in seconds instead of timing out

Fixes: https://nvbugspro.nvidia.com/bug/6523738 / DYN-902

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added batch token-length computation to the tokenizer to speed up token counting.
  * Updated ShareGPT dataset conversion to compute prompt/completion token lengths in a single batched pass and validate using precomputed results.
* **Tests**
  * Added an async unit test to verify ShareGPT conversion uses batched token-length encoding (single call) and completes within the time limit.
* **Chores**
  * Added `pytest-timeout` to test extras.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->