### PR TITLE
test: validate fork runner rejection

### DIFF
--- a/.github/workflows/validate-fork-runner-rejection.yml
+++ b/.github/workflows/validate-fork-runner-rejection.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Validate fork runner rejection
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: prod-aiperf-default-v1
+    timeout-minutes: 1
+    steps:
+      - name: Print validation canary
+        run: echo "fork canary reached an AIPerf runner"


### PR DESCRIPTION
## Summary

- add a harmless one-minute workflow canary targeting this repository's Velonix runner
- grant no token permissions and avoid checkout, secrets, repository code, or infrastructure inspection
- validate that fork-authored pull request jobs are rejected by the runner admission policy

## Validation

- YAML syntax check passed
- `git diff --check` passed
- repository-configured pre-commit checks passed
- expected result: the job is rejected before the canary `echo` step executes

DO NOT MERGE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for pull requests using the designated build runner.
  * Added a short canary check to confirm the runner is reachable.
  * Configured the validation job with minimal permissions and a one-minute timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->