### PR TITLE
fix(security): bump ffmpeg to 8.1.2 for CVE-2026-8461

### DIFF
--- a/ATTRIBUTIONS-container.md
+++ b/ATTRIBUTIONS-container.md
@@ -13,7 +13,7 @@ This document provides attribution information for third-party software componen
 
 **Component Information:**
 - **Software**: FFmpeg
-- **Version**: 8.1.1
+- **Version**: 8.1.2
 - **Website**: https://ffmpeg.org/
 - **License**: LGPL v2.1+
 - **Usage**: Video and audio processing library (included in runtime container)
@@ -38,7 +38,7 @@ This document provides attribution information for third-party software componen
 **Source Code Availability:**
 
 The FFmpeg source code used to build this container is available at:
-- Official release: https://ffmpeg.org/releases/ffmpeg-8.1.1.tar.xz
+- Official release: https://ffmpeg.org/releases/ffmpeg-8.1.2.tar.xz
 - Our build configuration is documented in the Dockerfile
 
 **Compliance Notes:**

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir -p /opt/licenses/dpkg \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and build ffmpeg with libvpx (VP9 codec)
-ARG FFMPEG_VERSION=8.1.1
+ARG FFMPEG_VERSION=8.1.2
 RUN wget https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz \
     && tar -xf ffmpeg-${FFMPEG_VERSION}.tar.xz \
     && cd ffmpeg-${FFMPEG_VERSION} \


### PR DESCRIPTION
FFmpeg 8.1.1 is affected by CVE-2026-8461 (CVSS 8.8), an out-of-bounds write in the MagicYUV decoder (libavcodec/magicyuv.c) that can cause memory corruption and potentially remote code execution when decoding a crafted file. Fixed upstream in 8.1.2.

The vulnerable decoder is compiled into the runtime image: the build passes no --disable-decoders, and `ffmpeg -decoders` in the shipped container lists `VFS..D magicyuv`.

AIPerf's own code never decodes untrusted media -- all three ffmpeg.input() call sites in the video generator feed self-generated content (a rawvideo pipe of PIL frames, a PNG frame pattern, and a Gaussian-noise WAV written by soundfile). The ffmpeg binary is on PATH in the runtime image, though, so the vulnerable code is still reachable for anything else executing in the container.

Keep ATTRIBUTIONS-container.md in sync with the new version and source tarball URL.

Verified: env-builder and test stages build clean at 8.1.2; `ffmpeg -version` reports 8.1.2; libvpx-vp9 and libvorbis encoders are still present and the vorbis/ogg/vpx libs stage correctly.