### PR TITLE
fix(dataset): accept bounded Mooncake hash tails

### DIFF
--- a/docs/benchmark-modes/trace-replay.md
+++ b/docs/benchmark-modes/trace-replay.md
@@ -134,9 +134,12 @@ the selected concurrency drive throughput. Rows with the same `session_id`
 remain causally ordered, so session-level throughput and completion metrics
 still describe complete trajectories.
 
-Mooncake exporters can disagree with `input_length` by one hash block when
-tokenizer-added affixes are counted on only one side. AIPerf accepts this
-one-block difference while reconstructing the exact recorded input length;
+Mooncake exporters can disagree with `input_length` when tokenizer-added
+affixes are counted on only one side. AIPerf accepts a hash-count delta from
+three blocks below through one block above
+`ceil(input_length / block_size)`. Missing suffix tokens are synthesized
+without reusable hashes, and one trailing hash outside `input_length` is
+ignored. The reconstructed prompt retains the exact recorded input length;
 larger disagreements fail validation.
 
 ## Using Pre-formatted Messages

--- a/docs/reference/conversation-context-mode.md
+++ b/docs/reference/conversation-context-mode.md
@@ -110,11 +110,12 @@ only the current row's synthesized prompt and does not merge the live response
 into the next request. Every row in a session must declare the same mode.
 
 Hash blocks are reconstructed at the configured Mooncake block size. AIPerf
-also accepts a hash count that differs by exactly one block from
+also accepts a hash-count delta from three blocks below through one block above
 `ceil(input_length / block_size)`, as produced by exporters that count
-tokenizer-added affixes differently between `input_length` and `hash_ids`. A
-missing short remainder is synthesized without a reusable hash; a trailing hash
-outside `input_length` is ignored. Larger mismatches remain validation errors.
+tokenizer-added affixes differently between `input_length` and `hash_ids`.
+Missing suffix tokens are synthesized without reusable hashes; one trailing
+hash outside `input_length` is ignored. Larger mismatches remain validation
+errors.
 
 ### `message_array_without_responses`
 

--- a/src/aiperf/dataset/generator/prompt.py
+++ b/src/aiperf/dataset/generator/prompt.py
@@ -273,11 +273,10 @@ class PromptGenerator(BaseGenerator):
         Build a token sequence without decoding. Used for batch parallel decode.
 
         Each effective hash index corresponds to a block of `block_size`
-        tokens. The final hashed block may be partial. A trace may differ from
-        the exact ``ceil(num_tokens / block_size)`` count by one block; this
-        accommodates Mooncake exporters that exclude a short tokenizer-added
-        remainder from ``hash_ids`` or hash a short suffix not included in
-        ``num_tokens``. A single trailing hash outside ``num_tokens`` is ignored.
+        tokens. The final hashed block may be partial. A trace may omit up to
+        three trailing hash blocks; this accommodates Mooncake exporters whose
+        tokenizer-accounted input includes a short suffix that is not represented
+        in ``hash_ids``. A single trailing hash outside ``num_tokens`` is ignored.
 
         Cached hash blocks are always materialized at full size and sliced when
         a row uses only part of the final block. This preserves prefix identity
@@ -303,20 +302,22 @@ class PromptGenerator(BaseGenerator):
 
         expected_hash_count = (num_tokens + block_size - 1) // block_size
         hash_count_delta = len(hash_ids) - expected_hash_count
-        if hash_count_delta < -1 or hash_count_delta > 1:
+        max_missing_hash_blocks = 3
+        if hash_count_delta < -max_missing_hash_blocks or hash_count_delta > 1:
             raise ConfigurationError(
                 f"Input length: {num_tokens}, Hash IDs: {hash_ids}, Block size: {block_size} "
-                "are not compatible. The hash count may differ from "
-                f"ceil(input_length / block_size)={expected_hash_count} by at most one."
+                "are not compatible. The hash count may be at most "
+                f"{max_missing_hash_blocks} below or one above "
+                f"ceil(input_length / block_size)={expected_hash_count}."
             )
 
         # One extra hash represents a tokenizer-added suffix outside the
         # recorded input length. It has no prompt tokens to reconstruct.
         effective_hash_ids = hash_ids[:-1] if hash_count_delta == 1 else hash_ids
 
-        # Sanity-check the represented final block or one-block unhashed remainder.
+        # Sanity-check the represented final block and any unhashed suffix.
         final_block_size = num_tokens - ((len(effective_hash_ids) - 1) * block_size)
-        max_supported_size = 2 * block_size
+        max_supported_size = (max_missing_hash_blocks + 1) * block_size
         if final_block_size <= 0 or final_block_size > max_supported_size:
             raise ConfigurationError(
                 f"Input length: {num_tokens}, Hash IDs: {hash_ids}, Block size: {block_size} "

--- a/tests/unit/dataset/generator/test_prompt_generator.py
+++ b/tests/unit/dataset/generator/test_prompt_generator.py
@@ -242,7 +242,7 @@ class TestPromptGeneratorComprehensive:
         [
             # Failing cases
             (5, [1, 2, 3], 5, True),  # Two extra hash blocks (should fail)
-            (20, [1, 2], 5, True),  # More than one unhashed block (should fail)
+            (30, [1, 2], 5, True),  # More than three unhashed blocks (should fail)
             (0, [1], 5, True),  # final_block_size = 0 (should fail)
             (10, [1, 2, 3], 0, True),  # block_size = 0 (should fail)
             (10, [1, 2, 3], -1, True),  # negative block_size (should fail)
@@ -255,6 +255,8 @@ class TestPromptGeneratorComprehensive:
             (12, [1, 2, 3], 5, False),  # final_block_size < block_size
             (11, [1, 2], 5, False),  # One-token unhashed remainder
             (15, [1, 2], 5, False),  # One full unhashed remainder block
+            (20, [1, 2], 5, False),  # Two full unhashed remainder blocks
+            (25, [1, 2], 5, False),  # Three full unhashed remainder blocks
             (10, [1, 2, 3], 5, False),  # One trailing hash outside input_length
         ],
     )
@@ -847,23 +849,23 @@ class TestPromptGeneratorComprehensive:
         assert extended[:7] == partial
         assert len(generator._cache[2]) == 5
 
-    def test_build_token_sequence_supports_one_unhashed_remainder_block(
+    def test_build_token_sequence_supports_three_unhashed_remainder_blocks(
         self, basic_config
     ):
-        """One-block-short Mooncake hash lists retain their exact input length."""
+        """Three-block-short Mooncake hash lists retain their exact input length."""
         tokenizer, prompts, prefix_prompts = basic_config
         generator = _make_generator(
             tokenizer, prompts=prompts, prefix_prompts=prefix_prompts
         )
 
-        first = generator._build_token_sequence(11, [1, 2], 5)
-        second = generator._build_token_sequence(11, [1, 2], 5)
+        first = generator._build_token_sequence(25, [1, 2], 5)
+        second = generator._build_token_sequence(25, [1, 2], 5)
 
-        assert len(first) == 11
+        assert len(first) == 25
         assert second == first
         assert len(generator._cache[1]) == 5
         assert len(generator._cache[2]) == 5
-        assert len(generator._unhashed_remainder_cache[((1, 2), 11, 5)]) == 1
+        assert len(generator._unhashed_remainder_cache[((1, 2), 25, 5)]) == 15
 
     def test_build_token_sequence_ignores_one_trailing_hash_outside_input_length(
         self, basic_config


### PR DESCRIPTION
## Summary

- Accept full-context Mooncake hash-count deltas from three blocks below through one block above `ceil(input_length / block_size)`.
- Preserve every supplied hash block and synthesize only the unmatched suffix without reusable hashes.
- Continue rejecting larger shortfalls and more than one trailing hash.
- Document the bounded contract and extend generator coverage for `-3` acceptance and `-4` rejection.

## Root cause

The Gemma 4 PinchBench full-context export contains 1,301 of 19,500 rows whose tokenizer-accounted `input_length` is two or three 128-token blocks above the recorded `hash_ids` span. The existing one-block guard rejected those rows during dataset configuration even though the hashes and recorded input length were otherwise valid.

## Validation

- The source and focused test changes exactly match the tested source archive with SHA-256 `0b1a46352703e1e2266f642577badde1ebd5a5e94eca8b3d510f8f59e461bcf5`.
- cw-dfw smoke job `14609963` configured all 19,500 turns / 1,468 conversations into a 5.14 GB mmap, completed 1,020 profiling requests with zero errors, and uploaded 31 verified artifacts.
- `pytest tests/unit/dataset/generator/test_prompt_generator.py tests/unit/dataset/loader/test_trace.py -n auto`: 148 passed.
- All staged pre-commit hooks passed, including imports, generated artifacts, schema validation, ergonomics, and Ruff.
- Full unit run: 15,554 passed, 88 skipped, 1 xfailed. Three unrelated exporter tests failed; the branch has no exporter diff, one passed on serial rerun, and two existing console-render tests remained environment-sensitive on macOS.

## Stack

This draft targets `codex/port-aiperf-main-features`, the exact full-context-capable base used by the validated smoke package, so the PR contains one commit and four files. Retarget it to `main` when the base port lands.