### PR TITLE
fix: correct defects surfaced by a docstring audit

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -198,6 +198,7 @@ Network latency calibration configuration. Controls the TCP-handshake RTT probes
 | `AIPERF_NETWORK_LATENCY_MIN_SAMPLES` | `5` | ≥ 1, ≤ 100000 | Minimum number of successful RTT samples to collect; extra probes are issued at profile completion if a short run did not reach this floor |
 | `AIPERF_NETWORK_LATENCY_CONNECT_TIMEOUT` | `5.0` | ≥ 0.001, ≤ 300.0 | Timeout in seconds for a single TCP-handshake RTT probe |
 | `AIPERF_NETWORK_LATENCY_COMPLETE_TOPUP_TIMEOUT` | `3.0` | ≥ 0.0, ≤ 30.0 | Wall-clock budget in seconds for the final MIN_SAMPLES top-up probes at PROFILE_COMPLETE, kept well under the command-response budget so a slow endpoint cannot stall completion |
+| `AIPERF_NETWORK_LATENCY_SHUTDOWN_DELAY` | `5.0` | ≥ 1.0, ≤ 300.0 | Delay in seconds before shutting down the network latency service to allow command response transmission |
 | `AIPERF_NETWORK_LATENCY_EXPORT_BATCH_SIZE` | `100` | ≥ 1, ≤ 1000000 | Batch size for the network latency jsonl writer export results processor |
 
 ## OTEL

--- a/src/aiperf/cli_runner/_multi_run.py
+++ b/src/aiperf/cli_runner/_multi_run.py
@@ -228,7 +228,7 @@ def _reject_in_process_sweep_under_operator(plan: BenchmarkPlan) -> None:
             f"In-process parameter sweep ({len(plan.configs)} variations across "
             f"{swept_params or '<unknown>'}) is not supported in operator-managed "
             f"runs (AIPERF_OPERATOR_MANAGED=1). Use the AIPerfSweep CRD "
-            f"(cluster-scope) for cross-job sweeps - see docs/kubernetes/sweeps.md "
+            f"(cluster-scope) for cross-job sweeps - see docs/tutorials/sweeps.md "
             f"- or submit one AIPerfJob per variation. To run as a single point "
             f"benchmark, drop the comma in --concurrency / other magic-list flags."
         )
@@ -245,8 +245,9 @@ def _summarize_and_export(
 ) -> int:
     """Log success/failure summary and run confidence + sweep aggregation.
 
-    Returns an exit code (0 on full success, 1 when fewer than 2 runs
-    succeeded). Does not call ``sys.exit`` - the caller is responsible for
+    Returns an exit code (0 once at least 2 runs succeeded - even if others
+    failed - and 1 when fewer than 2 runs succeeded, because confidence
+    statistics need 2 samples). Does not call ``sys.exit`` - the caller is responsible for
     propagating the code so that registered ``on_complete`` callbacks still
     run on whatever per-run artifacts were produced.
     """

--- a/src/aiperf/cli_runner/_process_setup.py
+++ b/src/aiperf/cli_runner/_process_setup.py
@@ -35,8 +35,8 @@ def _configure_multiprocessing_start_method(using_dashboard: bool) -> None:
     Env override takes precedence for all platforms.
     """
     import multiprocessing
-    import platform
 
+    from aiperf.common.constants import IS_MACOS
     from aiperf.common.environment import Environment
 
     configured_start_method = getattr(
@@ -47,7 +47,7 @@ def _configure_multiprocessing_start_method(using_dashboard: bool) -> None:
             multiprocessing.set_start_method(configured_start_method, force=True)
         return
 
-    if platform.system() == "Darwin" and using_dashboard:
+    if IS_MACOS and using_dashboard:
         with contextlib.suppress(RuntimeError):
             multiprocessing.set_start_method("spawn", force=True)
 
@@ -61,7 +61,7 @@ def _setup_ui_queues(
     Dashboard UI is running on macOS, FD_CLOEXEC is set on terminal
     descriptors to prevent child processes corrupting the parent terminal.
     """
-    import platform
+    from aiperf.common.constants import IS_MACOS
 
     if not using_dashboard:
         from aiperf.common.logging import setup_rich_logging
@@ -73,7 +73,7 @@ def _setup_ui_queues(
 
     log_queue = get_global_log_queue()
 
-    if platform.system() == "Darwin":
+    if IS_MACOS:
         _set_fd_cloexec_on_terminal(logger)
     return log_queue
 

--- a/src/aiperf/common/aiperf_logger.py
+++ b/src/aiperf/common/aiperf_logger.py
@@ -21,6 +21,17 @@ logging.addLevelName(_TRACE, "TRACE")
 logging.addLevelName(_NOTICE, "NOTICE")
 logging.addLevelName(_SUCCESS, "SUCCESS")
 
+_LEVEL_NAME_TO_NUMBER: dict[str, int] = {
+    "TRACE": _TRACE,
+    "DEBUG": _DEBUG,
+    "INFO": _INFO,
+    "NOTICE": _NOTICE,
+    "WARNING": _WARNING,
+    "SUCCESS": _SUCCESS,
+    "ERROR": _ERROR,
+    "CRITICAL": _CRITICAL,
+}
+
 
 class AIPerfLogger:
     """Logger for AIPerf messages with lazy evaluation support for f-strings.
@@ -89,33 +100,25 @@ class AIPerfLogger:
     def is_valid_level(cls, level: int | str) -> bool:
         """Check if the given level is a valid level."""
         if isinstance(level, str):
-            return level in [
-                "TRACE",
-                "DEBUG",
-                "INFO",
-                "NOTICE",
-                "WARNING",
-                "SUCCESS",
-                "ERROR",
-                "CRITICAL",
-            ]
+            return level in _LEVEL_NAME_TO_NUMBER
         else:
-            return level in [
-                _TRACE,
-                _DEBUG,
-                _INFO,
-                _NOTICE,
-                _WARNING,
-                _SUCCESS,
-                _ERROR,
-                _CRITICAL,
-            ]
+            return level in _LEVEL_NAME_TO_NUMBER.values()
 
     @classmethod
     def get_level_number(cls, level: int | str) -> int:
-        """Get the numeric level for the given level."""
+        """Get the numeric level for the given level.
+
+        Raises:
+            ValueError: If the level is a string that is not a known level name.
+        """
         if isinstance(level, str):
-            return getattr(cls, level.upper())
+            try:
+                return _LEVEL_NAME_TO_NUMBER[level.upper()]
+            except KeyError:
+                raise ValueError(
+                    f"Unknown log level name '{level}'. Valid levels: "
+                    f"{', '.join(_LEVEL_NAME_TO_NUMBER)}"
+                ) from None
         else:
             return level
 

--- a/src/aiperf/common/environment.py
+++ b/src/aiperf/common/environment.py
@@ -1134,6 +1134,12 @@ class _NetworkLatencySettings(BaseSettings):
         "at PROFILE_COMPLETE, kept well under the command-response budget so a slow "
         "endpoint cannot stall completion",
     )
+    SHUTDOWN_DELAY: float = Field(
+        ge=1.0,
+        le=300.0,
+        default=5.0,
+        description="Delay in seconds before shutting down the network latency service to allow command response transmission",
+    )
     EXPORT_BATCH_SIZE: int = Field(
         ge=1,
         le=1000000,

--- a/src/aiperf/common/mixins/task_manager_mixin.py
+++ b/src/aiperf/common/mixins/task_manager_mixin.py
@@ -41,10 +41,13 @@ class TaskManagerMixin(AIPerfLoggerMixin):
     async def cancel_all_tasks(
         self, timeout: float = Environment.SERVICE.TASK_CANCEL_TIMEOUT_SHORT
     ) -> None:
-        """Cancel all tasks in the set and wait for up to timeout seconds for them to complete.
+        """Cancel all tasks in the set and wait (bounded) for them to finish.
+
+        Tasks that do not finish within the timeout are abandoned rather than
+        blocking shutdown.
 
         Args:
-            timeout: The timeout to wait for the tasks to complete.
+            timeout: Maximum number of seconds to wait for cancelled tasks to finish.
         """
         if not self.tasks:
             return
@@ -52,6 +55,22 @@ class TaskManagerMixin(AIPerfLoggerMixin):
         task_list = list(self.tasks)
         for task in task_list:
             task.cancel()
+
+        # Never await ourselves: cancel_all_tasks can be invoked from inside one of
+        # the managed tasks, and awaiting the current task would deadlock.
+        current = asyncio.current_task()
+        pending = [
+            task for task in task_list if not task.done() and task is not current
+        ]
+        if not pending:
+            return
+
+        _, still_pending = await asyncio.wait(pending, timeout=timeout)
+        if still_pending:
+            self.warning(
+                lambda: f"{len(still_pending)} task(s) did not finish within "
+                f"{timeout}s of cancellation; abandoning them."
+            )
 
     def start_background_task(
         self,
@@ -62,7 +81,8 @@ class TaskManagerMixin(AIPerfLoggerMixin):
         stop_on_error: bool = False,
         stop_event: asyncio.Event | None = None,
     ) -> None:
-        """Run a task in the background, in a loop until cancelled."""
+        """Run a task in the background, in a loop until cancelled. If interval is None,
+        the task runs a single time and the loop exits."""
         self.execute_async(
             self._background_task_loop(
                 method, interval, immediate, stop_on_error, stop_event
@@ -81,9 +101,10 @@ class TaskManagerMixin(AIPerfLoggerMixin):
 
         Args:
             method: The method to run as a background task.
-            interval: The interval to run the task in seconds. Can be a callable that returns the interval, and will be called with 'self' as the argument.
+            interval: The interval to run the task in seconds. Can be a callable that returns the interval, and will be called with 'self' as the argument. If None, the method is run once and the loop exits.
             immediate: If True, run the task immediately on start, otherwise wait for the interval first.
             stop_on_error: If True, stop the task on any exception, otherwise log and continue.
+            stop_event: If set, the loop exits before the next iteration.
         """
         while stop_event is None or not stop_event.is_set():
             try:

--- a/src/aiperf/common/models/server_metrics_models.py
+++ b/src/aiperf/common/models/server_metrics_models.py
@@ -183,8 +183,10 @@ class SlimRecord(AIPerfBaseModel):
     timestamp_ns: int = Field(
         description="Nanosecond wall-clock timestamp representing when server generated metrics"
     )
-    endpoint_latency_ns: int = Field(
-        description="Nanoseconds for total HTTP round-trip (request start to completion)"
+    endpoint_latency_ns: int | None = Field(
+        default=None,
+        description="Nanoseconds for total HTTP round-trip (request start to completion). "
+        "None when no HTTP trace timing was captured for the scrape.",
     )
     metrics: dict[str, list[MetricSample]] = Field(
         description="Metrics grouped by family name, mapping directly to metric sample list"
@@ -257,7 +259,7 @@ class ServerMetricsRecord(AIPerfBaseModel):
         so they will be include in the final export, but not in the JSONL records.
 
         Returns:
-            ServerMetricsSlimRecord with only timestamp and slim samples (flat structure)
+            SlimRecord with only timestamp and slim samples (flat structure)
         """
         slim_metrics = {
             name: family.samples

--- a/src/aiperf/common/models/telemetry_models.py
+++ b/src/aiperf/common/models/telemetry_models.py
@@ -602,7 +602,8 @@ class GpuTelemetryData(AIPerfBaseModel):
         """Add telemetry record as a grouped snapshot.
 
         Args:
-            record: New telemetry data point from DCGM collector
+            record: New telemetry data point from a GPU telemetry collector
+                (DCGM, PyNVML, or AMDSMI)
 
         Note: Groups all metric values from the record into a single snapshot
         """
@@ -686,6 +687,8 @@ class TelemetryHierarchy(AIPerfBaseModel):
                     gpu_index=record.gpu_index,
                     gpu_uuid=record.gpu_uuid,
                     gpu_model_name=record.gpu_model_name,
+                    pci_bus_id=record.pci_bus_id,
+                    device=record.device,
                     hostname=record.hostname,
                     namespace=record.namespace,
                     pod_name=record.pod_name,
@@ -703,7 +706,7 @@ class ProcessTelemetryResult(AIPerfBaseModel):
     maintaining complete separation while following the same architectural patterns.
 
     Note: Uses TelemetryExportData (wire-safe, pre-computed stats) rather than
-    TelemetryResults (internal, contains non-serializable GpuMetricTimeSeries).
+    TelemetryHierarchy (internal, contains non-serializable GpuMetricTimeSeries).
     """
 
     results: TelemetryExportData | None = Field(

--- a/src/aiperf/common/protocols.py
+++ b/src/aiperf/common/protocols.py
@@ -13,13 +13,14 @@ if TYPE_CHECKING:
     from typing import Any
 
     from aiperf.common.enums import LifecycleState
-    from aiperf.common.models import (
+    from aiperf.common.types import (
+        CommAddressType,
         MessageCallbackMapT,
         MessageOutputT,
         MessageT,
         MessageTypeT,
+        ServiceTypeT,
     )
-    from aiperf.common.types import CommAddressType, ServiceTypeT
     from aiperf.config.resolution.plan import BenchmarkRun
     from aiperf.plugin.enums import CommClientType
 
@@ -259,7 +260,7 @@ class SubClientProtocol(CommunicationClientProtocol, Protocol):
 @runtime_checkable
 class CommunicationProtocol(AIPerfLifecycleProtocol, Protocol):
     """Protocol for the base communication layer.
-    see :class:`aiperf.common.comms.base_comms.BaseCommunication` for more details.
+    see :class:`aiperf.common.base_comms.BaseCommunication` for more details.
     """
 
     def get_address(self, address_type: CommAddressType) -> str: ...

--- a/src/aiperf/dataset/composer/custom.py
+++ b/src/aiperf/dataset/composer/custom.py
@@ -128,7 +128,8 @@ class CustomDatasetComposer(BaseDatasetComposer):
             CustomDatasetType if successfully inferred
 
         Raises:
-            ValueError: If no loader can handle the data format
+            ValueError: If the file has no non-empty lines, or no loader can
+                handle the data format
         """
         try:
             path = Path(file_path)
@@ -151,6 +152,12 @@ class CustomDatasetComposer(BaseDatasetComposer):
                         return self._infer_type(data=data, filename=file_path)
                 except UnicodeDecodeError:
                     return self._infer_type(data=None, filename=file_path)
+
+            raise ValueError(
+                f"Cannot infer the dataset type of '{file_path}': the file has "
+                "no non-empty lines. Provide a non-empty input file, or specify "
+                "--custom-dataset-type explicitly."
+            )
 
         except ValueError as e:
             self.exception(

--- a/src/aiperf/dataset/composer/synthetic_rankings.py
+++ b/src/aiperf/dataset/composer/synthetic_rankings.py
@@ -68,6 +68,10 @@ class SyntheticRankingsDatasetComposer(BaseDatasetComposer):
             conversation.turns.append(turn)
             conversations.append(conversation)
 
+        # Conversation-level context prompts (shared system prompt, per-session
+        # user context) are set on the Conversation, not the Turn, so they apply
+        # to the single-turn rankings shape unchanged.
+        self._finalize_conversations(conversations)
         return conversations
 
     def _create_turn(self, num_passages: int) -> Turn:

--- a/src/aiperf/dataset/generator/audio.py
+++ b/src/aiperf/dataset/generator/audio.py
@@ -133,6 +133,7 @@ class AudioGenerator(BaseGenerator):
                 - audio length is less than 0.01 seconds
                 - sampling rate is not supported for MP3 format
                 - bit depth is not supported (must be 8, 16, 24, or 32)
+                - the configured audio format is not supported (must be wav or mp3)
         """
         length_dist = self.config.length
         length_mean = float(length_dist.expected_value)
@@ -176,6 +177,12 @@ class AudioGenerator(BaseGenerator):
             subtype = "MPEG_LAYER_III"
         elif self.config.format == AudioFormat.WAV:
             _, subtype = SUPPORTED_BIT_DEPTHS[bit_depth]
+        else:
+            supported_formats = sorted(f.value for f in AudioFormat)
+            raise ConfigurationError(
+                f"Unsupported audio format: {self.config.format}. "
+                f"Supported audio formats are: {supported_formats}"
+            )
 
         sf = import_soundfile()
 

--- a/src/aiperf/dataset/generator/prompt.py
+++ b/src/aiperf/dataset/generator/prompt.py
@@ -469,16 +469,20 @@ class PromptGenerator(BaseGenerator):
             raise NotInitializedError("Tokenized corpus is not initialized.")
         if num_tokens > self._corpus_size:
             self.warning(
-                f"Requested prompt length {num_tokens} is longer than the corpus. "
-                f"Returning a prompt of length {self._corpus_size}."
+                f"Requested prompt length {num_tokens} is longer than the corpus "
+                f"({self._corpus_size} tokens). The corpus will wrap around, so "
+                f"the prompt repeats corpus content but still has {num_tokens} tokens."
             )
 
         start_idx = self._corpus_rng.randrange(self._corpus_size)
 
         end_idx = start_idx + num_tokens
         prompt_tokens = self._tokenized_corpus[start_idx:end_idx]
-        if end_idx > self._corpus_size:
-            prompt_tokens += self._tokenized_corpus[: end_idx - self._corpus_size]
+        # Wrap as many times as needed: a single wrap is short whenever
+        # num_tokens exceeds twice the corpus size.
+        while len(prompt_tokens) < num_tokens:
+            remaining = num_tokens - len(prompt_tokens)
+            prompt_tokens += self._tokenized_corpus[:remaining]
 
         self.trace(lambda: f"Sampled {len(prompt_tokens)} tokens from corpus")
         return prompt_tokens

--- a/src/aiperf/dataset/loader/sagemaker_data_capture.py
+++ b/src/aiperf/dataset/loader/sagemaker_data_capture.py
@@ -44,8 +44,8 @@ def _decode_payload(
 
     Handles JSON (raw) and BASE64 encoded payloads. Returns None for
     CSV or unknown encodings. A malformed base64 or inner-JSON payload is
-    re-raised as DatasetLoaderError so one bad record does not abort the
-    whole load (matching the per-record attribution in _parse_trace).
+    re-raised as DatasetLoaderError naming the offending record, aborting the
+    load (matching the per-record attribution in _parse_trace).
     """
     data = capture_entry.get("data")
     if data is None:
@@ -284,6 +284,13 @@ class SageMakerDataCaptureLoader(
         self._skipped_traces = 0
         self._skipped_max_isl = 0
         self._capped_max_osl = 0
+        # This override replaces BaseTraceDatasetLoader.load_dataset (directory
+        # globbing instead of a single JSONL), so it must reset the same
+        # per-load state the base does: delay-cap counters (otherwise a prior
+        # load's counts leak into this load's summary) and the per-file hash_id
+        # scope (reseeds the corpus RNG and clears the prompt block cache).
+        self._delay_cap_tracker.reset()
+        self._init_trace_scope()
 
         if self.inline_records is not None:
             raw_items: list[SageMakerDataCaptureTrace] = []

--- a/src/aiperf/endpoints/huggingface_generate.py
+++ b/src/aiperf/endpoints/huggingface_generate.py
@@ -12,8 +12,9 @@ from aiperf.endpoints.base_endpoint import BaseEndpoint
 class HuggingFaceGenerateEndpoint(BaseEndpoint):
     """Hugging Face TGI (Text Generation Inference) endpoint.
 
-    Supports both non-streaming (/ or /generate) and streaming (/generate_stream)
-    endpoints automatically, based on the model endpoint's `streaming` flag.
+    Supports both non-streaming (/generate) and streaming (/generate_stream)
+    endpoints automatically. The request side keys on the effective per-request
+    wire mode; the read side dispatches on the shape of each response.
     """
 
     def format_payload(self, request_info: RequestInfo) -> dict[str, Any]:
@@ -51,9 +52,17 @@ class HuggingFaceGenerateEndpoint(BaseEndpoint):
     ) -> ParsedResponse | None:
         """Parse TGI response into ParsedResponse.
 
-        Handles both streaming and non-streaming modes.
+        Dispatches on the shape of the response itself, not the global
+        ``endpoint.streaming`` flag: a graph credit may carry a per-request
+        ``stream_override`` so the wire mode of any single response can differ
+        from the global setting. TGI stream events carry an incremental
+        ``token`` object; full ``/generate`` bodies do not.
         """
-        if self.model_endpoint.endpoint.streaming:
+        json_obj = response.get_json()
+        if not json_obj:
+            return None
+
+        if isinstance(json_obj, dict) and json_obj.get("token") is not None:
             return self._parse_streaming(response)
         return self._parse_non_streaming(response)
 

--- a/src/aiperf/endpoints/solido_rag.py
+++ b/src/aiperf/endpoints/solido_rag.py
@@ -88,14 +88,15 @@ class SolidoEndpoint(BaseEndpoint):
 
     def _extract_solido_response_data(
         self, json_obj: JsonObject
-    ) -> tuple[TextResponseData, RAGSources | None]:
+    ) -> tuple[TextResponseData | None, RAGSources | None]:
         """Extract content from SOLIDO JSON response.
 
         Args:
             json_obj: Deserialized SOLIDO response
 
         Returns:
-            Extracted response data or None if no content
+            ``(data, sources)``; ``data`` is None when the response carries no
+            content, in which case ``sources`` is None as well.
         """
         # SOLIDO responses contain a "content" field with the generated text
         content = json_obj.get("content")

--- a/src/aiperf/gpu_telemetry/metrics_config.py
+++ b/src/aiperf/gpu_telemetry/metrics_config.py
@@ -227,6 +227,17 @@ class MetricsConfigLoader(AIPerfLoggerMixin):
             else:
                 dcgm_suffix = dcgm_field
             internal_name = f"nvidia_{dcgm_suffix.lower()}"
+
+            # why: distinct DCGM field names can collapse to the same derived
+            # internal_name (e.g. DCGM_FI_DEV_X and DCGM_FI_PROF_X), which would
+            # emit a duplicate metric column downstream.
+            if internal_name in existing_field_names:
+                self.debug(
+                    f"Skipping DCGM field {dcgm_field}: derived internal name "
+                    f"{internal_name} is already in use"
+                )
+                continue
+
             display_name = help_msg.split("(")[0].strip()
 
             if not display_name:

--- a/src/aiperf/network_latency/manager.py
+++ b/src/aiperf/network_latency/manager.py
@@ -215,7 +215,7 @@ class NetworkLatencyManager(BaseComponentService):
 
     async def _delayed_shutdown(self) -> None:
         """Shutdown the service after a delay so the command response can be sent."""
-        await asyncio.sleep(Environment.SERVER_METRICS.SHUTDOWN_DELAY)
+        await asyncio.sleep(Environment.NETWORK_LATENCY.SHUTDOWN_DELAY)
         await asyncio.shield(self.stop())
 
     async def _on_network_latency_samples(

--- a/src/aiperf/plugin/plugins.py
+++ b/src/aiperf/plugin/plugins.py
@@ -1297,17 +1297,49 @@ def get_search_planner_metadata(name: str) -> SearchPlannerMetadata:
     return get_entry("search_planner", name).get_typed_metadata(SearchPlannerMetadata)
 
 
-# Mapping of categories to their metadata classes (for categories with typed metadata)
-_CATEGORY_METADATA_CLASSES: dict[str, type] = {
-    "endpoint": EndpointMetadata,
-    "transport": TransportMetadata,
-    "plot": PlotMetadata,
-    "service": ServiceMetadata,
-    "custom_dataset_loader": CustomDatasetLoaderMetadata,
-    "convergence_criterion": ConvergenceCriterionMetadata,
-    "search_planner": SearchPlannerMetadata,
-    "gpu_telemetry_collector": GPUTelemetryCollectorMetadata,
-}
+# Resolved metadata classes, keyed by normalized category. Populated lazily from
+# the `metadata_class` field in categories.yaml — never hand-maintained, since a
+# hand-written duplicate of that mapping silently drifts as categories are added.
+_CATEGORY_METADATA_CLASSES: dict[str, type] = {}
+
+
+def _get_category_metadata_class(category: str) -> type | None:
+    """Resolve the metadata class declared by a category in categories.yaml.
+
+    Args:
+        category: Normalized category name.
+
+    Returns:
+        The imported metadata class, or None when the category declares no
+        `metadata_class` (or its class path cannot be imported).
+    """
+    if (cached := _CATEGORY_METADATA_CLASSES.get(category)) is not None:
+        return cached
+
+    category_metadata = get_category_metadata(category) or {}
+    class_path = category_metadata.get("metadata_class")
+    if not class_path:
+        return None
+
+    module_path, _, class_name = str(class_path).rpartition(":")
+    if not module_path or not class_name:
+        _logger.warning(
+            f"Invalid metadata_class for category '{category}': {class_path!r} "
+            "(expected 'module.path:ClassName')"
+        )
+        return None
+
+    try:
+        metadata_cls = getattr(importlib.import_module(module_path), class_name)
+    except (ImportError, AttributeError) as e:
+        _logger.warning(
+            f"Failed to import metadata_class '{class_path}' for category "
+            f"'{category}': {e!r}"
+        )
+        return None
+
+    _CATEGORY_METADATA_CLASSES[category] = metadata_cls
+    return metadata_cls
 
 
 def get_typed_metadata(category: CategoryT, name: str) -> Any:
@@ -1333,7 +1365,7 @@ def get_typed_metadata(category: CategoryT, name: str) -> Any:
     """
     category = _normalize_category(category)
     entry = get_entry(category, name)
-    if metadata_cls := _CATEGORY_METADATA_CLASSES.get(category):
+    if metadata_cls := _get_category_metadata_class(category):
         return entry.get_typed_metadata(metadata_cls)
 
     # Fall back to raw metadata dict

--- a/src/aiperf/server_metrics/export_stats.py
+++ b/src/aiperf/server_metrics/export_stats.py
@@ -139,7 +139,8 @@ def _compute_timeslice_boundaries(
         Tuple of (starts, ends, is_complete) numpy arrays where:
         - starts[i] and ends[i] define the i-th timeslice boundaries
         - is_complete[i] is True if the slice covers the full duration, False for partial
-        Returns None if slice_duration > range duration (no slices fit).
+        Returns None if the range is empty (range_start_ns >= range_end_ns). A
+        slice_duration larger than the range yields a single partial slice.
 
     Example:
         >>> # 10 second range with 3 second slices
@@ -309,7 +310,7 @@ def _compute_counter_stats(
                         are not computed.
 
     Returns:
-        CounterSeriesStats with counter statistics, or None if no data in range
+        CounterSeries with counter statistics, or None if no data in range
     """
     reference_idx = time_series.get_reference_idx(time_filter)
     time_mask = time_series.get_time_mask(time_filter)
@@ -521,7 +522,7 @@ def _compute_gauge_stats(
                         are not computed.
 
     Returns:
-        GaugeSeriesStats with gauge statistics, or None if no data in range
+        GaugeSeries with gauge statistics, or None if no data in range
     """
     time_mask = time_series.get_time_mask(time_filter)
     filtered_values = time_series.values[time_mask]
@@ -635,9 +636,16 @@ def _compute_histogram_timeslices(
         )
         boundary_end_idx = np.searchsorted(timestamps, timeslice_end, side="right") - 1
 
-        # Clip to valid range
-        boundary_start_idx = max(0, min(boundary_start_idx, len(timestamps) - 1))
-        boundary_end_idx = max(0, min(boundary_end_idx, len(timestamps) - 1))
+        # why: a slice starting before the first sample has no baseline snapshot to
+        # subtract. Clipping the start index to 0 would collapse it onto the same
+        # (or a later) sample as the end index and report a delta measured from the
+        # wrong baseline — usually a fabricated zero — for a period with no data.
+        # Skip such slices; this also covers slices entirely before the first sample.
+        if boundary_start_idx < 0:
+            continue
+
+        boundary_start_idx = min(boundary_start_idx, len(timestamps) - 1)
+        boundary_end_idx = min(boundary_end_idx, len(timestamps) - 1)
 
         # Compute deltas
         sum_delta = sums[boundary_end_idx] - sums[boundary_start_idx]
@@ -706,7 +714,7 @@ def _compute_histogram_stats(
                         are not computed.
 
     Returns:
-        HistogramSeriesStats with histogram statistics, or None if no data in range
+        HistogramSeries with histogram statistics, or None if no data in range
     """
     # Return None if time series is empty
     if len(time_series) == 0:

--- a/src/aiperf/server_metrics/parquet_exporter.py
+++ b/src/aiperf/server_metrics/parquet_exporter.py
@@ -141,7 +141,7 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
             FileExportInfo with export type and file path
 
         Raises:
-            ImportError: If pyarrow is not installed (handled gracefully with warning)
+            RuntimeError: If the file was not created or fails post-write validation
         """
         self.debug("Discovering label keys...")
         all_label_keys = self._discover_all_label_keys()
@@ -483,59 +483,6 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
                     )
                     yield from rows
 
-    def _collect_all_rows(
-        self,
-        label_keys: set[str],
-    ) -> list[dict]:
-        """Collect all rows from all endpoints and metrics with delta calculations.
-
-        Uses normalized schema where histogram buckets are separate rows rather than
-        separate columns. This produces smaller files and better SQL ergonomics.
-
-        Uses self._time_filter for time range filtering.
-
-        Args:
-            label_keys: Set of all label keys for column population
-
-        Returns:
-            List of row dictionaries ready for PyArrow table creation
-        """
-        rows = []
-        hierarchy = self._accumulator.get_hierarchy_for_export()
-        for (
-            endpoint_url,
-            time_series_collection,
-        ) in hierarchy.endpoints.items():
-            for metric_key, metric_entry in time_series_collection.metrics.items():
-                metric_type = metric_entry.metric_type
-                labels_dict = metric_key.labels_dict
-
-                if metric_type in (
-                    PrometheusMetricType.GAUGE,
-                    PrometheusMetricType.COUNTER,
-                    PrometheusMetricType.UNKNOWN,
-                ):
-                    rows.extend(
-                        self._collect_scalar_rows(
-                            endpoint_url,
-                            metric_key.name,
-                            metric_entry,
-                            labels_dict,
-                            label_keys,
-                        )
-                    )
-                elif metric_type == PrometheusMetricType.HISTOGRAM:
-                    rows.extend(
-                        self._collect_histogram_rows(
-                            endpoint_url,
-                            metric_key.name,
-                            metric_entry,
-                            labels_dict,
-                            label_keys,
-                        )
-                    )
-        return rows
-
     def _collect_scalar_rows(
         self,
         endpoint: str,
@@ -683,10 +630,18 @@ class ServerMetricsParquetExporter(AIPerfLoggerMixin):
             )
             if final_idx is None:
                 return []
-            # Find first index in filter range
-            first_idx = np.searchsorted(
-                time_series.timestamps, self._time_filter.start_ns, side="left"
-            )
+            # Find first index in filter range. A None start bound means "from the
+            # beginning of collection", matching ScalarTimeSeries.get_time_mask.
+            if self._time_filter.start_ns is None:
+                first_idx = 0
+            else:
+                first_idx = int(
+                    np.searchsorted(
+                        time_series.timestamps,
+                        self._time_filter.start_ns,
+                        side="left",
+                    )
+                )
         else:
             reference_idx = None
             first_idx = 0

--- a/src/aiperf/ui/dashboard/realtime_telemetry_dashboard.py
+++ b/src/aiperf/ui/dashboard/realtime_telemetry_dashboard.py
@@ -302,10 +302,17 @@ class RealtimeTelemetryDashboard(Container, MaximizableWidget):
             status_widget = self.query_one("#telemetry-status")
             status_widget.update(message)
             status_widget.remove_class("hidden")
-            self.all_nodes_view.add_class("hidden")
+            if self.all_nodes_view is not None:
+                self.all_nodes_view.add_class("hidden")
 
     def on_realtime_telemetry_metrics(self, metrics: list[MetricResult]) -> None:
         """Handle GPU telemetry metrics updates."""
+
+        if self.all_nodes_view is None:
+            # Metrics can arrive before compose() runs (or after teardown); the
+            # view is created in compose, so there is nothing to update yet.
+            self.metrics = metrics
+            return
 
         if not self.metrics:
             with suppress(Exception):

--- a/src/aiperf/zmq/sub_client.py
+++ b/src/aiperf/zmq/sub_client.py
@@ -173,6 +173,17 @@ class ZMQSubClient(BaseZMQClient):
 
         # strip the final TOPIC_END chars from the topic
         topic = topic_bytes.decode()[:-TOPIC_END_LENGTH]
+
+        # A well-formed SUB envelope is [topic, payload]. A topic-only frame
+        # (no payload part, or an empty one) is malformed; drop it explicitly
+        # instead of handing b"" to the JSON decoder, which would only surface
+        # as an opaque zero-length-document parse error.
+        if not message_bytes:
+            self.warning(
+                f"Dropping malformed message with empty payload on topic '{topic}'"
+            )
+            return
+
         self.trace(
             lambda: f"Received message from topic: '{topic}', message: {message_bytes}"
         )

--- a/tests/unit/cli_runner/test_multi_run_operator_message.py
+++ b/tests/unit/cli_runner/test_multi_run_operator_message.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The operator-mode sweep rejection message points at documentation that exists."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from aiperf.cli_runner._multi_run import _reject_in_process_sweep_under_operator
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_reject_in_process_sweep_under_operator_references_existing_docs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every docs/ path named in the operator rejection message resolves on disk."""
+    monkeypatch.setenv("AIPERF_OPERATOR_MANAGED", "1")
+    plan = Mock()
+    plan.is_sweep = True
+    plan.configs = [Mock(), Mock()]
+    variation = Mock()
+    variation.values = {"concurrency": 1}
+    plan.variations = [variation]
+
+    with pytest.raises(SystemExit) as exc_info:
+        _reject_in_process_sweep_under_operator(plan)
+
+    referenced = re.findall(r"docs/[\w./-]+\.md", str(exc_info.value))
+    assert referenced, "message should point at documentation"
+    for rel_path in referenced:
+        assert (_REPO_ROOT / rel_path).is_file(), f"missing doc: {rel_path}"

--- a/tests/unit/cli_runner/test_process_setup_platform.py
+++ b/tests/unit/cli_runner/test_process_setup_platform.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Platform-conditional bootstrap branches read the shared IS_MACOS constant."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from pytest import param
+
+from aiperf.cli_runner._process_setup import _setup_ui_queues
+
+
+@pytest.mark.parametrize(
+    "is_macos,expect_cloexec",
+    [
+        param(True, True, id="macos"),
+        param(False, False, id="not_macos"),
+    ],
+)  # fmt: skip
+def test_setup_ui_queues_dashboard_branches_on_is_macos_constant(
+    is_macos: bool, expect_cloexec: bool
+) -> None:
+    """The FD_CLOEXEC mitigation is driven by aiperf.common.constants.IS_MACOS."""
+    with (
+        patch("aiperf.common.constants.IS_MACOS", is_macos),
+        patch(
+            "aiperf.cli_runner._process_setup._set_fd_cloexec_on_terminal"
+        ) as mock_cloexec,
+        patch("aiperf.common.logging.get_global_log_queue", return_value=Mock()),
+    ):
+        _setup_ui_queues(using_dashboard=True, run=Mock(), logger=Mock())
+
+    assert mock_cloexec.called is expect_cloexec

--- a/tests/unit/common/test_docstring_audit_bugs.py
+++ b/tests/unit/common/test_docstring_audit_bugs.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for bugs found during a docstring audit of `aiperf.common`."""
+
+import asyncio
+import logging
+import time
+
+import pytest
+from pytest import param
+
+from aiperf.common.aiperf_logger import AIPerfLogger
+from aiperf.common.enums import PrometheusMetricType
+from aiperf.common.mixins.task_manager_mixin import TaskManagerMixin
+from aiperf.common.models.server_metrics_models import (
+    MetricFamily,
+    MetricSample,
+    ServerMetricsRecord,
+)
+from aiperf.common.models.telemetry_models import (
+    TelemetryHierarchy,
+    TelemetryMetrics,
+    TelemetryRecord,
+)
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        param("TRACE", logging.DEBUG - 5, id="trace"),
+        param("DEBUG", logging.DEBUG, id="debug"),
+        param("INFO", logging.INFO, id="info"),
+        param("NOTICE", logging.WARNING - 5, id="notice"),
+        param("WARNING", logging.WARNING, id="warning"),
+        param("SUCCESS", logging.WARNING + 5, id="success"),
+        param("ERROR", logging.ERROR, id="error"),
+        param("CRITICAL", logging.CRITICAL, id="critical"),
+        param("debug", logging.DEBUG, id="lowercase"),
+        param("Notice", logging.WARNING - 5, id="mixed-case"),
+    ],
+)  # fmt: skip
+def test_get_level_number_string_level_returns_numeric_level(
+    name: str, expected: int
+) -> None:
+    assert AIPerfLogger.get_level_number(name) == expected
+
+
+def test_get_level_number_int_level_returns_unchanged() -> None:
+    assert AIPerfLogger.get_level_number(logging.INFO) == logging.INFO
+
+
+def test_get_level_number_unknown_name_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        AIPerfLogger.get_level_number("NOT_A_LEVEL")
+
+
+def _record(latency_ns: int | None) -> ServerMetricsRecord:
+    return ServerMetricsRecord(
+        endpoint_url="http://localhost:8081/metrics",
+        timestamp_ns=1,
+        endpoint_latency_ns=latency_ns,
+        metrics={
+            "foo": MetricFamily(
+                type=PrometheusMetricType.GAUGE,
+                description="d",
+                samples=[MetricSample(value=1.0)],
+            )
+        },
+    )
+
+
+def test_to_slim_missing_endpoint_latency_preserves_none() -> None:
+    slim = _record(None).to_slim()
+    assert slim.endpoint_latency_ns is None
+
+
+def test_to_slim_with_endpoint_latency_preserves_value() -> None:
+    assert _record(1234).to_slim().endpoint_latency_ns == 1234
+
+
+def test_add_record_preserves_pci_bus_id_and_device() -> None:
+    hierarchy = TelemetryHierarchy()
+    hierarchy.add_record(
+        TelemetryRecord(
+            gpu_index=0,
+            gpu_uuid="GPU-abc",
+            gpu_model_name="NVIDIA H100",
+            pci_bus_id="00000000:02:00.0",
+            device="nvidia0",
+            timestamp_ns=1,
+            telemetry_source_url="http://node1:9401/metrics",
+            telemetry_data=TelemetryMetrics(),
+        )
+    )
+    metadata = hierarchy.telemetry_source_endpoints["http://node1:9401/metrics"][
+        "GPU-abc"
+    ].metadata
+    assert metadata.pci_bus_id == "00000000:02:00.0"
+    assert metadata.device == "nvidia0"
+
+
+class _TaskManager(TaskManagerMixin):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_tasks_awaits_task_cleanup() -> None:
+    manager = _TaskManager()
+    cleaned_up = asyncio.Event()
+
+    async def _long_running() -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            cleaned_up.set()
+            raise
+
+    task = manager.execute_async(_long_running())
+    await asyncio.sleep(0)
+
+    await manager.cancel_all_tasks(timeout=5.0)
+
+    assert cleaned_up.is_set()
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_tasks_uncancellable_task_returns_within_timeout() -> None:
+    manager = _TaskManager()
+
+    async def _uncancellable() -> None:
+        # to_thread cannot be interrupted by cancellation until the thread returns.
+        await asyncio.to_thread(time.sleep, 0.5)
+
+    manager.execute_async(_uncancellable())
+    await asyncio.sleep(0)
+
+    await asyncio.wait_for(manager.cancel_all_tasks(timeout=0.05), timeout=5.0)
+
+
+def test_cancel_all_tasks_no_tasks_returns_immediately() -> None:
+    manager = _TaskManager()
+    asyncio.run(manager.cancel_all_tasks(timeout=0.01))

--- a/tests/unit/dataset/composer/test_custom_composer.py
+++ b/tests/unit/dataset/composer/test_custom_composer.py
@@ -561,3 +561,33 @@ class TestExplicitCustomDatasetType:
             run=make_run(cli_config), tokenizer=mock_tokenizer
         )
         assert composer._explicit_format() is None
+
+
+class TestInferDatasetTypeEmptyFile:
+    """Blank/empty input files must fail with a clear error, not return None."""
+
+    def test_infer_dataset_type_blank_only_file_raises_value_error(
+        self, custom_config, mock_tokenizer, tmp_path
+    ):
+        """A file containing only blank lines has no inferable dataset type."""
+        blank_file = tmp_path / "blank.jsonl"
+        blank_file.write_text("\n   \n\n")
+        composer = CustomDatasetComposer(
+            run=make_run(custom_config), tokenizer=mock_tokenizer
+        )
+
+        with pytest.raises(ValueError, match="no non-empty lines"):
+            composer._infer_dataset_type(str(blank_file))
+
+    def test_infer_dataset_type_empty_file_raises_value_error(
+        self, custom_config, mock_tokenizer, tmp_path
+    ):
+        """A zero-byte file has no inferable dataset type."""
+        empty_file = tmp_path / "empty.jsonl"
+        empty_file.write_text("")
+        composer = CustomDatasetComposer(
+            run=make_run(custom_config), tokenizer=mock_tokenizer
+        )
+
+        with pytest.raises(ValueError, match="no non-empty lines"):
+            composer._infer_dataset_type(str(empty_file))

--- a/tests/unit/dataset/composer/test_synthetic_rankings_composer.py
+++ b/tests/unit/dataset/composer/test_synthetic_rankings_composer.py
@@ -107,3 +107,31 @@ def test_rankings_specific_token_options(synthetic_config, mock_tokenizer):
         # Query and passages should have content
         assert len(query.contents) == 1
         assert len(passages.contents) >= 1
+
+
+def test_create_dataset_with_shared_system_prompt_injects_system_message(
+    synthetic_config, mock_tokenizer
+):
+    """Rankings conversations must receive the configured shared system prompt."""
+    synthetic_config.prompt_prefix_shared_system_length = 20
+    composer = SyntheticRankingsDatasetComposer(
+        run=make_run(synthetic_config), tokenizer=mock_tokenizer
+    )
+
+    dataset = composer.create_dataset()
+
+    assert all(conv.system_message for conv in dataset)
+
+
+def test_create_dataset_with_user_context_injects_user_context_message(
+    synthetic_config, mock_tokenizer
+):
+    """Rankings conversations must receive per-session user context prompts."""
+    synthetic_config.prompt_prefix_user_context_length = 20
+    composer = SyntheticRankingsDatasetComposer(
+        run=make_run(synthetic_config), tokenizer=mock_tokenizer
+    )
+
+    dataset = composer.create_dataset()
+
+    assert all(conv.user_context_message for conv in dataset)

--- a/tests/unit/dataset/generator/test_audio_generator.py
+++ b/tests/unit/dataset/generator/test_audio_generator.py
@@ -286,3 +286,16 @@ class TestSoundfileGuard:
         monkeypatch.setitem(sys.modules, "soundfile", None)
         with pytest.raises(ConfigurationError, match="libsndfile"):
             import_soundfile()
+
+
+class TestUnsupportedFormat:
+    """Tests for the unsupported-audio-format guard in ``generate``."""
+
+    def test_generate_unsupported_format_raises_configuration_error(self):
+        """A format that is neither MP3 nor WAV must raise ConfigurationError."""
+        config = make_config(mean=0.1, stddev=0.0)
+        generator = AudioGenerator(config)
+        object.__setattr__(generator.config, "format", "flac")
+
+        with pytest.raises(ConfigurationError, match="flac"):
+            generator.generate()

--- a/tests/unit/dataset/generator/test_prompt_generator.py
+++ b/tests/unit/dataset/generator/test_prompt_generator.py
@@ -446,6 +446,40 @@ class TestPromptGeneratorComprehensive:
         assert "longer than the corpus" in str(mock_warning.call_args)
         assert len(tokens) == corpus_size * 2
 
+    @patch("aiperf.common.mixins.aiperf_logger_mixin.AIPerfLoggerMixin.warning")
+    def test_sample_tokens_longer_than_corpus_warns_about_wraparound(
+        self, mock_warning, basic_config
+    ):
+        """The warning must describe wraparound, not a truncation that never happens."""
+        tokenizer, prompts, prefix_prompts = basic_config
+        generator = _make_generator(
+            tokenizer, prompts=prompts, prefix_prompts=prefix_prompts
+        )
+        corpus_size = generator._corpus_size
+
+        with patch.object(generator._corpus_rng, "randrange", return_value=0):
+            tokens = generator._sample_tokens(corpus_size * 2)
+
+        message = str(mock_warning.call_args)
+        assert len(tokens) == corpus_size * 2
+        assert "Returning a prompt of length" not in message
+        assert "wrap" in message.lower()
+
+    def test_sample_tokens_multiple_corpus_lengths_returns_exact_count(
+        self, basic_config
+    ):
+        """Requests beyond twice the corpus size must still wrap to the full length."""
+        tokenizer, prompts, prefix_prompts = basic_config
+        generator = _make_generator(
+            tokenizer, prompts=prompts, prefix_prompts=prefix_prompts
+        )
+        corpus_size = generator._corpus_size
+
+        with patch.object(generator._corpus_rng, "randrange", return_value=0):
+            tokens = generator._sample_tokens(corpus_size * 3 + 7)
+
+        assert len(tokens) == corpus_size * 3 + 7
+
     def test_sample_tokens_empty_corpus(self, basic_config):
         """Test _sample_tokens with empty corpus."""
         tokenizer, prompts, prefix_prompts = basic_config

--- a/tests/unit/dataset/loader/test_can_load.py
+++ b/tests/unit/dataset/loader/test_can_load.py
@@ -405,12 +405,11 @@ class TestCustomDatasetComposerInferDatasetType:
     def test_infer_from_file_empty(
         self, create_cfg_and_composer, create_jsonl_file, content
     ):
-        """Test that empty files return None (no valid lines to infer from)."""
+        """Test that empty files raise a clear error (no valid lines to infer from)."""
         _, composer = create_cfg_and_composer()
         filepath = create_jsonl_file(content)
-        # Empty files have no valid lines, so the method exits the loop without calling _infer_type
-        result = composer._infer_dataset_type(filepath)
-        assert result is None
+        with pytest.raises(ValueError, match="no non-empty lines"):
+            composer._infer_dataset_type(filepath)
 
     def test_infer_from_file_invalid_json(
         self, create_cfg_and_composer, create_jsonl_file

--- a/tests/unit/dataset/loader/test_sagemaker_data_capture.py
+++ b/tests/unit/dataset/loader/test_sagemaker_data_capture.py
@@ -887,3 +887,37 @@ class TestMaxOslCapApplied:
         osls = [t.output_length for traces in data.values() for t in traces]
         assert osls == [30]
         assert loader._capped_max_osl == 0
+
+
+class TestLoadDatasetResetsPerLoadState:
+    """The load_dataset override must reset per-load state like the base class."""
+
+    def _make_loader(self, tmp_path: Path) -> SageMakerDataCaptureLoader:
+        capture_file = tmp_path / "capture.jsonl"
+        capture_file.write_text(_make_capture_record() + "\n")
+        config = CLIConfig(model_names=["test-model"])
+        return SageMakerDataCaptureLoader(
+            filename=str(capture_file),
+            run=make_run_from_cli(config),
+            prompt_generator=MagicMock(),
+        )
+
+    def test_load_dataset_resets_delay_cap_tracker(self, tmp_path: Path) -> None:
+        """Stale delay-cap counters from a prior load must not leak forward."""
+        loader = self._make_loader(tmp_path)
+        loader._delay_cap_tracker.capped_count = 7
+        loader._delay_cap_tracker.max_observed_ms = 12345.0
+
+        loader.load_dataset()
+
+        assert loader._delay_cap_tracker.capped_count == 0
+        assert loader._delay_cap_tracker.max_observed_ms == 0.0
+
+    def test_load_dataset_initializes_trace_scope(self, tmp_path: Path) -> None:
+        """The per-file trace_id scope must be established on every load."""
+        loader = self._make_loader(tmp_path)
+
+        loader.load_dataset()
+
+        assert loader._trace_id is not None
+        loader.prompt_generator._cache.clear.assert_called_once()

--- a/tests/unit/endpoints/test_huggingface_generate.py
+++ b/tests/unit/endpoints/test_huggingface_generate.py
@@ -105,21 +105,65 @@ class TestHuggingFaceGenerateEndpoint:
         assert "vendor_x" not in payload["parameters"]
         assert "stream" not in payload["parameters"]
 
-    def test_parse_response_streaming_calls_streaming(self, endpoint):
+    @pytest.mark.parametrize("global_streaming", [True, False])  # fmt: skip
+    def test_parse_response_stream_event_shape_calls_streaming(
+        self, endpoint, global_streaming
+    ):
+        """A TGI stream event dispatches to the streaming parser regardless of
+        the global `endpoint.streaming` flag (per-request wire mode wins)."""
         response = Mock(spec=InferenceServerResponse)
-        endpoint.model_endpoint.endpoint.streaming = True
+        response.get_json.return_value = {"token": {"text": "hi"}}
+        endpoint.model_endpoint.endpoint.streaming = global_streaming
         endpoint._parse_streaming = Mock(return_value="stream_result")
         result = endpoint.parse_response(response)
         assert result == "stream_result"
         endpoint._parse_streaming.assert_called_once_with(response)
 
-    def test_parse_response_non_streaming_calls_non_streaming(self, endpoint):
+    @pytest.mark.parametrize("global_streaming", [True, False])  # fmt: skip
+    def test_parse_response_full_body_shape_calls_non_streaming(
+        self, endpoint, global_streaming
+    ):
+        """A full TGI /generate body dispatches to the non-streaming parser
+        regardless of the global `endpoint.streaming` flag."""
         response = Mock(spec=InferenceServerResponse)
-        endpoint.model_endpoint.endpoint.streaming = False
+        response.get_json.return_value = {"generated_text": "done"}
+        endpoint.model_endpoint.endpoint.streaming = global_streaming
         endpoint._parse_non_streaming = Mock(return_value="non_stream_result")
         result = endpoint.parse_response(response)
         assert result == "non_stream_result"
         endpoint._parse_non_streaming.assert_called_once_with(response)
+
+    def test_parse_response_stream_override_non_streaming_global_parses_token(
+        self, endpoint
+    ):
+        """End-to-end: a streamed event parsed while the global setting says
+        non-streaming still yields the incremental token text."""
+        response = Mock(spec=InferenceServerResponse)
+        response.get_json.return_value = {"token": {"text": "hi there"}}
+        response.perf_ns = 42
+        endpoint.model_endpoint.endpoint.streaming = False
+
+        result = endpoint.parse_response(response)
+
+        assert isinstance(result, ParsedResponse)
+        endpoint.make_text_response_data.assert_called_once_with("hi there")
+
+    def test_parse_response_list_body_calls_non_streaming(self, endpoint):
+        """TGI /generate may return a single-element list body."""
+        response = Mock(spec=InferenceServerResponse)
+        response.get_json.return_value = [{"generated_text": "ok"}]
+        response.perf_ns = 7
+        endpoint.model_endpoint.endpoint.streaming = True
+
+        result = endpoint.parse_response(response)
+
+        assert isinstance(result, ParsedResponse)
+        endpoint.make_text_response_data.assert_called_once_with("ok")
+
+    def test_parse_response_empty_json_returns_none(self, endpoint):
+        response = Mock(spec=InferenceServerResponse)
+        response.get_json.return_value = None
+        assert endpoint.parse_response(response) is None
 
     def test_parse_non_streaming_with_list(self, endpoint):
         response = Mock(spec=InferenceServerResponse)

--- a/tests/unit/endpoints/test_solido_rag.py
+++ b/tests/unit/endpoints/test_solido_rag.py
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+from typing import get_type_hints
+
 import pytest
 
-from aiperf.common.models import Text, Turn
+from aiperf.common.models import RAGSources, Text, Turn
 from aiperf.common.models.record_models import (
     TextResponseData,
 )
@@ -294,6 +297,22 @@ class TestSolidoEndpointParseResponse:
         parsed = endpoint.parse_response(mock_response)
 
         assert parsed is None
+
+    def test_extract_solido_response_data_missing_content_returns_none_pair(
+        self, endpoint
+    ):
+        """The extractor's documented no-content path yields ``(None, None)``,
+        which the declared return type must admit."""
+        data, sources = endpoint._extract_solido_response_data({"message": "nope"})
+
+        assert data is None
+        assert sources is None
+
+        hints = get_type_hints(
+            type(endpoint)._extract_solido_response_data,
+            vars(sys.modules[type(endpoint).__module__]),
+        )
+        assert hints["return"] == tuple[TextResponseData | None, RAGSources | None]
 
     @pytest.mark.parametrize(
         "content",

--- a/tests/unit/gpu_telemetry/test_metrics_config.py
+++ b/tests/unit/gpu_telemetry/test_metrics_config.py
@@ -454,3 +454,56 @@ DCGM_FI_DEV_GPU_UTIL, invalid_type, Should be skipped
             assert new_dcgm_mappings == {}
         finally:
             csv_path.unlink()
+
+    def test_build_custom_metrics_from_csv_colliding_internal_names_dedupes(self):
+        """Two custom DCGM fields whose derived internal_name collides must not
+        both be emitted as metrics — the second one is skipped."""
+        csv_content = """DCGM_FI_DEV_CUSTOM_THING, gauge, Custom Thing (in W)
+DCGM_FI_PROF_CUSTOM_THING, gauge, Custom Thing Prof (in W)
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(csv_content)
+            csv_path = Path(f.name)
+
+        try:
+            loader = MetricsConfigLoader()
+            custom_metrics, new_dcgm_mappings = loader.build_custom_metrics_from_csv(
+                custom_csv_path=csv_path
+            )
+
+            internal_names = [m[1] for m in custom_metrics]
+            assert internal_names == ["nvidia_custom_thing"]
+            assert len(internal_names) == len(set(internal_names))
+            assert new_dcgm_mappings == {
+                "DCGM_FI_DEV_CUSTOM_THING": "nvidia_custom_thing"
+            }
+        finally:
+            csv_path.unlink()
+
+    def test_build_custom_metrics_from_csv_collision_with_default_internal_name_skipped(
+        self,
+    ):
+        """A custom field deriving an internal_name already present in the default
+        config must be skipped even though its DCGM field name is new."""
+        default_internal = GPU_TELEMETRY_METRICS_CONFIG[0][1]
+        assert default_internal.startswith("nvidia_")
+        suffix = default_internal.removeprefix("nvidia_").upper()
+        csv_content = f"DCGM_FI_PROF_{suffix}, gauge, Colliding Metric (in W)\n"
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(csv_content)
+            csv_path = Path(f.name)
+
+        try:
+            loader = MetricsConfigLoader()
+            custom_metrics, new_dcgm_mappings = loader.build_custom_metrics_from_csv(
+                custom_csv_path=csv_path
+            )
+            assert custom_metrics == []
+            assert new_dcgm_mappings == {}
+        finally:
+            csv_path.unlink()

--- a/tests/unit/network_latency/test_manager.py
+++ b/tests/unit/network_latency/test_manager.py
@@ -494,3 +494,25 @@ class TestSampleAndErrorCallbacks:
         error = ErrorDetails.from_exception(ConnectionRefusedError("refused"))
         # Must not raise.
         await manager._on_network_latency_error(error, "localhost:8000")
+
+
+class TestNetworkLatencyManagerDelayedShutdown:
+    """The delayed-shutdown grace period must be owned by this subsystem."""
+
+    @pytest.mark.asyncio
+    async def test_delayed_shutdown_uses_network_latency_shutdown_delay(
+        self, cfg_automatic: CLIConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`_delayed_shutdown` must sleep on AIPERF_NETWORK_LATENCY_SHUTDOWN_DELAY,
+        not on the unrelated server-metrics knob."""
+        monkeypatch.setattr(Environment.NETWORK_LATENCY, "SHUTDOWN_DELAY", 1.5)
+        monkeypatch.setattr(Environment.SERVER_METRICS, "SHUTDOWN_DELAY", 42.0)
+
+        manager = _make_manager(cfg_automatic)
+        manager.stop = AsyncMock()
+
+        sleep_mock = AsyncMock()
+        with patch("aiperf.network_latency.manager.asyncio.sleep", sleep_mock):
+            await manager._delayed_shutdown()
+
+        sleep_mock.assert_awaited_once_with(1.5)

--- a/tests/unit/plugin/test_orchestrator_categories.py
+++ b/tests/unit/plugin/test_orchestrator_categories.py
@@ -107,3 +107,39 @@ def test_search_planner_metadata_via_generic_helper():
     md = get_typed_metadata(PluginType.SEARCH_PLANNER, "bayesian")
     assert isinstance(md, SearchPlannerMetadata)
     assert md.compatible_objective_directions == ["maximize", "minimize"]
+
+
+def _categories_declaring_metadata_class() -> list[str]:
+    """Categories whose categories.yaml entry declares a metadata_class.
+
+    Derived from the registry rather than hardcoded so the test covers every
+    declaring category automatically, including ones added later.
+    """
+    return sorted(
+        category
+        for category in plugins.list_categories()
+        if (plugins.get_category_metadata(category) or {}).get("metadata_class")
+    )
+
+
+def test_get_typed_metadata_all_declared_categories_returns_typed_object() -> None:
+    """Every category declaring metadata_class in categories.yaml gets a typed object.
+
+    Guards against the mapping used by `get_typed_metadata` drifting behind
+    categories.yaml, which silently degrades those categories to raw dicts.
+    """
+    declaring = _categories_declaring_metadata_class()
+    assert declaring, "no categories declare metadata_class"
+
+    untyped: list[str] = []
+    for category in declaring:
+        names = [e.name for e in plugins.list_entries(category)]
+        if not names:
+            continue
+        md = get_typed_metadata(category, names[0])
+        if isinstance(md, dict):
+            untyped.append(f"{category}:{names[0]}")
+
+    assert not untyped, (
+        f"categories returned raw dicts instead of typed metadata: {untyped}"
+    )

--- a/tests/unit/server_metrics/test_parquet_exporter.py
+++ b/tests/unit/server_metrics/test_parquet_exporter.py
@@ -1446,3 +1446,32 @@ class TestHistogramWindowGuards:
         )
 
         assert rows == []
+
+
+class TestCollectHistogramRowsOpenStartFilter:
+    """Histogram row collection must tolerate a filter with only ``end_ns`` set,
+    matching the scalar ``get_time_mask`` path's None-bound semantics."""
+
+    def test_collect_histogram_rows_open_start_filter_includes_all_rows_up_to_end(
+        self, mock_cfg: BenchmarkRun
+    ) -> None:
+        hist_ts = build_histogram_time_series(
+            timestamps_ns=[1_000_000_000, 2_000_000_000, 3_000_000_000],
+            sums=[10.0, 20.0, 30.0],
+            counts=[1.0, 2.0, 3.0],
+            bucket_les=("1.0", "+Inf"),
+            bucket_counts=[[1.0, 1.0], [1.0, 2.0], [2.0, 3.0]],
+        )
+        entry = build_metric_entry(PrometheusMetricType.HISTOGRAM, hist_ts)
+        hierarchy = build_hierarchy({"http://test": [("latency", None, entry)]})
+        mock_accumulator = create_mock_accumulator(mock_cfg, hierarchy)
+
+        time_filter = TimeRangeFilter(start_ns=None, end_ns=2_000_000_000)
+        exporter = ServerMetricsParquetExporter(mock_accumulator, time_filter)
+
+        rows = exporter._collect_histogram_rows(
+            "http://test", "latency", entry, {}, set()
+        )
+
+        timestamps = sorted({row["timestamp_ns"] for row in rows})
+        assert timestamps == [1_000_000_000, 2_000_000_000]

--- a/tests/unit/server_metrics/test_timeslices.py
+++ b/tests/unit/server_metrics/test_timeslices.py
@@ -1187,3 +1187,34 @@ class TestOutOfOrderDataHandling:
         assert result.stats.avg == pytest.approx(5.5)
         assert result.stats.min == 1.0
         assert result.stats.max == 10.0
+
+
+class TestHistogramTimeslicesBeforeFirstSample:
+    """Timeslices lying entirely before the first sample have no baseline and must
+    not be emitted as fabricated zero-delta slices."""
+
+    def test_histogram_timeslices_slices_before_first_sample_are_skipped(self):
+        ts = ServerMetricsTimeSeries()
+        # First sample lands at t=3s; the filter starts at t=0.
+        add_histogram_snapshots(
+            ts,
+            "latency",
+            [
+                (3 * NANOS_PER_SECOND, hist({"1.0": 1.0, "+Inf": 2.0}, 20.0, 2.0)),
+                (4 * NANOS_PER_SECOND, hist({"1.0": 2.0, "+Inf": 4.0}, 40.0, 4.0)),
+                (5 * NANOS_PER_SECOND, hist({"1.0": 3.0, "+Inf": 6.0}, 60.0, 6.0)),
+            ],
+        )
+
+        slices = _compute_histogram_timeslices(
+            get_histogram(ts, "latency"),
+            slice_duration=1.0,
+            time_filter=make_time_filter(start_ns=0, end_ns=5 * NANOS_PER_SECOND),
+        )
+
+        assert slices is not None
+        # [0-1), [1-2), [2-3) all end before the first sample at t=3s.
+        assert all(s.start_ns >= 3 * NANOS_PER_SECOND for s in slices), (
+            f"Slices before first sample were emitted: "
+            f"{[(s.start_ns, s.count) for s in slices]}"
+        )

--- a/tests/unit/ui/test_realtime_telemetry_dashboard.py
+++ b/tests/unit/ui/test_realtime_telemetry_dashboard.py
@@ -648,3 +648,16 @@ class TestRealtimeTelemetryDashboard:
 
         assert dashboard.metrics == metrics
         mock_all_nodes.update.assert_called_once_with(metrics)
+
+
+class TestRealtimeTelemetryDashboardBeforeMount:
+    """Metrics can arrive before compose() creates the node view."""
+
+    def test_on_realtime_telemetry_metrics_before_compose_does_not_raise(self):
+        """A metrics message before mount is a no-op rather than an AttributeError."""
+        dashboard = RealtimeTelemetryDashboard(run=Mock())
+        assert dashboard.all_nodes_view is None
+
+        dashboard.on_realtime_telemetry_metrics([])
+
+        assert dashboard.metrics == []

--- a/tests/unit/zmq/test_sub_client.py
+++ b/tests/unit/zmq/test_sub_client.py
@@ -193,6 +193,21 @@ class TestZMQSubClientMessageHandling:
         assert received_messages[0].message_type == sample_message.message_type
 
     @pytest.mark.asyncio
+    async def test_handle_message_empty_payload_is_dropped(
+        self, mock_zmq_context, sample_message, create_callback_tracker
+    ):
+        """A topic-only SUB frame is dropped, not fed to the JSON decoder."""
+        client = ZMQSubClient(address="tcp://127.0.0.1:5555", bind=False)
+
+        callback, _, received_messages = create_callback_tracker()
+        client._subscribers[sample_message.message_type] = [callback]
+        topic_bytes = f"{sample_message.message_type}{TOPIC_END}".encode()
+
+        await client._handle_message(topic_bytes, b"")
+
+        assert received_messages == []
+
+    @pytest.mark.asyncio
     async def test_handle_message_with_targeted_topic(self, mock_zmq_context):
         """Test handling messages with targeted topics (service_id/type)."""
         client = ZMQSubClient(address="tcp://127.0.0.1:5555", bind=False)


### PR DESCRIPTION
## Summary

A docstring audit surfaced places where a comment disagreed with the code because **the code was wrong**. This PR carries those fixes — 41 files, each defect reproduced with a failing test before being fixed.

Companion to #1242 (the comment-only half). The two touch no files in common and can merge in either order.

Reports that did **not** reproduce were left alone rather than "fixed" — several turned out to be intentional, and two would have caused regressions if changed (see below).

## Defects fixed

| Defect | Impact |
|---|---|
| `PromptGenerator` wraparound re-appended at most one corpus | Silently returned fewer than `num_tokens` whenever `num_tokens > 2 * corpus_size` |
| `huggingface_generate` dispatched on the global `endpoint.streaming` flag, not payload shape | Silently dropped a streamed token when a per-request stream override disagreed |
| `SlimRecord.endpoint_latency_ns` required a non-optional `int` | `to_slim()` raised `ValidationError` on a live path — `data_collector` passes `None` when no aiohttp trace timing exists |
| `get_level_number` did `getattr(cls, level.upper())` | Raised `AttributeError` for every string level name |
| Custom GPU telemetry fields colliding on a derived `internal_name` | Emitted duplicate metrics, including collisions with built-in defaults |
| Histogram timeslices starting before the first sample | Emitted with a fabricated zero baseline instead of being skipped |
| `network_latency` shutdown slept on `Environment.SERVER_METRICS.SHUTDOWN_DELAY` | Governed by an unrelated subsystem's env var; its own settings class had no such field |
| `get_typed_metadata`'s hand-maintained category mapping | Silently returned raw dicts for 5 categories; now derived from `categories.yaml` so it cannot drift again |
| `cancel_all_tasks` accepted a `timeout` it never used | Cancelled tasks were never awaited, so callers returned before cleanup ran |
| Operator-mode rejection message pointed at `docs/kubernetes/sweeps.md` | That path does not exist |

Also: rankings composer skipped `_finalize_conversations`; sagemaker loader skipped per-load state resets, reusing the previous file's `trace_id`; empty-file and unsupported-format paths returned `None` or raised `UnboundLocalError`; topic-only ZMQ frames fed an empty payload to the decoder; unguarded `all_nodes_view` dereference before mount; `platform.system()` replaced with `IS_MACOS` per project convention.

## Choices worth a reviewer's attention

- **`SlimRecord.endpoint_latency_ns` made optional** rather than defaulting to `0` in `to_slim()` — the sole consumer already guards `None`, and a synthetic zero would silently skew latency statistics.
- **Pre-first-sample timeslices are skipped, not zero-filled.** For a *sliced* series a fabricated zero is worse than an absent slice; `_compute_histogram_stats`' fallback exists because whole-range stats must return something.
- **`cancel_all_tasks` excludes the current task** from its wait set — it is called from inside managed tasks on the shutdown path, and awaiting self would deadlock. A genuinely uncancellable task is used in the test to prove the bounded return.
- **The rankings fix does not change the wire payload.** `base_rankings_endpoint.format_payload` reads only `query`/`passages`. This makes the `Conversation` objects and exported `inputs.json` consistent with every sibling composer; carrying a system prompt in a rankings *request* would need an endpoint-side change.
- **Two regression guards were added deliberately**: the plugin metadata test now enumerates declaring categories from the registry rather than a hardcoded list, and the operator-message test asserts every `docs/` path named in the message resolves on disk. Both catch the next instance of the bug they guard rather than the one instance found.

## Deliberately not changed

- Three socket-option constants in `http_defaults.py` are **dead**, not missing a `setsockopt` — `SO_LINGER` takes a `struct linger` (not an int), and `SO_REUSEADDR`/`SO_REUSEPORT` only affect `bind()` on a socket that is never bound. Adding the calls would change connection behavior at scale for no benefit.
- A `sticky_router` `pop()` ordering hazard is unreachable today (no `await` between selection and tracking, single-threaded asyncio) but is one refactor away from routing a credit to `None`. Flagged rather than changed on a hot path.

## Verification

- `uv run pytest tests/unit/ -n auto` → **17730 passed**, 0 failed
- `ruff check` / `ruff format --check` clean
- Generated CLI docs (15 commands, 585 params) and env-var docs (26 subsystems, 167 vars) in sync
- 35 plugin categories and 261 plugins validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable network-latency shutdown delay, defaulting to five seconds.
  - Synthetic ranking datasets now include configured context prompts.
  - Oversized prompt requests now generate the full requested token count.

- **Bug Fixes**
  - Improved Hugging Face response handling for streaming, full, and empty responses.
  - Prevented shutdown hangs, duplicate telemetry metrics, invalid histogram slices, and dashboard errors during startup.
  - Added clearer errors for empty datasets and unsupported audio formats.
  - Empty messages are safely ignored.

- **Documentation**
  - Updated environment-variable guidance and sweep instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->