### PR TITLE
fix(docs): raise dataset timeouts for cold-cache ShareGPT tutorial run

### DIFF
--- a/docs/tutorials/sharegpt.md
+++ b/docs/tutorials/sharegpt.md
@@ -35,8 +35,16 @@ curl -s localhost:8000/v1/chat/completions \
 
 AIPerf automatically downloads and caches the ShareGPT dataset from HuggingFace.
 
+On a cold cache, AIPerf downloads the full corpus and tokenizes every turn of all
+73,499 conversations before profiling starts. This can take several minutes and
+exceed the default 300s dataset-configuration timeout, so raise both timeouts for
+the first run (`AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT` must be greater than or
+equal to `AIPERF_DATASET_CONFIGURATION_TIMEOUT`).
+
 <!-- aiperf-run-vllm-default-openai-endpoint-server weight=200 -->
 ```bash
+AIPERF_DATASET_CONFIGURATION_TIMEOUT=1200 \
+AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT=1200 \
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
     --endpoint-type chat \

--- a/docs/tutorials/sharegpt.md
+++ b/docs/tutorials/sharegpt.md
@@ -59,8 +59,10 @@ aiperf profile \
 **Sample Output (Successful Run):**
 ```
 INFO     Starting AIPerf System
-INFO     Downloading ShareGPT dataset from HuggingFace
-INFO     Cached ShareGPT dataset loaded
+INFO     No local dataset cache found, downloading from https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/...
+INFO     Saving ShareGPT dataset to local cache .cache/aiperf/datasets/ShareGPT_V3_unfiltered_cleaned_split.json
+INFO     Validating ShareGPT dataset and constructing conversation dataset
+INFO     Data file finalized: 73499 conversations, 219.34 MB
 INFO     AIPerf System is PROFILING
 
 Profiling: 20/20 |████████████████████████| 100% [00:45<00:00]


### PR DESCRIPTION
## Problem

`Test Docs End-to-End (vllm-default-openai-3of4)` fails **intermittently** — 3 of the last 20 completed runs (~15%), including runs on `main`:

| run | 3of4 |
|---|---|
| 30482702684 | pass |
| 30383205391 | **fail** |
| 30339020028 | **fail** |
| 30133697082 | **fail** |
| (16 others) | pass |

All three failures are the same failure, on the same test: shard 3's test 10/10, the `--public-dataset sharegpt` command from `docs/tutorials/sharegpt.md`.

```
18:00:28.742 INFO  No local dataset cache found, downloading from https://huggingface.co/.../ShareGPT_V3_unfiltered_cleaned_split.json (base_public_dataset.py:112)
18:00:43.185 INFO  Validating ShareGPT dataset and constructing conversation dataset (sharegpt.py:102)
18:05:20.458 INFO  Data file finalized: 73499 conversations, 219.34 MB (memory_map_utils.py:288)
18:05:26.710 ERROR Failed to perform operation 'Configure Profiling'
                     Operation: Configure Profiling
                     Error: TimeoutError
                     Reason: TimeoutError()
```

## Root cause

On a cold cache (always, in a fresh CI container) AIPerf downloads the full ShareGPT corpus and then tokenizes **every turn of all 73,499 conversations** before profiling can start — `ShareGPTLoader.convert_to_conversations` (`src/aiperf/dataset/loader/sharegpt.py`) flattens all prompt/completion pairs and hands them to `Tokenizer.encode_lengths_batch` (`src/aiperf/common/tokenizer.py:740`) in one shot.

`--request-count 20` does **not** bound this work, and neither would `--num-dataset-entries`: `PublicDatasetComposer.create_dataset_async` (`src/aiperf/dataset/composer/public.py:36-61`) calls `loader.convert_to_conversations(data)` without ever applying `PublicDataset.entries`. The cost is proportional to the whole corpus regardless of flags.

Meanwhile `Worker._on_profile_configure_command` (`src/aiperf/workers/worker.py:1619-1625`) waits only:

```python
await asyncio.wait_for(
    self._dataset_configured_event.wait(),
    timeout=Environment.DATASET.CONFIGURATION_TIMEOUT,
)
```

whose default is `300.0` (`src/aiperf/common/environment.py:297-302`).

Corpus build time on the AMD GPU runner varies ~4x run to run, straddling that fixed budget:

| run | validating -> finalized | elapsed | result |
|---|---|---|---|
| 30482702684 | 19:27:38 -> 19:28:47 | 69s | pass |
| 30383205391 | 18:00:43 -> 18:05:20 | 277s | fail |
| 30339020028 | 08:00:06 -> 08:04:44 | 278s | fail |
| 30133697082 | 23:48:12 -> 23:52:53 | 281s | fail |

In every failure the dataset finished building **1-6 seconds after the deadline had already fired**. Same code path, same command, same image in the passing run — the only variable is runner speed against a hardcoded 300s budget. This is a genuine (and narrow) timeout-headroom bug, not a server-flag or OOM issue.

## Fix

Raise both timeouts on the documented command, with a note explaining why.

Both are required together: the validator at `src/aiperf/common/environment.py:1847-1853` rejects `SERVICE.PROFILE_CONFIGURE_TIMEOUT < DATASET.CONFIGURATION_TIMEOUT` (defaults 600.0 / 300.0), so raising only the dataset one to 1200 would fail config validation. 1200s gives >4x headroom over the slowest observed build (281s).

## Validation (no GPU)

- **Parser extracts the command intact** — `MarkdownParser().parse_directory` returns the full 10-line command including both leading env assignments.
- **Shard slicing unchanged** — still 40 commands, shard weights `[1660, 1660, 1610, 1590]`, `sharegpt.md` still shard index 2's 10th and final test (weight unchanged at 200).
- **`dump_config_hash.py` changes** — `db2b5d29...` (origin/main) -> `aa87cec8...`, so `detect-changes` will actually run the GPU job rather than skipping it.
- **Harness compatibility** — the runner rewrites the command via `command.replace("aiperf profile", "aiperf profile --ui-type ...")` (`tests/ci/test_docs_end_to_end/test_runner.py:381`) and runs it under `docker exec ... bash -c '<cmd>'`, so a leading inline env assignment survives the rewrite and is honored by bash.

Unrelated to #1223 (that fixed a CUDA OOM in `vllm-video-openai`); no overlap in files touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added cold-cache guidance to the ShareGPT profiling tutorial.
  * Documented recommended timeout settings for the first run.
  * Expanded sample output to clarify dataset detection, download, caching, and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->