### PR TITLE
build(makefile): no-stash pre-commit hook, Python 3.13 default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ make first-time-setup
 # Or manually:
 make setup-venv       # Create virtual environment
 make install          # Install project + mock server + fake amdsmi bindings
-pre-commit install    # Install pre-commit hooks
+make install-hooks    # Install pre-commit hooks (staged-only, no stash)
 ```
 
 ### Available Commands
@@ -40,6 +40,7 @@ pre-commit install    # Install pre-commit hooks
 | `make install-app` | Install project only |
 | `make install-mock-server` | Install mock server only |
 | `make install-mock-amdsmi` | Install fake `amdsmi` bindings to exercise the AMD telemetry path on non-AMD hardware (see [Mocking a ROCm Environment](docs/reference/mock-amdsmi.md)) |
+| `make install-hooks` | Install pre-commit hooks (staged-only, no stash) |
 | `make test` | Unit tests (parallel, excludes integration) |
 | `make test-verbose` | Unit tests with DEBUG logging |
 | `make test-all` | All tests (unit + component integration + integration) |

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ COV ?= 1
 # The path to the virtual environment
 VENV_PATH ?= .venv
 # The python version to use
-PYTHON_VERSION ?= 3.12
+PYTHON_VERSION ?= 3.13
 # The command to activate the virtual environment
 activate_venv = . $(VENV_PATH)/bin/activate
 
@@ -171,6 +171,19 @@ install-mock-server: #? install the mock server in editable mode.
 install-mock-amdsmi: #? install the fake amdsmi bindings for testing the AMD telemetry path.
 	$(activate_venv) && uv pip install -e "tests/aiperf_mock_amdsmi[dev]"
 
+install-hooks: #? write the no-stash pre-commit hook and pre-install hook environments.
+	@hooks_dir=$$(git rev-parse --git-common-dir)/hooks && \
+	mkdir -p "$$hooks_dir" && \
+	printf '%s\n' \
+		'#!/usr/bin/env bash' \
+		'mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACM)' \
+		'if (( $${#staged[@]} )); then' \
+		'    exec $(VENV_PATH)/bin/pre-commit run --files "$${staged[@]}"' \
+		'fi' \
+		> "$$hooks_dir/pre-commit" && \
+	chmod +x "$$hooks_dir/pre-commit"
+	$(activate_venv) && pre-commit install-hooks
+
 check-mock-server-install: #? verify the mock server package and CLI entry point are installed.
 	$(activate_venv) && python -c "import aiperf_mock_server" && command -v aiperf-mock-server >/dev/null
 
@@ -220,9 +233,13 @@ first-time-setup: #? convenience command to setup the environment for the first 
 	@printf "$(bold)$(green)Generating plugin overloads...$(reset)\n"
 	@PATH="$(UV_PATH):$(PATH)" $(MAKE) --no-print-directory generate-plugin-overloads
 
-	@# Install pre-commit hooks
+	@# Install pre-commit hooks.
+	@# We write the hook manually instead of using `pre-commit install` so the hook
+	@# passes only staged files via --files, which bypasses pre-commit's internal
+	@# stash (staged_files_only). `pre-commit install-hooks` still pre-installs
+	@# tool environments without overwriting the hook file.
 	@printf "$(bold)$(green)Installing pre-commit hooks...$(reset)\n"
-	$(activate_venv) && pre-commit install --install-hooks
+	@PATH="$(UV_PATH):$(PATH)" $(MAKE) --no-print-directory install-hooks
 
 	@# Print a success message
 	@printf "$(bold)$(green)Done!$(reset)\n"


### PR DESCRIPTION
## Summary

> [!TIP]
> Our docker image already defaults to python 3.13, and this only changes the developer install path
> Python 3.13 has speed advantages over 3.12, so its beneficial to use as default

- Adds `make install-hooks` target that writes a custom `.git/hooks/pre-commit` instead of using `pre-commit install`. The hook passes only staged files via `--files`, bypassing pre-commit's internal `staged_files_only` stash (`git checkout -- .` + patch restore) that causes corruption under parallel agents.
- Uses `git rev-parse --git-common-dir` for the hook path so the target works correctly in linked worktrees (where `.git` is a gitfile). Installing once covers all worktrees sharing the repo.
- `make first-time-setup` delegates to `install-hooks` for the hook step.
- CONTRIBUTING.md updated: manual steps reference `make install-hooks`, commands table has the new target.
- Bumps `PYTHON_VERSION` default from 3.12 to 3.13.

## Test plan

- [ ] `make install-hooks` writes hook to correct path in both a regular checkout and a linked worktree
- [ ] `git commit` with unstaged changes present: hook runs, unstaged changes survive untouched (no stash)
- [ ] `make first-time-setup` completes without error

---

> [!Tip]
> **10 agents walk into a repo.**
> pre-commit: *stashes everyone's unstaged work*
> pre-commit: *applies it back wrong*
> pre-commit: *"Stashed changes conflicted with hook auto-fixes... Rolling back fixes..."*
> 9 agents lose their work.
> The 1 survivor passes `--files`. This PR is for the survivors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to use the new `make install-hooks` command.
  * Documented the command as installing staged-only pre-commit hooks without stashing changes.

* **Chores**
  * Updated the default Python version for setup to 3.13.
  * Improved first-time setup by automatically configuring and preparing pre-commit hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->