### PR TITLE
fix(dag): update BranchStats test expectations for graphs_admitted/graphs_completed_to_end

### DIFF
--- a/tests/unit/records/test_dag_metadata_tagging.py
+++ b/tests/unit/records/test_dag_metadata_tagging.py
@@ -137,6 +137,8 @@ class TestBranchStatsExport:
             "joins_suppressed": 0,
             "children_truncated": 0,
             "children_delayed": 0,
+            "graphs_admitted": 0,
+            "graphs_completed_to_end": 0,
         }
 
     def test_branch_stats_dict_helper(self):
@@ -157,6 +159,8 @@ class TestBranchStatsExport:
             "joins_suppressed": 0,
             "children_truncated": 0,
             "children_delayed": 0,
+            "graphs_admitted": 0,
+            "graphs_completed_to_end": 0,
         }
 
     def test_branch_stats_roundtrip_through_profile_results(self):


### PR DESCRIPTION
## Summary

- PR #1218 added `graphs_admitted` and `graphs_completed_to_end` fields to `BranchStats` but didn't update the unit test expectations in `TestBranchStatsExport`
- Two tests were failing on `main`: `test_branch_stats_defaults_all_zero` and `test_branch_stats_dict_helper`
- Adds the two missing fields (both defaulting to `0`) to both expected dicts

Fixes AIP-1114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming BranchStats exports include zero-valued graph admission and completion metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->