### PR TITLE
fix(synthesize): keep shared prefix blocks full so synthesized traces replay (#1208)

### DIFF
--- a/src/aiperf/dataset/agentic_code_gen/prefix_model.py
+++ b/src/aiperf/dataset/agentic_code_gen/prefix_model.py
@@ -64,6 +64,20 @@ class PrefixAllocator:
         return self._prefix_blocks
 
     @property
+    def prefix_tokens(self) -> int:
+        """Token span reserved by the shared prefix (L1 + L1.5) as WHOLE blocks.
+
+        L1 and L1.5 each round up to a whole number of blocks independently, so
+        the reserved prefix occupies ``prefix_blocks * block_size`` tokens, which
+        can exceed ``layer1_tokens + layer1_5_tokens``. Session (L2) content must
+        begin past this boundary; otherwise a small L2 remainder gets absorbed
+        into the last shared prefix block, making that shared hash_id the partial
+        final block in one session and a full block in another. That maps one
+        hash_id to two block sizes and fails trace reconstruction on replay.
+        """
+        return self._prefix_blocks * self._block_size
+
+    @property
     def block_size(self) -> int:
         return self._block_size
 

--- a/src/aiperf/dataset/agentic_code_gen/session_synthesizer.py
+++ b/src/aiperf/dataset/agentic_code_gen/session_synthesizer.py
@@ -64,8 +64,12 @@ class SessionSynthesizer:
         )
         self._group_weights = weights / weights.sum()
 
-        # Fixed prefix size (L1 + L1.5)
-        self._fixed_prefix = config.cache.layer1_tokens + config.cache.layer1_5_tokens
+        # Fixed prefix (L1 + L1.5) reserved as whole cache blocks, so session
+        # (L2) content always begins in its own block. This keeps the partial
+        # final block of a turn-0 row session-unique -- a shared prefix hash_id
+        # must never be a row's final (partial) block, or it would map to two
+        # different block sizes across sessions and fail trace reconstruction.
+        self._fixed_prefix = self._allocator.prefix_tokens
 
         # Output floor: respect config max if it's below the default minimum
         gen_max = config.generation_length.max

--- a/tests/integration/agentic_code_gen/test_profile_with_synthesized_dataset.py
+++ b/tests/integration/agentic_code_gen/test_profile_with_synthesized_dataset.py
@@ -77,3 +77,72 @@ class TestAgenticCodeGenProfile:
         assert sorted(turns_per_session.values()) == sorted(
             len(synth_session.turns) for synth_session in sessions
         )
+
+    async def test_synthesized_dataset_with_shared_partial_prefix_blocks(
+        self,
+        cli: AIPerfCLI,
+        aiperf_mock_server: AIPerfMockServer,
+        tmp_path: Path,
+    ) -> None:
+        """Regression: a synthesized dataset whose sessions have small L2 tails
+        (landing on the shared-prefix block boundary) must still replay through
+        the real trace loader.
+
+        Before the fix the synthesizer absorbed a small L2 remainder into the
+        last shared L1.5 block, so that shared hash_id was a partial final block
+        in one session and a full block in another. Trace reconstruction then
+        raised ``ConfigurationError`` at Configure Profiling time and the whole
+        run aborted. This config (small block size, tiny L2 relative to a
+        block, few groups) reliably produces that shared-partial-block case.
+        """
+        from aiperf.dataset.agentic_code_gen.distributions import (
+            lognormal_from_mean_median,
+        )
+        from aiperf.dataset.agentic_code_gen.models import (
+            CacheLayerConfig,
+            Layer15GroupConfig,
+            SessionDistributionConfig,
+        )
+        from aiperf.dataset.agentic_code_gen.session_synthesizer import (
+            SessionSynthesizer,
+        )
+        from aiperf.dataset.agentic_code_gen.writer import write_dataset
+
+        config = SessionDistributionConfig(
+            block_size=64,
+            max_prompt_tokens=6_000,
+            reset=None,
+            cache=CacheLayerConfig(
+                layer1_tokens=1_000,
+                layer1_5_tokens=500,
+                layer2=lognormal_from_mean_median(mean=40, median=30),
+                layer1_5_groups=Layer15GroupConfig(num_groups=3, zipf_alpha=1.2),
+            ),
+        )
+        synth = SessionSynthesizer(config, seed=42)
+        sessions = synth.synthesize_sessions(8)
+        run_dir = tmp_path / "run"
+        write_dataset(sessions, run_dir, config, seed=42, config_name="default")
+
+        jsonl_path = run_dir / "dataset.jsonl"
+        total_turns = sum(len(s.turns) for s in sessions)
+
+        result = await cli.run(
+            f"""
+            aiperf profile \
+                --model {defaults.model} \
+                --tokenizer {defaults.tokenizer} \
+                --url {aiperf_mock_server.url} \
+                --endpoint-type chat \
+                --input-file {jsonl_path} \
+                --custom-dataset-type mooncake_trace \
+                --isl-block-size {config.block_size} \
+                --request-count {total_turns} \
+                --concurrency {len(sessions)} \
+                --workers-max {defaults.workers_max} \
+                --ui {defaults.ui}
+            """
+        )
+
+        assert result.request_count == total_turns
+        assert result.has_all_outputs_except_inputs

--- a/tests/unit/dataset/agentic_code_gen/test_roundtrip.py
+++ b/tests/unit/dataset/agentic_code_gen/test_roundtrip.py
@@ -129,6 +129,53 @@ class TestRoundtrip:
                     f"not in [1, {block_size}]"
                 )
 
+    def test_shared_hash_ids_have_consistent_block_size(self, tmp_path: Path) -> None:
+        """Regression: a hash_id shared across rows must always represent the
+        same number of tokens.
+
+        The trace loader reconstructs each non-final block as ``block_size`` and
+        the final block as ``input_length - (n-1) * block_size``, then rejects
+        any hash_id seen at two different sizes with a ``ConfigurationError``. A
+        small L2 remainder must not be absorbed into the last shared prefix
+        (L1/L1.5) block: that would make the shared hash_id a partial final
+        block in one session and a full block in another, so ``aiperf profile``
+        would fail to replay the synthesized dataset. The per-row invariant
+        tests above do NOT catch this -- it is a cross-row property.
+        """
+        config = SessionDistributionConfig()
+        synth = SessionSynthesizer(config, seed=42)
+        sessions = synth.synthesize_sessions(200)
+
+        run_dir = tmp_path / "run"
+        jsonl_path, _, _ = write_dataset(
+            sessions, run_dir, config, seed=42, config_name="default"
+        )
+        block_size = config.block_size
+
+        hash_id_tokens: dict[int, int] = {}
+        with jsonl_path.open("rb") as f:
+            for line_num, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                row = orjson.loads(line)
+                hash_ids = row["hash_ids"]
+                input_length = row["input_length"]
+                n = len(hash_ids)
+                for i, h in enumerate(hash_ids):
+                    tokens = (
+                        block_size if i < n - 1 else input_length - (n - 1) * block_size
+                    )
+                    if h in hash_id_tokens:
+                        assert hash_id_tokens[h] == tokens, (
+                            f"line {line_num}: hash_id {h} derives to {tokens} "
+                            f"tokens but was already materialized at "
+                            f"{hash_id_tokens[h]} tokens; a shared hash_id must "
+                            f"map to a single fixed block size"
+                        )
+                    else:
+                        hash_id_tokens[h] = tokens
+
     def test_cache_invariants_at_scale(self, tmp_path: Path) -> None:
         config = SessionDistributionConfig()
         synth = SessionSynthesizer(config, seed=42)


### PR DESCRIPTION
Cherry-pick of #1208 (merged to `main` as `844efe1b3`) onto `release/0.12.0`.

The bug was reported against **0.12.0rc0**: `aiperf synthesize agentic-code` produced datasets that fail to replay — `aiperf profile --custom-dataset-type mooncake_trace` aborts at *Configure Profiling* with `ConfigurationError('hash_id X requested at N tokens but was already materialized at M tokens')`.

Root cause: the shared prefix (L1/L1.5) was floored on the raw token sum instead of the reserved block-aligned size, so a small L2 tail got absorbed into the last shared block — making one hash_id partial in one session and full in another. Fix floors on `prefix_blocks * block_size` so L2 always starts in its own block.

Clean cherry-pick (no conflicts). Includes the two regression tests (unit cross-row invariant + integration through the real loader).

Original PR: #1208