### PR TITLE
docs: spell out Visual Studio Code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ You can use the `act` tool to run GitHub Actions locally. See [act usage](https:
 act -j run-integration-tests
 ```
 
-You can also use the VSCode extension [GitHub Local Actions](https://marketplace.visualstudio.com/items?itemName=SanjulaGanepola.github-local-actions).
+You can also use the Visual Studio Code extension [GitHub Local Actions](https://marketplace.visualstudio.com/items?itemName=SanjulaGanepola.github-local-actions).
 
 ## Developer Certificate of Origin
 


### PR DESCRIPTION
## What changed

Spell out “Visual Studio Code” in the contributing guide.

## Why

This intentionally small documentation-only change is a canary for the new `@ai-dynamo/aiperf-codeowners` review-assignment configuration. It should cause GitHub to request review from one team member.

## Impact

Documentation wording only; there is no runtime or user-facing behavior change.

## Validation

- `git diff --check`
- `uv run pre-commit run --files CONTRIBUTING.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution instructions to use the full “Visual Studio Code” extension name for GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->