### PR TITLE
fix(spec-decode): align vLLM adapter with #48915 review-updated wire format

### DIFF
--- a/docs/reference/spec-decode-acceptance.md
+++ b/docs/reference/spec-decode-acceptance.md
@@ -66,7 +66,7 @@ class SpecDecodeAdapterProtocol(Protocol):
 
 ```mermaid
 flowchart LR
-    R["Raw response<br/>choices[].speculative_decoding_stats"]
+    R["Raw response<br/>metrics.speculative_decoding"]
     P["ParsedResponse<br/>.spec_decode_stats (raw dict)"]
     A["Engine adapter<br/>(auto-detected)"]
     N["SpecDecodeAcceptanceRecord<br/>(engine-neutral)"]
@@ -76,22 +76,26 @@ flowchart LR
 
 ## The vLLM adapter
 
-`VLLMSpecDecodeAdapter` reads vLLM's per-choice `speculative_decoding_stats`
-object, emitted when the server runs with `--per-request-spec-decode-stats`
+`VLLMSpecDecodeAdapter` reads vLLM's response-root `metrics.speculative_decoding`
+object, emitted when the server runs with `--per-request-spec-decode-metrics`
 (`summary` or `detailed`). The field names and shape track vLLM PR
 [#48915](https://github.com/vllm-project/vllm/pull/48915); its *Per-Request
 Acceptance Metrics* feature doc is the authoritative wire-format reference. It is
 present on chat and completions, streaming and non-streaming; in streaming it
-rides the finish-reason chunk's choice, which AIPerf already parses, so no extra
-endpoint code is needed.
+rides the trailing `include_usage` chunk (empty `choices`) at the response root,
+which AIPerf already parses, so no extra endpoint code is needed.
 
 The wire object maps to the record one-to-one, except:
 
-- **Histogram keys are JSON strings** and are int-cast into the record.
-- **`completion_tokens`** comes from the response `usage`, not the payload. In
-  streaming that usage rides the trailing `include_usage` chunk, which AIPerf
-  auto-injects only when `endpoint.use_server_token_count` is enabled; otherwise
-  (or whenever the server omits usage) `completion_tokens` stays `None`.
+- **`acceptance_histogram` is a dense `list[int]`** -- index `j` holds the number
+  of verify steps that accepted exactly `j` draft tokens (length
+  `num_spec_tokens + 1`). AIPerf inflates it into the record's sparse
+  `{j: count}` map, dropping zero-count buckets.
+- **`completion_tokens`** is copied from the response `usage` (not the payload)
+  so the record trace carries it next to acceptance; no metric consumes it yet.
+  `None` when usage is absent -- in streaming, usage rides the trailing
+  `include_usage` chunk, which AIPerf auto-injects only when
+  `endpoint.use_server_token_count` is enabled.
 - **`num_draft_tokens`** is vLLM's post-adjustment count: drafts invalidated by
   structured-output/grammar constraints are already subtracted server-side.
 - **`num_spec_tokens`** is always present (the configured `num_speculative_tokens`);
@@ -112,10 +116,11 @@ The wire object maps to the record one-to-one, except:
   one bad response cannot abort a run. Records whose aggregate counts contradict
   each other (histogram not summing to `num_spec_steps`, etc.) are rejected the
   same way.
-- **`n > 1`**: when a request produces multiple sequences, each choice carries
-  its own per-sequence stats, but `completion_tokens` is request-level. Rather
-  than mix one sequence's acceptance with all sequences' token count, the record
-  is suppressed (`None`) for `n > 1`, mirroring how per-request timing metrics
-  are suppressed for multi-sequence requests.
+- **`n > 1`**: vLLM populates `metrics.speculative_decoding` only for
+  single-sequence requests, leaving it `null` for `n > 1` (mixing one sequence's
+  acceptance with request-level token counts would be misleading). Because the
+  object is at the response root -- not per-choice -- AIPerf simply reads it as
+  present or absent; no client-side suppression is needed, and an `n > 1` request
+  yields no record.
 - **Behind Dynamo** the custom field is currently stripped, so this path is
   direct-to-vLLM only.

--- a/docs/reference/spec-decode-acceptance.md
+++ b/docs/reference/spec-decode-acceptance.md
@@ -82,8 +82,16 @@ object, emitted when the server runs with `--per-request-spec-decode-metrics`
 [#48915](https://github.com/vllm-project/vllm/pull/48915); its *Per-Request
 Acceptance Metrics* feature doc is the authoritative wire-format reference. It is
 present on chat and completions, streaming and non-streaming; in streaming it
-rides the trailing `include_usage` chunk (empty `choices`) at the response root,
-which AIPerf already parses, so no extra endpoint code is needed.
+rides the trailing `include_usage` chunk (empty `choices`) at the response root.
+
+Because vLLM emits that trailing chunk only when `stream_options.include_usage`
+is set, AIPerf requests it on **every** streaming run -- not just when
+`--use-server-token-count` is on, which would otherwise silently drop the
+metrics. The chunk carries no content, so it is excluded from timing metrics via
+`ParsedResponseRecord.content_responses`, and token counting still follows the
+`use_server_token_count` config rather than the presence of `usage`. To opt out,
+set the field explicitly: `--extra-inputs '{"stream_options":
+{"include_usage": false}}'`.
 
 The wire object maps to the record one-to-one, except:
 
@@ -93,9 +101,7 @@ The wire object maps to the record one-to-one, except:
   `{j: count}` map, dropping zero-count buckets.
 - **`completion_tokens`** is copied from the response `usage` (not the payload)
   so the record trace carries it next to acceptance; no metric consumes it yet.
-  `None` when usage is absent -- in streaming, usage rides the trailing
-  `include_usage` chunk, which AIPerf auto-injects only when
-  `endpoint.use_server_token_count` is enabled.
+  `None` when the server omits usage.
 - **`num_draft_tokens`** is vLLM's post-adjustment count: drafts invalidated by
   structured-output/grammar constraints are already subtracted server-side.
 - **`num_spec_tokens`** is always present (the configured `num_speculative_tokens`);
@@ -116,11 +122,13 @@ The wire object maps to the record one-to-one, except:
   one bad response cannot abort a run. Records whose aggregate counts contradict
   each other (histogram not summing to `num_spec_steps`, etc.) are rejected the
   same way.
-- **`n > 1`**: vLLM populates `metrics.speculative_decoding` only for
-  single-sequence requests, leaving it `null` for `n > 1` (mixing one sequence's
-  acceptance with request-level token counts would be misleading). Because the
-  object is at the response root -- not per-choice -- AIPerf simply reads it as
-  present or absent; no client-side suppression is needed, and an `n > 1` request
-  yields no record.
+- **`n > 1`**: vLLM populates `metrics.speculative_decoding` only when the stats
+  are attributable to a single generation stream, leaving it `null` otherwise --
+  for `n > 1` on both endpoints, and additionally for **multi-prompt** requests
+  on completions (`prompt: ["a", "b"]`), where timestamps would span prompts.
+  Because the object is at the response root -- not per-choice -- AIPerf simply
+  reads it as present or absent; no client-side suppression is needed, and such
+  requests yield no record. AIPerf sends one prompt per request, so in practice
+  only `n > 1` triggers this.
 - **Behind Dynamo** the custom field is currently stripped, so this path is
   direct-to-vLLM only.

--- a/docs/tutorials/spec-decode-metrics.md
+++ b/docs/tutorials/spec-decode-metrics.md
@@ -34,8 +34,8 @@ of the metrics reference.
 
 ## Prerequisites
 
-- A vLLM server running **speculative decoding** with **per-request stats enabled** via
-  `--per-request-spec-decode-stats summary` (or `detailed`). The field shape tracks vLLM
+- A vLLM server running **speculative decoding** with **per-request metrics enabled** via
+  `--per-request-spec-decode-metrics summary` (or `detailed`). The field shape tracks vLLM
   [PR #48915](https://github.com/vllm-project/vllm/pull/48915) -- confirm your vLLM build
   includes it.
 - **Direct-to-vLLM only.** Behind Dynamo the custom stats field is currently stripped, so
@@ -45,20 +45,22 @@ of the metrics reference.
 
 ---
 
-## Start a vLLM server with per-request spec-decode stats
+## Start a vLLM server with per-request spec-decode metrics
 
 This example uses a Llama-3.1-8B target with a Llama-3.2-1B draft model and a 5-token draft
-budget. `--per-request-spec-decode-stats` is the flag that makes vLLM attach acceptance
-stats to each response choice:
+budget. `--per-request-spec-decode-metrics` is the flag that makes vLLM attach acceptance
+metrics to each response at the root `metrics.speculative_decoding` object (single-sequence
+requests only):
 
 ```bash
 docker run --gpus all -p 8000:8000 vllm/vllm-openai:latest \
   --model meta-llama/Llama-3.1-8B-Instruct \
   --speculative-config '{"model": "meta-llama/Llama-3.2-1B-Instruct", "num_speculative_tokens": 5, "method": "draft_model"}' \
-  --per-request-spec-decode-stats summary
+  --per-request-spec-decode-metrics summary
 ```
 
-Verify the server is ready:
+Verify the server is ready and emitting the field (look for `metrics.speculative_decoding`
+in the response):
 
 ```bash
 curl -s localhost:8000/v1/chat/completions \
@@ -186,7 +188,7 @@ If the Spec Decode section, histogram, and `spec_decode_*` fields are all absent
 the expected clean-degradation behavior -- not an error. Common causes:
 
 - speculative decoding is off, or the requests had no verify steps;
-- the server was not started with `--per-request-spec-decode-stats`;
+- the server was not started with `--per-request-spec-decode-metrics`;
 - the server is behind Dynamo, which strips the custom field (use the
   [server-scrape path](speed-bench.md) instead);
 - the vLLM build predates [PR #48915](https://github.com/vllm-project/vllm/pull/48915).

--- a/docs/tutorials/spec-decode-metrics.md
+++ b/docs/tutorials/spec-decode-metrics.md
@@ -40,8 +40,9 @@ of the metrics reference.
   includes it.
 - **Direct-to-vLLM only.** Behind Dynamo the custom stats field is currently stripped, so
   the per-request path is unavailable there (use the server-scrape path instead).
-- Streaming works out of the box; per-request `completion_tokens` is only populated when
-  the server also returns usage (enable server token counting if you want it).
+- Streaming works out of the box. In streaming, vLLM sends the metrics on the trailing
+  usage chunk, so AIPerf requests `stream_options.include_usage` on every streaming run;
+  no extra flag is needed.
 
 ---
 

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -1458,8 +1458,8 @@ class ParsedResponse:
     """Additional metadata from the response useful for analysis (rate limits, content filters, etc.)."""
 
     spec_decode_stats: dict[str, Any] | None = None
-    """Raw per-choice speculative-decoding payload captured from the wire (e.g.
-    vLLM's ``choices[].speculative_decoding_stats``), or None when absent. Left
+    """Raw speculative-decoding payload captured from the response root (e.g.
+    vLLM's ``metrics.speculative_decoding``), or None when absent. Left
     uninterpreted here; a ``SpecDecodeAdapterProtocol`` converts it into the
     engine-neutral ``SpecDecodeAcceptanceRecord`` at record-assembly time."""
 

--- a/src/aiperf/common/models/spec_decode_models.py
+++ b/src/aiperf/common/models/spec_decode_models.py
@@ -51,8 +51,9 @@ class SpecDecodeAcceptanceRecord(AIPerfBaseModel):
     )
     acceptance_histogram: dict[NonNegativeInt, NonNegativeInt] = Field(
         description="Sparse map from accepted draft count j to the number of "
-        "verification steps that accepted exactly j draft tokens. Keys are "
-        "integers (int-cast from the string JSON object keys on the wire); "
+        "verification steps that accepted exactly j draft tokens. Engine "
+        "adapters populate it (e.g. vLLM inflates its dense on-the-wire "
+        "list[int], dropping zero-count buckets); keys are integers and "
         "zero-count buckets are omitted. Excludes the bonus token.",
     )
     num_accepted_draft_tokens: int = Field(

--- a/src/aiperf/dataset/mmap_cache.py
+++ b/src/aiperf/dataset/mmap_cache.py
@@ -78,6 +78,13 @@ _logger = AIPerfLogger(__name__)
 # Version 5 fixed the Conversation.metadata() projection of per-turn
 # theoretical prefix-cache block counts for realtime infinite-cache hit rate.
 MANIFEST_VERSION = (
+    # v27: streaming chat/completions payloads now always carry
+    # stream_options.include_usage, not just when use_server_token_count is set
+    # (vLLM only emits the trailing usage chunk -- which carries per-request
+    # spec-decode metrics -- when it is present). Under PREFORMAT_PAYLOADS the
+    # payload bytes are baked at build time, and the key's preformat_endpoint
+    # dict is unchanged for a streaming + use_server_token_count=False run, so
+    # a warm entry would keep serving payloads without the field.
     # v26: weka inter-turn delays are now always end-to-start
     # (t_k - (t_{k-1} + api_{k-1}), floored at 0) instead of start-to-start.
     # The use_end_to_start_delays flag was removed, so Turn.delay decodes to
@@ -174,7 +181,7 @@ MANIFEST_VERSION = (
     # v10: merge of the flattened-agent-splitting lineage and the
     # tool-shaping lineage (boundary-cut overhang strip; shaping decided at
     # first emission so reset re-emits reproduce the first-sent shape).
-    26
+    27
 )
 MANIFEST_FILENAME = "manifest.json"
 INPUTS_JSON_FILENAME = "inputs.json"
@@ -796,10 +803,12 @@ def _settings_payload_from_run(run: BenchmarkRun) -> dict[str, object]:
         # When preformat_payloads is on, endpoint.format_payload() bakes the
         # stream flag, endpoint.extra, the max_tokens-vs-max_completion_tokens
         # field name, and (for streaming OpenAI-compatible endpoints)
-        # stream_options.include_usage from use_server_token_count into the
-        # stored bytes, so those knobs must key the cache or a warm entry serves
-        # bytes the run never asked for (e.g. "stream": true). Gated on the flag
-        # so the common non-preformat key stays stable.
+        # stream_options.include_usage into the stored bytes, so those knobs
+        # must key the cache or a warm entry serves bytes the run never asked
+        # for (e.g. "stream": true). include_usage now follows streaming alone,
+        # but use_server_token_count still keys the cache because it selects
+        # the token-count source baked into the run. Gated on the flag so the
+        # common non-preformat key stays stable.
         "preformat_endpoint": (
             {
                 "streaming": cfg.endpoint.streaming,

--- a/src/aiperf/endpoints/base_endpoint.py
+++ b/src/aiperf/endpoints/base_endpoint.py
@@ -107,30 +107,23 @@ class BaseEndpoint(AIPerfLoggerMixin, ABC):
 
     @staticmethod
     def extract_spec_decode_stats(json_obj: dict[str, Any]) -> dict[str, Any] | None:
-        """Capture the raw ``choices[0]`` speculative-decoding payload, if any.
+        """Capture the raw speculative-decoding payload from the response root.
 
-        vLLM attaches ``speculative_decoding_stats`` per choice (the finish-reason
-        chunk in streaming). Captured verbatim and uninterpreted so a
-        ``SpecDecodeAdapterProtocol`` owns the engine-specific interpretation
-        downstream; None when absent.
+        vLLM nests it at ``metrics.speculative_decoding`` -- on the response body
+        non-streaming, or on the trailing usage chunk (empty ``choices``)
+        streaming -- when the server runs with ``--per-request-spec-decode-metrics``.
+        Captured verbatim and uninterpreted so a ``SpecDecodeAdapterProtocol``
+        owns the engine-specific interpretation downstream; None when absent.
 
-        A response with more than one choice is an ``n > 1`` non-streaming
-        request; its record is suppressed (None) because a single per-request
-        record can't attribute request-level usage to one sequence -- reporting
-        one choice's acceptance alongside all choices' token count would be a
-        mixed, misleading record. (``n > 1`` streaming is suppressed in the
-        parser, where each sequence's stats arrive on separate chunks.)
+        vLLM populates it only for single-sequence requests (``n == 1``), leaving
+        it ``null`` otherwise, so no client-side ``n > 1`` suppression is needed:
+        a mixed per-request record can never arise here.
         """
-        choices = json_obj.get("choices")
-        if (
-            not isinstance(choices, list)
-            or not choices
-            or not isinstance(choices[0], dict)
-        ):
+        metrics = json_obj.get("metrics")
+        if not isinstance(metrics, dict):
             return None
-        if len(choices) > 1:
-            return None
-        return choices[0].get("speculative_decoding_stats")
+        stats = metrics.get("speculative_decoding")
+        return stats if isinstance(stats, dict) else None
 
     def build_assistant_turn(self, record: RequestRecord) -> Turn | None:
         """Build a Turn representing the assistant response for context replay.

--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -86,12 +86,16 @@ class ChatEndpoint(BaseEndpoint):
         if extra_body:
             payload.update(extra_body)
 
-        # per_chunk_usage implies use_server_token_count (enforced by the endpoint
-        # config validator), so gating on use_server_token_count alone is sufficient.
-        if (
-            model_endpoint.endpoint.streaming
-            and model_endpoint.endpoint.use_server_token_count
-        ):
+        if model_endpoint.endpoint.streaming:
+            # Requested for every streaming run, not just server-token-count
+            # ones: vLLM rides per-request metrics (including
+            # metrics.speculative_decoding) on the trailing usage chunk and
+            # only emits that chunk when include_usage is set, so gating it on
+            # an unrelated flag would silently drop those metrics. Authors who
+            # want it off can set stream_options.include_usage explicitly.
+            # continuous_usage_stats stays opt-in regardless: per_chunk_usage
+            # implies use_server_token_count (enforced by the endpoint config
+            # validator), so widening this gate cannot turn it on by itself.
             self._ensure_include_usage(
                 payload, continuous=model_endpoint.endpoint.per_chunk_usage
             )

--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -175,12 +175,20 @@ class ChatEndpoint(BaseEndpoint):
         extension (strict OpenAI rejects it), so it is only injected when the
         caller opts in via ``--per-chunk-usage``.
         """
-        stream_options = payload.setdefault("stream_options", {})
-        if not isinstance(stream_options, dict):
+        stream_options = payload.get("stream_options")
+        if stream_options is None:
+            stream_options = {}
+        elif not isinstance(stream_options, dict):
             return
-        stream_options.setdefault("include_usage", True)
+        # Copy rather than mutate: the payload merge aliases endpoint.extra /
+        # turn.extra_body, which are long-lived config reused across every
+        # request (and endpoint.extra feeds the mmap cache key), so an in-place
+        # edit would rewrite the author's config.
+        merged = {**stream_options}
+        merged.setdefault("include_usage", True)
         if continuous:
-            stream_options.setdefault("continuous_usage_stats", True)
+            merged.setdefault("continuous_usage_stats", True)
+        payload["stream_options"] = merged
 
     def parse_response(
         self, response: InferenceServerResponse

--- a/src/aiperf/endpoints/openai_chat.py
+++ b/src/aiperf/endpoints/openai_chat.py
@@ -86,7 +86,10 @@ class ChatEndpoint(BaseEndpoint):
         if extra_body:
             payload.update(extra_body)
 
-        if model_endpoint.endpoint.streaming:
+        # Read the merged payload, not endpoint.streaming: the extras above can
+        # override "stream", and a server rejects stream_options when stream is
+        # false ("Stream options can only be defined when stream=True").
+        if payload.get("stream"):
             # Requested for every streaming run, not just server-token-count
             # ones: vLLM rides per-request metrics (including
             # metrics.speculative_decoding) on the trailing usage chunk and
@@ -182,8 +185,8 @@ class ChatEndpoint(BaseEndpoint):
             return
         # Copy rather than mutate: the payload merge aliases endpoint.extra /
         # turn.extra_body, which are long-lived config reused across every
-        # request (and endpoint.extra feeds the mmap cache key), so an in-place
-        # edit would rewrite the author's config.
+        # request, so an in-place edit would rewrite the author's config and
+        # leak into every subsequent request.
         merged = {**stream_options}
         merged.setdefault("include_usage", True)
         if continuous:

--- a/src/aiperf/endpoints/openai_completions.py
+++ b/src/aiperf/endpoints/openai_completions.py
@@ -57,28 +57,30 @@ class CompletionsEndpoint(BaseEndpoint):
         if turn.extra_body:
             payload.update(turn.extra_body)
 
-        if model_endpoint.endpoint.streaming:
+        # Read the merged payload, not endpoint.streaming: the extras above can
+        # override "stream", and a server rejects stream_options when stream is
+        # false ("Stream options can only be defined when stream=True").
+        if payload.get("stream"):
             # Requested for every streaming run, not just server-token-count
             # ones: vLLM rides per-request metrics (including
             # metrics.speculative_decoding) on the trailing usage chunk and
             # only emits that chunk when include_usage is set, so gating it on
             # an unrelated flag would silently drop those metrics. Authors who
             # want it off can set stream_options.include_usage explicitly.
-            if "stream_options" not in payload:
-                payload["stream_options"] = {"include_usage": True}
-            elif (
-                isinstance(payload["stream_options"], dict)
-                and "include_usage" not in payload["stream_options"]
-            ):
+            stream_options = payload.get("stream_options")
+            # An explicit null parses straight from the CLI
+            # (--extra-inputs '{"stream_options": null}'); treat it as absent so
+            # this endpoint agrees with chat instead of silently skipping.
+            if stream_options is None:
+                stream_options = {}
+            if isinstance(stream_options, dict):
                 # Copy rather than mutate: the payload merge aliases
                 # endpoint.extra / turn.extra_body, which are long-lived config
-                # reused across every request (and endpoint.extra feeds the mmap
-                # cache key), so an in-place edit would rewrite the author's
-                # config.
-                payload["stream_options"] = {
-                    **payload["stream_options"],
-                    "include_usage": True,
-                }
+                # reused across every request, so an in-place edit would rewrite
+                # the author's config and leak into every subsequent request.
+                merged = {**stream_options}
+                merged.setdefault("include_usage", True)
+                payload["stream_options"] = merged
 
         self.trace(lambda: f"Formatted payload: {payload}")
         return payload

--- a/src/aiperf/endpoints/openai_completions.py
+++ b/src/aiperf/endpoints/openai_completions.py
@@ -70,7 +70,15 @@ class CompletionsEndpoint(BaseEndpoint):
                 isinstance(payload["stream_options"], dict)
                 and "include_usage" not in payload["stream_options"]
             ):
-                payload["stream_options"]["include_usage"] = True
+                # Copy rather than mutate: the payload merge aliases
+                # endpoint.extra / turn.extra_body, which are long-lived config
+                # reused across every request (and endpoint.extra feeds the mmap
+                # cache key), so an in-place edit would rewrite the author's
+                # config.
+                payload["stream_options"] = {
+                    **payload["stream_options"],
+                    "include_usage": True,
+                }
 
         self.trace(lambda: f"Formatted payload: {payload}")
         return payload

--- a/src/aiperf/endpoints/openai_completions.py
+++ b/src/aiperf/endpoints/openai_completions.py
@@ -57,11 +57,13 @@ class CompletionsEndpoint(BaseEndpoint):
         if turn.extra_body:
             payload.update(turn.extra_body)
 
-        if (
-            model_endpoint.endpoint.streaming
-            and model_endpoint.endpoint.use_server_token_count
-        ):
-            # Automatically set stream_options to include usage when using server token counts
+        if model_endpoint.endpoint.streaming:
+            # Requested for every streaming run, not just server-token-count
+            # ones: vLLM rides per-request metrics (including
+            # metrics.speculative_decoding) on the trailing usage chunk and
+            # only emits that chunk when include_usage is set, so gating it on
+            # an unrelated flag would silently drop those metrics. Authors who
+            # want it off can set stream_options.include_usage explicitly.
             if "stream_options" not in payload:
                 payload["stream_options"] = {"include_usage": True}
             elif (

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -1566,10 +1566,11 @@ spec_decode_adapter:
   vllm:
     class: aiperf.spec_decode.vllm_adapter:VLLMSpecDecodeAdapter
     description: |
-      Reads vLLM's per-choice ``speculative_decoding_stats`` (emitted when the
-      server runs with ``--per-request-spec-decode-stats``) and fills the
+      Reads vLLM's response-root ``metrics.speculative_decoding`` (emitted when
+      the server runs with ``--per-request-spec-decode-metrics``) and fills the
       engine-neutral SpecDecodeAcceptanceRecord. Handles chat and completions,
-      streaming and non-streaming; int-casts the string histogram keys.
+      streaming and non-streaming; inflates the dense ``acceptance_histogram``
+      list into the record's sparse map.
     metadata: {}
 
 accuracy_grader:

--- a/src/aiperf/records/inference_result_parser.py
+++ b/src/aiperf/records/inference_result_parser.py
@@ -340,8 +340,9 @@ class InferenceResultParser(CommunicationMixin):
         ``n > 1`` streaming request, where each sequence's stats ride its own
         finish chunk): the per-request record can't attribute request-level
         ``completion_tokens`` to a single sequence, so a mixed record is worse
-        than none. ``n > 1`` non-streaming is suppressed upstream in
-        ``BaseEndpoint.extract_spec_decode_stats``.
+        than none. ``n > 1`` non-streaming needs no client-side guard: vLLM
+        populates ``metrics.speculative_decoding`` only for single-sequence
+        requests and leaves it null otherwise.
 
         Counts payloads by truthiness (not ``is not None``) to match the
         adapter's ``_find_spec_decode_payload``: an empty ``{}`` is treated as

--- a/src/aiperf/spec_decode/vllm_adapter.py
+++ b/src/aiperf/spec_decode/vllm_adapter.py
@@ -94,6 +94,22 @@ class VLLMSpecDecodeAdapter:
                     "acceptance_histogram must be a list of ints, got "
                     f"{raw_histogram!r}"
                 )
+            # Length is num_spec_tokens + 1 (one bucket per accepted count from
+            # 0..k). Enforcing it rejects a payload whose bucket indices exceed
+            # the draft budget -- j > k is physically impossible, yet satisfies
+            # the record's arithmetic validators, so it would otherwise be
+            # reported as a real acceptance length. Doubles as a tripwire if the
+            # still-unmerged upstream PR changes the histogram shape.
+            # Optional on the record, so only enforce when the server sent it.
+            num_spec_tokens = payload.get("num_spec_tokens")
+            if (
+                num_spec_tokens is not None
+                and len(raw_histogram) != num_spec_tokens + 1
+            ):
+                raise ValueError(
+                    f"acceptance_histogram has {len(raw_histogram)} buckets, "
+                    f"expected num_spec_tokens + 1 = {num_spec_tokens + 1}"
+                )
             histogram = {
                 j: count for j, count in enumerate(raw_histogram) if count != 0
             }

--- a/src/aiperf/spec_decode/vllm_adapter.py
+++ b/src/aiperf/spec_decode/vllm_adapter.py
@@ -79,11 +79,15 @@ class VLLMSpecDecodeAdapter:
         try:
             # vLLM sends a dense ``list[int]`` (index j -> step count); inflate
             # into the neutral record's sparse map, dropping zero-count buckets.
-            histogram = {
-                j: count
-                for j, count in enumerate(payload["acceptance_histogram"])
-                if count
-            }
+            # Reject non-list shapes up front: a str/dict is iterable, so
+            # enumerate would silently build a bucket-per-character/key map that
+            # only the record's cross-field validators would catch.
+            raw_histogram = payload["acceptance_histogram"]
+            if not isinstance(raw_histogram, list):
+                raise TypeError(
+                    f"acceptance_histogram must be a list, got {type(raw_histogram).__name__}"
+                )
+            histogram = {j: count for j, count in enumerate(raw_histogram) if count}
             usage = find_last_non_empty_usage(responses)
             return SpecDecodeAcceptanceRecord(
                 engine=ENGINE,

--- a/src/aiperf/spec_decode/vllm_adapter.py
+++ b/src/aiperf/spec_decode/vllm_adapter.py
@@ -79,15 +79,24 @@ class VLLMSpecDecodeAdapter:
         try:
             # vLLM sends a dense ``list[int]`` (index j -> step count); inflate
             # into the neutral record's sparse map, dropping zero-count buckets.
-            # Reject non-list shapes up front: a str/dict is iterable, so
-            # enumerate would silently build a bucket-per-character/key map that
-            # only the record's cross-field validators would catch.
+            # Validate the shape AND every element before filtering: a str/dict
+            # is iterable (enumerate would build a bucket per character/key),
+            # and filtering on truthiness first would silently drop a falsey
+            # malformed entry (None/False/0.0) while keeping a truthy one that
+            # coerces to zero ("0"), which would violate the record's
+            # zero-buckets-omitted invariant. ``type(...) is int`` rather than
+            # isinstance so bools -- an int subclass -- are rejected too.
             raw_histogram = payload["acceptance_histogram"]
-            if not isinstance(raw_histogram, list):
+            if not isinstance(raw_histogram, list) or not all(
+                type(count) is int for count in raw_histogram
+            ):
                 raise TypeError(
-                    f"acceptance_histogram must be a list, got {type(raw_histogram).__name__}"
+                    "acceptance_histogram must be a list of ints, got "
+                    f"{raw_histogram!r}"
                 )
-            histogram = {j: count for j, count in enumerate(raw_histogram) if count}
+            histogram = {
+                j: count for j, count in enumerate(raw_histogram) if count != 0
+            }
             usage = find_last_non_empty_usage(responses)
             return SpecDecodeAcceptanceRecord(
                 engine=ENGINE,

--- a/src/aiperf/spec_decode/vllm_adapter.py
+++ b/src/aiperf/spec_decode/vllm_adapter.py
@@ -18,11 +18,11 @@ _logger = AIPerfLogger(__name__)
 
 ENGINE = "vllm"
 
-# Keys that identify a payload as vLLM's ``speculative_decoding_stats`` shape.
+# Keys that identify a payload as vLLM's ``speculative_decoding`` shape.
 # ``can_adapt`` checks for these so that, once other engines populate the same
 # raw slot, this adapter claims only its own payloads (auto-detection) rather
 # than greedily matching on mere presence. Both are always emitted by vLLM,
-# including the zero-step case (``acceptance_histogram`` is ``{}`` but present).
+# including the zero-step case (``acceptance_histogram`` is all-zero but present).
 _VLLM_SIGNATURE_KEYS = ("acceptance_histogram", "num_spec_steps")
 
 
@@ -37,9 +37,9 @@ def _find_spec_decode_payload(
 ) -> dict[str, Any] | None:
     """Return the last non-empty ``spec_decode_stats`` payload across responses.
 
-    vLLM attaches the payload to a single choice: the finish-reason chunk in
-    streaming, or the sole choice non-streaming. Walking from the end mirrors
-    ``find_last_non_empty_usage`` and tolerates either layout.
+    vLLM attaches the payload once per request at the response root: on the body
+    non-streaming, or on the trailing usage chunk streaming. Walking from the end
+    mirrors ``find_last_non_empty_usage`` and tolerates either layout.
     """
     for response in reversed(responses):
         stats = response.spec_decode_stats
@@ -49,12 +49,15 @@ def _find_spec_decode_payload(
 
 
 class VLLMSpecDecodeAdapter:
-    """Fills the acceptance record from vLLM's ``speculative_decoding_stats``.
+    """Fills the acceptance record from vLLM's ``metrics.speculative_decoding``.
 
-    Reads the per-choice ``speculative_decoding_stats`` object emitted by vLLM
-    when the server runs with ``--per-request-spec-decode-stats``. Present on
-    chat and completions, streaming and non-streaming. The object's histogram
-    keys are JSON strings, so they are int-cast into the neutral record.
+    Reads the response-root ``metrics.speculative_decoding`` object emitted by
+    vLLM when the server runs with ``--per-request-spec-decode-metrics``
+    (``summary`` or ``detailed``). Present on chat and completions, streaming and
+    non-streaming. Its ``acceptance_histogram`` is a dense ``list[int]`` (index j
+    holds the number of steps that accepted exactly j draft tokens), inflated
+    into the neutral record's sparse ``{j: count}`` map with zero-count buckets
+    dropped.
 
     The field names and shape track vLLM PR
     https://github.com/vllm-project/vllm/pull/48915; its per-request
@@ -74,8 +77,12 @@ class VLLMSpecDecodeAdapter:
             return None
 
         try:
+            # vLLM sends a dense ``list[int]`` (index j -> step count); inflate
+            # into the neutral record's sparse map, dropping zero-count buckets.
             histogram = {
-                int(j): count for j, count in payload["acceptance_histogram"].items()
+                j: count
+                for j, count in enumerate(payload["acceptance_histogram"])
+                if count
             }
             usage = find_last_non_empty_usage(responses)
             return SpecDecodeAcceptanceRecord(

--- a/tests/unit/dataset/test_mmap_cache.py
+++ b/tests/unit/dataset/test_mmap_cache.py
@@ -641,7 +641,7 @@ class TestLookupAndPopulate:
         raw["version"] = 22
         manifest_path.write_bytes(orjson.dumps(raw))
 
-        assert mmap_cache.MANIFEST_VERSION == 26
+        assert mmap_cache.MANIFEST_VERSION == 27
         assert mmap_cache.lookup("pre-overlap-frontier", compressed=False) is None
 
     def test_lookup_compressed_mismatch_returns_none(self, tmp_path: Path) -> None:

--- a/tests/unit/endpoints/test_openai_chat_completions.py
+++ b/tests/unit/endpoints/test_openai_chat_completions.py
@@ -276,6 +276,32 @@ class TestChatEndpoint:
         else:
             assert payload["stream_options"] == expected
 
+    def test_format_payload_does_not_mutate_endpoint_extra(
+        self, model_endpoint, sample_conversations
+    ):
+        """Auto-adding include_usage must not write back into endpoint.extra.
+
+        The payload merge aliases the shared config dict, and endpoint.extra
+        feeds the mmap dataset cache key, so an in-place edit would rewrite the
+        author's config mid-run.
+        """
+        endpoint = ChatEndpoint(model_endpoint)
+        turns = [sample_conversations["session_1"].turns[0]]
+        model_endpoint.endpoint.streaming = True
+        model_endpoint.endpoint.use_server_token_count = False
+        model_endpoint.endpoint.extra = {"stream_options": {"continuous_updates": True}}
+
+        request_info = create_request_info(turns=turns, model_endpoint=model_endpoint)
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["stream_options"] == {
+            "continuous_updates": True,
+            "include_usage": True,
+        }
+        assert model_endpoint.endpoint.extra == {
+            "stream_options": {"continuous_updates": True}
+        }
+
     def test_create_messages_with_system_message(
         self, model_endpoint, sample_conversations
     ):

--- a/tests/unit/endpoints/test_openai_chat_completions.py
+++ b/tests/unit/endpoints/test_openai_chat_completions.py
@@ -71,6 +71,9 @@ class TestChatEndpoint:
             "model": "test-model",
             "stream": True,
             "max_completion_tokens": 42,
+            # Requested on every streaming run so vLLM emits the trailing
+            # usage chunk that carries per-request metrics.
+            "stream_options": {"include_usage": True},
         }
         assert payload == expected_payload
 
@@ -197,12 +200,16 @@ class TestChatEndpoint:
             (True, True, None, {"include_usage": True}),
             # Don't add when not streaming
             (False, True, None, None),
-            # Don't add when flag disabled
-            (True, False, None, None),
-            # Don't add when neither enabled
+            # Add for any streaming run, even without server token counts:
+            # vLLM only emits the metrics-bearing trailing usage chunk when
+            # include_usage is set, and per-request spec-decode metrics ride it.
+            (True, False, None, {"include_usage": True}),
+            # Don't add when not streaming
             (False, False, None, None),
             # Preserve user's include_usage=False
             (True, True, {"stream_options": {"include_usage": False}}, {"include_usage": False}),
+            # Preserve the opt-out without server token counts too
+            (True, False, {"stream_options": {"include_usage": False}}, {"include_usage": False}),
             # Merge with user's other options
             (True, True, {"stream_options": {"continuous_updates": True}}, {"continuous_updates": True, "include_usage": True}),
         ],

--- a/tests/unit/endpoints/test_openai_chat_completions.py
+++ b/tests/unit/endpoints/test_openai_chat_completions.py
@@ -283,15 +283,17 @@ class TestChatEndpoint:
     ) -> None:
         """Auto-adding include_usage must not write back into endpoint.extra.
 
-        The payload merge aliases the shared config dict, and endpoint.extra
-        feeds the mmap dataset cache key, so an in-place edit would rewrite the
-        author's config mid-run.
+        The payload merge aliases the shared config dict, so an in-place edit
+        would rewrite the author's config mid-run and leak into every
+        subsequent request.
         """
         endpoint = ChatEndpoint(model_endpoint)
         turns = [sample_conversations["session_1"].turns[0]]
         model_endpoint.endpoint.streaming = True
         model_endpoint.endpoint.use_server_token_count = False
-        model_endpoint.endpoint.extra = {"stream_options": {"continuous_updates": True}}
+        model_endpoint.endpoint.extra = [
+            ("stream_options", {"continuous_updates": True})
+        ]
 
         request_info = create_request_info(turns=turns, model_endpoint=model_endpoint)
         payload = endpoint.format_payload(request_info)
@@ -300,9 +302,44 @@ class TestChatEndpoint:
             "continuous_updates": True,
             "include_usage": True,
         }
-        assert model_endpoint.endpoint.extra == {
-            "stream_options": {"continuous_updates": True}
-        }
+        assert model_endpoint.endpoint.extra == [
+            ("stream_options", {"continuous_updates": True})
+        ]
+
+    def test_format_payload_stream_override_suppresses_stream_options(
+        self,
+        model_endpoint: ModelEndpointInfo,
+        sample_conversations: dict[str, Conversation],
+    ) -> None:
+        """extra_body may turn streaming off; stream_options must follow it.
+
+        A server rejects stream_options when stream is false, so the injection
+        decision reads the merged payload rather than the endpoint config.
+        """
+        endpoint = ChatEndpoint(model_endpoint)
+        turns = [sample_conversations["session_1"].turns[0]]
+        model_endpoint.endpoint.streaming = True
+        turns[-1].extra_body = {"stream": False}
+        request_info = create_request_info(turns=turns, model_endpoint=model_endpoint)
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["stream"] is False
+        assert "stream_options" not in payload
+
+    def test_format_payload_explicit_null_stream_options_still_injects(
+        self,
+        model_endpoint: ModelEndpointInfo,
+        sample_conversations: dict[str, Conversation],
+    ) -> None:
+        """An explicit null parses from the CLI; treat it as absent, not as opt-out."""
+        endpoint = ChatEndpoint(model_endpoint)
+        turns = [sample_conversations["session_1"].turns[0]]
+        model_endpoint.endpoint.streaming = True
+        model_endpoint.endpoint.extra = [("stream_options", None)]
+        request_info = create_request_info(turns=turns, model_endpoint=model_endpoint)
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["stream_options"] == {"include_usage": True}
 
     def test_create_messages_with_system_message(
         self, model_endpoint, sample_conversations

--- a/tests/unit/endpoints/test_openai_chat_completions.py
+++ b/tests/unit/endpoints/test_openai_chat_completions.py
@@ -3,7 +3,7 @@
 import pytest
 
 from aiperf.common.enums import ModelSelectionStrategy
-from aiperf.common.models import Image, Text, Turn
+from aiperf.common.models import Conversation, Image, Text, Turn
 from aiperf.common.models.model_endpoint_info import (
     EndpointInfo,
     ModelEndpointInfo,
@@ -277,8 +277,10 @@ class TestChatEndpoint:
             assert payload["stream_options"] == expected
 
     def test_format_payload_does_not_mutate_endpoint_extra(
-        self, model_endpoint, sample_conversations
-    ):
+        self,
+        model_endpoint: ModelEndpointInfo,
+        sample_conversations: dict[str, Conversation],
+    ) -> None:
         """Auto-adding include_usage must not write back into endpoint.extra.
 
         The payload merge aliases the shared config dict, and endpoint.extra

--- a/tests/unit/endpoints/test_openai_completions.py
+++ b/tests/unit/endpoints/test_openai_completions.py
@@ -67,6 +67,9 @@ class TestCompletionsEndpoint:
             "stream": True,
             "max_tokens": 50,
             "ignore_eos": True,
+            # Requested on every streaming run so vLLM emits the trailing
+            # usage chunk that carries per-request metrics.
+            "stream_options": {"include_usage": True},
         }
         assert payload == expected_payload
 
@@ -120,12 +123,16 @@ class TestCompletionsEndpoint:
             (True, True, None, {"include_usage": True}),
             # Don't add when not streaming
             (False, True, None, None),
-            # Don't add when flag disabled
-            (True, False, None, None),
-            # Don't add when neither enabled
+            # Add for any streaming run, even without server token counts:
+            # vLLM only emits the metrics-bearing trailing usage chunk when
+            # include_usage is set, and per-request spec-decode metrics ride it.
+            (True, False, None, {"include_usage": True}),
+            # Don't add when not streaming
             (False, False, None, None),
             # Preserve user's include_usage=False
             (True, True, [("stream_options", {"include_usage": False})], {"include_usage": False}),
+            # Preserve the opt-out without server token counts too
+            (True, False, [("stream_options", {"include_usage": False})], {"include_usage": False}),
             # Merge with user's other options
             (True, True, [("stream_options", {"continuous_updates": True})], {"continuous_updates": True, "include_usage": True}),
         ],

--- a/tests/unit/endpoints/test_openai_completions.py
+++ b/tests/unit/endpoints/test_openai_completions.py
@@ -171,9 +171,9 @@ class TestCompletionsEndpoint:
     ) -> None:
         """Auto-adding include_usage must not write back into endpoint.extra.
 
-        The payload merge aliases the shared config dict, and endpoint.extra
-        feeds the mmap dataset cache key, so an in-place edit would rewrite the
-        author's config mid-run.
+        The payload merge aliases the shared config dict, so an in-place edit
+        would rewrite the author's config mid-run and leak into every
+        subsequent request.
         """
         endpoint = CompletionsEndpoint(model_endpoint)
         turns = [sample_conversations["session_1"].turns[0]]
@@ -193,3 +193,38 @@ class TestCompletionsEndpoint:
         assert model_endpoint.endpoint.extra == [
             ("stream_options", {"continuous_updates": True})
         ]
+
+    def test_format_payload_stream_override_suppresses_stream_options(
+        self,
+        model_endpoint: ModelEndpointInfo,
+        sample_conversations: dict[str, Conversation],
+    ) -> None:
+        """extra_body may turn streaming off; stream_options must follow it.
+
+        A server rejects stream_options when stream is false, so the injection
+        decision reads the merged payload rather than the endpoint config.
+        """
+        endpoint = CompletionsEndpoint(model_endpoint)
+        turns = [sample_conversations["session_1"].turns[0]]
+        model_endpoint.endpoint.streaming = True
+        turns[-1].extra_body = {"stream": False}
+        request_info = create_request_info(turns=turns, model_endpoint=model_endpoint)
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["stream"] is False
+        assert "stream_options" not in payload
+
+    def test_format_payload_explicit_null_stream_options_still_injects(
+        self,
+        model_endpoint: ModelEndpointInfo,
+        sample_conversations: dict[str, Conversation],
+    ) -> None:
+        """An explicit null parses from the CLI; treat it as absent, not as opt-out."""
+        endpoint = CompletionsEndpoint(model_endpoint)
+        turns = [sample_conversations["session_1"].turns[0]]
+        model_endpoint.endpoint.streaming = True
+        model_endpoint.endpoint.extra = [("stream_options", None)]
+        request_info = create_request_info(turns=turns, model_endpoint=model_endpoint)
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["stream_options"] == {"include_usage": True}

--- a/tests/unit/endpoints/test_openai_completions.py
+++ b/tests/unit/endpoints/test_openai_completions.py
@@ -162,3 +162,31 @@ class TestCompletionsEndpoint:
         else:
             assert "stream_options" in payload
             assert payload["stream_options"] == expected_stream_options
+
+    def test_format_payload_does_not_mutate_endpoint_extra(
+        self, model_endpoint, sample_conversations
+    ):
+        """Auto-adding include_usage must not write back into endpoint.extra.
+
+        The payload merge aliases the shared config dict, and endpoint.extra
+        feeds the mmap dataset cache key, so an in-place edit would rewrite the
+        author's config mid-run.
+        """
+        endpoint = CompletionsEndpoint(model_endpoint)
+        turns = [sample_conversations["session_1"].turns[0]]
+        model_endpoint.endpoint.streaming = True
+        model_endpoint.endpoint.use_server_token_count = False
+        model_endpoint.endpoint.extra = [
+            ("stream_options", {"continuous_updates": True})
+        ]
+
+        request_info = create_request_info(turns=turns, model_endpoint=model_endpoint)
+        payload = endpoint.format_payload(request_info)
+
+        assert payload["stream_options"] == {
+            "continuous_updates": True,
+            "include_usage": True,
+        }
+        assert model_endpoint.endpoint.extra == [
+            ("stream_options", {"continuous_updates": True})
+        ]

--- a/tests/unit/endpoints/test_openai_completions.py
+++ b/tests/unit/endpoints/test_openai_completions.py
@@ -5,6 +5,7 @@ import pytest
 from pytest import param
 
 from aiperf.common.enums import CreditPhase, ModelSelectionStrategy
+from aiperf.common.models import Conversation
 from aiperf.common.models.model_endpoint_info import (
     EndpointInfo,
     ModelEndpointInfo,
@@ -164,8 +165,10 @@ class TestCompletionsEndpoint:
             assert payload["stream_options"] == expected_stream_options
 
     def test_format_payload_does_not_mutate_endpoint_extra(
-        self, model_endpoint, sample_conversations
-    ):
+        self,
+        model_endpoint: ModelEndpointInfo,
+        sample_conversations: dict[str, Conversation],
+    ) -> None:
         """Auto-adding include_usage must not write back into endpoint.extra.
 
         The payload merge aliases the shared config dict, and endpoint.extra

--- a/tests/unit/endpoints/test_spec_decode_capture.py
+++ b/tests/unit/endpoints/test_spec_decode_capture.py
@@ -3,10 +3,10 @@
 
 """Tests that chat/completions endpoints capture the raw spec-decode payload.
 
-``parse_response`` must lift ``choices[0].speculative_decoding_stats`` onto the
-``ParsedResponse`` uninterpreted, including on a streaming finish-reason chunk
-whose delta is empty (which otherwise carries no data and would be dropped), and
-must not choke on a malformed non-list ``choices``.
+``parse_response`` must lift ``metrics.speculative_decoding`` from the response
+root onto the ``ParsedResponse`` uninterpreted -- including on a streaming
+trailing usage chunk whose ``choices`` is empty (it carries no content and would
+otherwise be dropped) -- and must not choke on a malformed non-list ``choices``.
 """
 
 from typing import Any, TypeVar
@@ -30,7 +30,7 @@ from aiperf.plugin.enums import EndpointType
 STATS = {
     "mean_acceptance_length": 1.5,
     "draft_acceptance_rate": 0.25,
-    "acceptance_histogram": {"0": 2, "2": 2},
+    "acceptance_histogram": [2, 0, 2, 0],
     "num_spec_steps": 4,
     "num_accepted_draft_tokens": 4,
     "num_draft_tokens": 16,
@@ -83,27 +83,23 @@ class TestChatSpecDecodeCapture:
                 {
                     "message": {"role": "assistant", "content": "hi"},
                     "finish_reason": "stop",
-                    "speculative_decoding_stats": STATS,
                 }
             ],
+            "metrics": {"speculative_decoding": STATS},
         }
         parsed = chat_endpoint.parse_response(_mock_response(json_obj))
         assert parsed is not None
         assert parsed.spec_decode_stats == STATS
 
-    def test_parse_response_streaming_empty_delta_retains_stats(
+    def test_parse_response_streaming_usage_chunk_retains_stats(
         self, chat_endpoint: ChatEndpoint
     ) -> None:
-        """The finish chunk has no content but must still surface the stats."""
+        """The trailing usage chunk has empty choices but carries stats at root."""
         json_obj = {
             "object": "chat.completion.chunk",
-            "choices": [
-                {
-                    "delta": {},
-                    "finish_reason": "stop",
-                    "speculative_decoding_stats": STATS,
-                }
-            ],
+            "choices": [],
+            "usage": {"completion_tokens": 50},
+            "metrics": {"speculative_decoding": STATS},
         }
         parsed = chat_endpoint.parse_response(_mock_response(json_obj))
         assert parsed is not None
@@ -128,16 +124,15 @@ class TestChatSpecDecodeCapture:
         json_obj = {"object": "error", "choices": {"0": {"message": {}}}}
         assert chat_endpoint.parse_response(_mock_response(json_obj)) is None
 
-    def test_parse_response_multi_choice_suppresses_stats(
+    def test_parse_response_metrics_without_spec_decode_yields_none(
         self, chat_endpoint: ChatEndpoint
     ) -> None:
-        """n > 1 (multiple stats-bearing choices): stats suppressed, not mixed."""
+        """``metrics`` present (timing only, or ``n > 1`` where vLLM nulls the
+        ``speculative_decoding`` sub-object): no spec-decode payload captured."""
         json_obj = {
             "object": "chat.completion",
-            "choices": [
-                {"message": {"content": "a"}, "speculative_decoding_stats": STATS},
-                {"message": {"content": "b"}, "speculative_decoding_stats": STATS},
-            ],
+            "choices": [{"message": {"content": "hi"}}],
+            "metrics": {"time_to_first_token_ms": 12.0, "speculative_decoding": None},
         }
         parsed = chat_endpoint.parse_response(_mock_response(json_obj))
         assert parsed is not None
@@ -150,24 +145,21 @@ class TestCompletionsSpecDecodeCapture:
     ) -> None:
         json_obj = {
             "object": "text_completion",
-            "choices": [{"text": "hi", "speculative_decoding_stats": STATS}],
+            "choices": [{"text": "hi"}],
+            "metrics": {"speculative_decoding": STATS},
         }
         parsed = completions_endpoint.parse_response(_mock_response(json_obj))
         assert parsed is not None
         assert parsed.spec_decode_stats == STATS
 
-    def test_parse_response_streaming_empty_text_retains_stats(
+    def test_parse_response_streaming_usage_chunk_retains_stats(
         self, completions_endpoint: CompletionsEndpoint
     ) -> None:
         json_obj = {
             "object": "text_completion",
-            "choices": [
-                {
-                    "text": "",
-                    "finish_reason": "stop",
-                    "speculative_decoding_stats": STATS,
-                }
-            ],
+            "choices": [],
+            "usage": {"completion_tokens": 50},
+            "metrics": {"speculative_decoding": STATS},
         }
         parsed = completions_endpoint.parse_response(_mock_response(json_obj))
         assert parsed is not None

--- a/tests/unit/spec_decode/test_vllm_adapter.py
+++ b/tests/unit/spec_decode/test_vllm_adapter.py
@@ -4,13 +4,14 @@
 """Unit tests for the vLLM per-request spec-decode adapter.
 
 Covers the engine-neutral ``SpecDecodeAcceptanceRecord`` filled from vLLM's
-per-choice ``speculative_decoding_stats`` payload across the shapes the ticket
-calls out: present, absent, zero-step, and fully-rejected, in both streaming
-and non-streaming layouts, plus the detailed per-step arrays and malformed
+root ``metrics.speculative_decoding`` payload across the shapes the ticket calls
+out: present, absent, zero-step, and fully-rejected, in both streaming and
+non-streaming layouts, plus the detailed per-step arrays and malformed
 degradation.
 
 The sample payloads mirror the wire format from vLLM PR
-https://github.com/vllm-project/vllm/pull/48915.
+https://github.com/vllm-project/vllm/pull/48915: ``acceptance_histogram`` is a
+dense ``list[int]`` (index j -> step count, length num_spec_tokens + 1).
 """
 
 from collections.abc import Callable
@@ -23,28 +24,28 @@ from pytest import param
 from aiperf.common.models import ParsedResponse, SpecDecodeAcceptanceRecord
 from aiperf.spec_decode.vllm_adapter import VLLMSpecDecodeAdapter
 
-# A representative vLLM ``summary`` payload (histogram keys are JSON strings).
-# 39 steps accepted 0 drafts, 1 step accepted 1, 3 steps accepted 3:
-#   num_spec_steps      = 39 + 1 + 3            = 43
-#   num_accepted_draft  = 0*39 + 1*1 + 3*3      = 10
-#   mean_acceptance_len = 1 + 10 / 43           = 1.2325...
-#   draft_acceptance    = 10 / 129              = 0.0775...
+# A representative vLLM ``summary`` payload. The dense acceptance_histogram
+# [39, 1, 0, 3] means 39 steps accepted 0 drafts, 1 accepted 1, 3 accepted 3:
+#   num_spec_steps      = 39 + 1 + 0 + 3         = 43
+#   num_accepted_draft  = 0*39 + 1*1 + 2*0 + 3*3 = 10
+#   mean_acceptance_len = 1 + 10 / 43            = 1.2325...
+#   draft_acceptance    = 10 / 129               = 0.0775...
 SUMMARY_PAYLOAD: dict[str, Any] = {
     "mean_acceptance_length": 1.2325581395348837,
     "draft_acceptance_rate": 0.07751937984496124,
-    "acceptance_histogram": {"0": 39, "1": 1, "3": 3},
+    "acceptance_histogram": [39, 1, 0, 3],
     "num_spec_steps": 43,
     "num_accepted_draft_tokens": 10,
     "num_draft_tokens": 129,
     "num_spec_tokens": 3,
 }
 
-# A self-consistent ``detailed`` payload: 4 steps, accepted [0,1,3,0] ->
-# histogram {0:2, 1:1, 3:1} and 4 accepted; drafted [3,3,3,3] -> 12 proposed.
+# A self-consistent ``detailed`` payload: 4 steps, accepted [0,1,3,0] -> dense
+# histogram [2, 1, 0, 1] and 4 accepted; drafted [3,3,3,3] -> 12 proposed.
 DETAILED_PAYLOAD: dict[str, Any] = {
     "mean_acceptance_length": 2.0,
     "draft_acceptance_rate": 4 / 12,
-    "acceptance_histogram": {"0": 2, "1": 1, "3": 1},
+    "acceptance_histogram": [2, 1, 0, 1],
     "num_spec_steps": 4,
     "num_accepted_draft_tokens": 4,
     "num_draft_tokens": 12,
@@ -73,15 +74,15 @@ def _non_streaming(payload: dict[str, Any]) -> list[ParsedResponse]:
 
 
 def _streaming(payload: dict[str, Any]) -> list[ParsedResponse]:
-    """Streaming layout: content chunk, terminal stats chunk, usage-only chunk.
+    """Streaming layout: content chunk, then the trailing usage chunk.
 
-    Mirrors vLLM: acceptance stats ride the finish-reason chunk's choice while
-    the trailing ``include_usage`` chunk carries usage on empty choices.
+    Mirrors vLLM: the ``metrics.speculative_decoding`` payload and the usage both
+    ride the trailing ``include_usage`` chunk (empty choices) at the response
+    root.
     """
     return [
         _response(),
-        _response(spec_decode_stats=payload),
-        _response(usage={"completion_tokens": 50}),
+        _response(spec_decode_stats=payload, usage={"completion_tokens": 50}),
     ]
 
 
@@ -105,7 +106,7 @@ class TestVLLMSpecDecodeAdapter:
         assert record.engine == "vllm"
         assert record.mean_acceptance_length == pytest.approx(1.2325581395348837)
         assert record.draft_acceptance_rate == pytest.approx(0.07751937984496124)
-        # Histogram string keys are int-cast into the neutral record.
+        # The dense list is inflated into the sparse map (zero buckets dropped).
         assert record.acceptance_histogram == {0: 39, 1: 1, 3: 3}
         assert record.num_spec_steps == 43
         assert record.num_accepted_draft_tokens == 10
@@ -155,7 +156,7 @@ class TestVLLMSpecDecodeAdapter:
         payload = {
             "mean_acceptance_length": 1.0,
             "draft_acceptance_rate": 0.0,
-            "acceptance_histogram": {},
+            "acceptance_histogram": [0, 0, 0, 0],
             "num_spec_steps": 0,
             "num_accepted_draft_tokens": 0,
             "num_draft_tokens": 0,
@@ -176,7 +177,7 @@ class TestVLLMSpecDecodeAdapter:
         payload = {
             "mean_acceptance_length": 1.0,
             "draft_acceptance_rate": 0.0,
-            "acceptance_histogram": {"0": 20},
+            "acceptance_histogram": [20, 0, 0, 0],
             "num_spec_steps": 20,
             "num_accepted_draft_tokens": 0,
             "num_draft_tokens": 60,
@@ -250,16 +251,18 @@ class TestVLLMSpecDecodeAdapter:
             # Signature keys present (so can_adapt matches) but the rest of the
             # required body is missing.
             param(
-                {"acceptance_histogram": {"0": 1}, "num_spec_steps": 1},
+                {"acceptance_histogram": [0, 1], "num_spec_steps": 1},
                 id="signature_only_missing_rest",
             ),
             param(
-                {**SUMMARY_PAYLOAD, "acceptance_histogram": {"x": 1}},
-                id="non_integer_histogram_key",
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": [39, 1, "x", 3]},
+                id="non_integer_histogram_element",
             ),
             param(
-                {**SUMMARY_PAYLOAD, "acceptance_histogram": [1, 2, 3]},
-                id="histogram_wrong_type",
+                # A dict is the pre-rework wire shape; the current list-based
+                # parser must reject it rather than emit a garbled record.
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": {"0": 39, "1": 1, "3": 3}},
+                id="histogram_dict_not_list",
             ),
         ],
     )  # fmt: skip
@@ -287,7 +290,7 @@ class TestVLLMSpecDecodeAdapter:
     def test_adapt_negative_count_payload_degrades_to_none(self) -> None:
         """A signature-matching payload with a negative count is rejected by the
         record's ge=0 constraints, and the adapter degrades to None."""
-        bad = {**SUMMARY_PAYLOAD, "acceptance_histogram": {"0": -1}}
+        bad = {**SUMMARY_PAYLOAD, "acceptance_histogram": [-1, 1, 0, 3]}
         responses = [_response(spec_decode_stats=bad)]
         assert VLLMSpecDecodeAdapter.can_adapt(responses) is True
         assert VLLMSpecDecodeAdapter.adapt(responses) is None

--- a/tests/unit/spec_decode/test_vllm_adapter.py
+++ b/tests/unit/spec_decode/test_vllm_adapter.py
@@ -106,7 +106,8 @@ class TestVLLMSpecDecodeAdapter:
         assert record.engine == "vllm"
         assert record.mean_acceptance_length == pytest.approx(1.2325581395348837)
         assert record.draft_acceptance_rate == pytest.approx(0.07751937984496124)
-        # The dense list is inflated into the sparse map (zero buckets dropped).
+        # Index 2 is absent because the neutral record stays sparse: engines
+        # may report any bucket layout, so zero counts carry no information.
         assert record.acceptance_histogram == {0: 39, 1: 1, 3: 3}
         assert record.num_spec_steps == 43
         assert record.num_accepted_draft_tokens == 10

--- a/tests/unit/spec_decode/test_vllm_adapter.py
+++ b/tests/unit/spec_decode/test_vllm_adapter.py
@@ -264,6 +264,20 @@ class TestVLLMSpecDecodeAdapter:
                 {**SUMMARY_PAYLOAD, "acceptance_histogram": {"0": 39, "1": 1, "3": 3}},
                 id="histogram_dict_not_list",
             ),
+            param(
+                # A str is iterable, so without an explicit type check enumerate
+                # would build a bucket per character.
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": "303"},
+                id="histogram_str_not_list",
+            ),
+            param(
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": 5},
+                id="histogram_int_not_list",
+            ),
+            param(
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": None},
+                id="histogram_none_not_list",
+            ),
         ],
     )  # fmt: skip
     def test_adapt_malformed_payload_degrades_to_none(

--- a/tests/unit/spec_decode/test_vllm_adapter.py
+++ b/tests/unit/spec_decode/test_vllm_adapter.py
@@ -278,6 +278,26 @@ class TestVLLMSpecDecodeAdapter:
                 {**SUMMARY_PAYLOAD, "acceptance_histogram": None},
                 id="histogram_none_not_list",
             ),
+            param(
+                # Falsey malformed elements must not slip through the
+                # zero-bucket filter and yield a valid-looking record.
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": [39, 1, None, 3]},
+                id="histogram_falsey_none_element",
+            ),
+            param(
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": [39, 1, False, 3]},
+                id="histogram_falsey_bool_element",
+            ),
+            param(
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": [39, 1, 0.0, 3]},
+                id="histogram_falsey_float_element",
+            ),
+            param(
+                # Truthy but coerces to zero -- would land a 0 bucket in a map
+                # that promises zero buckets are omitted.
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": [39, 1, "0", 3]},
+                id="histogram_str_zero_element",
+            ),
         ],
     )  # fmt: skip
     def test_adapt_malformed_payload_degrades_to_none(

--- a/tests/unit/spec_decode/test_vllm_adapter.py
+++ b/tests/unit/spec_decode/test_vllm_adapter.py
@@ -299,6 +299,22 @@ class TestVLLMSpecDecodeAdapter:
                 {**SUMMARY_PAYLOAD, "acceptance_histogram": [39, 1, "0", 3]},
                 id="histogram_str_zero_element",
             ),
+            param(
+                # Length must be num_spec_tokens + 1; a longer list puts a
+                # bucket at j > k, which is impossible yet satisfies every
+                # arithmetic invariant the record checks.
+                {
+                    **SUMMARY_PAYLOAD,
+                    "acceptance_histogram": [0, 0, 0, 0, 1],
+                    "num_spec_steps": 1,
+                    "num_accepted_draft_tokens": 4,
+                },
+                id="histogram_longer_than_num_spec_tokens",
+            ),
+            param(
+                {**SUMMARY_PAYLOAD, "acceptance_histogram": [39, 1, 3]},
+                id="histogram_shorter_than_num_spec_tokens",
+            ),
         ],
     )  # fmt: skip
     def test_adapt_malformed_payload_degrades_to_none(


### PR DESCRIPTION
## What

AIPerf reads vLLM's per-request speculative-decoding metrics off each response. The shape of those metrics changed during review of [vLLM PR #48915](https://github.com/vllm-project/vllm/pull/48915), so our reader was looking in the wrong place and silently found nothing. This updates it to the current shape.

Note: #48915 is still open. This PR tracks the in-review format, not a released one — no vLLM release has ever carried the old shape, so there is nothing to stay backward compatible with.

## The change, in one picture

The metrics used to hang off each **choice**. They now sit at the **root** of the response, inside the existing `metrics` object — and the histogram went from a string-keyed map to a plain array.

**Before** (what we used to read):

```json
{
  "choices": [
    {
      "message": { "role": "assistant", "content": "..." },
      "finish_reason": "stop",
      "speculative_decoding_stats": {
        "mean_acceptance_length": 1.23,
        "draft_acceptance_rate": 0.078,
        "acceptance_histogram": { "0": 39, "1": 1, "3": 3 },
        "num_spec_steps": 43,
        "num_accepted_draft_tokens": 10,
        "num_draft_tokens": 129,
        "num_spec_tokens": 3
      }
    }
  ],
  "usage": { "completion_tokens": 53 }
}
```

**After** (what vLLM sends now):

```json
{
  "choices": [
    {
      "message": { "role": "assistant", "content": "..." },
      "finish_reason": "stop"
    }
  ],
  "usage": { "completion_tokens": 53 },
  "metrics": {
    "time_to_first_token_ms": 12.4,
    "speculative_decoding": {
      "mean_acceptance_length": 1.23,
      "draft_acceptance_rate": 0.078,
      "acceptance_histogram": [39, 1, 0, 3],
      "num_spec_steps": 43,
      "num_accepted_draft_tokens": 10,
      "num_draft_tokens": 129,
      "num_spec_tokens": 3
    }
  }
}
```

Reading the new histogram: `[39, 1, 0, 3]` means 39 steps accepted 0 draft tokens, 1 step accepted 1, none accepted 2, and 3 steps accepted 3. Position = how many were accepted, value = how often. The old map said the same thing with string keys and no zero entries.

Three smaller things came along with it:

- **Streaming**: the payload now rides the final usage chunk (the one with empty `choices`) instead of the finish-reason chunk.
- **`n > 1`**: vLLM sets `speculative_decoding` to `null` itself, so we no longer need to suppress it on our side.
- **Server flag renamed**: `--per-request-spec-decode-metrics` → `--per-request-spec-decode-metrics`.

## What we changed

- `base_endpoint.py` reads `metrics.speculative_decoding` from the root instead of digging through choices.
- `vllm_adapter.py` converts the array into the sparse map our record already uses (`[39, 1, 0, 3]` → `{0: 39, 1: 1, 3: 3}`).
- Tests, docs, and the plugin registry description updated to match.

## What we deliberately did not change

`SpecDecodeAcceptanceRecord` — our engine-neutral record — keeps its sparse `{accepted: steps}` map. The dense array is a vLLM encoding detail, and absorbing it is exactly the adapter's job. Because the record is untouched, the metrics, console, and JSON export layers needed zero changes.

## Verification

795 tests pass (spec_decode + endpoint capture + metrics), ruff clean, plugin schema validation OK, docs index OK. Also exercised end to end against a vLLM server built from #48915: chat and completions, streaming and non-streaming, `summary` and `detailed` levels, plus an `n > 1` run confirming the section degrades away cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Speculative-decoding metrics are now captured from response-level data in streaming and non-streaming responses.
  * Streaming usage chunks, including empty-choice responses, are supported.
  * Missing or malformed metrics are handled safely.
  * Acceptance histograms are converted from dense lists to sparse maps with zero-count buckets omitted.
  * Streaming requests include usage details by default while preserving explicit opt-outs.
  * Cache handling is updated for the revised streaming payload format.

* **Documentation**
  * Updated setup guidance, API references, and adapter documentation for the current metrics format and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->