### PR TITLE
fix: always project recorded-outcome columns so fidelity survives load

### DIFF
--- a/src/aiperf/dataset/loader/baseten_trace.py
+++ b/src/aiperf/dataset/loader/baseten_trace.py
@@ -696,20 +696,28 @@ class BasetenTraceDatasetLoader(BaseTraceDatasetLoader[BasetenTrace]):
         )
 
     def _projected_trace_columns(self, session_key: str | None) -> list[str]:
-        """Return source columns needed by the configured replay behavior."""
+        """Return source columns needed by the configured replay behavior.
+
+        Recorded-outcome columns (durations, cached-token reference) are always
+        projected: they are ground truth that must survive load for later
+        fidelity comparison, independent of replay mode. They are small integer
+        columns, so keeping them costs negligibly against the projection's I/O
+        savings on the large prompt/hash columns.
+        """
         schema_names = self._source_schema_names()
         columns = {
             METADATA_COLUMNS_TIME,
             "prompt",
             "input_tokens",
             "output_tokens",
+            "duration_e2e_ms",
+            "duration_ttft_ms",
+            "cached_tokens_reference",
         }
         if session_key is not None:
             columns.add(session_key)
         if not self._omit_kv_hints:
             columns.update(("total_hashes", "block_size"))
-        if not self._open_loop:
-            columns.add("duration_e2e_ms")
         return sorted(columns & schema_names)
 
     def _iter_trace_rows(

--- a/tests/unit/dataset/loader/test_baseten_trace.py
+++ b/tests/unit/dataset/loader/test_baseten_trace.py
@@ -1011,6 +1011,7 @@ class TestBasetenTraceDatasetLoader:
                 {},
                 {
                     "block_size",
+                    "duration_e2e_ms",
                     "input_tokens",
                     "output_tokens",
                     "poor_man_session_id",
@@ -1023,6 +1024,7 @@ class TestBasetenTraceDatasetLoader:
             param(
                 {"omit_kv_hints": True},
                 {
+                    "duration_e2e_ms",
                     "input_tokens",
                     "output_tokens",
                     "poor_man_session_id",

--- a/tests/unit/dataset/loader/test_baseten_trace.py
+++ b/tests/unit/dataset/loader/test_baseten_trace.py
@@ -1011,7 +1011,9 @@ class TestBasetenTraceDatasetLoader:
                 {},
                 {
                     "block_size",
+                    "cached_tokens_reference",
                     "duration_e2e_ms",
+                    "duration_ttft_ms",
                     "input_tokens",
                     "output_tokens",
                     "poor_man_session_id",
@@ -1024,7 +1026,9 @@ class TestBasetenTraceDatasetLoader:
             param(
                 {"omit_kv_hints": True},
                 {
+                    "cached_tokens_reference",
                     "duration_e2e_ms",
+                    "duration_ttft_ms",
                     "input_tokens",
                     "output_tokens",
                     "poor_man_session_id",
@@ -1037,7 +1041,9 @@ class TestBasetenTraceDatasetLoader:
                 {"open_loop_replay": False},
                 {
                     "block_size",
+                    "cached_tokens_reference",
                     "duration_e2e_ms",
+                    "duration_ttft_ms",
                     "input_tokens",
                     "output_tokens",
                     "poor_man_session_id",
@@ -1072,6 +1078,8 @@ class TestBasetenTraceDatasetLoader:
                     "total_hashes": [1, 2],
                     "block_size": 64,
                     "duration_e2e_ms": 10,
+                    "duration_ttft_ms": 4,
+                    "cached_tokens_reference": 2,
                 }
                 for index in range(12)
             ],
@@ -1108,6 +1116,11 @@ class TestBasetenTraceDatasetLoader:
         assert all(not hasattr(trace, "model_name") for trace in traces)
         assert all(not hasattr(trace, "request_canceled") for trace in traces)
         assert all(not hasattr(trace, "dataset_version") for trace in traces)
+        # Recorded outcomes must survive load for later fidelity comparison,
+        # regardless of replay mode.
+        assert all(trace.duration_e2e_ms == 10 for trace in traces)
+        assert all(trace.duration_ttft_ms == 4 for trace in traces)
+        assert all(trace.cached_tokens_reference == 2 for trace in traces)
 
     @pytest.mark.parametrize(
         ("field", "invalid_value"),


### PR DESCRIPTION
## What

Main is red: `test_baseten_offline_suite.py::TestFidelityCarryThrough::test_recorded_outcomes_present` fails with `assert None == 800`. This restores the recorded-outcome fields so the fidelity test passes.

## Root cause

#1248 (speed up Baseten trace loading) added columnar projection that reads only the columns needed for replay. `_projected_trace_columns` projected `duration_e2e_ms` **only in closed-loop mode** and never projected `duration_ttft_ms` / `cached_tokens_reference` at all. But those are **recorded ground truth** that must survive load for later fidelity comparison (the #1129 faithful-replay contract), independent of replay mode. In open-loop they came back `None`.

Verified by reproduction: the test passes on the pre-#1248 loader and fails on the merged loader, in isolation (not a parallelism artifact).

Why it landed on main: the failing test lives in the unit suite, and on #1248's merged head the **Run Unit Tests** workflow never ran (its self-hosted build legs weren't executed for that commit) — only the GitHub-hosted integration-tests and pre-commit ran, both green. So the unit test was executed for the first time on main.

## Fix

`_projected_trace_columns` now always projects the recorded-outcome columns (`duration_e2e_ms`, `duration_ttft_ms`, `cached_tokens_reference`). They are small integer columns, so #1248's I/O win on the large prompt/hash columns is preserved — genuinely unused columns (`output_text`, `model_name`, `request_canceled`, `__version__`) are still skipped.

`test_load_dataset_validates_sample_and_skips_unused_columns` is updated: its `default` and `omit-kv-hints` (open-loop) cases now expect `duration_e2e_ms` in the projected set, since it is always projected. That test had codified the over-aggressive projection.

## Validation

- `test_recorded_outcomes_present` passes.
- Full Baseten loader suite: 65 passed.
- `tests/unit/dataset/`: 2785 passed, 5 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace data loading to consistently include available end-to-end duration, time-to-first-token, and cached-token metrics.
  * Ensured these performance metrics are preserved across replay configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->