### PR TITLE
ci(k8s): add GitHub Actions workflows for Kubernetes CI

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: "Validate Helm Chart"
+
+# Match the trusted-branch CI convention used by the unit and Kubernetes
+# workflows. Fork PRs enter this workflow after being mirrored to
+# pull-request/<number>.
+on:
+  push:
+    branches:
+      - main
+      - 'pull-request/[0-9]+'
+      - 'release/*'
+    paths:
+      - 'deploy/helm/**'
+      - 'Makefile'
+      - '.github/workflows/helm-chart.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint and render chart
+        run: |
+          make helm-lint
+          make helm-template
+
+      - name: Render release artifacts
+        run: |
+          make crd-release HELM_DIST_DIR=dist/crds
+          make helm-package HELM_DIST_DIR=dist/chart
+
+      - name: Upload rendered artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: aiperf-operator-helm-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            dist/chart/*.tgz
+            dist/crds/*.yaml
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/run-kubernetes-audit-tests.yml
+++ b/.github/workflows/run-kubernetes-audit-tests.yml
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: "Run Kubernetes Audit Tests"
+
+# Operator-vs-bare-pod comparisons are intentionally isolated from the PR gate.
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      pytest_args:
+        description: "Extra pytest arguments, such as -k test_operator_index_matches_disk"
+        type: string
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  kubernetes-audit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      K8S_TEST_CLUSTER: aiperf-audit-${{ github.run_id }}-${{ github.run_attempt }}
+      KUBECONFIG: ${{ runner.temp }}/aiperf-audit-kubeconfig-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - name: Free disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+          sudo apt-get -y clean
+          docker system prune -af || true
+          df -h
+
+      - uses: actions/checkout@v6
+
+      - name: Create isolated kubeconfig
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${KUBECONFIG}")"
+          touch "${KUBECONFIG}"
+          chmod 600 "${KUBECONFIG}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv with cache
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install Kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - name: Install dependencies
+        run: make ci-install PYTHON_VERSION=3.12
+
+      - name: Report pre-test disk and tool versions
+        shell: bash
+        run: |
+          df -h
+          docker version
+          kind version
+          kubectl version --client
+          helm version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build AIPerf image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          build-args: ENABLE_FFMPEG=0
+          platforms: linux/amd64
+          load: true
+          tags: aiperf:local
+          cache-from: type=gha,scope=aiperf-kubernetes-audit
+          cache-to: type=gha,scope=aiperf-kubernetes-audit,mode=max
+        timeout-minutes: 20
+
+      - name: Build mock server image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dev/deploy/Dockerfile.mock-server
+          platforms: linux/amd64
+          load: true
+          tags: aiperf-mock-server:latest
+          cache-from: type=gha,scope=aiperf-mock-server-kubernetes-audit
+          cache-to: type=gha,scope=aiperf-mock-server-kubernetes-audit,mode=max
+        timeout-minutes: 10
+
+      - name: Run Kubernetes audit tests
+        id: pytest
+        shell: bash
+        run: make kubernetes-audit-tests-ci args='--k8s-skip-build ${{ inputs.pytest_args }}'
+        timeout-minutes: 165
+
+      - name: Collect cluster diagnostics on failure
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p k8s-audit-logs
+          kind export logs k8s-audit-logs/kind --name "${K8S_TEST_CLUSTER}" || true
+          kubectl get all -A > k8s-audit-logs/all-resources.txt 2>&1 || true
+          kubectl get events -A --sort-by=.lastTimestamp > k8s-audit-logs/events.txt 2>&1 || true
+          kubectl describe nodes > k8s-audit-logs/describe-nodes.txt 2>&1 || true
+          kubectl describe pods -A > k8s-audit-logs/describe-pods.txt 2>&1 || true
+          kubectl get aiperfjobs -A -o yaml > k8s-audit-logs/aiperfjobs.yaml 2>&1 || true
+          kubectl get aiperfsweeps -A -o yaml > k8s-audit-logs/aiperfsweeps.yaml 2>&1 || true
+          kubectl get jobsets -A -o yaml > k8s-audit-logs/jobsets.yaml 2>&1 || true
+          kubectl get pods -A -o yaml > k8s-audit-logs/pods.yaml 2>&1 || true
+          while read -r namespace pod; do
+            kubectl logs -n "${namespace}" "${pod}" --all-containers --prefix --tail=-1 > "k8s-audit-logs/logs-${namespace}-${pod}.txt" 2>&1 || true
+          done < <(kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+          docker ps -a > k8s-audit-logs/docker-ps.txt 2>&1 || true
+          docker images > k8s-audit-logs/docker-images.txt 2>&1 || true
+          df -h > k8s-audit-logs/disk-usage.txt 2>&1 || true
+          free -h > k8s-audit-logs/memory.txt 2>&1 || true
+          dmesg | tail -500 > k8s-audit-logs/dmesg.txt 2>&1 || true
+
+      - name: Upload cluster diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-audit-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: k8s-audit-logs/
+          retention-days: 7
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Kubernetes audit tests"
+            echo ""
+            echo "Result: **${{ steps.pytest.outcome }}**"
+            if [[ "${{ steps.pytest.outcome }}" != "success" ]]; then
+              echo ""
+              echo "Diagnostics artifact: \`k8s-audit-logs-${{ github.run_id }}-${{ github.run_attempt }}\` (7 day retention)"
+            fi
+            echo ""
+            echo "- Runner: \`ubuntu-latest\`"
+            echo "- Python: \`3.12\`"
+            echo "- Cluster: \`${K8S_TEST_CLUSTER}\`"
+            echo "- Command: \`make kubernetes-audit-tests-ci args=--k8s-skip-build\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Teardown Kind cluster
+        if: always()
+        shell: bash
+        run: kind delete cluster --name "${K8S_TEST_CLUSTER}" || true

--- a/.github/workflows/run-kubernetes-chaos-tests.yml
+++ b/.github/workflows/run-kubernetes-chaos-tests.yml
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: "Run Kubernetes Chaos Tests"
+
+# The normal Kubernetes gate covers deterministic E2E behavior and the
+# hermetic chaos_common contracts. These long-running jobs exercise real pod,
+# operator, network, and control-plane faults against isolated Kind clusters.
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'llms.txt'
+      - 'LICENSE'
+      - '.gitignore'
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      pytest_args:
+        description: "Extra pytest arguments, such as -k test_c1"
+        type: string
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  kubernetes-chaos-tests:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 210
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: legacy
+            label: Legacy AIPerf chaos
+            make_target: kubernetes-chaos-tests-ci
+          - id: unified
+            label: Unified-API AIPerf chaos
+            make_target: kubernetes-chaos-aiperf-tests-ci
+    env:
+      AIPERF_K8S_SHARE_PROCESS_NAMESPACE: "true"
+      K8S_TEST_CLUSTER: aiperf-chaos-${{ matrix.id }}-${{ github.run_id }}-${{ github.run_attempt }}
+      KUBECONFIG: ${{ runner.temp }}/aiperf-chaos-kubeconfig-${{ matrix.id }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - name: Free disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+          sudo apt-get -y clean
+          docker system prune -af || true
+          df -h
+
+      - uses: actions/checkout@v6
+
+      - name: Create isolated kubeconfig
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${KUBECONFIG}")"
+          touch "${KUBECONFIG}"
+          chmod 600 "${KUBECONFIG}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv with cache
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install Kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - name: Install dependencies
+        run: make ci-install PYTHON_VERSION=3.12
+
+      - name: Report pre-test disk and tool versions
+        shell: bash
+        run: |
+          df -h
+          docker version
+          kind version
+          kubectl version --client
+          helm version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build AIPerf image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          build-args: ENABLE_FFMPEG=0
+          platforms: linux/amd64
+          load: true
+          tags: aiperf:local
+          cache-from: type=gha,scope=aiperf-kubernetes-chaos
+          cache-to: type=gha,scope=aiperf-kubernetes-chaos,mode=max
+        timeout-minutes: 20
+
+      - name: Build mock server image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dev/deploy/Dockerfile.mock-server
+          platforms: linux/amd64
+          load: true
+          tags: aiperf-mock-server:latest
+          cache-from: type=gha,scope=aiperf-mock-server-kubernetes-chaos
+          cache-to: type=gha,scope=aiperf-mock-server-kubernetes-chaos,mode=max
+        timeout-minutes: 10
+
+      - name: Run ${{ matrix.label }} tests
+        id: pytest
+        shell: bash
+        run: make ${{ matrix.make_target }} args='--k8s-skip-build ${{ inputs.pytest_args }}'
+        timeout-minutes: 165
+
+      - name: Collect cluster diagnostics on failure
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p k8s-chaos-logs
+          kind export logs k8s-chaos-logs/kind --name "${K8S_TEST_CLUSTER}" || true
+          kubectl get all -A > k8s-chaos-logs/all-resources.txt 2>&1 || true
+          kubectl get events -A --sort-by=.lastTimestamp > k8s-chaos-logs/events.txt 2>&1 || true
+          kubectl describe nodes > k8s-chaos-logs/describe-nodes.txt 2>&1 || true
+          kubectl describe pods -A > k8s-chaos-logs/describe-pods.txt 2>&1 || true
+          kubectl get aiperfjobs -A -o yaml > k8s-chaos-logs/aiperfjobs.yaml 2>&1 || true
+          kubectl get aiperfsweeps -A -o yaml > k8s-chaos-logs/aiperfsweeps.yaml 2>&1 || true
+          kubectl get jobsets -A -o yaml > k8s-chaos-logs/jobsets.yaml 2>&1 || true
+          kubectl get pods -A -o yaml > k8s-chaos-logs/pods.yaml 2>&1 || true
+          while read -r namespace pod; do
+            kubectl logs -n "${namespace}" "${pod}" --all-containers --prefix --tail=-1 > "k8s-chaos-logs/logs-${namespace}-${pod}.txt" 2>&1 || true
+          done < <(kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+          docker ps -a > k8s-chaos-logs/docker-ps.txt 2>&1 || true
+          docker images > k8s-chaos-logs/docker-images.txt 2>&1 || true
+          df -h > k8s-chaos-logs/disk-usage.txt 2>&1 || true
+          free -h > k8s-chaos-logs/memory.txt 2>&1 || true
+          dmesg | tail -500 > k8s-chaos-logs/dmesg.txt 2>&1 || true
+
+      - name: Upload cluster diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-chaos-${{ matrix.id }}-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: k8s-chaos-logs/
+          retention-days: 7
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## ${{ matrix.label }}"
+            echo ""
+            echo "Result: **${{ steps.pytest.outcome }}**"
+            if [[ "${{ steps.pytest.outcome }}" != "success" ]]; then
+              echo ""
+              echo "Diagnostics artifact: \`k8s-chaos-${{ matrix.id }}-logs-${{ github.run_id }}-${{ github.run_attempt }}\`"
+            fi
+            echo ""
+            echo "- Cluster: \`${K8S_TEST_CLUSTER}\`"
+            echo "- Target: \`${{ matrix.make_target }}\`"
+            echo "- AIPERF_K8S_SHARE_PROCESS_NAMESPACE: \`true\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Teardown Kind cluster
+        if: always()
+        shell: bash
+        run: kind delete cluster --name "${K8S_TEST_CLUSTER}" || true

--- a/.github/workflows/run-kubernetes-tests.yml
+++ b/.github/workflows/run-kubernetes-tests.yml
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: "Run Kubernetes Tests"
+
+# Kind requires Docker daemon access. Match the trusted-branch CI convention:
+# fork PRs run after being mirrored to pull-request/<number>.
+on:
+  push:
+    branches:
+      - main
+      - 'pull-request/[0-9]+'
+      - 'release/*'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'llms.txt'
+      - 'LICENSE'
+      - '.gitignore'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  operator-ui-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv with cache
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: make ci-install PYTHON_VERSION=3.12
+
+      - name: Install Chromium for browser E2E
+        run: |
+          uv pip install playwright pytest-playwright
+          uv run playwright install --with-deps chromium
+          uv run python -c "from playwright.sync_api import sync_playwright; p = sync_playwright().start(); browser = p.chromium.launch(headless=True); browser.close(); p.stop()"
+
+      - name: Run operator UI browser E2E
+        run: uv run pytest -m e2e tests/unit/operator/ui_e2e/ -n 0 -v --tb=long
+
+  kubernetes-tests:
+    runs-on: ubuntu-latest
+    # Serial live deployments, hermetic chaos-adapter contracts, and cold
+    # cluster setup need multi-hour headroom, including diagnostics time.
+    timeout-minutes: 240
+    env:
+      K8S_TEST_CLUSTER: aiperf-ci-${{ github.run_id }}-${{ github.run_attempt }}
+      KUBECONFIG: ${{ runner.temp }}/aiperf-kubeconfig-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - name: Free disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+          sudo apt-get -y clean
+          docker system prune -af || true
+          df -h
+
+      - uses: actions/checkout@v6
+
+      - name: Create isolated kubeconfig
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${KUBECONFIG}")"
+          touch "${KUBECONFIG}"
+          chmod 600 "${KUBECONFIG}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv with cache
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install Kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - name: Install dependencies
+        run: make ci-install PYTHON_VERSION=3.12
+
+      - name: Report pre-test disk and tool versions
+        shell: bash
+        run: |
+          df -h
+          docker version
+          kind version
+          kubectl version --client
+          helm version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build AIPerf image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          build-args: ENABLE_FFMPEG=0
+          platforms: linux/amd64
+          load: true
+          tags: aiperf:local
+          cache-from: type=gha,scope=aiperf-kubernetes
+          cache-to: type=gha,scope=aiperf-kubernetes,mode=max
+        timeout-minutes: 20
+
+      - name: Build mock server image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dev/deploy/Dockerfile.mock-server
+          platforms: linux/amd64
+          load: true
+          tags: aiperf-mock-server:latest
+          cache-from: type=gha,scope=aiperf-mock-server-kubernetes
+          cache-to: type=gha,scope=aiperf-mock-server-kubernetes,mode=max
+        timeout-minutes: 10
+
+      - name: Run Kubernetes tests
+        id: pytest
+        run: make kubernetes-tests-ci args=--k8s-skip-build
+        timeout-minutes: 165
+
+      - name: Collect cluster diagnostics on failure
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p k8s-ci-logs
+          kind export logs k8s-ci-logs/kind --name "${K8S_TEST_CLUSTER}" || true
+          kubectl get all -A > k8s-ci-logs/all-resources.txt 2>&1 || true
+          kubectl get events -A --sort-by=.lastTimestamp > k8s-ci-logs/events.txt 2>&1 || true
+          kubectl describe nodes > k8s-ci-logs/describe-nodes.txt 2>&1 || true
+          kubectl describe pods -A > k8s-ci-logs/describe-pods.txt 2>&1 || true
+          kubectl get aiperfjobs -A -o yaml > k8s-ci-logs/aiperfjobs.yaml 2>&1 || true
+          kubectl get aiperfsweeps -A -o yaml > k8s-ci-logs/aiperfsweeps.yaml 2>&1 || true
+          kubectl get jobsets -A -o yaml > k8s-ci-logs/jobsets.yaml 2>&1 || true
+          kubectl get pods -A -o yaml > k8s-ci-logs/pods.yaml 2>&1 || true
+          while read -r namespace pod; do
+            kubectl logs -n "${namespace}" "${pod}" --all-containers --prefix --tail=-1 > "k8s-ci-logs/logs-${namespace}-${pod}.txt" 2>&1 || true
+          done < <(kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+          docker ps -a > k8s-ci-logs/docker-ps.txt 2>&1 || true
+          docker images > k8s-ci-logs/docker-images.txt 2>&1 || true
+          df -h > k8s-ci-logs/disk-usage.txt 2>&1 || true
+          free -h > k8s-ci-logs/memory.txt 2>&1 || true
+          dmesg | tail -500 > k8s-ci-logs/dmesg.txt 2>&1 || true
+
+      - name: Upload cluster diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-ci-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: k8s-ci-logs/
+          retention-days: 7
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Kubernetes tests"
+            echo ""
+            echo "Result: **${{ steps.pytest.outcome }}**"
+            if [[ "${{ steps.pytest.outcome }}" != "success" ]]; then
+              echo ""
+              echo "Diagnostics artifact: \`k8s-ci-logs-${{ github.run_id }}-${{ github.run_attempt }}\` (7 day retention)"
+            fi
+            echo ""
+            echo "- Runner: \`ubuntu-latest\`"
+            echo "- Python: \`3.12\`"
+            echo "- Cluster: \`${K8S_TEST_CLUSTER}\`"
+            echo "- Command: \`make kubernetes-tests-ci args=--k8s-skip-build\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Teardown Kind cluster
+        if: always()
+        shell: bash
+        run: kind delete cluster --name "${K8S_TEST_CLUSTER}" || true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,22 @@ The System Controller is the central orchestrator that manages the lifecycle and
 - Monitoring the overall progress and health of the benchmarking process
 - Managing error handling, cleanup, and graceful termination of all modules
 
+Result-producing services register their result domains with the System Controller.
+Shutdown begins only after profiling has started and every registered domain has
+either completed or been evicted after a confirmed service failure. This lifecycle
+gate prevents an empty startup barrier from being mistaken for completed results.
+
+Kubernetes result publication is a fail-closed filesystem transaction. Before
+a controller starts benchmark work, and again immediately before export, it
+durably removes any stale ready marker and atomically installs a processing
+marker. After every required artifact is flushed and exported, it atomically
+installs and fsyncs the ready marker before clearing the processing marker. Only
+then does it publish `ResultsExportedMessage` and notify the operator. A crash
+or restarted export before that commit leaves top-level artifacts hidden from
+the results sidecar. Kubernetes sweep aggregation uses
+the same durable ready-marker commit after plotting and scratch-artifact pruning
+finish, so the operator never harvests a partially published aggregate tree.
+
 ### Dataset Manager
 
 The Dataset Manager handles all aspects of input data management during benchmarking runs.
@@ -118,14 +134,16 @@ The Records Manager handles the collection, organization, and storage of benchma
 
 The Records Manager does not hard-wire one handler per producer. Instead, every typed record carries a `record_type` class attribute and is fanned out through a metadata-driven routing table: each accumulator and stream exporter declares the record types it consumes via `record_types` in `plugins.yaml`, and `_dispatch_record` routes each record by `getattr(record, "record_type")` to all registered handlers. This makes each record type a dedicated channel.
 
-Accuracy benchmarking is one such dedicated channel, joining `metric_records`, `gpu_telemetry`, and `server_metrics`:
+Accuracy benchmarking and GPU telemetry use dedicated Records Manager channels.
+Server metrics use the same plugin metadata to select local consumers, but raw
+Prometheus snapshots remain inside Server Metrics Manager:
 
 | Channel (`record_type`) | Producer | Message | Consumers (`record_types`) |
 |---|---|---|---|
 | `metric_records` | Record Processor (`MetricRecordProcessor`) | `RecordsMessage` | `MetricsAccumulator`, JSONL/OTel stream exporters |
 | `accuracy` | Record Processor (`AccuracyRecordProcessor`) | `RecordsMessage` | `AccuracyAccumulator`, `AccuracyJSONLWriter` |
 | `gpu_telemetry` | GPU Telemetry Manager | `TelemetryRecordsMessage` | `GPUTelemetryAccumulator`, GPU JSONL writer |
-| `server_metrics` | Server Metrics Manager | `ServerMetricsRecordMessage` | `ServerMetricsAccumulator`, server-metrics JSONL writer |
+| `server_metrics` | Server Metrics Manager | None (manager-local callback) | `ServerMetricsAccumulator`, server-metrics JSONL writer, both hosted by Server Metrics Manager |
 
 **Two-stage record processing.** The `RecordProcessorService` runs two roles per parsed response (mirroring the accumulator/stream-exporter split on the consumer side): **producers** (`record_processor` category) parse and emit one finished typed record on a declared `record_type` channel — `MetricRecordProcessor` → `MetricRecordsData` (`metric_records`), `AccuracyRecordProcessor` → `AccuracyRecordsData` (`accuracy`) — and **observers** (`record_observer` category, e.g. the raw-record and outputs-json writers) receive a `RecordObserverContext` (the parsed record + all producer outputs keyed by `record_type`) and act without emitting a channel record. Each producer's output carries its own serialized `record_type` discriminator, so the service ships **one generic `RecordsMessage`** per request — `{metadata, records: list[RecordData], error}` — and the `RecordsManager` dispatches each record to its channel handlers by `record.record_type` (no per-type message classes, no type-sniffing). The metric record is the canonical per-request record that drives the phase-completion lockstep, keyed off the message metadata.
 
@@ -159,6 +177,13 @@ The GPU Telemetry Manager collects GPU metrics during benchmarking runs via plug
 - Supporting custom endpoints via `--gpu-telemetry` flag
 - Exporting GPU telemetry alongside benchmark results
 
+Final GPU samples and the completion command use different message-bus channels, so
+the command response alone is not an ingest barrier. The GPU Telemetry Manager closes
+record admission and sends a sequenced terminal marker on the telemetry PUSH socket.
+The Records Manager waits until every sequence through that marker has finished
+dispatch before summarizing or finalizing stream exporters. A missing marker or
+sequence fails result finalization closed instead of publishing a partial JSONL file.
+
 ### GPU Power Efficiency Analysis
 
 At the end of each profiling phase, `EnergyEfficiencyAnalyzer` — an `analyzer` plugin — joins GPU telemetry energy/power data with inference token and throughput totals to produce the GPU power-efficiency metric family.
@@ -176,8 +201,10 @@ The Server Metrics Manager collects metrics from Prometheus-compatible endpoints
 **Key Responsibilities:**
 - Collecting metrics from Prometheus-compatible endpoints (inference server application metrics, system metrics, custom metrics)
 - Auto-discovering metrics endpoints from configured inference server URLs (`--url`)
+- Discovering eligible inference-server pods through the Kubernetes API, scoped to the benchmark namespace unless another namespace is explicitly configured
 - Supporting custom Prometheus endpoints via `--server-metrics` flag
 - Parsing any metrics exposed in Prometheus format (gauges, counters, histograms)
+- Owning raw server-metric accumulation and JSONL writes locally; only bounded realtime summaries and the final aggregate cross the message bus
 - Typical metrics collected: inference server KV cache usage, request counts, latencies, batch sizes, model-specific metrics, and server resource metrics
 - Auto-detecting non-Prometheus endpoints (e.g. TRT-LLM serves an iteration-stats JSON array at `/metrics` by default), probing `<base>/prometheus/metrics` once as a fallback, and disabling collection for that endpoint after a single warning if neither path yields parseable Prometheus data — see [Server Metrics Compatibility & auto-disable](server-metrics/server-metrics.md#compatibility--auto-disable)
 - Exporting server metrics alongside benchmark results
@@ -204,6 +231,7 @@ The Timing Manager uses a **credit-based flow control system** to control when r
 **Credit Distribution:**
 - Credits are dispatched to workers via a ROUTER/DEALER pattern (the Timing Manager's sticky ROUTER to each worker's DEALER)
 - Router selects workers based on sticky sessions (multi-turn conversations) or least-loaded worker selection
+- If a sticky worker is lost, sessions whose dataset does not contain the assistant responses needed to reconstruct context fail through the normal credit-return accounting path instead of silently migrating. Dataset-authored-response sessions may re-home; DAG descendants never opt into migration because FORK context and replay placement are worker-local. Lost-session routing state is scoped to the named phase instance so starting a seamless phase cannot erase safeguards for the prior phase while it drains.
 - Credit returns travel back on a dedicated PUSH/PULL fan-in channel: each worker PUSHes its `CreditReturn`/`FirstToken` to the Timing Manager's single PULL, separating the high-volume return path from credit dispatch
 - The return channel carries no ZMQ envelope identity, so the returning worker id travels inside the message
 - No coordination required between workers

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -40,6 +40,108 @@ Expand a sweep config and print the resulting variations.
 
 Validate an AIPerf config file.
 
+### [`kube init`](#aiperf-kube-init)
+
+Generate a starter configuration template
+
+### [`kube validate`](#aiperf-kube-validate)
+
+Validate AIPerfJob and AIPerfSweep YAML files against the CRD schema
+
+### [`kube profile`](#aiperf-kube-profile)
+
+Run a benchmark in Kubernetes
+
+[Endpoint](#endpoint) • [Tokenizer](#tokenizer) • [Input](#input) • [Fixed Schedule](#fixed-schedule) • [Goodput](#goodput) • [Conversation Input](#conversation-input) • [Prompt](#prompt) • [Cache Bust](#cache-bust) • [Prefix Prompt](#prefix-prompt) • [Input Sequence Length (ISL)](#input-sequence-length-isl) • [Output Sequence Length (OSL)](#output-sequence-length-osl) • [Audio Input](#audio-input) • [Image Input](#image-input) • [Video Input](#video-input) • [Rankings](#rankings) • [Synthesis](#synthesis) • [Load Generator](#load-generator) • [Scenario](#scenario) • [Warmup](#warmup) • [User-Centric Rate](#user-centric-rate) • [Request Cancellation](#request-cancellation) • [Output](#output) • [HTTP Trace](#http-trace) • [Server Metrics](#server-metrics) • [Network Latency](#network-latency) • [GPU Telemetry](#gpu-telemetry) • [UI](#ui) • [Multi-Run](#multi-run) • [Accuracy](#accuracy) • [Service](#service) • [ZMQ Communication](#zmq-communication) • [Kubernetes](#kubernetes) • [Kubernetes Node Placement](#kubernetes-node-placement) • [Kubernetes Scheduling](#kubernetes-scheduling) • [Kubernetes Metadata](#kubernetes-metadata) • [Kubernetes Secrets](#kubernetes-secrets) • [Parameters](#parameters)
+
+### [`kube sweep`](#aiperf-kube-sweep)
+
+Run a parameter sweep or multi-run benchmark in Kubernetes
+
+[Endpoint](#endpoint) • [Tokenizer](#tokenizer) • [Input](#input) • [Fixed Schedule](#fixed-schedule) • [Goodput](#goodput) • [Conversation Input](#conversation-input) • [Prompt](#prompt) • [Cache Bust](#cache-bust) • [Prefix Prompt](#prefix-prompt) • [Input Sequence Length (ISL)](#input-sequence-length-isl) • [Output Sequence Length (OSL)](#output-sequence-length-osl) • [Audio Input](#audio-input) • [Image Input](#image-input) • [Video Input](#video-input) • [Rankings](#rankings) • [Synthesis](#synthesis) • [Load Generator](#load-generator) • [Scenario](#scenario) • [Warmup](#warmup) • [User-Centric Rate](#user-centric-rate) • [Request Cancellation](#request-cancellation) • [Output](#output) • [HTTP Trace](#http-trace) • [Server Metrics](#server-metrics) • [Network Latency](#network-latency) • [GPU Telemetry](#gpu-telemetry) • [UI](#ui) • [Multi-Run](#multi-run) • [Accuracy](#accuracy) • [Service](#service) • [ZMQ Communication](#zmq-communication) • [Kubernetes](#kubernetes) • [Kubernetes Node Placement](#kubernetes-node-placement) • [Kubernetes Scheduling](#kubernetes-scheduling) • [Kubernetes Metadata](#kubernetes-metadata) • [Kubernetes Secrets](#kubernetes-secrets) • [Parameters](#parameters)
+
+### [`kube generate`](#aiperf-kube-generate)
+
+Generate Kubernetes YAML manifests
+
+[Endpoint](#endpoint) • [Tokenizer](#tokenizer) • [Input](#input) • [Fixed Schedule](#fixed-schedule) • [Goodput](#goodput) • [Conversation Input](#conversation-input) • [Prompt](#prompt) • [Cache Bust](#cache-bust) • [Prefix Prompt](#prefix-prompt) • [Input Sequence Length (ISL)](#input-sequence-length-isl) • [Output Sequence Length (OSL)](#output-sequence-length-osl) • [Audio Input](#audio-input) • [Image Input](#image-input) • [Video Input](#video-input) • [Rankings](#rankings) • [Synthesis](#synthesis) • [Load Generator](#load-generator) • [Scenario](#scenario) • [Warmup](#warmup) • [User-Centric Rate](#user-centric-rate) • [Request Cancellation](#request-cancellation) • [Output](#output) • [HTTP Trace](#http-trace) • [Server Metrics](#server-metrics) • [Network Latency](#network-latency) • [GPU Telemetry](#gpu-telemetry) • [UI](#ui) • [Multi-Run](#multi-run) • [Accuracy](#accuracy) • [Service](#service) • [ZMQ Communication](#zmq-communication) • [Kubernetes](#kubernetes) • [Kubernetes Node Placement](#kubernetes-node-placement) • [Kubernetes Scheduling](#kubernetes-scheduling) • [Kubernetes Metadata](#kubernetes-metadata) • [Kubernetes Secrets](#kubernetes-secrets) • [Parameters](#parameters)
+
+### [`kube setup`](#aiperf-kube-setup)
+
+Install cluster prerequisites (JobSet CRD, namespaces, AIPerf operator)
+
+[Kubernetes](#kubernetes) • [Parameters](#parameters)
+
+### [`kube delete`](#aiperf-kube-delete)
+
+Delete a benchmark and its backing Kubernetes resources
+
+[Parameters](#parameters) • [Kubernetes](#kubernetes)
+
+### [`kube cleanup`](#aiperf-kube-cleanup)
+
+Bulk-remove finished benchmarks from a namespace
+
+[Kubernetes](#kubernetes) • [Parameters](#parameters)
+
+### [`kube shutdown`](#aiperf-kube-shutdown)
+
+Retire a finished benchmark's controller pod
+
+[Parameters](#parameters) • [Kubernetes](#kubernetes)
+
+### [`kube cancel`](#aiperf-kube-cancel)
+
+Cancel a running benchmark (patches spec.cancel on the CR)
+
+[Parameters](#parameters) • [Kubernetes](#kubernetes)
+
+### [`kube attach`](#aiperf-kube-attach)
+
+Attach to a running benchmark and stream progress
+
+[Parameters](#parameters) • [Kubernetes](#kubernetes)
+
+### [`kube list`](#aiperf-kube-list)
+
+List benchmark jobs and their status
+
+[Parameters](#parameters) • [Kubernetes](#kubernetes)
+
+### [`kube logs`](#aiperf-kube-logs)
+
+Retrieve logs from benchmark pods
+
+[Parameters](#parameters) • [Kubernetes](#kubernetes)
+
+### [`kube results`](#aiperf-kube-results)
+
+Retrieve benchmark results
+
+[Parameters](#parameters) • [Kubernetes](#kubernetes)
+
+### [`kube show`](#aiperf-kube-show)
+
+Render an AIPerfJob CR with Jinja2/env-vars resolved
+
+### [`kube debug`](#aiperf-kube-debug)
+
+Run diagnostic analysis on a deployment
+
+[Kubernetes](#kubernetes) • [Parameters](#parameters)
+
+### [`kube preflight`](#aiperf-kube-preflight)
+
+Run pre-flight checks against the target Kubernetes cluster
+
+[Kubernetes](#kubernetes) • [Parameters](#parameters)
+
+### [`kube dashboard`](#aiperf-kube-dashboard)
+
+Open the operator results server UI in your browser
+
+[Kubernetes](#kubernetes) • [Parameters](#parameters)
+
 ### [`profile`](#aiperf-profile)
 
 Run the Profile subcommand.
@@ -54,11 +156,13 @@ Generate visualizations from AIPerf profiling data.
 
 Explore AIPerf plugins: aiperf plugins [category] [type]
 
+### [`proxy`](#aiperf-proxy)
+
+Run a single ZMQ proxy in this process until SIGTERM/SIGINT.
+
 ### [`service`](#aiperf-service)
 
 Run an AIPerf service in a single process.
-
-[Parameters](#parameters) • [Endpoint](#endpoint) • [Tokenizer](#tokenizer) • [Input](#input) • [Fixed Schedule](#fixed-schedule) • [Goodput](#goodput) • [Conversation Input](#conversation-input) • [Prompt](#prompt) • [Cache Bust](#cache-bust) • [Prefix Prompt](#prefix-prompt) • [Input Sequence Length (ISL)](#input-sequence-length-isl) • [Output Sequence Length (OSL)](#output-sequence-length-osl) • [Audio Input](#audio-input) • [Image Input](#image-input) • [Video Input](#video-input) • [Rankings](#rankings) • [Synthesis](#synthesis) • [Load Generator](#load-generator) • [Scenario](#scenario) • [Warmup](#warmup) • [User-Centric Rate](#user-centric-rate) • [Request Cancellation](#request-cancellation) • [Output](#output) • [HTTP Trace](#http-trace) • [Server Metrics](#server-metrics) • [Network Latency](#network-latency) • [GPU Telemetry](#gpu-telemetry) • [UI](#ui) • [Multi-Run](#multi-run) • [Accuracy](#accuracy) • [Service](#service) • [Workers](#workers) • [ZMQ Communication](#zmq-communication)
 
 ### [`speed-bench-report`](#aiperf-speed-bench-report)
 
@@ -289,6 +393,5295 @@ Loads the config through the same pipeline as `aiperf profile`, surfacing fatal 
 ### `--config-file` `<str>` _(Required)_
 
 Path to an AIPerf YAML config to validate.
+
+<hr/>
+
+## `aiperf kube init`
+
+Generate a starter configuration template
+
+### `-t`, `--template` `<str>`
+
+Template name to use (e.g. 'minimal', 'goodput_slo'). Run with --list to see all available templates.
+
+### `-l`, `--list`, `--no-list`
+
+List all available templates grouped by category.
+
+### `-s`, `--search` `<str>`
+
+Search templates by keyword (matches name, description, tags, features).
+
+### `-c`, `--category` `<str>`
+
+Filter templates by category (substring match).
+
+### `-v`, `--verbose`, `--no-verbose`
+
+Show tags, features, and difficulty in template listings.
+
+### `--model` `<str>`
+
+Override model name in the generated config.
+
+### `--url` `<str>`
+
+Override endpoint URL in the generated config.
+
+### `-o`, `--output` `<str>`
+
+Output file path. If not specified, prints to stdout.
+
+### `--job-name` `<str>`
+
+Value for metadata.name on the generated AIPerfJob.
+<br/>_Default: `my-benchmark`_
+
+<hr/>
+
+## `aiperf kube validate`
+
+Validate AIPerfJob and AIPerfSweep YAML files against the CRD schema
+
+### `--files` `<list>` _(Required)_
+
+One or more AIPerfJob or AIPerfSweep YAML file paths to validate.
+
+### `-s`, `--strict`, `--no-strict`
+
+Fail on warnings such as unknown spec fields.
+
+### `-o`, `--output` `<str>`
+
+Output format: "text" for human-readable, "json" for machine-parseable.
+<br/>_Default: `text`_
+
+<hr/>
+
+## `aiperf kube profile`
+
+Run a benchmark in Kubernetes
+
+### Endpoint
+
+#### `-m`, `--model-names`, `--model` `<list>`
+
+Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
+
+#### `--model-selection-strategy` `<str>`
+
+When multiple models are specified, this is how a specific model should be assigned to a prompt. round_robin: nth prompt in the list gets assigned to n-mod len(models). random: assignment is uniformly random.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `round_robin` | _default_ | Cycle through models in order. The nth prompt is assigned to model at index (n mod number_of_models). |
+| `random` |  | Randomly select a model for each prompt using uniform distribution. |
+| `weighted` |  | Select a model with probability proportional to a per-model weight. |
+
+#### `--custom-endpoint`, `--endpoint` `<str>`
+
+Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default, endpoints follow OpenAI-compatible paths like `/v1/chat/completions`. Use this option to override the default path for non-standard API implementations.
+
+#### `--endpoint-type` `<str>`
+
+The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
+<br/>_Choices: [`audio_transcription`, `chat`, `cohere_rankings`, `completions`, `responses`, `messages`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
+<br/>_Default: `chat`_
+
+#### `--streaming`
+
+Enable streaming responses. When enabled, the server streams tokens incrementally as they are generated. Automatically disabled if the selected endpoint type does not support streaming. Enables measurement of time-to-first-token (TTFT) and inter-token latency (ITL) metrics.
+<br/>_Flag (no value required)_
+
+#### `-u`, `--url` `<list>`
+
+Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). URLs that do not include a scheme (no `://`) have `http://` prepended automatically.
+<br/>_Constraints: min: 1_
+<br/>_Default: `['http://localhost:8000']`_
+
+#### `--url-strategy` `<str>`
+
+Strategy for selecting URLs when multiple `--url` values are provided. 'round_robin' (default): distribute requests evenly across URLs in sequential order.
+<br/>_Choices: [`round_robin`]_
+<br/>_Default: `round_robin`_
+
+#### `--request-timeout-seconds` `<float>`
+
+Maximum time in seconds to wait for each HTTP request to complete, including connection establishment, request transmission, and response receipt. Applies to both streaming and non-streaming requests. Requests exceeding this timeout are cancelled and recorded as failures.
+<br/>_Constraints: > 0_
+<br/>_Default: `21600`_
+
+#### `--wait-for-model-timeout` `<float>`
+
+Seconds to wait for endpoint readiness before benchmarking (0 = skip). Sends a real inference request to verify the model is loaded and can generate output.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--wait-for-model-mode` `<str>`
+
+How readiness probes the endpoint: 'models' checks /v1/models, 'inference' sends a canned one-token inference request, and 'both' runs the models check before inference.
+<br/>_Default: `inference`_
+
+#### `--wait-for-model-interval` `<float>`
+
+Seconds between endpoint readiness probe attempts.
+<br/>_Constraints: > 0.0_
+<br/>_Default: `5.0`_
+
+#### `--reset-kv-cache`
+
+Enable once-per-cell KV-cache reset via POST to the endpoint.
+<br/>_Flag (no value required)_
+
+#### `--reset-kv-cache-timeout-seconds` `<float>`
+
+Timeout seconds for reset_kv_cache control requests.
+<br/>_Constraints: > 0_
+
+#### `--reset-kv-cache-path` `<str>`
+
+Relative path for reset_kv_cache (default /reset_prefix_cache).
+
+#### `--server-profiler`
+
+Enable server profiler start/stop around profiling phases.
+<br/>_Flag (no value required)_
+
+#### `--server-profiler-timeout-seconds` `<float>`
+
+Timeout seconds for server_profiler control requests.
+<br/>_Constraints: > 0_
+
+#### `--server-profiler-start-path` `<str>`
+
+Relative path for profiler start (default /start_profile).
+
+#### `--server-profiler-stop-path` `<str>`
+
+Relative path for profiler stop (default /stop_profile).
+
+#### `--api-key` `<str>`
+
+API authentication key for the endpoint. When provided, automatically included in request headers as `Authorization: Bearer <api_key>`.
+
+#### `--transport`, `--transport-type` `<str>`
+
+Transport protocol to use for API requests. If not specified, auto-detected from the URL scheme (`http`/`https` -> `TransportType.HTTP`). Currently supports `http` transport using aiohttp with connection pooling, TCP optimization, and Server-Sent Events (SSE) for streaming. Explicit override rarely needed.
+<br/>_Choices: [`http`]_
+
+#### `--use-legacy-max-tokens`
+
+Use the legacy 'max_tokens' field instead of 'max_completion_tokens' in request payloads. The OpenAI API now prefers 'max_completion_tokens', but some older APIs or implementations may require 'max_tokens'.
+<br/>_Flag (no value required)_
+
+#### `--use-server-token-count`
+
+Use server-reported token counts from API usage fields instead of client-side tokenization. When enabled, tokenizers are still loaded (needed for dataset generation) but tokenizer.encode() is not called for computing metrics. Token count fields will be None if the server does not provide usage information. For OpenAI-compatible streaming endpoints (chat/completions), stream_options.include_usage is automatically configured when this flag is enabled.
+<br/>_Flag (no value required)_
+
+#### `--connection-reuse-strategy` `<str>`
+
+Transport connection reuse strategy. 'pooled' (default): connections are pooled and reused across all requests. 'never': new connection for each request, closed after response. 'sticky-user-sessions': connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `pooled` | _default_ | Connections are pooled and reused across all requests |
+| `never` |  | New connection for each request, closed after response |
+| `sticky-user-sessions` |  | Connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing) |
+
+#### `--download-video-content`
+
+For video generation endpoints, download the video content after generation completes. When enabled, request latency includes the video download time. When disabled (default), only generation time is measured.
+<br/>_Flag (no value required)_
+
+#### `--request-content-type` `<str>`
+
+Content type for request body serialization. By default, requests are sent as 'application/json'. Set to 'multipart/form-data' for servers that require form-encoded requests (e.g., vLLM video generation endpoints).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `application/json` |  | Standard JSON encoding. Default for all endpoints. |
+| `multipart/form-data` |  | Multipart form encoding. Required by some video generation servers (e.g., vLLM). |
+
+#### `--session-header` `<str>`
+
+HTTP header name used to carry the per-session affinity identifier. When set, replaces the default `X-Correlation-ID` header with the provided name (e.g., `--session-header X-Session-ID`).
+
+#### `--uuid-and-strip`
+
+Enable AIPerf-managed image stripping for vLLM's multimodal processor cache. Dataset-authored image UUIDs, including UUID-only cache references, always pass through on the chat endpoint; this flag only strips repeated content after AIPerf observes it in the same session. Automatic stripping supports only single_turn datasets with session_id-grouped rows; multi_turn is rejected. The server cache must cover the working set, and requests in a session must reach a replica that retains earlier UUIDs.
+<br/>_Flag (no value required)_
+
+### Tokenizer
+
+#### `--tokenizer` `<str>`
+
+HuggingFace tokenizer identifier, local path, or `builtin` for token counting in prompts and responses. Accepts model names (e.g., `meta-llama/Llama-2-7b-hf`), filesystem paths to tokenizer files, or `builtin` for a zero-network-access tokenizer backed by tiktoken (o200k_base encoding). If not specified, defaults to the value of `--model-names`. If `--tokenizer` is not set and the model name looks like an obvious placeholder (e.g. `mock-model`, `test-model`, `fake-model`), AIPerf substitutes `builtin` automatically and emits a warning. Essential for accurate token-based metrics (input/output token counts, token throughput).
+
+#### `--tokenizer-revision` `<str>`
+
+Specific tokenizer version to load from HuggingFace Hub. Can be a branch name (e.g., `main`), tag name (e.g., `v1.0`), or full commit hash. Ensures reproducible tokenization across runs by pinning to a specific version. Defaults to `main` branch if not specified.
+<br/>_Default: `main`_
+
+#### `--tokenizer-trust-remote-code`
+
+Allow execution of custom Python code from HuggingFace Hub tokenizer repositories. Required for tokenizers with custom implementations not in the standard `transformers` library. **Security Warning**: Only enable for trusted repositories, as this executes arbitrary code. Unnecessary for standard tokenizers.
+<br/>_Flag (no value required)_
+
+#### `--apply-chat-template`
+
+Apply the HuggingFace tokenizer's chat template when counting input tokens. When enabled: synthetic ISL is compensated for chat-template wrapping (BOS, role headers, EOT, generation-prompt suffix) and the record processor reports ISL using `apply_chat_template(tokenize=True, add_generation_prompt=True)` for chat-shape payloads. When disabled (default), both paths use bare-text encoding, so reported ISL matches the prompt content the user asked for and ignores template overhead. Requires an HF tokenizer with a chat template configured; no-ops on tiktoken / un-templated models.
+<br/>_Flag (no value required)_
+
+### Input
+
+#### `--extra-inputs` `<list>`
+
+Additional input parameters to include in every API request payload. Specify as `key:value` pairs (e.g., `--extra-inputs temperature:0.7 top_p:0.9`) or as JSON string (e.g., `'{"temperature": 0.7}'`). These parameters are merged with request-specific inputs and sent directly to the endpoint API.
+
+#### `-H`, `--header` `<list>`
+
+Custom HTTP headers to include with every request. Specify as `Header:Value` pairs (e.g., `--header X-Custom-Header:value`) or as JSON string. Can be specified multiple times. Useful for custom authentication, tracking, or API-specific requirements. Combined with auto-generated headers (e.g., `Authorization` from `--api-key`).
+
+#### `--input-file` `<str>`
+
+Path to file or directory containing benchmark dataset. Required when using `--custom-dataset-type`. Supported formats depend on dataset type: JSONL for `single_turn`/`multi_turn`, JSONL for `mooncake_trace`/`bailian_trace` (timestamped traces), Parquet for `baseten_trace`, directories for `random_pool`. File is parsed according to `--custom-dataset-type` specification.
+
+#### `--public-dataset` `<str>`
+
+Pre-configured public dataset to download and use for benchmarking (e.g., `sharegpt`). AIPerf automatically downloads and parses these datasets. Mutually exclusive with `--custom-dataset-type`. Run `aiperf plugins public_dataset_loader` to list available datasets. Use `--hf-subset` to override the HuggingFace subset/config for HF-backed datasets.
+<br/>_Choices: [`exgentic_v2`, `exgentic`, `sharegpt`, `aimo`, `mmstar`, `mmvu`, `vision_arena`, `llava_onevision`, `aimo_aime`, `aimo_numina_cot`, `aimo_numina_1_5`, `spec_bench`, `spec_al_gsm8k`, `spec_al_math500`, `spec_al_humaneval`, `spec_al_mbpp`, `spec_al_mtbench`, `instruct_coder`, `blazedit_5k`, `blazedit_10k`, `librispeech`, `voxpopuli`, `gigaspeech`, `ami`, `spgispeech`, `semianalysis_cc_traces_weka`, `semianalysis_cc_traces_weka_no_subagents`, `semianalysis_cc_traces_weka_with_subagents`, `semianalysis_cc_traces_weka_with_subagents_256k`, `semianalysis_cc_traces_weka_with_subagents_060226`, `semianalysis_cc_traces_weka_with_subagents_060226_256k`, `semianalysis_cc_traces_weka_with_subagents_060526`, `semianalysis_cc_traces_weka_with_subagents_060526_256k`, `semianalysis_cc_traces_weka_with_subagents_060826`, `semianalysis_cc_traces_weka_with_subagents_060826_256k`, `semianalysis_cc_traces_weka_061326`, `semianalysis_cc_traces_weka_061326_256k`, `semianalysis_cc_traces_weka_061526`, `semianalysis_cc_traces_weka_061526_256k`, `semianalysis_cc_traces_weka_062126`, `semianalysis_cc_traces_weka_062126_256k`, `weka_hf`]_
+
+#### `--hf-subset` `<str>`
+
+HuggingFace dataset subset/config name to override the plugin default (e.g. `sharegpt4o`). Only applies when using `--public-dataset` with a HuggingFace-backed loader. Takes priority over the subset defined in the plugin registry.
+
+#### `--hf-weka-dataset` `<str>`
+
+HuggingFace dataset repo for the generic Weka loader (e.g. `semianalysisai/cc-traces-weka-061526`). Passing this auto-selects `--public-dataset weka_hf`, so the repo flag works on its own; setting it alongside any other `--public-dataset` or `--custom-dataset-type` is an error. Pinned Weka public dataset aliases keep their registry-defined repo names.
+
+#### `--dataset-filter` `<list>`
+
+Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
+
+#### `--custom-dataset-type` `<str>`
+
+Format specification for custom dataset provided via `--input-file`. Determines parsing logic and expected file structure. Options: `single_turn` (JSONL with single exchanges), `multi_turn` (JSONL with conversation history), `tracelab` (TraceLab agentic-coding corpus, JSONL or gzipped JSONL), `mooncake_trace`/`bailian_trace`/`baseten_trace` (timestamped trace files), `random_pool` (directory of reusable prompts; when using `random_pool`, `--conversation-num` defaults to 100 if not specified; batch sizes > 1 sample each modality independently from a flat pool and do not preserve per-entry associations - use `single_turn` if paired modalities must stay together). Requires `--input-file`. Mutually exclusive with `--public-dataset`.
+<br/>_Choices: [`burst_gpt_trace`, `bailian_trace`, `baseten_trace`, `mooncake_trace`, `raw_payload`, `inputs_json`, `dag_jsonl`, `sagemaker_data_capture`, `multi_turn`, `random_pool`, `single_turn`, `speed_bench_qualitative`, `speed_bench_coding`, `speed_bench_humanities`, `speed_bench_math`, `speed_bench_multilingual`, `speed_bench_qa`, `speed_bench_rag`, `speed_bench_reasoning`, `speed_bench_roleplay`, `speed_bench_stem`, `speed_bench_summarization`, `speed_bench_writing`, `speed_bench_throughput_1k`, `speed_bench_throughput_2k`, `speed_bench_throughput_8k`, `speed_bench_throughput_16k`, `speed_bench_throughput_32k`, `speed_bench_throughput_1k_low_entropy`, `speed_bench_throughput_1k_mixed`, `speed_bench_throughput_1k_high_entropy`, `speed_bench_throughput_2k_low_entropy`, `speed_bench_throughput_2k_mixed`, `speed_bench_throughput_2k_high_entropy`, `speed_bench_throughput_8k_low_entropy`, `speed_bench_throughput_8k_mixed`, `speed_bench_throughput_8k_high_entropy`, `speed_bench_throughput_16k_low_entropy`, `speed_bench_throughput_16k_mixed`, `speed_bench_throughput_16k_high_entropy`, `speed_bench_throughput_32k_low_entropy`, `speed_bench_throughput_32k_mixed`, `speed_bench_throughput_32k_high_entropy`, `tracelab`, `weka_trace`]_
+
+#### `--ignore-trace-delays`
+
+Strip per-turn timestamps and inter-turn delays from trace datasets at load time. With this flag, Turn.timestamp and Turn.delay are emitted as None so concurrency / request-rate timing modes dispatch turns back-to-back instead of reproducing the recorded user think-time gaps. No effect under `--fixed-schedule` (timestamps drive that mode before they could be ignored -- combine with `--no-fixed-schedule` if you want both behaviors).
+<br/>_Flag (no value required)_
+
+#### `--use-think-time-only`
+
+For weka_trace inputs, emit Turn.delay using only the recorded per-request `think_time` (client-side delay before each request) instead of the full `t_curr - t_prev` inter-request delta. Compresses replay wall time against zero-latency mocks because the recorded `api_time` portion of each gap is dropped. Mirrors kv-cache-tester's default `--timing-strategy think-only`. Falls back to the full delta for turns whose recorded `think_time` is null. Mutually exclusive with `--ignore-trace-delays`. No effect on non-weka trace loaders.
+<br/>_Flag (no value required)_
+
+#### `--max-context-length` `<int>`
+
+Maximum peak prompt+output context length (tokens) per Weka root trace. Weka loaders (--custom-dataset-type weka_trace or a weka --public-dataset) drop whole traces whose *recorded* peak exceeds this ceiling at load time (filter-then-cap before --num-dataset-entries). Not a DatasetManager tokenize filter; rejected for non-Weka formats.
+<br/>_Constraints: ≥ 1_
+
+#### `--dataset-sampling-strategy` `<str>`
+
+Strategy for selecting entries from dataset during benchmarking. `sequential`: Iterate through dataset in order, wrapping to start after end. `random`: Randomly sample with replacement (entries may repeat before all are used). `shuffle`: Shuffle dataset and iterate without replacement, re-shuffling after exhaustion. Default behavior depends on dataset type (e.g., `sequential` for traces, `shuffle` for synthetic).
+<br/>_Choices: [`random`, `sequential`, `shuffle`]_
+
+#### `--allow-dataset-wrap`, `--no-allow-dataset-wrap`
+
+Allow weka/agentic replay to wrap (reuse distinct eligible traces across concurrency lanes) when concurrency exceeds the loaded pool. Defaults to False: over-subscription fails unless wrapping is explicitly enabled or an active --cache-bust target already keeps repeated-trace traffic distinct.
+
+#### `--random-seed` `<int>`
+
+Random seed for deterministic data generation. When set, makes synthetic prompts, sampling, delays, and other random operations reproducible across runs. Essential for A/B testing and debugging. Uses system entropy if not specified. Initialized globally at config creation.
+<br/>_Constraints: ≥ 0_
+
+#### `--trace-session-sample-ratio` `<float>`
+
+Fraction of trace sessions to keep for replay, sampled whole-session to preserve multi-turn integrity; deterministic when `--random-seed` is set. Only supported by the baseten_trace loader.
+<br/>_Constraints: > 0.0, ≤ 1.0_
+
+#### `-f`, `--config` `<str>`
+
+Path to a YAML configuration file. CLI flags override values from the config file.
+
+### Fixed Schedule
+
+#### `--fixed-schedule`
+
+Run requests according to timestamps specified in the input dataset. When enabled, AIPerf replays the exact timing pattern from the dataset. This mode is automatically enabled for trace datasets.
+<br/>_Flag (no value required)_
+
+#### `--no-fixed-schedule`
+
+Suppress the automatic switch to fixed-schedule mode for trace datasets that carry per-record timestamps. By default a trace input (e.g. mooncake_trace) with timestamps in the first record auto-promotes the profiling phase to fixed_schedule. Pass --no-fixed-schedule to keep the user-selected timing mode (e.g. concurrency, request_rate) and ignore the trace timestamps.
+
+#### `--fixed-schedule-auto-offset`
+
+Automatically normalize timestamps in fixed schedule by shifting all timestamps so the first timestamp becomes 0. When enabled, benchmark starts immediately with the timing pattern preserved. When disabled, timestamps are used as absolute offsets from benchmark start. Mutually exclusive with `--fixed-schedule-start-offset`.
+<br/>_Flag (no value required)_
+
+#### `--fixed-schedule-start-offset` `<int>`
+
+Start offset in milliseconds for fixed schedule replay. Skips all requests before this timestamp, allowing benchmark to start from a specific point in the trace. Requests at exactly the start offset are included. Useful for analyzing specific time windows. Mutually exclusive with `--fixed-schedule-auto-offset`. Must be ≤ `--fixed-schedule-end-offset` if both specified.
+<br/>_Constraints: ≥ 0_
+
+#### `--fixed-schedule-end-offset` `<int>`
+
+End offset in milliseconds for fixed schedule replay. Stops issuing requests after this timestamp, allowing benchmark of specific trace subsets. Requests at exactly the end offset are included. Defaults to last timestamp in dataset. Must be ≥ `--fixed-schedule-start-offset` if both specified.
+<br/>_Constraints: ≥ 0_
+
+### Goodput
+
+#### `--goodput` `<str>`
+
+Specify service level objectives (SLOs) for goodput as space-separated 'KEY:VALUE' pairs, where KEY is a metric tag and VALUE is a number in the metric's display unit (falls back to its base unit if no display unit is defined). Examples: 'request_latency:250' (ms), 'inter_token_latency:10' (ms), `output_token_throughput_per_user:600` (tokens/s). Only metrics applicable to the current endpoint/config are considered. For more context on the definition of goodput, refer to DistServe paper: https://arxiv.org/pdf/2401.09670 and the blog: https://hao-ai-lab.github.io/blogs/distserve.
+
+### Conversation Input
+
+#### `--conversation-num`, `--num-conversations`, `--num-sessions` `<str>`
+
+The total number of unique conversations to generate. Each conversation represents a single request session between client and server. Supported on synthetic mode and the custom random_pool dataset. The number of conversations will be used to determine the number of entries in both the custom random_pool and synthetic datasets and will be reused until benchmarking is complete. Pass a comma-separated list (e.g. `--num-conversations 50,100,200`) to sweep over session-bounded run lengths; the converter promotes the list to a sweep on phases.profiling.sessions before AIPerfConfig validation. The synthetic dataset pool is sized to max(list) so every variation has its full unique-session set.
+
+#### `--num-dataset-entries`, `--num-prompts` `<int>`
+
+Total number of unique entries to generate for the dataset. Each entry represents one user message that can be used as a turn in conversations. Entries are reused across conversations and turns according to `--dataset-sampling-strategy`. Higher values provide more diversity.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `100`_
+
+#### `--conversation-turn-mean`, `--session-turns-mean` `<int>`
+
+Mean number of request-response turns per conversation. Each turn consists of a user message and model response. Turn counts follow normal distribution around this mean (±`--conversation-turn-stddev`). Set to 1 for single-turn interactions. Multi-turn conversations enable testing of context retention and conversation history handling. Pass a comma-separated list (e.g. `--conversation-turn-mean 1,3,8`) to sweep over multiple turn-mean values; the converter promotes the list to a sweep on datasets.main.turns.mean before AIPerfConfig validation.
+<br/>_Default: `1`_
+
+#### `--conversation-turn-stddev`, `--session-turns-stddev` `<int>`
+
+Standard deviation for number of turns per conversation. Creates variability in conversation lengths, simulating diverse interaction patterns (quick questions vs. extended dialogues). Turn counts follow normal distribution. Set to 0 for uniform conversation lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--conversation-turn-delay-mean`, `--session-turn-delay-mean` `<float>`
+
+Mean delay in milliseconds between consecutive turns within a multi-turn conversation. Simulates user think time between receiving a response and sending the next message. Delays follow normal distribution around this mean (±`--conversation-turn-delay-stddev`). Only applies to multi-turn conversations (`--conversation-turn-mean` > 1). Set to 0 for back-to-back turns.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--conversation-turn-delay-stddev`, `--session-turn-delay-stddev` `<float>`
+
+Standard deviation for turn delays in milliseconds. Creates variability in user think time between conversation turns. Delays follow normal distribution. Set to 0 for deterministic delays. Models realistic human interaction patterns with variable response times.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--conversation-turn-delay-ratio`, `--session-delay-ratio` `<float>`
+
+Multiplier for scaling all turn delays within conversations. Applied after mean/stddev calculation: `actual_delay = calculated_delay × ratio`. Use to proportionally adjust timing without changing distribution shape. Values &lt; 1 speed up conversations, > 1 slow them down. Set to 0 to eliminate delays entirely.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1.0`_
+
+#### `--inter-turn-delay-cap-seconds` `<float>`
+
+Clamp per-turn replay delays to at most this many seconds; ``None`` disables the cap. Honored by the DAG JSONL loader and the baseten_trace loader's closed-loop think-times; the clamp count is reported at end of load. Maps to FileDataset ``inter_turn_delay_cap_seconds``.
+<br/>_Constraints: ≥ 0.0_
+
+#### `--max-idle-gap-cap-seconds` `<float>`
+
+Collapse idle gaps between consecutive requests (across all sessions) to at most this many seconds, so a sparse or session-sampled trace does not replay dead air; ``None`` disables the cap. The cap is in replay wall-clock seconds, applied after --replay-speedup compression, so it bounds actual benchmark idle time regardless of speedup. Only supported by the baseten_trace loader. Maps to FileDataset ``max_idle_gap_cap_seconds``.
+<br/>_Constraints: > 0.0_
+
+#### `--replay-speedup` `<float>`
+
+Trace replay wall-clock compression (10 = 10x faster than recorded): divides normalized timestamps and inter-turn delays; ``None`` = real time. Unlike synthesis speedup_ratio, hash_ids stay untouched (KV-cache fidelity). Only supported by the baseten_trace loader. Maps to FileDataset ``replay_speedup``.
+<br/>_Constraints: > 0.0_
+
+#### `--open-loop-replay`, `--no-open-loop-replay`
+
+Open-loop replay (the default): each session starts at its absolute, speedup-scaled recorded timestamp; continuation turns fire at max(recorded timestamp, prior-turn completion). Pass `--no-open-loop-replay` for closed-loop back-pressure: continuation turns fire a think-time (recorded start-to-start gap minus recorded e2e duration) after the prior turn completes, keeping sessions causally ordered when replayed service times differ from recorded (e.g. A/A comparisons). Only honored by the baseten_trace loader. Maps to FileDataset ``open_loop_replay``.
+<br/>_Default: `True`_
+
+#### `--open-loop-strict`
+
+In open-loop replay, fire every trace row at its absolute recorded timestamp as an independent single-turn session, trading away multi-turn grouping and session metrics. Only honored by the baseten_trace loader. Maps to FileDataset ``open_loop_strict``.
+<br/>_Flag (no value required)_
+
+#### `--omit-kv-hints`
+
+Drop recorded KV-cache hints (``hash_ids``, ``block_size``) from replayed request bodies, for strict frontends that reject unknown parameters. Only honored by the baseten_trace loader. Maps to FileDataset ``omit_kv_hints``.
+<br/>_Flag (no value required)_
+
+#### `--force-min-tokens`, `--no-force-min-tokens`
+
+Pin ``min_tokens`` to the recorded output length so replayed generations match recorded lengths; pass `--no-force-min-tokens` to let EOS end generations naturally (some servers reject ``min_tokens``). Only honored by the baseten_trace loader. Maps to FileDataset ``force_min_tokens``.
+<br/>_Default: `True`_
+
+### Prompt
+
+#### `-b`, `--prompt-batch-size`, `--batch-size-text`, `--batch-size` `<int>`
+
+Number of text inputs to include in each request for batch processing endpoints. Supported by `embeddings` and `rankings` endpoint types where models can process multiple inputs simultaneously for efficiency. Set to 1 for single-input requests. Not applicable to `chat` or `completions` endpoints.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--prompt-corpus` `<str>`
+
+Source corpus for synthetic prompt text generation. 'sonnet' uses Shakespeare sonnets. 'coding' uses realistic coding content (code, bash output, JSON, error tracebacks, git diffs). Honored only for synthesized content (synthetic datasets and count/hash-id trace loaders); verbatim formats ignore it. When unset, the active dataset loader's default applies (most loaders default to 'sonnet'; agentic-coding loaders such as weka_trace default to 'coding').
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `sonnet` |  | Shakespeare sonnets (default). Classic prose for filler text. |
+| `coding` |  | Realistic coding content: code, bash output, JSON, error tracebacks, git diffs. |
+
+### Cache Bust
+
+#### `--cache-bust` `<str>`
+
+Where (and how) to inject a cache-bust marker. Two families: (1) RID targets (system_prefix, system_suffix, first_turn_prefix, first_turn_suffix) — inject a per-trajectory unique SHA-256 digest marker that is identical across warmup and profiling, so warmup KV-cache work transfers to profiling while preventing cross-trajectory cache sharing. Prefix variants prepend at token 0; suffix variants append after existing content. (2) Warmup-isolation targets (warmup_isolation_system, warmup_isolation_first_turn) — inject a constant '[warmup]' marker only during the WARMUP phase; profiling sees no marker (fully cold start or system-pre-warmed). Incompatible with agentic_replay timing mode. 'none' disables the feature (default). See [cache-bust.md](reference/cache-bust.md) for detailed semantics, trade-offs, and examples.
+<br/>_Choices: [`none`, `system_prefix`, `system_suffix`, `first_turn_prefix`, `first_turn_suffix`, `warmup_isolation_system`, `warmup_isolation_first_turn`]_
+<br/>_Default: `none`_
+
+### Prefix Prompt
+
+#### `--system-prompt` `<str>`
+
+Verbatim system prompt text, identical across every conversation. Sent as a system-role message ahead of all turns. Works with both synthetic and file/public datasets; when the dataset already carries its own system message, this text is prepended to it. Tokens are additive: `--isl` continues to size the generated user prompt only. Mutually exclusive with `--system-prompt-file`, `--shared-system-prompt-length`, and `--num-prefix-prompts`/`--prefix-prompt-length`.
+
+#### `--system-prompt-file` `<str>`
+
+Path to a UTF-8 text file holding the verbatim system prompt. Preferred over `--system-prompt` for real production prompts, which are long enough that shell quoting mangles them. Read once at startup, so a missing or unreadable file fails immediately rather than mid-run. Mutually exclusive with `--system-prompt`, `--shared-system-prompt-length`, and `--num-prefix-prompts`/`--prefix-prompt-length`.
+
+#### `--prompt-prefix-pool-size`, `--prefix-prompt-pool-size`, `--num-prefix-prompts` `<int>`
+
+Number of distinct prefix prompts to generate for K-V cache testing. Each prefix is prepended to user prompts, simulating cached context scenarios. Prefixes randomly selected from pool per request. Set to 0 to disable prefix prompts. Mutually exclusive with `--shared-system-prompt-length`/`--user-context-prompt-length`.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--prompt-prefix-length`, `--prefix-prompt-length` `<int>`
+
+The number of tokens in each prefix prompt. This is only used if `--num-prefix-prompts` is greater than zero. Note that due to the prefix and user prompts being concatenated, the number of tokens in the final prompt may be off by one.Mutually exclusive with `--shared-system-prompt-length`/`--user-context-prompt-length`.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--shared-system-prompt-length` `<int>`
+
+Length of shared system prompt in tokens. This prompt is identical across all sessions and appears as a system message. Mutually exclusive with `--prefix-prompt-length`/`--prefix-prompt-pool-size`.
+<br/>_Constraints: ≥ 1_
+
+#### `--user-context-prompt-length` `<int>`
+
+Length of per-session user context prompt in tokens. Each dataset entry gets a unique user context prompt. Requires --num-dataset-entries to be specified. Mutually exclusive with --prefix-prompt-length/--prefix-prompt-pool-size.
+<br/>_Constraints: ≥ 1_
+
+### Input Sequence Length (ISL)
+
+#### `--prompt-input-tokens-mean`, `--synthetic-input-tokens-mean`, `--isl` `<int>`
+
+Mean number of tokens for synthetically generated input prompts. AIPerf generates prompts with lengths following a normal distribution around this mean (±`--prompt-input-tokens-stddev`). Applies only to synthetic datasets, not custom or public datasets. Pass a comma-separated list (e.g. `--isl 128,512,2048`) to sweep over multiple input lengths; the converter promotes the list to a sweep on datasets.main.prompts.isl.mean before AIPerfConfig validation.
+<br/>_Default: `550`_
+
+#### `--prompt-input-tokens-stddev`, `--synthetic-input-tokens-stddev`, `--isl-stddev` `<float>`
+
+Standard deviation for synthetic input prompt token lengths. Creates variability in prompt sizes when > 0, simulating realistic workloads with mixed request sizes. Lengths follow normal distribution. Set to 0 for uniform prompt lengths. Applies only to synthetic data generation. Pass a comma-separated list (e.g. `--isl-stddev 10,50,200`) to sweep over multiple stddev values; the converter promotes the list to a sweep on datasets.main.prompts.isl.stddev. Pair with a zip-mode `--isl` sweep to model realistic small/medium/large traffic shapes.
+<br/>_Default: `0.0`_
+
+#### `--prompt-input-tokens-block-size`, `--synthetic-input-tokens-block-size`, `--isl-block-size` `<int>`
+
+Token block size for hash-based prompt synthesis when dataset entries carry `hash_ids`: each `hash_id` maps to a cached block of `block_size` tokens, enabling simulation of KV-cache sharing patterns from production workloads. The total prompt length equals `(num_hash_ids - 1) * block_size + final_block_size`. With `--input-file` this overrides the trace loader's `default_block_size` plugin metadata (16 for `bailian_trace`, 512 for `mooncake_trace`) for loaders that reconstruct prompts from `hash_ids`; it has no effect on `baseten_trace`, which replays literal recorded prompts. Set it when a trace was recorded at a block size different from its loader default (e.g. a Mooncake-format trace recorded at 16).
+<br/>_Constraints: ≥ 1_
+
+#### `--seq-dist`, `--sequence-distribution` `<str>`
+
+Distribution of (ISL, OSL) pairs with probabilities for mixed workload simulation. Format: `ISL,OSL:prob;ISL,OSL:prob` (semicolons separate pairs, probabilities are percentages 0-100 that must sum to 100). Supports optional stddev: `ISL|stddev,OSL|stddev:prob`. Examples: `128,64:25;512,128:50;1024,256:25` or with variance: `256|10,128|5:40;512|20,256|10:60`. Also supports bracket `[(256,128):40,(512,256):60]` and JSON formats.
+
+### Output Sequence Length (OSL)
+
+#### `--prompt-output-tokens-mean`, `--output-tokens-mean`, `--osl` `<str>`
+
+Mean number of tokens to request in model outputs via `max_completion_tokens` field. Controls response length for synthetic and some custom datasets. If specified, included in request payload to limit generation length. When not set, model determines output length. Pass a comma-separated list (e.g. `--osl 128,256,512`) to sweep over multiple output lengths; the converter promotes the list to a sweep on datasets.main.prompts.osl.mean before AIPerfConfig validation.
+
+#### `--prompt-output-tokens-stddev`, `--output-tokens-stddev`, `--osl-stddev` `<int>`
+
+Standard deviation for output token length requests. Creates variability in `max_completion_tokens` field across requests, simulating mixed response length requirements. Lengths follow normal distribution. Only applies when `--prompt-output-tokens-mean` is set. Pass a comma-separated list (e.g. `--osl-stddev 5,25,100`) to sweep over multiple stddev values; the converter promotes the list to a sweep on datasets.main.prompts.osl.stddev. Pair with a zip-mode `--osl` sweep to model realistic output-length variance across traffic tiers.
+<br/>_Default: `0`_
+
+### Audio Input
+
+#### `--audio-batch-size`, `--batch-size-audio` `<int>`
+
+The number of audio inputs to include in each request. Supported with the `chat` endpoint type for multimodal models.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--audio-length-mean` `<float>`
+
+Mean duration in seconds for synthetically generated audio files. Audio lengths follow a normal distribution around this mean (±`--audio-length-stddev`). Used when `--audio-batch-size` > 0 for multimodal benchmarking. Generated audio is random noise with specified sample rate, bit depth, and format.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--audio-length-stddev` `<float>`
+
+Standard deviation for synthetic audio duration in seconds. Creates variability in audio lengths when > 0, simulating mixed-duration audio inputs. Durations follow normal distribution. Set to 0 for uniform audio lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--audio-format` `<str>`
+
+File format for generated audio files. Supports `wav` (uncompressed PCM, larger files) and `mp3` (compressed, smaller files). Format choice affects file size in multimodal requests but not audio characteristics (sample rate, bit depth, duration).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `wav` | _default_ | WAV format. Uncompressed audio, larger file sizes, best quality. |
+| `mp3` |  | MP3 format. Compressed audio, smaller file sizes, good quality. |
+
+#### `--audio-depths` `<list>`
+
+List of audio bit depths in bits to randomly select from when generating audio files. Each audio file is assigned a random depth from this list. Common values: `8` (low quality), `16` (CD quality), `24` (professional), `32` (high-end). Specify multiple values (e.g., `--audio-depths 16 24`) for mixed-quality testing.
+<br/>_Constraints: min: 1_
+<br/>_Default: `[16]`_
+
+#### `--audio-sample-rates` `<list>`
+
+A list of audio sample rates to randomly select from in kHz. Common sample rates are 16, 44.1, 48, 96, etc.
+<br/>_Constraints: min: 1_
+<br/>_Default: `[16.0]`_
+
+#### `--audio-num-channels` `<int>`
+
+Number of audio channels for synthetic audio generation. `1` = mono (single channel), `2` = stereo (left/right channels). Stereo doubles file size but simulates realistic audio for models supporting spatial audio processing. Most speech models use mono.
+<br/>_Constraints: ≥ 1, ≤ 2_
+<br/>_Default: `1`_
+
+### Image Input
+
+#### `--image-width-mean` `<float>`
+
+Mean width in pixels for synthetically generated images. Image widths follow a normal distribution around this mean (±`--image-width-stddev`). Combined with `--image-height-mean` to determine image dimensions and file sizes for multimodal benchmarking.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-width-stddev` `<float>`
+
+Standard deviation for synthetic image widths in pixels. Creates variability in horizontal resolution when > 0, simulating mixed-resolution image inputs. Widths follow normal distribution. Set to 0 for uniform image widths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-height-mean` `<float>`
+
+Mean height in pixels for synthetically generated images. Image heights follow a normal distribution around this mean (±`--image-height-stddev`). Used when `--image-batch-size` > 0 for multimodal vision benchmarking. Generated images are resized from source images in `assets/source_images` directory.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-height-stddev` `<float>`
+
+Standard deviation for synthetic image heights in pixels. Creates variability in vertical resolution when > 0, simulating mixed-resolution image inputs. Heights follow normal distribution. Set to 0 for uniform image heights.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-batch-size`, `--batch-size-image` `<int>`
+
+Number of images to include in each multimodal request. Supported with `chat` endpoint type for vision-language models. Each image is generated by randomly sampling and resizing source images from `assets/source_images` directory to specified dimensions. Set to 0 to disable image inputs. Higher batch sizes test multi-image understanding and increase request payload size.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--image-format` `<str>`
+
+Image file format for generated images. Choose `png` for lossless compression (larger files, best quality), `jpeg` for lossy compression (smaller files, good quality), or `random` to randomly select between PNG and JPEG for each image. Format affects file size in multimodal requests and encoding overhead.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `png` | _default_ | PNG format. Lossless compression, larger file sizes, best quality. |
+| `jpeg` |  | JPEG format. Lossy compression, smaller file sizes, good for photos. |
+| `random` |  | Randomly select PNG or JPEG for each image. |
+
+#### `--image-source` `<str>`
+
+Source image generation mode (default `noise`). `noise` generates random noise images on the fly at the requested dimensions — no files on disk required, and the pool is effectively unbounded so servers cannot dedupe on identical inputs. `assets` indexes images from the built-in `assets/source_images` directory (ships with a small set of 4 images) and lazily loads them at the requested dimensions. A path to a directory indexes images from the given directory (e.g. `--image-source ./source_images`). Note: random-noise images are roughly incompressible, so payload bytes are larger than equivalent natural images.
+<br/>_Default: `noise`_
+
+#### `--image-source-sampling` `<str>`
+
+How source images are selected from finite image sources selected by `--image-source assets` or `--image-source <directory>`. `random-with-replacement` draws each source image independently; repeats may occur immediately. `shuffle-cycle` draws every source image once per shuffled cycle, reshuffling after exhaustion. `sequential-cycle` walks source images in sorted load order and wraps after exhaustion. For `noise`, only `random-with-replacement` is valid because there is no finite source pool.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `random-with-replacement` | _default_ | Draw each source image independently; repeats may occur immediately. |
+| `shuffle-cycle` |  | Draw every source image once per shuffled cycle; reshuffle after exhaustion. |
+| `sequential-cycle` |  | Walk source images in sorted load order; wrap after exhaustion. |
+
+### Video Input
+
+#### `--video-batch-size`, `--batch-size-video` `<int>`
+
+Number of video files to include in each multimodal request. Supported with `chat` endpoint type for video understanding models. Each video is generated synthetically with specified duration, FPS, resolution, and codec. Set to 0 to disable video inputs. Higher batch sizes test multi-video understanding and significantly increase request payload size.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--video-duration` `<float>`
+
+Duration in seconds for each synthetically generated video clip. Combined with `--video-fps`, determines total frame count (frames = duration × FPS). Longer durations increase file size and processing time. Typical values: 1-10 seconds for testing. Requires FFmpeg for video generation.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `5.0`_
+
+#### `--video-fps` `<int>`
+
+Frames per second for generated video. Higher FPS creates smoother video but increases frame count and file size. Common values: `4` (minimal motion, recommended for Cosmos models), `24` (cinematic), `30` (standard video), `60` (high frame rate). Total frames = `--video-duration` × FPS.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `4`_
+
+#### `--video-width` `<int>`
+
+Video frame width in pixels. Must be specified together with `--video-height` (both or neither). Determines video resolution and file size. Common resolutions: `640×480` (SD), `1280×720` (HD), `1920×1080` (Full HD). If not specified, uses codec/format defaults.
+<br/>_Constraints: ≥ 1_
+
+#### `--video-height` `<int>`
+
+Video frame height in pixels. Must be specified together with `--video-width` (both or neither). Combined with width determines aspect ratio and total pixel count per frame. Higher resolution increases processing demands and file size.
+<br/>_Constraints: ≥ 1_
+
+#### `--video-synth-type` `<str>`
+
+Algorithm for generating synthetic video content. Different types produce different visual patterns for testing. Options: `moving_shapes` (animated geometric shapes), `grid_clock` (grid with rotating clock hands), `noise` (random pixel frames). Content doesn't affect semantic meaning but may impact encoding efficiency and file size.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `moving_shapes` | _default_ | Generate videos with animated geometric shapes moving across the frame |
+| `grid_clock` |  | Generate videos with a grid pattern and frame number overlay for frame-accurate verification |
+| `noise` |  | Generate videos with random noise frames |
+
+#### `--video-format` `<str>`
+
+Container format for generated video files. Supports `webm` (VP9, recommended, BSD-licensed) and `mp4` (widely compatible container, VP9 by default). Format choice affects compatibility, file size, and encoding options. `mp4` is the more portable container, but note that the default VP9 video and Opus audio are less widely supported by players than H.264/AAC would be.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `mp4` |  | MP4 container. Widely compatible, good for H.264/H.265 codecs. |
+| `webm` | _default_ | WebM container. Open format, optimized for web, good for VP9 codec. |
+
+#### `--video-codec` `<str>`
+
+The video codec to use for encoding. Common options: libvpx-vp9 (CPU, BSD-licensed, default), libvpx (CPU, BSD-licensed, VP8). Any codec the local FFmpeg supports can be used, but the AIPerf container ships a minimal FFmpeg build limited to VP8/VP9 video with Vorbis/Opus audio; codecs such as libx264 or h264_nvenc require an FFmpeg build that includes them.
+<br/>_Default: `libvpx-vp9`_
+
+#### `--video-audio-sample-rate` `<float>`
+
+Audio sample rate in Hz or kHz for the embedded audio track. Common values: 8/8000 (telephony), 16/16000 (speech), 44.1/44100 (CD quality), 48/48000 (professional). Higher sample rates increase audio fidelity and file size.
+<br/>_Constraints: ≥ 8, ≤ 96000_
+<br/>_Default: `44100`_
+
+#### `--video-audio-num-channels` `<int>`
+
+Number of audio channels to embed in generated video files. 0 = disabled (no audio track, default), 1 = mono, 2 = stereo. When set to 1 or 2, a Gaussian noise audio track matching the video duration is muxed into each video via FFmpeg.
+<br/>_Constraints: ≥ 0, ≤ 2_
+<br/>_Default: `0`_
+
+#### `--video-audio-codec` `<str>`
+
+Audio codec for the embedded audio track. If not specified, auto-selects based on video format: libopus for MP4, libvorbis for WebM. Options: libvorbis, libopus, aac. The AIPerf container ships only libvorbis and libopus; aac requires an FFmpeg build that includes an AAC encoder. libopus always encodes at 48 kHz, so any --video-audio-sample-rate is resampled during muxing.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `aac` |  | AAC codec. Not built into the AIPerf container's FFmpeg; selecting it requires an FFmpeg build that includes an AAC encoder. |
+| `libvorbis` |  | Vorbis codec. Default for WebM containers. |
+| `libopus` |  | Opus codec. Default for MP4 containers. Always encodes at 48 kHz regardless of the requested sample rate. |
+
+#### `--video-audio-depth` `<str>`
+
+Audio bit depth for the embedded audio track. Supported values: 8, 16, 24, or 32 bits. Higher bit depths provide greater dynamic range but increase file size.
+<br/>_Default: `16`_
+
+### Rankings
+
+#### `--rankings-passages-mean` `<int>`
+
+Mean number of passages to include per ranking request. For `rankings` endpoint type, each request contains a query and multiple passages to rank. Passages follow normal distribution around this mean (±`--rankings-passages-stddev`). Higher values test ranking at scale but increase request payload size and processing time.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `1`_
+
+#### `--rankings-passages-stddev` `<int>`
+
+Standard deviation for number of passages per ranking request. Creates variability in ranking workload complexity. Passage counts follow normal distribution. Set to 0 for uniform passage counts across all requests.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--rankings-passages-prompt-token-mean` `<int>`
+
+Mean token length for each passage in ranking requests. Passages are synthetically generated text with lengths following normal distribution around this mean (±`--rankings-passages-prompt-token-stddev`). Longer passages increase input processing demands and request size.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `550`_
+
+#### `--rankings-passages-prompt-token-stddev` `<int>`
+
+Standard deviation for passage token lengths in ranking requests. Creates variability in passage sizes, simulating realistic heterogeneous document collections. Token lengths follow normal distribution. Set to 0 for uniform passage lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--rankings-query-prompt-token-mean` `<int>`
+
+Mean token length for query text in ranking requests. Each ranking request contains one query and multiple passages. Queries are synthetically generated with lengths following normal distribution around this mean (±`--rankings-query-prompt-token-stddev`).
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `550`_
+
+#### `--rankings-query-prompt-token-stddev` `<int>`
+
+Standard deviation for query token lengths in ranking requests. Creates variability in query complexity, simulating realistic user search patterns. Token lengths follow normal distribution. Set to 0 for uniform query lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+### Synthesis
+
+#### `--synthesis-speedup-ratio` `<float>`
+
+Multiplier for timestamp scaling in synthesized traces.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-prefix-len-multiplier` `<float>`
+
+Multiplier for core prefix branch lengths in radix tree.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-prefix-root-multiplier` `<int>`
+
+Number of independent radix trees to distribute traces across.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `1`_
+
+#### `--synthesis-prompt-len-multiplier` `<float>`
+
+Multiplier for leaf path (unique prompt) lengths.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-output-len-multiplier` `<float>`
+
+Multiplier for output lengths in synthesized traces.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-max-isl` `<int>`
+
+Maximum input sequence length for filtering. Traces with input_length > max_isl are skipped.
+<br/>_Constraints: ≥ 1_
+
+#### `--synthesis-max-osl` `<int>`
+
+Maximum output sequence length cap for top-level (parent) turns. Turns with output_length > max_osl are capped to max_osl. Subagent child turns are intentionally uncapped so their decode load stays faithful; flat-chain sidecars still honor the cap.
+<br/>_Constraints: ≥ 1_
+
+### Load Generator
+
+#### `--benchmark-duration` `<str>`
+
+Maximum benchmark runtime in seconds. When set, AIPerf stops issuing new requests after this duration, Responses received within `--benchmark-grace-period` after duration ends are included in metrics. Pass a comma-separated list (e.g. `--benchmark-duration 30,60,120`) to sweep over multiple durations; the converter promotes the list to a sweep on phases.profiling.duration before AIPerfConfig validation.
+
+#### `--benchmark-grace-period` `<float>`
+
+The grace period in seconds to wait for responses after benchmark duration ends. Only applies when --benchmark-duration is set. Responses received within this period are included in metrics. Use 'inf' to wait indefinitely for all responses.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `30.0`_
+
+#### `--concurrency` `<str>`
+
+Number of concurrent requests to maintain. AIPerf issues a new request immediately when one completes, maintaining this level of in-flight requests. Can be combined with `--request-rate` to control the request rate. Pass a comma-separated list (e.g. `--concurrency 10,20,30`) to sweep over multiple concurrencies; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--prefill-concurrency` `<str>`
+
+Max concurrent requests waiting for first token (prefill phase). Limits how many requests can be in the prefill/prompt-processing stage simultaneously. Pass a comma-separated list (e.g. `--prefill-concurrency 1,2,4`) to sweep over multiple values; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--request-rate` `<str>`
+
+Target request rate in requests per second. AIPerf generates request timing according to `--request-rate-mode` to achieve this average rate. Can be combined with `--concurrency` to control the number of concurrent requests. Supports fractional rates (e.g., `0.5` = 1 request every 2 seconds). Pass a comma-separated list (e.g. `--request-rate 10,20,50`) to sweep over multiple rates; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--arrival-pattern`, `--request-rate-mode` `<str>`
+
+Sets the arrival pattern for the load generated by AIPerf. Valid values: constant, poisson, gamma. `constant`: Generate requests at a fixed rate. `poisson`: Generate requests using a poisson distribution. `gamma`: Generate requests using a gamma distribution with tunable smoothness.
+<br/>_Choices: [`concurrency_burst`, `constant`, `gamma`, `poisson`]_
+<br/>_Default: `poisson`_
+
+#### `--arrival-smoothness`, `--vllm-burstiness` `<float>`
+
+Smoothness parameter for gamma distribution arrivals (--arrival-pattern gamma). Controls the shape of the arrival pattern: - 1.0: Poisson-like (exponential inter-arrivals, default) - &lt;1.0: Bursty/clustered arrivals (higher variance) - >1.0: Smooth/regular arrivals (lower variance) Compatible with vLLM's --burstiness parameter (same value = same distribution).
+<br/>_Constraints: > 0_
+
+#### `--request-count`, `--num-requests` `<str>`
+
+The maximum number of requests to send. If not set, will be automatically determined based on the timing mode and dataset size. For synthetic datasets, this will be `max(10, concurrency * 2)`. Pass a comma-separated list (e.g. `--request-count 100,500,1000`) to sweep over multiple request counts; the converter promotes the list to a sweep on phases.profiling.requests before AIPerfConfig validation.
+
+#### `--concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp session concurrency from 1 to target. Useful for gradual warm-up of the target system.
+<br/>_Constraints: > 0_
+
+#### `--prefill-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp prefill concurrency from 1 to target.
+<br/>_Constraints: > 0_
+
+#### `--request-rate-ramp-duration` `<float>`
+
+Duration in seconds to ramp request rate from a proportional minimum to target. Start rate is calculated as target * (update_interval / duration), ensuring correct behavior for target rates below 1 QPS. Useful for gradual warm-up of the target system.
+<br/>_Constraints: > 0_
+
+#### `--request-rate-series` `<str>`
+
+JSON file containing request-rate points for piecewise-linear request-rate control.
+
+#### `--failed-request-threshold` `<float>`
+
+Abort the run early when (failed_records / total_records) exceeds this ratio. Default None disables the check. Only PROFILING-phase records count toward the ratio. A grace floor of max(concurrency, 10) records must accumulate before the check is armed, so a single early failure cannot kill the run. When the threshold is exceeded a ProfileCancelCommand is broadcast: in-flight requests drain via the normal cancel path, partial results are still aggregated, and the run exits non-zero. Pairs with the AGENTIC_REPLAY context-overflow drop in record_processor_service so the rate measures real failures only.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+
+#### `--trajectory-start-min-ratio` `<float>`
+
+AGENTIC_REPLAY only: lower bound (inclusive) on the random start position within each trajectory, expressed as a fraction of the trace's total turn count. Sampled per trajectory at trajectory-build time; deterministic given --random-seed.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+<br/>_Default: `0.25`_
+
+#### `--trajectory-start-max-ratio` `<float>`
+
+AGENTIC_REPLAY only: upper bound (inclusive) on the random start position within each trajectory, expressed as a fraction of the trace's total turn count. The effective per-trace ceiling is min(int(max_ratio * n), n - 2) so at least one profile turn remains after warmup.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+<br/>_Default: `0.75`_
+
+#### `--burst-phase-starts`
+
+AGENTIC_REPLAY only: collapse the WARMUP-start and PROFILING-start dispatches into synchronized bursts instead of spreading them by each request's recorded offset from t*. By default (False) the phase starts are SPREAD: WARMUP requests are aligned globally so every trajectory reaches its t* at the same instant (the warmup end), and each lane's first PROFILING request waits out its recorded gap after t* -- reproducing the recorded arrival pattern at both phase boundaries. The rest of the replay (inter-turn delays) is timing-faithful regardless of this flag; it governs ONLY the burst-vs-spread of the two phase starts. Pass --burst-phase-starts to fire each phase's first requests together (faster concurrency ramp, synchronized start), e.g. for a throughput-oriented run rather than a faithful arrival replay.
+<br/>_Flag (no value required)_
+
+#### `--trace-idle-gap-cap-seconds` `<float>`
+
+Hard ceiling (seconds) for idle gaps within each individual trace. For Weka trace replay, AIPerf looks at all parent and subagent request submission timestamps within one root trace, compresses long gaps between consecutive request submissions, and derives turn delays from the compressed per-trace timeline. Original request api_time values are not used to decide these idle gaps. When set for Weka, this takes precedence over `--inter-turn-delay-cap-seconds` so individual parent/subagent-line delays are not separately capped. Defaults to None (no per-trace idle-gap compression).
+<br/>_Constraints: ≥ 0.0_
+
+#### `--system-idle-gap-cap-seconds` `<float>`
+
+AGENTIC_REPLAY only: maximum time in seconds the replay may remain globally idle while future requests are scheduled. When no requests are in flight or ready, all pending request timers shift earlier uniformly so the next request arrives within this limit. Per-trace timing is otherwise preserved. None disables the cap.
+<br/>_Constraints: ≥ 0.0_
+
+### Scenario
+
+#### `--scenario` `<str>`
+
+Lock all benchmark invariants for a named scenario (e.g. 'inferencex-agentx-mvp'). Conflicts with the locked invariants raise ScenarioLockError at startup unless --unsafe-override is also passed. Distinct from the sweep ``scenarios`` strategy (hand-picked named runs).
+
+#### `--unsafe-override`
+
+Convert scenario lock errors to warnings; stamps submission_valid=false in the aggregate output. No-op without --scenario.
+<br/>_Flag (no value required)_
+
+### Warmup
+
+#### `--warmup-request-count`, `--num-warmup-requests` `<int>`
+
+The maximum number of warmup requests to send before benchmarking. If not set and no --warmup-duration is set, then no warmup phase will be used.
+<br/>_Constraints: > 0_
+
+#### `--warmup-duration` `<float>`
+
+The maximum duration in seconds for the warmup phase. If not set, it will use the `--warmup-request-count` value. If neither are set, no warmup phase will be used.
+<br/>_Constraints: > 0_
+
+#### `--agentic-cache-warmup-duration` `<float>`
+
+Additional agentic replay warmup duration in seconds. After the normal snapshot warmup drains, AIPerf continues the live trajectories without recorded idle delays and with one-token outputs, then drains and resumes profiling from the resulting trajectory state using each live stream's residual next-turn delay.
+<br/>_Constraints: > 0_
+
+#### `--agentic-warmup-grace-period` `<float>`
+
+AGENTIC_REPLAY only: grace period in seconds the auto-synthesized warmup barrier waits for in-flight priming requests after the warmup burst sends. The agentic warmup is synthesized from the profiling phase rather than a user-declared warmup phase, so it does NOT honor `--warmup-grace-period` (which requires `--warmup-duration`). If not set, the warmup barrier waits indefinitely until every primed trajectory returns.
+<br/>_Constraints: ≥ 0_
+
+#### `--num-warmup-sessions` `<int>`
+
+The number of sessions to use for the warmup phase. If not set, it will use the `--warmup-request-count` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-concurrency` `<int>`
+
+The concurrency value to use for the warmup phase. If not set, it will use the `--concurrency` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-prefill-concurrency` `<int>`
+
+The prefill concurrency value to use for the warmup phase. If not set, it will use the `--prefill-concurrency` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-request-rate` `<float>`
+
+The request rate to use for the warmup phase. If not set, it will use the `--request-rate` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-arrival-pattern` `<str>`
+
+The arrival pattern to use for the warmup phase. If not set, it will use the `--arrival-pattern` value. Valid values: constant, poisson, gamma.
+
+#### `--warmup-grace-period` `<float>`
+
+The grace period in seconds to wait for responses after warmup phase ends. Only applies when warmup is enabled. Responses received within this period are included in warmup completion. If not set, waits indefinitely for all warmup responses.
+<br/>_Constraints: ≥ 0_
+
+#### `--warmup-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup session concurrency from 1 to target. If not set, uses `--concurrency-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-prefill-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup prefill concurrency from 1 to target. If not set, uses `--prefill-concurrency-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-request-rate-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup request rate from a proportional minimum to target. Start rate is calculated as target * (update_interval / duration). If not set, uses `--request-rate-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+### User-Centric Rate
+
+#### `--user-centric-rate` `<float>`
+
+Enable user-centric rate limiting mode with the specified request rate (QPS). Each user has a gap = num_users / qps between turns. Users block on their previous turn (no interleaving within a user). New users are spawned on a fixed schedule to maintain steady-state throughput. Designed for KV cache benchmarking with realistic multi-user patterns. Requires --num-users to be set.
+<br/>_Constraints: > 0_
+
+#### `--num-users` `<str>`
+
+The number of initial users to use for --user-centric-rate mode. Pass a comma-separated list (e.g. `--num-users 4,8,16`) to sweep over user counts; the converter promotes the list to a sweep on phases.profiling.users before AIPerfConfig validation.
+
+### Request Cancellation
+
+#### `--request-cancellation-rate` `<float>`
+
+Percentage (0-100) of requests to cancel for testing cancellation handling. Cancelled requests are sent normally but aborted after `--request-cancellation-delay` seconds. Useful for testing graceful degradation and resource cleanup.
+<br/>_Constraints: > 0.0, ≤ 100.0_
+
+#### `--request-cancellation-delay` `<float>`
+
+Seconds to wait after the request is fully sent before cancelling. A delay of 0 means 'send the full request, then immediately disconnect'. Requires --request-cancellation-rate to be set.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `0.0`_
+
+### Output
+
+#### `--output-artifact-dir`, `--artifact-dir` `<str>`
+
+Output directory for all benchmark artifacts including metrics (`.csv`, `.json`, `.jsonl`), raw data (`_raw.jsonl`), GPU telemetry (`_gpu_telemetry.jsonl`), and time-sliced metrics (`_timeslices.csv/json`). Directory created if it doesn't exist. All output file paths are constructed relative to this directory.
+<br/>_Default: `artifacts`_
+
+#### `--profile-export-prefix`, `--profile-export-file` `<str>`
+
+Base filename for ALL exported files. With prefix='foo' every output becomes `foo.csv`, `foo.json`, `foo_timeslices.{csv,json}`, `foo.jsonl`, `foo_raw.jsonl`, `foo_gpu_telemetry.jsonl`, and `foo_server_metrics.{jsonl,json,csv,parquet}`. When unset (the default), historical per-file names are used: `profile_export_aiperf.{csv,json}` for the summary, `profile_export.jsonl` and `profile_export_raw.jsonl` for records, `gpu_telemetry_export.jsonl`, and `server_metrics_export.*`. Known suffixes (e.g. `_raw.jsonl`, `_timeslices.csv`, `_server_metrics.parquet`) are stripped from the supplied value.
+
+#### `--export-level`, `--profile-export-level` `<str>`
+
+Controls which output files are generated. `summary`: Only aggregate metrics files (`.csv`, `.json`). `records`: Includes per-request metrics (`.jsonl`). `raw`: Includes raw request/response data (`_raw.jsonl`).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `summary` |  | Export only aggregated/summarized metrics (most compact) |
+| `records` | _default_ | Export per-record metrics after aggregation with display unit conversion (CLI default) |
+| `raw` |  | Export raw parsed records with full request/response data (most detailed) |
+
+#### `--slice-duration` `<float>`
+
+Duration in seconds for time-sliced metric analysis. When set, AIPerf divides the benchmark timeline into fixed-length windows and computes metrics separately for each window. This enables analysis of performance trends and variations over time (e.g., warmup effects, degradation under sustained load).
+<br/>_Constraints: > 0_
+
+#### `--auto-plot`, `--no-auto-plot`
+
+Auto-invoke `aiperf plot` against the artifact directory after the benchmark completes. None = defer to recipe default (False if no recipe). True/False = explicit override. Failures are logged but do not fail the command unless --plot-required is set.
+
+#### `--plot-required`
+
+Treat auto-plot failures as fatal: re-raise so `aiperf profile` exits non-zero. Only meaningful when auto-plot is on. Default False = warn and continue.
+<br/>_Flag (no value required)_
+
+#### `--export-outputs-json`
+
+Export generated response text to outputs.json after the run. When enabled, the raw generated-text payload for each request is written to an outputs.json file in the artifact directory.
+<br/>_Flag (no value required)_
+
+#### `--otel-url` `<str>`
+
+OTLP/HTTP metrics endpoint URL.
+
+#### `--stream` `<list>`
+
+Select which AIPerf telemetry domains to stream over OTel. Valid values: 'metrics', 'timing', or 'default'. 'default' streams both metrics and timing. Examples: --stream metrics | --stream timing | --stream metrics timing.
+
+#### `--otel-resource-attributes` `<list>`
+
+Custom OTel resource attributes as key=value pairs. Merged into the default resource attributes on every exported metric.
+
+#### `--gen-ai-provider` `<str>`
+
+GenAI semantic convention provider override.
+
+#### `--mlflow-tracking-uri` `<str>`
+
+MLflow tracking URI.
+
+#### `--mlflow-experiment` `<str>`
+
+MLflow experiment name.
+
+#### `--mlflow-run-name` `<str>`
+
+MLflow run name.
+
+#### `--mlflow-tag` `<list>`
+
+Additional MLflow run tags to attach on upload. Specify as key:value pairs (e.g., --mlflow-tag team:perf) or as JSON string.
+
+#### `--mlflow-parent-run-id` `<str>`
+
+Optional MLflow parent run ID.
+
+#### `--mlflow-artifact-glob` `<list>`
+
+Artifact glob overrides for MLflow upload. Can be specified multiple times or as a comma-separated list.
+
+#### `--wandb-project` `<str>`
+
+Weights & Biases project name. Setting this enables wandb export.
+
+#### `--wandb-entity` `<str>`
+
+Weights & Biases entity (team or user). Defaults to the API key's default entity.
+
+#### `--wandb-run-name` `<str>`
+
+Weights & Biases run name.
+
+#### `--wandb-tag` `<list>`
+
+Additional Weights & Biases run tags to attach on upload. Can be specified multiple times or as a comma-separated list.
+
+### HTTP Trace
+
+#### `--export-http-trace`
+
+Include HTTP trace data (timestamps, chunks, headers, socket info) in profile_export.jsonl. Computed metrics (http_req_duration, http_req_waiting, etc.) are always included regardless of this setting. See the HTTP Trace Metrics guide for details on trace data fields.
+<br/>_Flag (no value required)_
+
+#### `--show-trace-timing`
+
+Display HTTP trace timing metrics in the console at the end of the benchmark. Shows detailed timing breakdown: blocked, DNS, connecting, sending, waiting (TTFB), receiving, and total duration following k6 naming conventions.
+<br/>_Flag (no value required)_
+
+### Server Metrics
+
+#### `--server-metrics` `<list>`
+
+Server metrics collection (ENABLED BY DEFAULT). Automatically collects from inference endpoint base_url + `/metrics`. Optionally specify additional custom Prometheus-compatible endpoint URLs (e.g., http://node1:8081/metrics, http://node2:9090/metrics). Use `--no-server-metrics` to disable collection. Example: `--server-metrics node1:8081 node2:9090/metrics` for additional endpoints.
+
+#### `--no-server-metrics`
+
+Disable server metrics collection entirely.
+
+#### `--server-metrics-formats` `<list>`
+
+Specify which output formats to generate for server metrics. Multiple formats can be specified (e.g., `--server-metrics-formats json csv parquet`).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `json` | _default_ | Export aggregated statistics in JSON hybrid format with metrics keyed by name. Best for: Programmatic access, CI/CD pipelines, automated analysis. |
+| `csv` | _default_ | Export aggregated statistics in CSV tabular format organized by metric type. Best for: Spreadsheet analysis, Excel/Google Sheets, pandas DataFrames. |
+| `jsonl` |  | Export raw time-series records in line-delimited JSON format. Best for: Time-series analysis, debugging, visualizing metric evolution. Warning: Can generate very large files for long-running benchmarks. |
+| `parquet` |  | Export raw time-series data with delta calculations in Parquet columnar format. Best for: Analytics with DuckDB/pandas/Polars, efficient storage, SQL queries. Includes cumulative deltas from reference point for counters and histograms. |
+
+### Network Latency
+
+#### `--network-latency-automatic`
+
+Automatically measure network latency (DISABLED BY DEFAULT). Opens a fresh TCP connection to the endpoint throughout the run, measures the handshake RTT, and subtracts the mean from request-start-anchored latency metrics (request_latency, time_to_first_token, time_to_first_output_token). Raw metrics are preserved; adjusted values are emitted as separate network_adjusted_* metrics plus a network_rtt summary. Mutually exclusive with --network-latency-mean.
+<br/>_Flag (no value required)_
+
+#### `--network-latency-mean` `<float>`
+
+Set a fixed mean network RTT in milliseconds to subtract, bypassing active probing. Implicitly enables network latency adjustment. Mutually exclusive with --network-latency-automatic.
+<br/>_Constraints: ≥ 0.0_
+
+#### `--network-latency-ping-interval` `<float>`
+
+Seconds between TCP-handshake RTT probes during profiling (default: 1.0s). Only applies with --network-latency-automatic.
+<br/>_Constraints: > 0.0_
+
+### GPU Telemetry
+
+#### `--gpu-telemetry` `<list>`
+
+Enable GPU telemetry console display and optionally specify: (1) 'pynvml' or 'amdsmi' to use a local GPU library instead of DCGM HTTP endpoints, (2) 'dashboard' for realtime dashboard mode, (3) custom DCGM exporter URLs (e.g., http://node1:9401/metrics), (4) custom metrics CSV file (e.g., custom_gpu_metrics.csv). Default: DCGM mode with localhost:9400 and localhost:9401 endpoints. Examples: --gpu-telemetry pynvml | --gpu-telemetry amdsmi | --gpu-telemetry dashboard node1:9400.
+
+#### `--no-gpu-telemetry`
+
+Disable GPU telemetry collection entirely.
+
+### UI
+
+#### `--ui-type`, `--ui` `<str>`
+
+Select the user interface type for displaying benchmark progress. `dashboard` shows real-time metrics in a Textual TUI, `simple` uses TQDM progress bars, `none` disables UI completely. Defaults to `dashboard` in interactive terminals, `none` when not a TTY (e.g., piped or redirected output). Automatically set to `simple` when using `--verbose` or `--extra-verbose` in a TTY.
+<br/>_Choices: [`dashboard`, `none`, `simple`]_
+<br/>_Default: `dashboard`_
+
+### Multi-Run
+
+#### `--num-profile-runs` `<int>`
+
+Number of profile runs to execute for confidence reporting. Must be between 1 and 10. When set to 1 (default), runs a single benchmark. When set to >1, runs multiple benchmarks and computes aggregate statistics (mean, std, confidence intervals, coefficient of variation) across runs. Useful for quantifying variance and establishing confidence in results.
+<br/>_Constraints: ≥ 1, ≤ 10_
+<br/>_Default: `1`_
+
+#### `--profile-run-cooldown-seconds` `<float>`
+
+Cooldown duration in seconds between profile runs. Only applies when --num-profile-runs > 1. Allows the system to stabilize between runs (e.g., clear caches, cool down GPUs). Default is 0 (no cooldown).
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--confidence-level` `<float>`
+
+Confidence level for computing confidence intervals (0-1). Only applies when --num-profile-runs > 1. Common values: 0.90 (90%), 0.95 (95%, default), 0.99 (99%). Higher values produce wider confidence intervals.
+<br/>_Constraints: > 0, &lt; 1_
+<br/>_Default: `0.95`_
+
+#### `--profile-run-disable-warmup-after-first`, `--no-profile-run-disable-warmup-after-first`
+
+Disable warmup for profile runs after the first. Only applies when --num-profile-runs > 1. When True (default), only the first run includes warmup, subsequent runs measure steady-state performance for more accurate aggregate statistics. When False, all runs include warmup (useful for long cooldown periods or when testing cold-start performance).
+<br/>_Default: `True`_
+
+#### `--set-consistent-seed`, `--no-set-consistent-seed`
+
+Automatically set random seed for consistent workloads across runs. Only applies when --num-profile-runs > 1. When True (default), automatically sets --random-seed=42 if not specified, ensuring identical workloads across all runs for valid statistical comparison. When False, preserves None seed, resulting in different workloads per run (not recommended for confidence reporting as it produces invalid statistics). If --random-seed is explicitly set, that value is always used regardless of this setting.
+<br/>_Default: `True`_
+
+#### `--vary-seed-per-trial`, `--no-vary-seed-per-trial`
+
+When True, derive a distinct seed for each trial of a variation via SHA-256 over (envelope_seed, variation.label, trial). When False (default), all trials of a variation share the same seed, giving pure-runtime variance for confidence intervals. Enable when you want trials to also sample different inputs (captures end-to-end variance at the cost of conflating input noise with runtime noise in the resulting confidence statistics).
+
+#### `--convergence-metric` `<str>`
+
+Target metric name for adaptive convergence stopping. When set with --num-profile-runs > 1, enables adaptive mode that stops early once the metric stabilizes according to --convergence-mode. Uses --num-profile-runs as the maximum run cap. Example metrics: time_to_first_token, request_latency, inter_token_latency.
+
+#### `--convergence-stat` `<str>`
+
+Statistic to evaluate for convergence when using ci_width or cv mode. Common values: avg, p50, p90, p95, p99. Only applies when --convergence-metric is set.
+<br/>_Choices: [`avg`, `p50`, `p90`, `p95`, `p99`, `min`, `max`]_
+<br/>_Default: `avg`_
+
+#### `--convergence-threshold` `<float>`
+
+Threshold for convergence detection. For ci_width mode: maximum CI width as a fraction of the mean. For cv mode: maximum coefficient of variation. For distribution mode: KS test p-value threshold. When unset, each mode uses its own algorithm-specific default. Only applies when --convergence-metric is set.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--convergence-mode` `<str>`
+
+Statistical method for convergence detection. ci_width: Stop when Student's t confidence interval width relative to mean is below threshold. cv: Stop when coefficient of variation (std/mean) is below threshold. distribution: Stop when KS test p-value indicates latest run matches prior runs (requires --export-level records or --export-level raw; rejected with --export-level summary). Only applies when --convergence-metric is set.
+<br/>_Choices: [`ci_width`, `cv`, `distribution`]_
+<br/>_Default: `ci_width`_
+
+#### `--parameter-sweep-cooldown-seconds` `<float>`
+
+Cooldown seconds between sweep variations (e.g. between --concurrency 10 and --concurrency 20). Honored by MultiRunOrchestrator when iterating plan.configs. Default 0.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--parameter-sweep-same-seed`, `--no-parameter-sweep-same-seed`
+
+If true, every sweep variation reuses the same random seed (correlated comparisons). If false (default), each variation derives a unique seed `base_seed + variation.index` so independent draws exercise different inputs. Requires --random-seed when true.
+
+#### `--parameter-sweep-mode` `<str>`
+
+Execution order for sweep + multi-trial composition. 'repeated' (default) iterates trials as the outer loop and variations as the inner loop, so all variations run within trial 1, then within trial 2, etc. 'independent' inverts the loops: all trials at one variation complete before the next variation starts. Both modes produce the same total runs, only the artifact-path layout and submit order differ.
+<br/>_Choices: [`independent`, `repeated`]_
+<br/>_Default: `repeated`_
+
+#### `--sweep-type` `<str>`
+
+Topology used when multiple CLI magic-list flags (--concurrency, --request-rate, --isl, --osl, ...) are passed together. 'grid' (default) takes the Cartesian product of all lists; 'zip' pairs them element-wise (all lists must have equal length, like the YAML `sweep: {type: zip}` block). Ignored when only one magic-list flag is set or when the sweep is declared in YAML.
+<br/>_Default: `grid`_
+
+#### `--no-sweep-table`
+
+Suppress the per-cell streaming sweep table during multi-variation sweeps. Auto-suppressed when stdout is non-interactive, when the dashboard UI is active, or for single-cell sweeps.
+
+#### `--search-space` `<list>`
+
+Adaptive-search space dimensions. Repeatable. Each value is 'path:lo,hi[:kind]', e.g. 'phases.profiling.concurrency:1,1000:int'. Mutually exclusive with magic-list flags (--concurrency 10,20,30) and with explicit sweep blocks. See docs/sweeping/bayesian-optimization.md.
+
+#### `--search-metric` `<str>`
+
+Metric tag to optimize, e.g. 'output_token_throughput'. Required when --search-space is set. Must match a key in RunResult.summary_metrics produced by the run (NOT the flattened '_avg' / '_p99' aggregator-suffixed key).
+
+#### `--search-stat` `<str>`
+
+Statistic on the metric: avg / p50 / p90 / p95 / p99. Defaults to 'avg' when omitted (set by the CLIConfig -> AIPerfConfig converter).
+
+#### `--search-direction` `<str>`
+
+Optimization direction. Required when --search-space is set.
+
+#### `--search-max-iterations` `<int>`
+
+Maximum number of search iterations. Each iteration runs --num-profile-runs benchmarks. Required when --search-space is set.
+<br/>_Constraints: ≥ 2, ≤ 200_
+
+#### `--search-initial-points` `<int>`
+
+Random Sobol points before fitting the GP. Defaults to 5 when omitted. Must be &lt; --search-max-iterations.
+<br/>_Constraints: ≥ 1_
+
+#### `--search-random-seed` `<int>`
+
+Random seed for reproducible search trajectories. When unset, the planner uses non-deterministic randomness.
+<br/>_Constraints: ≥ 0_
+
+#### `--search-planner` `<str>`
+
+Outer-loop search planner plugin. Default `bayesian` is a curated Optuna preset that uses BoTorch qLogNEI/qLogNEHVI when the optional `botorch` extra is installed and otherwise falls back to Optuna TPE with a warning. `optuna` is the expert-mode alternative exposing `--optuna-sampler` (tpe / gp / botorch) and `--optuna-acquisition`. Explicit unavailable optional samplers raise. Third-party planners registered under the `search_planner` plugin category are accepted here. Only applies when --search-space is set.
+<br/>_Choices: [`bayesian`, `monotonic_sla`, `smooth_isotonic`, `optuna`]_
+
+#### `--optuna-sampler` `<str>`
+
+Optuna sampler selection. Only consulted when --search-planner=optuna. ``botorch`` is the preferred implicit default and requires the optional ``botorch`` extra; when the implicit default is unavailable, the planner warns and falls back to ``tpe``. Explicit ``botorch`` requests raise if the optional stack is unavailable. ``tpe`` is dep-light and ships with Optuna core. ``gp`` is Optuna's native GP-EI with inequality constraints (Optuna 4.2+) but requires ``torch``.
+
+#### `--optuna-acquisition` `<str>`
+
+Acquisition function override for the Optuna BoTorch sampler. Only consulted when --search-planner=optuna AND --optuna-sampler=botorch; rejected otherwise. ``None`` (default) lets Optuna pick (single-objective unconstrained -> LogEI per Optuna v4.x). ``logei``/``qlogei`` make that explicit. ``qnei`` selects plain noisy EI (Letham 2017). ``qlognei`` selects qLogNoisyExpectedImprovement (Ament 2023, https://arxiv.org/abs/2310.20708) -- BoTorch's strongly recommended modern noisy-EI default; requires ``botorch>=0.10``. Multi-objective variants (``qehvi``/``qnehvi``/``qlognehvi``) are accepted when ``objectives`` has length > 1; the planner rejects them on single-objective configs.
+
+#### `--optuna-terminator` `<str>`
+
+Optional posterior-regret stopping rule layered on top of the three-signal convergence check. Only consulted when --search-planner=optuna. ``regret`` selects Optuna's ``RegretBoundEvaluator`` (Makarova et al. 2022, https://proceedings.mlr.press/v188/makarova22a.html). ``emmr`` selects ``EMMREvaluator`` (Ishibashi et al. 2023, https://proceedings.mlr.press/v206/ishibashi23a.html). Both are in the same family as Wilson 2024's PRB stopping rule and ship in Optuna core (no extra dep). ``none`` (default) disables; convergence is then driven by --search-max-iterations / --improvement-patience / --plateau-cv only.
+
+#### `--search-percentile-pooling` `<str>`
+
+Percentile aggregation strategy when --search-stat is a percentile (p50/p90/p95/p99). ``mean`` (default) computes the BO objective as the arithmetic mean of per-trial percentiles across --num-profile-runs trials. ``pooled`` walks each trial's per-request profile_export.jsonl, accumulates raw samples, and computes ``np.percentile`` over the pooled bag -- exposing more tail mass than mean-of-percentiles (correct for SLO claims; same argmax for ranking on monotone problems). ``pooled`` requires --export-level records; if the JSONL is missing the planner falls back to mean with a one-time warning. Rejected when --search-stat is ``avg``.
+
+#### `--bo-constraint-mode` `<str>`
+
+Deprecated and ignored. The bayesian preset and the optuna expert mode both use Optuna's native ``constraints_func`` (Letham et al. 2019, arXiv:1706.07094), which subsumes both the soft-penalty and EIC formulations. Accepted for backwards compatibility but has no effect: the value flows through ``_converter_optionals._SWEEP_OPTIONAL_FIELDS`` to ``AdaptiveSearchSweep.constraint_mode`` (see ``aiperf.config.sweep.config``), and that field is not read by any planner.
+
+#### `--variant`, `--sweep-variant` `<list>`
+
+Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
+
+#### `--search-sla` `<list>`
+
+SLA filter to attach to the adaptive-search or grid path. Format: 'metric_tag:stat:op:threshold'. Stat in {avg, min, max, p1, p5, p10, p25, p50, p75, p90, p95, p99}; op in {lt, le, gt, ge}; threshold is a float in the metric's native unit. For request_error_rate, 1 means 1% (percentage points), unlike --error-rate-sla, which accepts a fraction. Repeatable. Example: --search-sla 'time_to_first_token:p95:lt:200' --search-sla 'request_error_rate:avg:lt:1'. Composes with recipe-named SLA flags (--ttft-sla-ms etc.); the final filter list is recipe filters first, then --search-sla filters in CLI order.
+
+#### `--search-sla-tier` `<list>`
+
+Multi-tier SLO grouping flag. Each invocation defines one tier of SLA filters. Format: 'LABEL:FILTER[,FILTER...]' or 'FILTER[,FILTER...]' (auto-labels tier_1, tier_2, ...). Requires 2-10 invocations. Example: --search-sla-tier 'fast:output_token_throughput:avg:gt:300,time_to_first_token:p95:lt:5000' --search-sla-tier 'standard:output_token_throughput:avg:gt:100,time_to_first_token:p95:lt:10000'. When used, all --search-sla filters are still parsed and compose with tier definitions.
+
+#### `--search-recipe` `<str>`
+
+Named search-recipe preset that expands to an adaptive-search or sweep block. Mutually exclusive with explicit --search-* flags. Recipes are registered under the search_recipe plugin category. Example: --search-recipe max-throughput-ttft-sla --ttft-sla-ms 200.
+
+#### `--ttft-sla-ms` `<float>`
+
+Time-to-first-token SLA threshold in milliseconds. Required by TTFT-SLA recipes (e.g. max-throughput-ttft-sla); ignored otherwise. Must be > 0 — a 0 or negative threshold yields an unsatisfiable filter.
+<br/>_Constraints: > 0_
+
+#### `--isl-osl-pairs` `<str>`
+
+Paired ISL/OSL workload shapes for the pareto-sweep recipe, e.g. '128/128,512/256,2048/512'. Each pair is '&lt;isl>/&lt;osl>' with positive ints; pairs are comma-separated and whitespace-tolerant. Recipe-only flag; ignored unless --search-recipe pareto-sweep is set.
+
+#### `--itl-sla-ms` `<float>`
+
+Inter-token-latency SLA threshold in milliseconds. Required by ITL-SLA recipes (e.g. max-throughput-itl-sla); ignored otherwise. Must be > 0 — a 0 or negative threshold yields an unsatisfiable filter.
+<br/>_Constraints: > 0_
+
+#### `--tpot-sla-ms` `<float>`
+
+Time-per-output-token SLA threshold in milliseconds. Maps to the `inter_token_latency` metric tag (TPOT and ITL are equivalent in this codebase). Consumed by the max-concurrency-under-sla and max-goodput-under-slo recipes; ignored otherwise. Streaming required.
+<br/>_Constraints: > 0_
+
+#### `--e2e-sla-ms` `<float>`
+
+End-to-end request-latency SLA threshold in milliseconds (p99). Maps to the `request_latency` metric tag. Consumed by the max-concurrency-under-sla and max-goodput-under-slo recipes; ignored otherwise. Available without streaming.
+<br/>_Constraints: > 0_
+
+#### `--error-rate-sla` `<float>`
+
+Maximum acceptable request error rate as a fraction in (0, 1) (e.g. 0.05 = 5%). Maps to the `request_error_rate` metric tag (avg), converting the fraction to the metric's percentage-point scale. Consumed by the max-concurrency-under-sla recipe; ignored otherwise. Available without streaming.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--slo-attainment-fraction` `<float>`
+
+Minimum fraction of requests that must satisfy ALL configured per-request SLOs (TTFT/TPOT/E2E) for a configuration to be considered feasible by the goodput recipe. Bounded in (0, 1]. Default 0.95 matches DistServe's canonical attainment-fraction convention (https://arxiv.org/pdf/2401.09670). Consumed by the max-goodput-under-slo recipe; ignored otherwise.
+<br/>_Constraints: > 0, ≤ 1_
+
+#### `--search-style` `<str>`
+
+Search strategy for the max-concurrency-under-sla recipe. 'smooth_isotonic' (default) runs PAVA + PCHIP smooth-isotonic regression-based 1D SLA-saturation search. 'monotonic' runs a 1D binary-search via the MonotonicSLASearchPlanner (~10-20 iterations). 'bo' runs penalty Bayesian Optimization (~30 iterations). 'optuna' runs the same penalty-BO formulation via the OptunaSearchPlanner (TPE/GP/BoTorch samplers; BoTorch requires the optional botorch extra). 'grid' runs a log-spaced 8-step sweep + sla_breach_knee post-process. Recipe-only flag; ignored unless --search-recipe max-concurrency-under-sla is set.
+
+#### `--degradation-threshold` `<float>`
+
+Relative latency degradation threshold for the concurrency-ramp recipe (e.g. 0.20 = 20%). The recipe's post-process handler reports the first concurrency where p99 latency exceeds baseline * (1 + threshold). Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--degradation-metric-tag` `<str>`
+
+ConcurrencyRamp post-process: metric tag for knee detection (default: request_latency). Use, e.g., 'time_to_first_token' to detect the knee on TTFT instead of end-to-end request latency. Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+
+#### `--degradation-stat` `<str>`
+
+ConcurrencyRamp post-process: statistic for knee detection (default: p99). Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+
+#### `--isl-min` `<int>`
+
+Minimum input-sequence-length for the prefill-ttft-curve recipe (default 256 when omitted). The recipe sweeps ISL on a log scale from --isl-min to --isl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--isl-max` `<int>`
+
+Maximum input-sequence-length for the prefill-ttft-curve recipe (default 32768 when omitted). The recipe sweeps ISL on a log scale from --isl-min to --isl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--isl-steps` `<int>`
+
+Number of log-spaced steps for the prefill-ttft-curve recipe's ISL grid (default 8 when omitted). Must be >= 2 — a single-point ramp degenerates and post-process can't compute a baseline. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+#### `--concurrency-min` `<int>`
+
+Lower bound for the concurrency sweep axis used by concurrency-ramp and decode-itl-curve recipes (defaults: 1 for concurrency-ramp, 1 for decode-itl-curve). Must be &lt; --concurrency-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--concurrency-max` `<int>`
+
+Upper bound for the concurrency sweep axis used by concurrency-ramp and decode-itl-curve recipes (defaults: 1000 for concurrency-ramp, 200 for decode-itl-curve). Must be > --concurrency-min. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--concurrency-steps` `<int>`
+
+Number of log-spaced steps for the concurrency sweep axis used by concurrency-ramp (default 8) and decode-itl-curve (default 6). Must be >= 2. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+#### `--osl-min` `<int>`
+
+Minimum output-sequence-length for the decode-itl-curve recipe's OSL grid (default 64 when omitted). The recipe sweeps OSL on a log scale from --osl-min to --osl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--osl-max` `<int>`
+
+Maximum output-sequence-length for the decode-itl-curve recipe's OSL grid (default 1024 when omitted). The recipe sweeps OSL on a log scale from --osl-min to --osl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--osl-steps` `<int>`
+
+Number of log-spaced steps for the decode-itl-curve recipe's OSL grid (default 4 when omitted). Must be >= 2. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+### Accuracy
+
+#### `--accuracy-benchmark` `<str>`
+
+Accuracy benchmark to run (e.g., mmlu, aime, hellaswag). When set, enables accuracy benchmarking mode alongside performance profiling.
+<br/>_Choices: [`mmlu`, `mmlu_pro`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
+
+#### `--accuracy-tasks` `<list>`
+
+Specific tasks or subtasks within the benchmark to evaluate (e.g., specific MMLU subjects). Accepts comma-separated values (e.g. abstract_algebra,anatomy) or repeated flags. If not set, all tasks are included.
+
+#### `--accuracy-n-shots` `<int>`
+
+Number of few-shot examples to include in the prompt. 0 means zero-shot evaluation, None uses the benchmark default (e.g. MMLU=5). Maximum 32.
+<br/>_Constraints: ≥ 0, ≤ 32_
+
+#### `--accuracy-enable-cot`, `--accuracy-no-enable-cot`
+
+Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instructions to the prompt. Defaults to the benchmark's ``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).
+<br/>_Flag (no value required)_
+
+#### `--accuracy-grader` `<str>`
+
+Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
+<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`, `mmlu_pro`]_
+
+#### `--accuracy-system-prompt` `<str>`
+
+Custom system prompt to use for accuracy evaluation. Overrides any benchmark-specific system prompt.
+
+#### `--accuracy-verbose`
+
+Enable verbose output for accuracy evaluation, showing per-problem grading details.
+<br/>_Flag (no value required)_
+
+### Service
+
+#### `--log-level` `<str>`
+
+Set the logging verbosity level. Controls the amount of output displayed during benchmark execution. Use `TRACE` for debugging ZMQ messages, `DEBUG` for detailed operation logs, or `INFO` (default) for standard progress updates.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `TRACE` |  | Most verbose. Logs all operations including ZMQ messages and internal state changes. |
+| `DEBUG` |  | Detailed debugging information. Logs function calls and important state transitions. |
+| `INFO` | _default_ | General informational messages. Default level showing benchmark progress and results. |
+| `NOTICE` |  | Important informational messages that are more significant than INFO but not warnings. |
+| `WARNING` |  | Warning messages for potentially problematic situations that don't prevent execution. |
+| `SUCCESS` |  | Success messages for completed operations and milestones. |
+| `ERROR` |  | Error messages for failures that prevent specific operations but allow continued execution. |
+| `CRITICAL` |  | Critical errors that may cause the benchmark to fail or produce invalid results. |
+
+#### `-v`, `--verbose`
+
+Equivalent to `--log-level DEBUG`. Enables detailed logging output showing function calls and state transitions. Also automatically switches UI to `simple` mode for better console visibility. Does not include raw ZMQ message logging.
+<br/>_Flag (no value required)_
+
+#### `-vv`, `--extra-verbose`
+
+Equivalent to `--log-level TRACE`. Enables the most verbose logging possible, including all ZMQ messages, internal state changes, and low-level operations. Also switches UI to `simple` mode. Use for deep debugging.
+<br/>_Flag (no value required)_
+
+#### `--record-processor-service-count`, `--record-processors` `<int>`
+
+Number of `RecordProcessor` services to spawn for parallel metric computation. Higher request rates require more processors to keep up with incoming records. If not specified, automatically determined based on worker count (typically 1-2 processors per 8 workers).
+<br/>_Constraints: ≥ 1_
+
+#### `--api-port` `<int>`
+
+AIPerf API port (enables HTTP + WebSocket endpoints).
+<br/>_Constraints: ≥ 1, ≤ 65535_
+
+#### `--api-host` `<str>`
+
+AIPerf API host (requires --api-port or AIPERF_API_SERVER_PORT to be set).
+
+#### `--stats-interval` `<float>`
+
+Interval in seconds between realtime stats publishes (dashboards and the per-tick log block). 0 disables the log block while dashboards continue to poll. Defaults to 5s under --ui dashboard, 30s otherwise. Overrides AIPERF_UI_REALTIME_METRICS_INTERVAL.
+<br/>_Constraints: ≥ 0.0, ≤ 1000.0_
+
+### ZMQ Communication
+
+#### `--zmq-host` `<str>`
+
+Host address for internal ZMQ TCP communication between AIPerf services. Defaults to `127.0.0.1` (localhost) for single-machine deployments. For distributed setups, set to a reachable IP address. All internal service-to-service communication (message bus, dataset manager, workers) uses this host for TCP sockets.
+<br/>_Default: `127.0.0.1`_
+
+#### `--zmq-ipc-path` `<str>`
+
+Directory path for ZMQ IPC (Inter-Process Communication) socket files. When using IPC transport instead of TCP, AIPerf creates Unix domain socket files in this directory for faster local communication. Auto-generated in system temp directory if not specified. Only applicable when using IPC communication backend.
+
+#### `--zmq-dual-bind`
+
+Select the ZMQ dual-bind communication backend (IPC + TCP). All dual-bind knobs are cluster-managed; this flag only selects the discriminator and the converter routes downstream to the default.
+<br/>_Flag (no value required)_
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+#### `--name` `<str>`
+
+Human-readable name for the benchmark job (DNS label, max 40 chars).
+
+#### `--image` `<str>`
+
+AIPerf container image to use for Kubernetes deployment.
+<br/>_Constraints: min: 1_
+
+#### `--image-pull-policy` `<str>`
+
+Image pull policy (Always, IfNotPresent, Never). Use 'Never' for minikube (or local clusters) with locally loaded images.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `Always` |  | Every time the kubelet launches a container, it queries the registry to resolve the name to a digest. Uses cached image if digest matches, otherwise pulls the image. |
+| `Never` |  | The kubelet does not try fetching the image. Startup fails if the image is not already present locally. |
+| `IfNotPresent` |  | The image is pulled only if it is not already present locally. |
+
+#### `--total-workers` `<int>`
+
+Total number of workers. Automatically distributed across pods based on --workers-per-pod (default 10). E.g., --total-workers 50 = 5 pods × 10 workers.
+<br/>_Constraints: > 0_
+<br/>_Default: `10`_
+
+#### `--ttl-seconds` `<int>`
+
+Seconds to keep pods after completion (None to disable TTL).
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `300`_
+
+### Kubernetes Node Placement
+
+#### `--node-selector` `<list>`
+
+CLI-only node selector labels (JSON object or repeated key=value).
+
+#### `--tolerations` `<list>`
+
+Pod tolerations as JSON object/array or repeated JSON values.
+
+### Kubernetes Scheduling
+
+#### `--queue-name` `<str>`
+
+Kueue LocalQueue name for gang-scheduling. When set, the JobSet is submitted to Kueue for quota-managed admission.
+
+#### `--priority-class` `<str>`
+
+Kueue WorkloadPriorityClass name for scheduling priority.
+
+### Kubernetes Metadata
+
+#### `--annotations` `<str>`
+
+Additional pod annotations.
+
+#### `--labels` `<str>`
+
+Additional pod labels.
+
+### Kubernetes Secrets
+
+#### `--image-pull-secrets` `<list>`
+
+Image pull secret names.
+
+#### `--env-vars` `<str>`
+
+Extra environment variables (key: value).
+
+#### `--env-from-secrets` `<str>`
+
+Environment variables from secrets (ENV_NAME: secret_name/key).
+
+#### `--secret-mounts` `<list>`
+
+Secret volume mounts.
+
+#### `--service-account` `<str>`
+
+Service account name for pods.
+
+### Parameters
+
+#### `-d`, `--detach`, `--no-detach`
+
+Exit immediately after deploying (don't wait for completion). Automatically enabled in non-interactive environments (pipes, CI/CD).
+
+#### `--no-wait`
+
+Don't wait for pods to be ready before attaching (advanced). In operator mode this returns as soon as the AIPerfJob is created.
+
+#### `--attach-port` `<int>`
+
+Local port for API port-forward (default: 0 = ephemeral). Direct mode only; operator mode watches the AIPerfJob instead of port-forwarding.
+<br/>_Default: `0`_
+
+#### `--skip-endpoint-check`
+
+Skip endpoint health validation before deploying.
+<br/>_Flag (no value required)_
+
+#### `--dry-run`
+
+Print the AIPerfJob CR as JSON without submitting it.
+<br/>_Flag (no value required)_
+
+#### `--operator`
+
+Force operator deployment without probing the cluster-scoped AIPerfJob CRD. Use this with a pre-provisioned namespace when RBAC is namespace-scoped.
+<br/>_Flag (no value required)_
+
+#### `--no-operator`
+
+Force direct deployment without the operator. Automatically enabled if the AIPerfJob CRD is not installed on the cluster.
+
+<hr/>
+
+## `aiperf kube sweep`
+
+Run a parameter sweep or multi-run benchmark in Kubernetes
+
+### Endpoint
+
+#### `-m`, `--model-names`, `--model` `<list>`
+
+Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
+
+#### `--model-selection-strategy` `<str>`
+
+When multiple models are specified, this is how a specific model should be assigned to a prompt. round_robin: nth prompt in the list gets assigned to n-mod len(models). random: assignment is uniformly random.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `round_robin` | _default_ | Cycle through models in order. The nth prompt is assigned to model at index (n mod number_of_models). |
+| `random` |  | Randomly select a model for each prompt using uniform distribution. |
+| `weighted` |  | Select a model with probability proportional to a per-model weight. |
+
+#### `--custom-endpoint`, `--endpoint` `<str>`
+
+Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default, endpoints follow OpenAI-compatible paths like `/v1/chat/completions`. Use this option to override the default path for non-standard API implementations.
+
+#### `--endpoint-type` `<str>`
+
+The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
+<br/>_Choices: [`audio_transcription`, `chat`, `cohere_rankings`, `completions`, `responses`, `messages`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
+<br/>_Default: `chat`_
+
+#### `--streaming`
+
+Enable streaming responses. When enabled, the server streams tokens incrementally as they are generated. Automatically disabled if the selected endpoint type does not support streaming. Enables measurement of time-to-first-token (TTFT) and inter-token latency (ITL) metrics.
+<br/>_Flag (no value required)_
+
+#### `-u`, `--url` `<list>`
+
+Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). URLs that do not include a scheme (no `://`) have `http://` prepended automatically.
+<br/>_Constraints: min: 1_
+<br/>_Default: `['http://localhost:8000']`_
+
+#### `--url-strategy` `<str>`
+
+Strategy for selecting URLs when multiple `--url` values are provided. 'round_robin' (default): distribute requests evenly across URLs in sequential order.
+<br/>_Choices: [`round_robin`]_
+<br/>_Default: `round_robin`_
+
+#### `--request-timeout-seconds` `<float>`
+
+Maximum time in seconds to wait for each HTTP request to complete, including connection establishment, request transmission, and response receipt. Applies to both streaming and non-streaming requests. Requests exceeding this timeout are cancelled and recorded as failures.
+<br/>_Constraints: > 0_
+<br/>_Default: `21600`_
+
+#### `--wait-for-model-timeout` `<float>`
+
+Seconds to wait for endpoint readiness before benchmarking (0 = skip). Sends a real inference request to verify the model is loaded and can generate output.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--wait-for-model-mode` `<str>`
+
+How readiness probes the endpoint: 'models' checks /v1/models, 'inference' sends a canned one-token inference request, and 'both' runs the models check before inference.
+<br/>_Default: `inference`_
+
+#### `--wait-for-model-interval` `<float>`
+
+Seconds between endpoint readiness probe attempts.
+<br/>_Constraints: > 0.0_
+<br/>_Default: `5.0`_
+
+#### `--reset-kv-cache`
+
+Enable once-per-cell KV-cache reset via POST to the endpoint.
+<br/>_Flag (no value required)_
+
+#### `--reset-kv-cache-timeout-seconds` `<float>`
+
+Timeout seconds for reset_kv_cache control requests.
+<br/>_Constraints: > 0_
+
+#### `--reset-kv-cache-path` `<str>`
+
+Relative path for reset_kv_cache (default /reset_prefix_cache).
+
+#### `--server-profiler`
+
+Enable server profiler start/stop around profiling phases.
+<br/>_Flag (no value required)_
+
+#### `--server-profiler-timeout-seconds` `<float>`
+
+Timeout seconds for server_profiler control requests.
+<br/>_Constraints: > 0_
+
+#### `--server-profiler-start-path` `<str>`
+
+Relative path for profiler start (default /start_profile).
+
+#### `--server-profiler-stop-path` `<str>`
+
+Relative path for profiler stop (default /stop_profile).
+
+#### `--api-key` `<str>`
+
+API authentication key for the endpoint. When provided, automatically included in request headers as `Authorization: Bearer <api_key>`.
+
+#### `--transport`, `--transport-type` `<str>`
+
+Transport protocol to use for API requests. If not specified, auto-detected from the URL scheme (`http`/`https` -> `TransportType.HTTP`). Currently supports `http` transport using aiohttp with connection pooling, TCP optimization, and Server-Sent Events (SSE) for streaming. Explicit override rarely needed.
+<br/>_Choices: [`http`]_
+
+#### `--use-legacy-max-tokens`
+
+Use the legacy 'max_tokens' field instead of 'max_completion_tokens' in request payloads. The OpenAI API now prefers 'max_completion_tokens', but some older APIs or implementations may require 'max_tokens'.
+<br/>_Flag (no value required)_
+
+#### `--use-server-token-count`
+
+Use server-reported token counts from API usage fields instead of client-side tokenization. When enabled, tokenizers are still loaded (needed for dataset generation) but tokenizer.encode() is not called for computing metrics. Token count fields will be None if the server does not provide usage information. For OpenAI-compatible streaming endpoints (chat/completions), stream_options.include_usage is automatically configured when this flag is enabled.
+<br/>_Flag (no value required)_
+
+#### `--connection-reuse-strategy` `<str>`
+
+Transport connection reuse strategy. 'pooled' (default): connections are pooled and reused across all requests. 'never': new connection for each request, closed after response. 'sticky-user-sessions': connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `pooled` | _default_ | Connections are pooled and reused across all requests |
+| `never` |  | New connection for each request, closed after response |
+| `sticky-user-sessions` |  | Connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing) |
+
+#### `--download-video-content`
+
+For video generation endpoints, download the video content after generation completes. When enabled, request latency includes the video download time. When disabled (default), only generation time is measured.
+<br/>_Flag (no value required)_
+
+#### `--request-content-type` `<str>`
+
+Content type for request body serialization. By default, requests are sent as 'application/json'. Set to 'multipart/form-data' for servers that require form-encoded requests (e.g., vLLM video generation endpoints).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `application/json` |  | Standard JSON encoding. Default for all endpoints. |
+| `multipart/form-data` |  | Multipart form encoding. Required by some video generation servers (e.g., vLLM). |
+
+#### `--session-header` `<str>`
+
+HTTP header name used to carry the per-session affinity identifier. When set, replaces the default `X-Correlation-ID` header with the provided name (e.g., `--session-header X-Session-ID`).
+
+#### `--uuid-and-strip`
+
+Enable AIPerf-managed image stripping for vLLM's multimodal processor cache. Dataset-authored image UUIDs, including UUID-only cache references, always pass through on the chat endpoint; this flag only strips repeated content after AIPerf observes it in the same session. Automatic stripping supports only single_turn datasets with session_id-grouped rows; multi_turn is rejected. The server cache must cover the working set, and requests in a session must reach a replica that retains earlier UUIDs.
+<br/>_Flag (no value required)_
+
+### Tokenizer
+
+#### `--tokenizer` `<str>`
+
+HuggingFace tokenizer identifier, local path, or `builtin` for token counting in prompts and responses. Accepts model names (e.g., `meta-llama/Llama-2-7b-hf`), filesystem paths to tokenizer files, or `builtin` for a zero-network-access tokenizer backed by tiktoken (o200k_base encoding). If not specified, defaults to the value of `--model-names`. If `--tokenizer` is not set and the model name looks like an obvious placeholder (e.g. `mock-model`, `test-model`, `fake-model`), AIPerf substitutes `builtin` automatically and emits a warning. Essential for accurate token-based metrics (input/output token counts, token throughput).
+
+#### `--tokenizer-revision` `<str>`
+
+Specific tokenizer version to load from HuggingFace Hub. Can be a branch name (e.g., `main`), tag name (e.g., `v1.0`), or full commit hash. Ensures reproducible tokenization across runs by pinning to a specific version. Defaults to `main` branch if not specified.
+<br/>_Default: `main`_
+
+#### `--tokenizer-trust-remote-code`
+
+Allow execution of custom Python code from HuggingFace Hub tokenizer repositories. Required for tokenizers with custom implementations not in the standard `transformers` library. **Security Warning**: Only enable for trusted repositories, as this executes arbitrary code. Unnecessary for standard tokenizers.
+<br/>_Flag (no value required)_
+
+#### `--apply-chat-template`
+
+Apply the HuggingFace tokenizer's chat template when counting input tokens. When enabled: synthetic ISL is compensated for chat-template wrapping (BOS, role headers, EOT, generation-prompt suffix) and the record processor reports ISL using `apply_chat_template(tokenize=True, add_generation_prompt=True)` for chat-shape payloads. When disabled (default), both paths use bare-text encoding, so reported ISL matches the prompt content the user asked for and ignores template overhead. Requires an HF tokenizer with a chat template configured; no-ops on tiktoken / un-templated models.
+<br/>_Flag (no value required)_
+
+### Input
+
+#### `--extra-inputs` `<list>`
+
+Additional input parameters to include in every API request payload. Specify as `key:value` pairs (e.g., `--extra-inputs temperature:0.7 top_p:0.9`) or as JSON string (e.g., `'{"temperature": 0.7}'`). These parameters are merged with request-specific inputs and sent directly to the endpoint API.
+
+#### `-H`, `--header` `<list>`
+
+Custom HTTP headers to include with every request. Specify as `Header:Value` pairs (e.g., `--header X-Custom-Header:value`) or as JSON string. Can be specified multiple times. Useful for custom authentication, tracking, or API-specific requirements. Combined with auto-generated headers (e.g., `Authorization` from `--api-key`).
+
+#### `--input-file` `<str>`
+
+Path to file or directory containing benchmark dataset. Required when using `--custom-dataset-type`. Supported formats depend on dataset type: JSONL for `single_turn`/`multi_turn`, JSONL for `mooncake_trace`/`bailian_trace` (timestamped traces), Parquet for `baseten_trace`, directories for `random_pool`. File is parsed according to `--custom-dataset-type` specification.
+
+#### `--public-dataset` `<str>`
+
+Pre-configured public dataset to download and use for benchmarking (e.g., `sharegpt`). AIPerf automatically downloads and parses these datasets. Mutually exclusive with `--custom-dataset-type`. Run `aiperf plugins public_dataset_loader` to list available datasets. Use `--hf-subset` to override the HuggingFace subset/config for HF-backed datasets.
+<br/>_Choices: [`exgentic_v2`, `exgentic`, `sharegpt`, `aimo`, `mmstar`, `mmvu`, `vision_arena`, `llava_onevision`, `aimo_aime`, `aimo_numina_cot`, `aimo_numina_1_5`, `spec_bench`, `spec_al_gsm8k`, `spec_al_math500`, `spec_al_humaneval`, `spec_al_mbpp`, `spec_al_mtbench`, `instruct_coder`, `blazedit_5k`, `blazedit_10k`, `librispeech`, `voxpopuli`, `gigaspeech`, `ami`, `spgispeech`, `semianalysis_cc_traces_weka`, `semianalysis_cc_traces_weka_no_subagents`, `semianalysis_cc_traces_weka_with_subagents`, `semianalysis_cc_traces_weka_with_subagents_256k`, `semianalysis_cc_traces_weka_with_subagents_060226`, `semianalysis_cc_traces_weka_with_subagents_060226_256k`, `semianalysis_cc_traces_weka_with_subagents_060526`, `semianalysis_cc_traces_weka_with_subagents_060526_256k`, `semianalysis_cc_traces_weka_with_subagents_060826`, `semianalysis_cc_traces_weka_with_subagents_060826_256k`, `semianalysis_cc_traces_weka_061326`, `semianalysis_cc_traces_weka_061326_256k`, `semianalysis_cc_traces_weka_061526`, `semianalysis_cc_traces_weka_061526_256k`, `semianalysis_cc_traces_weka_062126`, `semianalysis_cc_traces_weka_062126_256k`, `weka_hf`]_
+
+#### `--hf-subset` `<str>`
+
+HuggingFace dataset subset/config name to override the plugin default (e.g. `sharegpt4o`). Only applies when using `--public-dataset` with a HuggingFace-backed loader. Takes priority over the subset defined in the plugin registry.
+
+#### `--hf-weka-dataset` `<str>`
+
+HuggingFace dataset repo for the generic Weka loader (e.g. `semianalysisai/cc-traces-weka-061526`). Passing this auto-selects `--public-dataset weka_hf`, so the repo flag works on its own; setting it alongside any other `--public-dataset` or `--custom-dataset-type` is an error. Pinned Weka public dataset aliases keep their registry-defined repo names.
+
+#### `--dataset-filter` `<list>`
+
+Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
+
+#### `--custom-dataset-type` `<str>`
+
+Format specification for custom dataset provided via `--input-file`. Determines parsing logic and expected file structure. Options: `single_turn` (JSONL with single exchanges), `multi_turn` (JSONL with conversation history), `tracelab` (TraceLab agentic-coding corpus, JSONL or gzipped JSONL), `mooncake_trace`/`bailian_trace`/`baseten_trace` (timestamped trace files), `random_pool` (directory of reusable prompts; when using `random_pool`, `--conversation-num` defaults to 100 if not specified; batch sizes > 1 sample each modality independently from a flat pool and do not preserve per-entry associations - use `single_turn` if paired modalities must stay together). Requires `--input-file`. Mutually exclusive with `--public-dataset`.
+<br/>_Choices: [`burst_gpt_trace`, `bailian_trace`, `baseten_trace`, `mooncake_trace`, `raw_payload`, `inputs_json`, `dag_jsonl`, `sagemaker_data_capture`, `multi_turn`, `random_pool`, `single_turn`, `speed_bench_qualitative`, `speed_bench_coding`, `speed_bench_humanities`, `speed_bench_math`, `speed_bench_multilingual`, `speed_bench_qa`, `speed_bench_rag`, `speed_bench_reasoning`, `speed_bench_roleplay`, `speed_bench_stem`, `speed_bench_summarization`, `speed_bench_writing`, `speed_bench_throughput_1k`, `speed_bench_throughput_2k`, `speed_bench_throughput_8k`, `speed_bench_throughput_16k`, `speed_bench_throughput_32k`, `speed_bench_throughput_1k_low_entropy`, `speed_bench_throughput_1k_mixed`, `speed_bench_throughput_1k_high_entropy`, `speed_bench_throughput_2k_low_entropy`, `speed_bench_throughput_2k_mixed`, `speed_bench_throughput_2k_high_entropy`, `speed_bench_throughput_8k_low_entropy`, `speed_bench_throughput_8k_mixed`, `speed_bench_throughput_8k_high_entropy`, `speed_bench_throughput_16k_low_entropy`, `speed_bench_throughput_16k_mixed`, `speed_bench_throughput_16k_high_entropy`, `speed_bench_throughput_32k_low_entropy`, `speed_bench_throughput_32k_mixed`, `speed_bench_throughput_32k_high_entropy`, `tracelab`, `weka_trace`]_
+
+#### `--ignore-trace-delays`
+
+Strip per-turn timestamps and inter-turn delays from trace datasets at load time. With this flag, Turn.timestamp and Turn.delay are emitted as None so concurrency / request-rate timing modes dispatch turns back-to-back instead of reproducing the recorded user think-time gaps. No effect under `--fixed-schedule` (timestamps drive that mode before they could be ignored -- combine with `--no-fixed-schedule` if you want both behaviors).
+<br/>_Flag (no value required)_
+
+#### `--use-think-time-only`
+
+For weka_trace inputs, emit Turn.delay using only the recorded per-request `think_time` (client-side delay before each request) instead of the full `t_curr - t_prev` inter-request delta. Compresses replay wall time against zero-latency mocks because the recorded `api_time` portion of each gap is dropped. Mirrors kv-cache-tester's default `--timing-strategy think-only`. Falls back to the full delta for turns whose recorded `think_time` is null. Mutually exclusive with `--ignore-trace-delays`. No effect on non-weka trace loaders.
+<br/>_Flag (no value required)_
+
+#### `--max-context-length` `<int>`
+
+Maximum peak prompt+output context length (tokens) per Weka root trace. Weka loaders (--custom-dataset-type weka_trace or a weka --public-dataset) drop whole traces whose *recorded* peak exceeds this ceiling at load time (filter-then-cap before --num-dataset-entries). Not a DatasetManager tokenize filter; rejected for non-Weka formats.
+<br/>_Constraints: ≥ 1_
+
+#### `--dataset-sampling-strategy` `<str>`
+
+Strategy for selecting entries from dataset during benchmarking. `sequential`: Iterate through dataset in order, wrapping to start after end. `random`: Randomly sample with replacement (entries may repeat before all are used). `shuffle`: Shuffle dataset and iterate without replacement, re-shuffling after exhaustion. Default behavior depends on dataset type (e.g., `sequential` for traces, `shuffle` for synthetic).
+<br/>_Choices: [`random`, `sequential`, `shuffle`]_
+
+#### `--allow-dataset-wrap`, `--no-allow-dataset-wrap`
+
+Allow weka/agentic replay to wrap (reuse distinct eligible traces across concurrency lanes) when concurrency exceeds the loaded pool. Defaults to False: over-subscription fails unless wrapping is explicitly enabled or an active --cache-bust target already keeps repeated-trace traffic distinct.
+
+#### `--random-seed` `<int>`
+
+Random seed for deterministic data generation. When set, makes synthetic prompts, sampling, delays, and other random operations reproducible across runs. Essential for A/B testing and debugging. Uses system entropy if not specified. Initialized globally at config creation.
+<br/>_Constraints: ≥ 0_
+
+#### `--trace-session-sample-ratio` `<float>`
+
+Fraction of trace sessions to keep for replay, sampled whole-session to preserve multi-turn integrity; deterministic when `--random-seed` is set. Only supported by the baseten_trace loader.
+<br/>_Constraints: > 0.0, ≤ 1.0_
+
+#### `-f`, `--config` `<str>`
+
+Path to a YAML configuration file. CLI flags override values from the config file.
+
+### Fixed Schedule
+
+#### `--fixed-schedule`
+
+Run requests according to timestamps specified in the input dataset. When enabled, AIPerf replays the exact timing pattern from the dataset. This mode is automatically enabled for trace datasets.
+<br/>_Flag (no value required)_
+
+#### `--no-fixed-schedule`
+
+Suppress the automatic switch to fixed-schedule mode for trace datasets that carry per-record timestamps. By default a trace input (e.g. mooncake_trace) with timestamps in the first record auto-promotes the profiling phase to fixed_schedule. Pass --no-fixed-schedule to keep the user-selected timing mode (e.g. concurrency, request_rate) and ignore the trace timestamps.
+
+#### `--fixed-schedule-auto-offset`
+
+Automatically normalize timestamps in fixed schedule by shifting all timestamps so the first timestamp becomes 0. When enabled, benchmark starts immediately with the timing pattern preserved. When disabled, timestamps are used as absolute offsets from benchmark start. Mutually exclusive with `--fixed-schedule-start-offset`.
+<br/>_Flag (no value required)_
+
+#### `--fixed-schedule-start-offset` `<int>`
+
+Start offset in milliseconds for fixed schedule replay. Skips all requests before this timestamp, allowing benchmark to start from a specific point in the trace. Requests at exactly the start offset are included. Useful for analyzing specific time windows. Mutually exclusive with `--fixed-schedule-auto-offset`. Must be ≤ `--fixed-schedule-end-offset` if both specified.
+<br/>_Constraints: ≥ 0_
+
+#### `--fixed-schedule-end-offset` `<int>`
+
+End offset in milliseconds for fixed schedule replay. Stops issuing requests after this timestamp, allowing benchmark of specific trace subsets. Requests at exactly the end offset are included. Defaults to last timestamp in dataset. Must be ≥ `--fixed-schedule-start-offset` if both specified.
+<br/>_Constraints: ≥ 0_
+
+### Goodput
+
+#### `--goodput` `<str>`
+
+Specify service level objectives (SLOs) for goodput as space-separated 'KEY:VALUE' pairs, where KEY is a metric tag and VALUE is a number in the metric's display unit (falls back to its base unit if no display unit is defined). Examples: 'request_latency:250' (ms), 'inter_token_latency:10' (ms), `output_token_throughput_per_user:600` (tokens/s). Only metrics applicable to the current endpoint/config are considered. For more context on the definition of goodput, refer to DistServe paper: https://arxiv.org/pdf/2401.09670 and the blog: https://hao-ai-lab.github.io/blogs/distserve.
+
+### Conversation Input
+
+#### `--conversation-num`, `--num-conversations`, `--num-sessions` `<str>`
+
+The total number of unique conversations to generate. Each conversation represents a single request session between client and server. Supported on synthetic mode and the custom random_pool dataset. The number of conversations will be used to determine the number of entries in both the custom random_pool and synthetic datasets and will be reused until benchmarking is complete. Pass a comma-separated list (e.g. `--num-conversations 50,100,200`) to sweep over session-bounded run lengths; the converter promotes the list to a sweep on phases.profiling.sessions before AIPerfConfig validation. The synthetic dataset pool is sized to max(list) so every variation has its full unique-session set.
+
+#### `--num-dataset-entries`, `--num-prompts` `<int>`
+
+Total number of unique entries to generate for the dataset. Each entry represents one user message that can be used as a turn in conversations. Entries are reused across conversations and turns according to `--dataset-sampling-strategy`. Higher values provide more diversity.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `100`_
+
+#### `--conversation-turn-mean`, `--session-turns-mean` `<int>`
+
+Mean number of request-response turns per conversation. Each turn consists of a user message and model response. Turn counts follow normal distribution around this mean (±`--conversation-turn-stddev`). Set to 1 for single-turn interactions. Multi-turn conversations enable testing of context retention and conversation history handling. Pass a comma-separated list (e.g. `--conversation-turn-mean 1,3,8`) to sweep over multiple turn-mean values; the converter promotes the list to a sweep on datasets.main.turns.mean before AIPerfConfig validation.
+<br/>_Default: `1`_
+
+#### `--conversation-turn-stddev`, `--session-turns-stddev` `<int>`
+
+Standard deviation for number of turns per conversation. Creates variability in conversation lengths, simulating diverse interaction patterns (quick questions vs. extended dialogues). Turn counts follow normal distribution. Set to 0 for uniform conversation lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--conversation-turn-delay-mean`, `--session-turn-delay-mean` `<float>`
+
+Mean delay in milliseconds between consecutive turns within a multi-turn conversation. Simulates user think time between receiving a response and sending the next message. Delays follow normal distribution around this mean (±`--conversation-turn-delay-stddev`). Only applies to multi-turn conversations (`--conversation-turn-mean` > 1). Set to 0 for back-to-back turns.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--conversation-turn-delay-stddev`, `--session-turn-delay-stddev` `<float>`
+
+Standard deviation for turn delays in milliseconds. Creates variability in user think time between conversation turns. Delays follow normal distribution. Set to 0 for deterministic delays. Models realistic human interaction patterns with variable response times.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--conversation-turn-delay-ratio`, `--session-delay-ratio` `<float>`
+
+Multiplier for scaling all turn delays within conversations. Applied after mean/stddev calculation: `actual_delay = calculated_delay × ratio`. Use to proportionally adjust timing without changing distribution shape. Values &lt; 1 speed up conversations, > 1 slow them down. Set to 0 to eliminate delays entirely.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1.0`_
+
+#### `--inter-turn-delay-cap-seconds` `<float>`
+
+Clamp per-turn replay delays to at most this many seconds; ``None`` disables the cap. Honored by the DAG JSONL loader and the baseten_trace loader's closed-loop think-times; the clamp count is reported at end of load. Maps to FileDataset ``inter_turn_delay_cap_seconds``.
+<br/>_Constraints: ≥ 0.0_
+
+#### `--max-idle-gap-cap-seconds` `<float>`
+
+Collapse idle gaps between consecutive requests (across all sessions) to at most this many seconds, so a sparse or session-sampled trace does not replay dead air; ``None`` disables the cap. The cap is in replay wall-clock seconds, applied after --replay-speedup compression, so it bounds actual benchmark idle time regardless of speedup. Only supported by the baseten_trace loader. Maps to FileDataset ``max_idle_gap_cap_seconds``.
+<br/>_Constraints: > 0.0_
+
+#### `--replay-speedup` `<float>`
+
+Trace replay wall-clock compression (10 = 10x faster than recorded): divides normalized timestamps and inter-turn delays; ``None`` = real time. Unlike synthesis speedup_ratio, hash_ids stay untouched (KV-cache fidelity). Only supported by the baseten_trace loader. Maps to FileDataset ``replay_speedup``.
+<br/>_Constraints: > 0.0_
+
+#### `--open-loop-replay`, `--no-open-loop-replay`
+
+Open-loop replay (the default): each session starts at its absolute, speedup-scaled recorded timestamp; continuation turns fire at max(recorded timestamp, prior-turn completion). Pass `--no-open-loop-replay` for closed-loop back-pressure: continuation turns fire a think-time (recorded start-to-start gap minus recorded e2e duration) after the prior turn completes, keeping sessions causally ordered when replayed service times differ from recorded (e.g. A/A comparisons). Only honored by the baseten_trace loader. Maps to FileDataset ``open_loop_replay``.
+<br/>_Default: `True`_
+
+#### `--open-loop-strict`
+
+In open-loop replay, fire every trace row at its absolute recorded timestamp as an independent single-turn session, trading away multi-turn grouping and session metrics. Only honored by the baseten_trace loader. Maps to FileDataset ``open_loop_strict``.
+<br/>_Flag (no value required)_
+
+#### `--omit-kv-hints`
+
+Drop recorded KV-cache hints (``hash_ids``, ``block_size``) from replayed request bodies, for strict frontends that reject unknown parameters. Only honored by the baseten_trace loader. Maps to FileDataset ``omit_kv_hints``.
+<br/>_Flag (no value required)_
+
+#### `--force-min-tokens`, `--no-force-min-tokens`
+
+Pin ``min_tokens`` to the recorded output length so replayed generations match recorded lengths; pass `--no-force-min-tokens` to let EOS end generations naturally (some servers reject ``min_tokens``). Only honored by the baseten_trace loader. Maps to FileDataset ``force_min_tokens``.
+<br/>_Default: `True`_
+
+### Prompt
+
+#### `-b`, `--prompt-batch-size`, `--batch-size-text`, `--batch-size` `<int>`
+
+Number of text inputs to include in each request for batch processing endpoints. Supported by `embeddings` and `rankings` endpoint types where models can process multiple inputs simultaneously for efficiency. Set to 1 for single-input requests. Not applicable to `chat` or `completions` endpoints.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--prompt-corpus` `<str>`
+
+Source corpus for synthetic prompt text generation. 'sonnet' uses Shakespeare sonnets. 'coding' uses realistic coding content (code, bash output, JSON, error tracebacks, git diffs). Honored only for synthesized content (synthetic datasets and count/hash-id trace loaders); verbatim formats ignore it. When unset, the active dataset loader's default applies (most loaders default to 'sonnet'; agentic-coding loaders such as weka_trace default to 'coding').
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `sonnet` |  | Shakespeare sonnets (default). Classic prose for filler text. |
+| `coding` |  | Realistic coding content: code, bash output, JSON, error tracebacks, git diffs. |
+
+### Cache Bust
+
+#### `--cache-bust` `<str>`
+
+Where (and how) to inject a cache-bust marker. Two families: (1) RID targets (system_prefix, system_suffix, first_turn_prefix, first_turn_suffix) — inject a per-trajectory unique SHA-256 digest marker that is identical across warmup and profiling, so warmup KV-cache work transfers to profiling while preventing cross-trajectory cache sharing. Prefix variants prepend at token 0; suffix variants append after existing content. (2) Warmup-isolation targets (warmup_isolation_system, warmup_isolation_first_turn) — inject a constant '[warmup]' marker only during the WARMUP phase; profiling sees no marker (fully cold start or system-pre-warmed). Incompatible with agentic_replay timing mode. 'none' disables the feature (default). See [cache-bust.md](reference/cache-bust.md) for detailed semantics, trade-offs, and examples.
+<br/>_Choices: [`none`, `system_prefix`, `system_suffix`, `first_turn_prefix`, `first_turn_suffix`, `warmup_isolation_system`, `warmup_isolation_first_turn`]_
+<br/>_Default: `none`_
+
+### Prefix Prompt
+
+#### `--system-prompt` `<str>`
+
+Verbatim system prompt text, identical across every conversation. Sent as a system-role message ahead of all turns. Works with both synthetic and file/public datasets; when the dataset already carries its own system message, this text is prepended to it. Tokens are additive: `--isl` continues to size the generated user prompt only. Mutually exclusive with `--system-prompt-file`, `--shared-system-prompt-length`, and `--num-prefix-prompts`/`--prefix-prompt-length`.
+
+#### `--system-prompt-file` `<str>`
+
+Path to a UTF-8 text file holding the verbatim system prompt. Preferred over `--system-prompt` for real production prompts, which are long enough that shell quoting mangles them. Read once at startup, so a missing or unreadable file fails immediately rather than mid-run. Mutually exclusive with `--system-prompt`, `--shared-system-prompt-length`, and `--num-prefix-prompts`/`--prefix-prompt-length`.
+
+#### `--prompt-prefix-pool-size`, `--prefix-prompt-pool-size`, `--num-prefix-prompts` `<int>`
+
+Number of distinct prefix prompts to generate for K-V cache testing. Each prefix is prepended to user prompts, simulating cached context scenarios. Prefixes randomly selected from pool per request. Set to 0 to disable prefix prompts. Mutually exclusive with `--shared-system-prompt-length`/`--user-context-prompt-length`.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--prompt-prefix-length`, `--prefix-prompt-length` `<int>`
+
+The number of tokens in each prefix prompt. This is only used if `--num-prefix-prompts` is greater than zero. Note that due to the prefix and user prompts being concatenated, the number of tokens in the final prompt may be off by one.Mutually exclusive with `--shared-system-prompt-length`/`--user-context-prompt-length`.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--shared-system-prompt-length` `<int>`
+
+Length of shared system prompt in tokens. This prompt is identical across all sessions and appears as a system message. Mutually exclusive with `--prefix-prompt-length`/`--prefix-prompt-pool-size`.
+<br/>_Constraints: ≥ 1_
+
+#### `--user-context-prompt-length` `<int>`
+
+Length of per-session user context prompt in tokens. Each dataset entry gets a unique user context prompt. Requires --num-dataset-entries to be specified. Mutually exclusive with --prefix-prompt-length/--prefix-prompt-pool-size.
+<br/>_Constraints: ≥ 1_
+
+### Input Sequence Length (ISL)
+
+#### `--prompt-input-tokens-mean`, `--synthetic-input-tokens-mean`, `--isl` `<int>`
+
+Mean number of tokens for synthetically generated input prompts. AIPerf generates prompts with lengths following a normal distribution around this mean (±`--prompt-input-tokens-stddev`). Applies only to synthetic datasets, not custom or public datasets. Pass a comma-separated list (e.g. `--isl 128,512,2048`) to sweep over multiple input lengths; the converter promotes the list to a sweep on datasets.main.prompts.isl.mean before AIPerfConfig validation.
+<br/>_Default: `550`_
+
+#### `--prompt-input-tokens-stddev`, `--synthetic-input-tokens-stddev`, `--isl-stddev` `<float>`
+
+Standard deviation for synthetic input prompt token lengths. Creates variability in prompt sizes when > 0, simulating realistic workloads with mixed request sizes. Lengths follow normal distribution. Set to 0 for uniform prompt lengths. Applies only to synthetic data generation. Pass a comma-separated list (e.g. `--isl-stddev 10,50,200`) to sweep over multiple stddev values; the converter promotes the list to a sweep on datasets.main.prompts.isl.stddev. Pair with a zip-mode `--isl` sweep to model realistic small/medium/large traffic shapes.
+<br/>_Default: `0.0`_
+
+#### `--prompt-input-tokens-block-size`, `--synthetic-input-tokens-block-size`, `--isl-block-size` `<int>`
+
+Token block size for hash-based prompt synthesis when dataset entries carry `hash_ids`: each `hash_id` maps to a cached block of `block_size` tokens, enabling simulation of KV-cache sharing patterns from production workloads. The total prompt length equals `(num_hash_ids - 1) * block_size + final_block_size`. With `--input-file` this overrides the trace loader's `default_block_size` plugin metadata (16 for `bailian_trace`, 512 for `mooncake_trace`) for loaders that reconstruct prompts from `hash_ids`; it has no effect on `baseten_trace`, which replays literal recorded prompts. Set it when a trace was recorded at a block size different from its loader default (e.g. a Mooncake-format trace recorded at 16).
+<br/>_Constraints: ≥ 1_
+
+#### `--seq-dist`, `--sequence-distribution` `<str>`
+
+Distribution of (ISL, OSL) pairs with probabilities for mixed workload simulation. Format: `ISL,OSL:prob;ISL,OSL:prob` (semicolons separate pairs, probabilities are percentages 0-100 that must sum to 100). Supports optional stddev: `ISL|stddev,OSL|stddev:prob`. Examples: `128,64:25;512,128:50;1024,256:25` or with variance: `256|10,128|5:40;512|20,256|10:60`. Also supports bracket `[(256,128):40,(512,256):60]` and JSON formats.
+
+### Output Sequence Length (OSL)
+
+#### `--prompt-output-tokens-mean`, `--output-tokens-mean`, `--osl` `<str>`
+
+Mean number of tokens to request in model outputs via `max_completion_tokens` field. Controls response length for synthetic and some custom datasets. If specified, included in request payload to limit generation length. When not set, model determines output length. Pass a comma-separated list (e.g. `--osl 128,256,512`) to sweep over multiple output lengths; the converter promotes the list to a sweep on datasets.main.prompts.osl.mean before AIPerfConfig validation.
+
+#### `--prompt-output-tokens-stddev`, `--output-tokens-stddev`, `--osl-stddev` `<int>`
+
+Standard deviation for output token length requests. Creates variability in `max_completion_tokens` field across requests, simulating mixed response length requirements. Lengths follow normal distribution. Only applies when `--prompt-output-tokens-mean` is set. Pass a comma-separated list (e.g. `--osl-stddev 5,25,100`) to sweep over multiple stddev values; the converter promotes the list to a sweep on datasets.main.prompts.osl.stddev. Pair with a zip-mode `--osl` sweep to model realistic output-length variance across traffic tiers.
+<br/>_Default: `0`_
+
+### Audio Input
+
+#### `--audio-batch-size`, `--batch-size-audio` `<int>`
+
+The number of audio inputs to include in each request. Supported with the `chat` endpoint type for multimodal models.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--audio-length-mean` `<float>`
+
+Mean duration in seconds for synthetically generated audio files. Audio lengths follow a normal distribution around this mean (±`--audio-length-stddev`). Used when `--audio-batch-size` > 0 for multimodal benchmarking. Generated audio is random noise with specified sample rate, bit depth, and format.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--audio-length-stddev` `<float>`
+
+Standard deviation for synthetic audio duration in seconds. Creates variability in audio lengths when > 0, simulating mixed-duration audio inputs. Durations follow normal distribution. Set to 0 for uniform audio lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--audio-format` `<str>`
+
+File format for generated audio files. Supports `wav` (uncompressed PCM, larger files) and `mp3` (compressed, smaller files). Format choice affects file size in multimodal requests but not audio characteristics (sample rate, bit depth, duration).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `wav` | _default_ | WAV format. Uncompressed audio, larger file sizes, best quality. |
+| `mp3` |  | MP3 format. Compressed audio, smaller file sizes, good quality. |
+
+#### `--audio-depths` `<list>`
+
+List of audio bit depths in bits to randomly select from when generating audio files. Each audio file is assigned a random depth from this list. Common values: `8` (low quality), `16` (CD quality), `24` (professional), `32` (high-end). Specify multiple values (e.g., `--audio-depths 16 24`) for mixed-quality testing.
+<br/>_Constraints: min: 1_
+<br/>_Default: `[16]`_
+
+#### `--audio-sample-rates` `<list>`
+
+A list of audio sample rates to randomly select from in kHz. Common sample rates are 16, 44.1, 48, 96, etc.
+<br/>_Constraints: min: 1_
+<br/>_Default: `[16.0]`_
+
+#### `--audio-num-channels` `<int>`
+
+Number of audio channels for synthetic audio generation. `1` = mono (single channel), `2` = stereo (left/right channels). Stereo doubles file size but simulates realistic audio for models supporting spatial audio processing. Most speech models use mono.
+<br/>_Constraints: ≥ 1, ≤ 2_
+<br/>_Default: `1`_
+
+### Image Input
+
+#### `--image-width-mean` `<float>`
+
+Mean width in pixels for synthetically generated images. Image widths follow a normal distribution around this mean (±`--image-width-stddev`). Combined with `--image-height-mean` to determine image dimensions and file sizes for multimodal benchmarking.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-width-stddev` `<float>`
+
+Standard deviation for synthetic image widths in pixels. Creates variability in horizontal resolution when > 0, simulating mixed-resolution image inputs. Widths follow normal distribution. Set to 0 for uniform image widths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-height-mean` `<float>`
+
+Mean height in pixels for synthetically generated images. Image heights follow a normal distribution around this mean (±`--image-height-stddev`). Used when `--image-batch-size` > 0 for multimodal vision benchmarking. Generated images are resized from source images in `assets/source_images` directory.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-height-stddev` `<float>`
+
+Standard deviation for synthetic image heights in pixels. Creates variability in vertical resolution when > 0, simulating mixed-resolution image inputs. Heights follow normal distribution. Set to 0 for uniform image heights.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-batch-size`, `--batch-size-image` `<int>`
+
+Number of images to include in each multimodal request. Supported with `chat` endpoint type for vision-language models. Each image is generated by randomly sampling and resizing source images from `assets/source_images` directory to specified dimensions. Set to 0 to disable image inputs. Higher batch sizes test multi-image understanding and increase request payload size.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--image-format` `<str>`
+
+Image file format for generated images. Choose `png` for lossless compression (larger files, best quality), `jpeg` for lossy compression (smaller files, good quality), or `random` to randomly select between PNG and JPEG for each image. Format affects file size in multimodal requests and encoding overhead.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `png` | _default_ | PNG format. Lossless compression, larger file sizes, best quality. |
+| `jpeg` |  | JPEG format. Lossy compression, smaller file sizes, good for photos. |
+| `random` |  | Randomly select PNG or JPEG for each image. |
+
+#### `--image-source` `<str>`
+
+Source image generation mode (default `noise`). `noise` generates random noise images on the fly at the requested dimensions — no files on disk required, and the pool is effectively unbounded so servers cannot dedupe on identical inputs. `assets` indexes images from the built-in `assets/source_images` directory (ships with a small set of 4 images) and lazily loads them at the requested dimensions. A path to a directory indexes images from the given directory (e.g. `--image-source ./source_images`). Note: random-noise images are roughly incompressible, so payload bytes are larger than equivalent natural images.
+<br/>_Default: `noise`_
+
+#### `--image-source-sampling` `<str>`
+
+How source images are selected from finite image sources selected by `--image-source assets` or `--image-source <directory>`. `random-with-replacement` draws each source image independently; repeats may occur immediately. `shuffle-cycle` draws every source image once per shuffled cycle, reshuffling after exhaustion. `sequential-cycle` walks source images in sorted load order and wraps after exhaustion. For `noise`, only `random-with-replacement` is valid because there is no finite source pool.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `random-with-replacement` | _default_ | Draw each source image independently; repeats may occur immediately. |
+| `shuffle-cycle` |  | Draw every source image once per shuffled cycle; reshuffle after exhaustion. |
+| `sequential-cycle` |  | Walk source images in sorted load order; wrap after exhaustion. |
+
+### Video Input
+
+#### `--video-batch-size`, `--batch-size-video` `<int>`
+
+Number of video files to include in each multimodal request. Supported with `chat` endpoint type for video understanding models. Each video is generated synthetically with specified duration, FPS, resolution, and codec. Set to 0 to disable video inputs. Higher batch sizes test multi-video understanding and significantly increase request payload size.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--video-duration` `<float>`
+
+Duration in seconds for each synthetically generated video clip. Combined with `--video-fps`, determines total frame count (frames = duration × FPS). Longer durations increase file size and processing time. Typical values: 1-10 seconds for testing. Requires FFmpeg for video generation.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `5.0`_
+
+#### `--video-fps` `<int>`
+
+Frames per second for generated video. Higher FPS creates smoother video but increases frame count and file size. Common values: `4` (minimal motion, recommended for Cosmos models), `24` (cinematic), `30` (standard video), `60` (high frame rate). Total frames = `--video-duration` × FPS.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `4`_
+
+#### `--video-width` `<int>`
+
+Video frame width in pixels. Must be specified together with `--video-height` (both or neither). Determines video resolution and file size. Common resolutions: `640×480` (SD), `1280×720` (HD), `1920×1080` (Full HD). If not specified, uses codec/format defaults.
+<br/>_Constraints: ≥ 1_
+
+#### `--video-height` `<int>`
+
+Video frame height in pixels. Must be specified together with `--video-width` (both or neither). Combined with width determines aspect ratio and total pixel count per frame. Higher resolution increases processing demands and file size.
+<br/>_Constraints: ≥ 1_
+
+#### `--video-synth-type` `<str>`
+
+Algorithm for generating synthetic video content. Different types produce different visual patterns for testing. Options: `moving_shapes` (animated geometric shapes), `grid_clock` (grid with rotating clock hands), `noise` (random pixel frames). Content doesn't affect semantic meaning but may impact encoding efficiency and file size.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `moving_shapes` | _default_ | Generate videos with animated geometric shapes moving across the frame |
+| `grid_clock` |  | Generate videos with a grid pattern and frame number overlay for frame-accurate verification |
+| `noise` |  | Generate videos with random noise frames |
+
+#### `--video-format` `<str>`
+
+Container format for generated video files. Supports `webm` (VP9, recommended, BSD-licensed) and `mp4` (widely compatible container, VP9 by default). Format choice affects compatibility, file size, and encoding options. `mp4` is the more portable container, but note that the default VP9 video and Opus audio are less widely supported by players than H.264/AAC would be.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `mp4` |  | MP4 container. Widely compatible, good for H.264/H.265 codecs. |
+| `webm` | _default_ | WebM container. Open format, optimized for web, good for VP9 codec. |
+
+#### `--video-codec` `<str>`
+
+The video codec to use for encoding. Common options: libvpx-vp9 (CPU, BSD-licensed, default), libvpx (CPU, BSD-licensed, VP8). Any codec the local FFmpeg supports can be used, but the AIPerf container ships a minimal FFmpeg build limited to VP8/VP9 video with Vorbis/Opus audio; codecs such as libx264 or h264_nvenc require an FFmpeg build that includes them.
+<br/>_Default: `libvpx-vp9`_
+
+#### `--video-audio-sample-rate` `<float>`
+
+Audio sample rate in Hz or kHz for the embedded audio track. Common values: 8/8000 (telephony), 16/16000 (speech), 44.1/44100 (CD quality), 48/48000 (professional). Higher sample rates increase audio fidelity and file size.
+<br/>_Constraints: ≥ 8, ≤ 96000_
+<br/>_Default: `44100`_
+
+#### `--video-audio-num-channels` `<int>`
+
+Number of audio channels to embed in generated video files. 0 = disabled (no audio track, default), 1 = mono, 2 = stereo. When set to 1 or 2, a Gaussian noise audio track matching the video duration is muxed into each video via FFmpeg.
+<br/>_Constraints: ≥ 0, ≤ 2_
+<br/>_Default: `0`_
+
+#### `--video-audio-codec` `<str>`
+
+Audio codec for the embedded audio track. If not specified, auto-selects based on video format: libopus for MP4, libvorbis for WebM. Options: libvorbis, libopus, aac. The AIPerf container ships only libvorbis and libopus; aac requires an FFmpeg build that includes an AAC encoder. libopus always encodes at 48 kHz, so any --video-audio-sample-rate is resampled during muxing.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `aac` |  | AAC codec. Not built into the AIPerf container's FFmpeg; selecting it requires an FFmpeg build that includes an AAC encoder. |
+| `libvorbis` |  | Vorbis codec. Default for WebM containers. |
+| `libopus` |  | Opus codec. Default for MP4 containers. Always encodes at 48 kHz regardless of the requested sample rate. |
+
+#### `--video-audio-depth` `<str>`
+
+Audio bit depth for the embedded audio track. Supported values: 8, 16, 24, or 32 bits. Higher bit depths provide greater dynamic range but increase file size.
+<br/>_Default: `16`_
+
+### Rankings
+
+#### `--rankings-passages-mean` `<int>`
+
+Mean number of passages to include per ranking request. For `rankings` endpoint type, each request contains a query and multiple passages to rank. Passages follow normal distribution around this mean (±`--rankings-passages-stddev`). Higher values test ranking at scale but increase request payload size and processing time.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `1`_
+
+#### `--rankings-passages-stddev` `<int>`
+
+Standard deviation for number of passages per ranking request. Creates variability in ranking workload complexity. Passage counts follow normal distribution. Set to 0 for uniform passage counts across all requests.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--rankings-passages-prompt-token-mean` `<int>`
+
+Mean token length for each passage in ranking requests. Passages are synthetically generated text with lengths following normal distribution around this mean (±`--rankings-passages-prompt-token-stddev`). Longer passages increase input processing demands and request size.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `550`_
+
+#### `--rankings-passages-prompt-token-stddev` `<int>`
+
+Standard deviation for passage token lengths in ranking requests. Creates variability in passage sizes, simulating realistic heterogeneous document collections. Token lengths follow normal distribution. Set to 0 for uniform passage lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--rankings-query-prompt-token-mean` `<int>`
+
+Mean token length for query text in ranking requests. Each ranking request contains one query and multiple passages. Queries are synthetically generated with lengths following normal distribution around this mean (±`--rankings-query-prompt-token-stddev`).
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `550`_
+
+#### `--rankings-query-prompt-token-stddev` `<int>`
+
+Standard deviation for query token lengths in ranking requests. Creates variability in query complexity, simulating realistic user search patterns. Token lengths follow normal distribution. Set to 0 for uniform query lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+### Synthesis
+
+#### `--synthesis-speedup-ratio` `<float>`
+
+Multiplier for timestamp scaling in synthesized traces.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-prefix-len-multiplier` `<float>`
+
+Multiplier for core prefix branch lengths in radix tree.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-prefix-root-multiplier` `<int>`
+
+Number of independent radix trees to distribute traces across.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `1`_
+
+#### `--synthesis-prompt-len-multiplier` `<float>`
+
+Multiplier for leaf path (unique prompt) lengths.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-output-len-multiplier` `<float>`
+
+Multiplier for output lengths in synthesized traces.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-max-isl` `<int>`
+
+Maximum input sequence length for filtering. Traces with input_length > max_isl are skipped.
+<br/>_Constraints: ≥ 1_
+
+#### `--synthesis-max-osl` `<int>`
+
+Maximum output sequence length cap for top-level (parent) turns. Turns with output_length > max_osl are capped to max_osl. Subagent child turns are intentionally uncapped so their decode load stays faithful; flat-chain sidecars still honor the cap.
+<br/>_Constraints: ≥ 1_
+
+### Load Generator
+
+#### `--benchmark-duration` `<str>`
+
+Maximum benchmark runtime in seconds. When set, AIPerf stops issuing new requests after this duration, Responses received within `--benchmark-grace-period` after duration ends are included in metrics. Pass a comma-separated list (e.g. `--benchmark-duration 30,60,120`) to sweep over multiple durations; the converter promotes the list to a sweep on phases.profiling.duration before AIPerfConfig validation.
+
+#### `--benchmark-grace-period` `<float>`
+
+The grace period in seconds to wait for responses after benchmark duration ends. Only applies when --benchmark-duration is set. Responses received within this period are included in metrics. Use 'inf' to wait indefinitely for all responses.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `30.0`_
+
+#### `--concurrency` `<str>`
+
+Number of concurrent requests to maintain. AIPerf issues a new request immediately when one completes, maintaining this level of in-flight requests. Can be combined with `--request-rate` to control the request rate. Pass a comma-separated list (e.g. `--concurrency 10,20,30`) to sweep over multiple concurrencies; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--prefill-concurrency` `<str>`
+
+Max concurrent requests waiting for first token (prefill phase). Limits how many requests can be in the prefill/prompt-processing stage simultaneously. Pass a comma-separated list (e.g. `--prefill-concurrency 1,2,4`) to sweep over multiple values; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--request-rate` `<str>`
+
+Target request rate in requests per second. AIPerf generates request timing according to `--request-rate-mode` to achieve this average rate. Can be combined with `--concurrency` to control the number of concurrent requests. Supports fractional rates (e.g., `0.5` = 1 request every 2 seconds). Pass a comma-separated list (e.g. `--request-rate 10,20,50`) to sweep over multiple rates; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--arrival-pattern`, `--request-rate-mode` `<str>`
+
+Sets the arrival pattern for the load generated by AIPerf. Valid values: constant, poisson, gamma. `constant`: Generate requests at a fixed rate. `poisson`: Generate requests using a poisson distribution. `gamma`: Generate requests using a gamma distribution with tunable smoothness.
+<br/>_Choices: [`concurrency_burst`, `constant`, `gamma`, `poisson`]_
+<br/>_Default: `poisson`_
+
+#### `--arrival-smoothness`, `--vllm-burstiness` `<float>`
+
+Smoothness parameter for gamma distribution arrivals (--arrival-pattern gamma). Controls the shape of the arrival pattern: - 1.0: Poisson-like (exponential inter-arrivals, default) - &lt;1.0: Bursty/clustered arrivals (higher variance) - >1.0: Smooth/regular arrivals (lower variance) Compatible with vLLM's --burstiness parameter (same value = same distribution).
+<br/>_Constraints: > 0_
+
+#### `--request-count`, `--num-requests` `<str>`
+
+The maximum number of requests to send. If not set, will be automatically determined based on the timing mode and dataset size. For synthetic datasets, this will be `max(10, concurrency * 2)`. Pass a comma-separated list (e.g. `--request-count 100,500,1000`) to sweep over multiple request counts; the converter promotes the list to a sweep on phases.profiling.requests before AIPerfConfig validation.
+
+#### `--concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp session concurrency from 1 to target. Useful for gradual warm-up of the target system.
+<br/>_Constraints: > 0_
+
+#### `--prefill-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp prefill concurrency from 1 to target.
+<br/>_Constraints: > 0_
+
+#### `--request-rate-ramp-duration` `<float>`
+
+Duration in seconds to ramp request rate from a proportional minimum to target. Start rate is calculated as target * (update_interval / duration), ensuring correct behavior for target rates below 1 QPS. Useful for gradual warm-up of the target system.
+<br/>_Constraints: > 0_
+
+#### `--request-rate-series` `<str>`
+
+JSON file containing request-rate points for piecewise-linear request-rate control.
+
+#### `--failed-request-threshold` `<float>`
+
+Abort the run early when (failed_records / total_records) exceeds this ratio. Default None disables the check. Only PROFILING-phase records count toward the ratio. A grace floor of max(concurrency, 10) records must accumulate before the check is armed, so a single early failure cannot kill the run. When the threshold is exceeded a ProfileCancelCommand is broadcast: in-flight requests drain via the normal cancel path, partial results are still aggregated, and the run exits non-zero. Pairs with the AGENTIC_REPLAY context-overflow drop in record_processor_service so the rate measures real failures only.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+
+#### `--trajectory-start-min-ratio` `<float>`
+
+AGENTIC_REPLAY only: lower bound (inclusive) on the random start position within each trajectory, expressed as a fraction of the trace's total turn count. Sampled per trajectory at trajectory-build time; deterministic given --random-seed.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+<br/>_Default: `0.25`_
+
+#### `--trajectory-start-max-ratio` `<float>`
+
+AGENTIC_REPLAY only: upper bound (inclusive) on the random start position within each trajectory, expressed as a fraction of the trace's total turn count. The effective per-trace ceiling is min(int(max_ratio * n), n - 2) so at least one profile turn remains after warmup.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+<br/>_Default: `0.75`_
+
+#### `--burst-phase-starts`
+
+AGENTIC_REPLAY only: collapse the WARMUP-start and PROFILING-start dispatches into synchronized bursts instead of spreading them by each request's recorded offset from t*. By default (False) the phase starts are SPREAD: WARMUP requests are aligned globally so every trajectory reaches its t* at the same instant (the warmup end), and each lane's first PROFILING request waits out its recorded gap after t* -- reproducing the recorded arrival pattern at both phase boundaries. The rest of the replay (inter-turn delays) is timing-faithful regardless of this flag; it governs ONLY the burst-vs-spread of the two phase starts. Pass --burst-phase-starts to fire each phase's first requests together (faster concurrency ramp, synchronized start), e.g. for a throughput-oriented run rather than a faithful arrival replay.
+<br/>_Flag (no value required)_
+
+#### `--trace-idle-gap-cap-seconds` `<float>`
+
+Hard ceiling (seconds) for idle gaps within each individual trace. For Weka trace replay, AIPerf looks at all parent and subagent request submission timestamps within one root trace, compresses long gaps between consecutive request submissions, and derives turn delays from the compressed per-trace timeline. Original request api_time values are not used to decide these idle gaps. When set for Weka, this takes precedence over `--inter-turn-delay-cap-seconds` so individual parent/subagent-line delays are not separately capped. Defaults to None (no per-trace idle-gap compression).
+<br/>_Constraints: ≥ 0.0_
+
+#### `--system-idle-gap-cap-seconds` `<float>`
+
+AGENTIC_REPLAY only: maximum time in seconds the replay may remain globally idle while future requests are scheduled. When no requests are in flight or ready, all pending request timers shift earlier uniformly so the next request arrives within this limit. Per-trace timing is otherwise preserved. None disables the cap.
+<br/>_Constraints: ≥ 0.0_
+
+### Scenario
+
+#### `--scenario` `<str>`
+
+Lock all benchmark invariants for a named scenario (e.g. 'inferencex-agentx-mvp'). Conflicts with the locked invariants raise ScenarioLockError at startup unless --unsafe-override is also passed. Distinct from the sweep ``scenarios`` strategy (hand-picked named runs).
+
+#### `--unsafe-override`
+
+Convert scenario lock errors to warnings; stamps submission_valid=false in the aggregate output. No-op without --scenario.
+<br/>_Flag (no value required)_
+
+### Warmup
+
+#### `--warmup-request-count`, `--num-warmup-requests` `<int>`
+
+The maximum number of warmup requests to send before benchmarking. If not set and no --warmup-duration is set, then no warmup phase will be used.
+<br/>_Constraints: > 0_
+
+#### `--warmup-duration` `<float>`
+
+The maximum duration in seconds for the warmup phase. If not set, it will use the `--warmup-request-count` value. If neither are set, no warmup phase will be used.
+<br/>_Constraints: > 0_
+
+#### `--agentic-cache-warmup-duration` `<float>`
+
+Additional agentic replay warmup duration in seconds. After the normal snapshot warmup drains, AIPerf continues the live trajectories without recorded idle delays and with one-token outputs, then drains and resumes profiling from the resulting trajectory state using each live stream's residual next-turn delay.
+<br/>_Constraints: > 0_
+
+#### `--agentic-warmup-grace-period` `<float>`
+
+AGENTIC_REPLAY only: grace period in seconds the auto-synthesized warmup barrier waits for in-flight priming requests after the warmup burst sends. The agentic warmup is synthesized from the profiling phase rather than a user-declared warmup phase, so it does NOT honor `--warmup-grace-period` (which requires `--warmup-duration`). If not set, the warmup barrier waits indefinitely until every primed trajectory returns.
+<br/>_Constraints: ≥ 0_
+
+#### `--num-warmup-sessions` `<int>`
+
+The number of sessions to use for the warmup phase. If not set, it will use the `--warmup-request-count` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-concurrency` `<int>`
+
+The concurrency value to use for the warmup phase. If not set, it will use the `--concurrency` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-prefill-concurrency` `<int>`
+
+The prefill concurrency value to use for the warmup phase. If not set, it will use the `--prefill-concurrency` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-request-rate` `<float>`
+
+The request rate to use for the warmup phase. If not set, it will use the `--request-rate` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-arrival-pattern` `<str>`
+
+The arrival pattern to use for the warmup phase. If not set, it will use the `--arrival-pattern` value. Valid values: constant, poisson, gamma.
+
+#### `--warmup-grace-period` `<float>`
+
+The grace period in seconds to wait for responses after warmup phase ends. Only applies when warmup is enabled. Responses received within this period are included in warmup completion. If not set, waits indefinitely for all warmup responses.
+<br/>_Constraints: ≥ 0_
+
+#### `--warmup-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup session concurrency from 1 to target. If not set, uses `--concurrency-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-prefill-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup prefill concurrency from 1 to target. If not set, uses `--prefill-concurrency-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-request-rate-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup request rate from a proportional minimum to target. Start rate is calculated as target * (update_interval / duration). If not set, uses `--request-rate-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+### User-Centric Rate
+
+#### `--user-centric-rate` `<float>`
+
+Enable user-centric rate limiting mode with the specified request rate (QPS). Each user has a gap = num_users / qps between turns. Users block on their previous turn (no interleaving within a user). New users are spawned on a fixed schedule to maintain steady-state throughput. Designed for KV cache benchmarking with realistic multi-user patterns. Requires --num-users to be set.
+<br/>_Constraints: > 0_
+
+#### `--num-users` `<str>`
+
+The number of initial users to use for --user-centric-rate mode. Pass a comma-separated list (e.g. `--num-users 4,8,16`) to sweep over user counts; the converter promotes the list to a sweep on phases.profiling.users before AIPerfConfig validation.
+
+### Request Cancellation
+
+#### `--request-cancellation-rate` `<float>`
+
+Percentage (0-100) of requests to cancel for testing cancellation handling. Cancelled requests are sent normally but aborted after `--request-cancellation-delay` seconds. Useful for testing graceful degradation and resource cleanup.
+<br/>_Constraints: > 0.0, ≤ 100.0_
+
+#### `--request-cancellation-delay` `<float>`
+
+Seconds to wait after the request is fully sent before cancelling. A delay of 0 means 'send the full request, then immediately disconnect'. Requires --request-cancellation-rate to be set.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `0.0`_
+
+### Output
+
+#### `--output-artifact-dir`, `--artifact-dir` `<str>`
+
+Output directory for all benchmark artifacts including metrics (`.csv`, `.json`, `.jsonl`), raw data (`_raw.jsonl`), GPU telemetry (`_gpu_telemetry.jsonl`), and time-sliced metrics (`_timeslices.csv/json`). Directory created if it doesn't exist. All output file paths are constructed relative to this directory.
+<br/>_Default: `artifacts`_
+
+#### `--profile-export-prefix`, `--profile-export-file` `<str>`
+
+Base filename for ALL exported files. With prefix='foo' every output becomes `foo.csv`, `foo.json`, `foo_timeslices.{csv,json}`, `foo.jsonl`, `foo_raw.jsonl`, `foo_gpu_telemetry.jsonl`, and `foo_server_metrics.{jsonl,json,csv,parquet}`. When unset (the default), historical per-file names are used: `profile_export_aiperf.{csv,json}` for the summary, `profile_export.jsonl` and `profile_export_raw.jsonl` for records, `gpu_telemetry_export.jsonl`, and `server_metrics_export.*`. Known suffixes (e.g. `_raw.jsonl`, `_timeslices.csv`, `_server_metrics.parquet`) are stripped from the supplied value.
+
+#### `--export-level`, `--profile-export-level` `<str>`
+
+Controls which output files are generated. `summary`: Only aggregate metrics files (`.csv`, `.json`). `records`: Includes per-request metrics (`.jsonl`). `raw`: Includes raw request/response data (`_raw.jsonl`).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `summary` |  | Export only aggregated/summarized metrics (most compact) |
+| `records` | _default_ | Export per-record metrics after aggregation with display unit conversion (CLI default) |
+| `raw` |  | Export raw parsed records with full request/response data (most detailed) |
+
+#### `--slice-duration` `<float>`
+
+Duration in seconds for time-sliced metric analysis. When set, AIPerf divides the benchmark timeline into fixed-length windows and computes metrics separately for each window. This enables analysis of performance trends and variations over time (e.g., warmup effects, degradation under sustained load).
+<br/>_Constraints: > 0_
+
+#### `--auto-plot`, `--no-auto-plot`
+
+Auto-invoke `aiperf plot` against the artifact directory after the benchmark completes. None = defer to recipe default (False if no recipe). True/False = explicit override. Failures are logged but do not fail the command unless --plot-required is set.
+
+#### `--plot-required`
+
+Treat auto-plot failures as fatal: re-raise so `aiperf profile` exits non-zero. Only meaningful when auto-plot is on. Default False = warn and continue.
+<br/>_Flag (no value required)_
+
+#### `--export-outputs-json`
+
+Export generated response text to outputs.json after the run. When enabled, the raw generated-text payload for each request is written to an outputs.json file in the artifact directory.
+<br/>_Flag (no value required)_
+
+#### `--otel-url` `<str>`
+
+OTLP/HTTP metrics endpoint URL.
+
+#### `--stream` `<list>`
+
+Select which AIPerf telemetry domains to stream over OTel. Valid values: 'metrics', 'timing', or 'default'. 'default' streams both metrics and timing. Examples: --stream metrics | --stream timing | --stream metrics timing.
+
+#### `--otel-resource-attributes` `<list>`
+
+Custom OTel resource attributes as key=value pairs. Merged into the default resource attributes on every exported metric.
+
+#### `--gen-ai-provider` `<str>`
+
+GenAI semantic convention provider override.
+
+#### `--mlflow-tracking-uri` `<str>`
+
+MLflow tracking URI.
+
+#### `--mlflow-experiment` `<str>`
+
+MLflow experiment name.
+
+#### `--mlflow-run-name` `<str>`
+
+MLflow run name.
+
+#### `--mlflow-tag` `<list>`
+
+Additional MLflow run tags to attach on upload. Specify as key:value pairs (e.g., --mlflow-tag team:perf) or as JSON string.
+
+#### `--mlflow-parent-run-id` `<str>`
+
+Optional MLflow parent run ID.
+
+#### `--mlflow-artifact-glob` `<list>`
+
+Artifact glob overrides for MLflow upload. Can be specified multiple times or as a comma-separated list.
+
+#### `--wandb-project` `<str>`
+
+Weights & Biases project name. Setting this enables wandb export.
+
+#### `--wandb-entity` `<str>`
+
+Weights & Biases entity (team or user). Defaults to the API key's default entity.
+
+#### `--wandb-run-name` `<str>`
+
+Weights & Biases run name.
+
+#### `--wandb-tag` `<list>`
+
+Additional Weights & Biases run tags to attach on upload. Can be specified multiple times or as a comma-separated list.
+
+### HTTP Trace
+
+#### `--export-http-trace`
+
+Include HTTP trace data (timestamps, chunks, headers, socket info) in profile_export.jsonl. Computed metrics (http_req_duration, http_req_waiting, etc.) are always included regardless of this setting. See the HTTP Trace Metrics guide for details on trace data fields.
+<br/>_Flag (no value required)_
+
+#### `--show-trace-timing`
+
+Display HTTP trace timing metrics in the console at the end of the benchmark. Shows detailed timing breakdown: blocked, DNS, connecting, sending, waiting (TTFB), receiving, and total duration following k6 naming conventions.
+<br/>_Flag (no value required)_
+
+### Server Metrics
+
+#### `--server-metrics` `<list>`
+
+Server metrics collection (ENABLED BY DEFAULT). Automatically collects from inference endpoint base_url + `/metrics`. Optionally specify additional custom Prometheus-compatible endpoint URLs (e.g., http://node1:8081/metrics, http://node2:9090/metrics). Use `--no-server-metrics` to disable collection. Example: `--server-metrics node1:8081 node2:9090/metrics` for additional endpoints.
+
+#### `--no-server-metrics`
+
+Disable server metrics collection entirely.
+
+#### `--server-metrics-formats` `<list>`
+
+Specify which output formats to generate for server metrics. Multiple formats can be specified (e.g., `--server-metrics-formats json csv parquet`).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `json` | _default_ | Export aggregated statistics in JSON hybrid format with metrics keyed by name. Best for: Programmatic access, CI/CD pipelines, automated analysis. |
+| `csv` | _default_ | Export aggregated statistics in CSV tabular format organized by metric type. Best for: Spreadsheet analysis, Excel/Google Sheets, pandas DataFrames. |
+| `jsonl` |  | Export raw time-series records in line-delimited JSON format. Best for: Time-series analysis, debugging, visualizing metric evolution. Warning: Can generate very large files for long-running benchmarks. |
+| `parquet` |  | Export raw time-series data with delta calculations in Parquet columnar format. Best for: Analytics with DuckDB/pandas/Polars, efficient storage, SQL queries. Includes cumulative deltas from reference point for counters and histograms. |
+
+### Network Latency
+
+#### `--network-latency-automatic`
+
+Automatically measure network latency (DISABLED BY DEFAULT). Opens a fresh TCP connection to the endpoint throughout the run, measures the handshake RTT, and subtracts the mean from request-start-anchored latency metrics (request_latency, time_to_first_token, time_to_first_output_token). Raw metrics are preserved; adjusted values are emitted as separate network_adjusted_* metrics plus a network_rtt summary. Mutually exclusive with --network-latency-mean.
+<br/>_Flag (no value required)_
+
+#### `--network-latency-mean` `<float>`
+
+Set a fixed mean network RTT in milliseconds to subtract, bypassing active probing. Implicitly enables network latency adjustment. Mutually exclusive with --network-latency-automatic.
+<br/>_Constraints: ≥ 0.0_
+
+#### `--network-latency-ping-interval` `<float>`
+
+Seconds between TCP-handshake RTT probes during profiling (default: 1.0s). Only applies with --network-latency-automatic.
+<br/>_Constraints: > 0.0_
+
+### GPU Telemetry
+
+#### `--gpu-telemetry` `<list>`
+
+Enable GPU telemetry console display and optionally specify: (1) 'pynvml' or 'amdsmi' to use a local GPU library instead of DCGM HTTP endpoints, (2) 'dashboard' for realtime dashboard mode, (3) custom DCGM exporter URLs (e.g., http://node1:9401/metrics), (4) custom metrics CSV file (e.g., custom_gpu_metrics.csv). Default: DCGM mode with localhost:9400 and localhost:9401 endpoints. Examples: --gpu-telemetry pynvml | --gpu-telemetry amdsmi | --gpu-telemetry dashboard node1:9400.
+
+#### `--no-gpu-telemetry`
+
+Disable GPU telemetry collection entirely.
+
+### UI
+
+#### `--ui-type`, `--ui` `<str>`
+
+Select the user interface type for displaying benchmark progress. `dashboard` shows real-time metrics in a Textual TUI, `simple` uses TQDM progress bars, `none` disables UI completely. Defaults to `dashboard` in interactive terminals, `none` when not a TTY (e.g., piped or redirected output). Automatically set to `simple` when using `--verbose` or `--extra-verbose` in a TTY.
+<br/>_Choices: [`dashboard`, `none`, `simple`]_
+<br/>_Default: `dashboard`_
+
+### Multi-Run
+
+#### `--num-profile-runs` `<int>`
+
+Number of profile runs to execute for confidence reporting. Must be between 1 and 10. When set to 1 (default), runs a single benchmark. When set to >1, runs multiple benchmarks and computes aggregate statistics (mean, std, confidence intervals, coefficient of variation) across runs. Useful for quantifying variance and establishing confidence in results.
+<br/>_Constraints: ≥ 1, ≤ 10_
+<br/>_Default: `1`_
+
+#### `--profile-run-cooldown-seconds` `<float>`
+
+Cooldown duration in seconds between profile runs. Only applies when --num-profile-runs > 1. Allows the system to stabilize between runs (e.g., clear caches, cool down GPUs). Default is 0 (no cooldown).
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--confidence-level` `<float>`
+
+Confidence level for computing confidence intervals (0-1). Only applies when --num-profile-runs > 1. Common values: 0.90 (90%), 0.95 (95%, default), 0.99 (99%). Higher values produce wider confidence intervals.
+<br/>_Constraints: > 0, &lt; 1_
+<br/>_Default: `0.95`_
+
+#### `--profile-run-disable-warmup-after-first`, `--no-profile-run-disable-warmup-after-first`
+
+Disable warmup for profile runs after the first. Only applies when --num-profile-runs > 1. When True (default), only the first run includes warmup, subsequent runs measure steady-state performance for more accurate aggregate statistics. When False, all runs include warmup (useful for long cooldown periods or when testing cold-start performance).
+<br/>_Default: `True`_
+
+#### `--set-consistent-seed`, `--no-set-consistent-seed`
+
+Automatically set random seed for consistent workloads across runs. Only applies when --num-profile-runs > 1. When True (default), automatically sets --random-seed=42 if not specified, ensuring identical workloads across all runs for valid statistical comparison. When False, preserves None seed, resulting in different workloads per run (not recommended for confidence reporting as it produces invalid statistics). If --random-seed is explicitly set, that value is always used regardless of this setting.
+<br/>_Default: `True`_
+
+#### `--vary-seed-per-trial`, `--no-vary-seed-per-trial`
+
+When True, derive a distinct seed for each trial of a variation via SHA-256 over (envelope_seed, variation.label, trial). When False (default), all trials of a variation share the same seed, giving pure-runtime variance for confidence intervals. Enable when you want trials to also sample different inputs (captures end-to-end variance at the cost of conflating input noise with runtime noise in the resulting confidence statistics).
+
+#### `--convergence-metric` `<str>`
+
+Target metric name for adaptive convergence stopping. When set with --num-profile-runs > 1, enables adaptive mode that stops early once the metric stabilizes according to --convergence-mode. Uses --num-profile-runs as the maximum run cap. Example metrics: time_to_first_token, request_latency, inter_token_latency.
+
+#### `--convergence-stat` `<str>`
+
+Statistic to evaluate for convergence when using ci_width or cv mode. Common values: avg, p50, p90, p95, p99. Only applies when --convergence-metric is set.
+<br/>_Choices: [`avg`, `p50`, `p90`, `p95`, `p99`, `min`, `max`]_
+<br/>_Default: `avg`_
+
+#### `--convergence-threshold` `<float>`
+
+Threshold for convergence detection. For ci_width mode: maximum CI width as a fraction of the mean. For cv mode: maximum coefficient of variation. For distribution mode: KS test p-value threshold. When unset, each mode uses its own algorithm-specific default. Only applies when --convergence-metric is set.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--convergence-mode` `<str>`
+
+Statistical method for convergence detection. ci_width: Stop when Student's t confidence interval width relative to mean is below threshold. cv: Stop when coefficient of variation (std/mean) is below threshold. distribution: Stop when KS test p-value indicates latest run matches prior runs (requires --export-level records or --export-level raw; rejected with --export-level summary). Only applies when --convergence-metric is set.
+<br/>_Choices: [`ci_width`, `cv`, `distribution`]_
+<br/>_Default: `ci_width`_
+
+#### `--parameter-sweep-cooldown-seconds` `<float>`
+
+Cooldown seconds between sweep variations (e.g. between --concurrency 10 and --concurrency 20). Honored by MultiRunOrchestrator when iterating plan.configs. Default 0.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--parameter-sweep-same-seed`, `--no-parameter-sweep-same-seed`
+
+If true, every sweep variation reuses the same random seed (correlated comparisons). If false (default), each variation derives a unique seed `base_seed + variation.index` so independent draws exercise different inputs. Requires --random-seed when true.
+
+#### `--parameter-sweep-mode` `<str>`
+
+Execution order for sweep + multi-trial composition. 'repeated' (default) iterates trials as the outer loop and variations as the inner loop, so all variations run within trial 1, then within trial 2, etc. 'independent' inverts the loops: all trials at one variation complete before the next variation starts. Both modes produce the same total runs, only the artifact-path layout and submit order differ.
+<br/>_Choices: [`independent`, `repeated`]_
+<br/>_Default: `repeated`_
+
+#### `--sweep-type` `<str>`
+
+Topology used when multiple CLI magic-list flags (--concurrency, --request-rate, --isl, --osl, ...) are passed together. 'grid' (default) takes the Cartesian product of all lists; 'zip' pairs them element-wise (all lists must have equal length, like the YAML `sweep: {type: zip}` block). Ignored when only one magic-list flag is set or when the sweep is declared in YAML.
+<br/>_Default: `grid`_
+
+#### `--no-sweep-table`
+
+Suppress the per-cell streaming sweep table during multi-variation sweeps. Auto-suppressed when stdout is non-interactive, when the dashboard UI is active, or for single-cell sweeps.
+
+#### `--search-space` `<list>`
+
+Adaptive-search space dimensions. Repeatable. Each value is 'path:lo,hi[:kind]', e.g. 'phases.profiling.concurrency:1,1000:int'. Mutually exclusive with magic-list flags (--concurrency 10,20,30) and with explicit sweep blocks. See docs/sweeping/bayesian-optimization.md.
+
+#### `--search-metric` `<str>`
+
+Metric tag to optimize, e.g. 'output_token_throughput'. Required when --search-space is set. Must match a key in RunResult.summary_metrics produced by the run (NOT the flattened '_avg' / '_p99' aggregator-suffixed key).
+
+#### `--search-stat` `<str>`
+
+Statistic on the metric: avg / p50 / p90 / p95 / p99. Defaults to 'avg' when omitted (set by the CLIConfig -> AIPerfConfig converter).
+
+#### `--search-direction` `<str>`
+
+Optimization direction. Required when --search-space is set.
+
+#### `--search-max-iterations` `<int>`
+
+Maximum number of search iterations. Each iteration runs --num-profile-runs benchmarks. Required when --search-space is set.
+<br/>_Constraints: ≥ 2, ≤ 200_
+
+#### `--search-initial-points` `<int>`
+
+Random Sobol points before fitting the GP. Defaults to 5 when omitted. Must be &lt; --search-max-iterations.
+<br/>_Constraints: ≥ 1_
+
+#### `--search-random-seed` `<int>`
+
+Random seed for reproducible search trajectories. When unset, the planner uses non-deterministic randomness.
+<br/>_Constraints: ≥ 0_
+
+#### `--search-planner` `<str>`
+
+Outer-loop search planner plugin. Default `bayesian` is a curated Optuna preset that uses BoTorch qLogNEI/qLogNEHVI when the optional `botorch` extra is installed and otherwise falls back to Optuna TPE with a warning. `optuna` is the expert-mode alternative exposing `--optuna-sampler` (tpe / gp / botorch) and `--optuna-acquisition`. Explicit unavailable optional samplers raise. Third-party planners registered under the `search_planner` plugin category are accepted here. Only applies when --search-space is set.
+<br/>_Choices: [`bayesian`, `monotonic_sla`, `smooth_isotonic`, `optuna`]_
+
+#### `--optuna-sampler` `<str>`
+
+Optuna sampler selection. Only consulted when --search-planner=optuna. ``botorch`` is the preferred implicit default and requires the optional ``botorch`` extra; when the implicit default is unavailable, the planner warns and falls back to ``tpe``. Explicit ``botorch`` requests raise if the optional stack is unavailable. ``tpe`` is dep-light and ships with Optuna core. ``gp`` is Optuna's native GP-EI with inequality constraints (Optuna 4.2+) but requires ``torch``.
+
+#### `--optuna-acquisition` `<str>`
+
+Acquisition function override for the Optuna BoTorch sampler. Only consulted when --search-planner=optuna AND --optuna-sampler=botorch; rejected otherwise. ``None`` (default) lets Optuna pick (single-objective unconstrained -> LogEI per Optuna v4.x). ``logei``/``qlogei`` make that explicit. ``qnei`` selects plain noisy EI (Letham 2017). ``qlognei`` selects qLogNoisyExpectedImprovement (Ament 2023, https://arxiv.org/abs/2310.20708) -- BoTorch's strongly recommended modern noisy-EI default; requires ``botorch>=0.10``. Multi-objective variants (``qehvi``/``qnehvi``/``qlognehvi``) are accepted when ``objectives`` has length > 1; the planner rejects them on single-objective configs.
+
+#### `--optuna-terminator` `<str>`
+
+Optional posterior-regret stopping rule layered on top of the three-signal convergence check. Only consulted when --search-planner=optuna. ``regret`` selects Optuna's ``RegretBoundEvaluator`` (Makarova et al. 2022, https://proceedings.mlr.press/v188/makarova22a.html). ``emmr`` selects ``EMMREvaluator`` (Ishibashi et al. 2023, https://proceedings.mlr.press/v206/ishibashi23a.html). Both are in the same family as Wilson 2024's PRB stopping rule and ship in Optuna core (no extra dep). ``none`` (default) disables; convergence is then driven by --search-max-iterations / --improvement-patience / --plateau-cv only.
+
+#### `--search-percentile-pooling` `<str>`
+
+Percentile aggregation strategy when --search-stat is a percentile (p50/p90/p95/p99). ``mean`` (default) computes the BO objective as the arithmetic mean of per-trial percentiles across --num-profile-runs trials. ``pooled`` walks each trial's per-request profile_export.jsonl, accumulates raw samples, and computes ``np.percentile`` over the pooled bag -- exposing more tail mass than mean-of-percentiles (correct for SLO claims; same argmax for ranking on monotone problems). ``pooled`` requires --export-level records; if the JSONL is missing the planner falls back to mean with a one-time warning. Rejected when --search-stat is ``avg``.
+
+#### `--bo-constraint-mode` `<str>`
+
+Deprecated and ignored. The bayesian preset and the optuna expert mode both use Optuna's native ``constraints_func`` (Letham et al. 2019, arXiv:1706.07094), which subsumes both the soft-penalty and EIC formulations. Accepted for backwards compatibility but has no effect: the value flows through ``_converter_optionals._SWEEP_OPTIONAL_FIELDS`` to ``AdaptiveSearchSweep.constraint_mode`` (see ``aiperf.config.sweep.config``), and that field is not read by any planner.
+
+#### `--variant`, `--sweep-variant` `<list>`
+
+Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
+
+#### `--search-sla` `<list>`
+
+SLA filter to attach to the adaptive-search or grid path. Format: 'metric_tag:stat:op:threshold'. Stat in {avg, min, max, p1, p5, p10, p25, p50, p75, p90, p95, p99}; op in {lt, le, gt, ge}; threshold is a float in the metric's native unit. For request_error_rate, 1 means 1% (percentage points), unlike --error-rate-sla, which accepts a fraction. Repeatable. Example: --search-sla 'time_to_first_token:p95:lt:200' --search-sla 'request_error_rate:avg:lt:1'. Composes with recipe-named SLA flags (--ttft-sla-ms etc.); the final filter list is recipe filters first, then --search-sla filters in CLI order.
+
+#### `--search-sla-tier` `<list>`
+
+Multi-tier SLO grouping flag. Each invocation defines one tier of SLA filters. Format: 'LABEL:FILTER[,FILTER...]' or 'FILTER[,FILTER...]' (auto-labels tier_1, tier_2, ...). Requires 2-10 invocations. Example: --search-sla-tier 'fast:output_token_throughput:avg:gt:300,time_to_first_token:p95:lt:5000' --search-sla-tier 'standard:output_token_throughput:avg:gt:100,time_to_first_token:p95:lt:10000'. When used, all --search-sla filters are still parsed and compose with tier definitions.
+
+#### `--search-recipe` `<str>`
+
+Named search-recipe preset that expands to an adaptive-search or sweep block. Mutually exclusive with explicit --search-* flags. Recipes are registered under the search_recipe plugin category. Example: --search-recipe max-throughput-ttft-sla --ttft-sla-ms 200.
+
+#### `--ttft-sla-ms` `<float>`
+
+Time-to-first-token SLA threshold in milliseconds. Required by TTFT-SLA recipes (e.g. max-throughput-ttft-sla); ignored otherwise. Must be > 0 — a 0 or negative threshold yields an unsatisfiable filter.
+<br/>_Constraints: > 0_
+
+#### `--isl-osl-pairs` `<str>`
+
+Paired ISL/OSL workload shapes for the pareto-sweep recipe, e.g. '128/128,512/256,2048/512'. Each pair is '&lt;isl>/&lt;osl>' with positive ints; pairs are comma-separated and whitespace-tolerant. Recipe-only flag; ignored unless --search-recipe pareto-sweep is set.
+
+#### `--itl-sla-ms` `<float>`
+
+Inter-token-latency SLA threshold in milliseconds. Required by ITL-SLA recipes (e.g. max-throughput-itl-sla); ignored otherwise. Must be > 0 — a 0 or negative threshold yields an unsatisfiable filter.
+<br/>_Constraints: > 0_
+
+#### `--tpot-sla-ms` `<float>`
+
+Time-per-output-token SLA threshold in milliseconds. Maps to the `inter_token_latency` metric tag (TPOT and ITL are equivalent in this codebase). Consumed by the max-concurrency-under-sla and max-goodput-under-slo recipes; ignored otherwise. Streaming required.
+<br/>_Constraints: > 0_
+
+#### `--e2e-sla-ms` `<float>`
+
+End-to-end request-latency SLA threshold in milliseconds (p99). Maps to the `request_latency` metric tag. Consumed by the max-concurrency-under-sla and max-goodput-under-slo recipes; ignored otherwise. Available without streaming.
+<br/>_Constraints: > 0_
+
+#### `--error-rate-sla` `<float>`
+
+Maximum acceptable request error rate as a fraction in (0, 1) (e.g. 0.05 = 5%). Maps to the `request_error_rate` metric tag (avg), converting the fraction to the metric's percentage-point scale. Consumed by the max-concurrency-under-sla recipe; ignored otherwise. Available without streaming.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--slo-attainment-fraction` `<float>`
+
+Minimum fraction of requests that must satisfy ALL configured per-request SLOs (TTFT/TPOT/E2E) for a configuration to be considered feasible by the goodput recipe. Bounded in (0, 1]. Default 0.95 matches DistServe's canonical attainment-fraction convention (https://arxiv.org/pdf/2401.09670). Consumed by the max-goodput-under-slo recipe; ignored otherwise.
+<br/>_Constraints: > 0, ≤ 1_
+
+#### `--search-style` `<str>`
+
+Search strategy for the max-concurrency-under-sla recipe. 'smooth_isotonic' (default) runs PAVA + PCHIP smooth-isotonic regression-based 1D SLA-saturation search. 'monotonic' runs a 1D binary-search via the MonotonicSLASearchPlanner (~10-20 iterations). 'bo' runs penalty Bayesian Optimization (~30 iterations). 'optuna' runs the same penalty-BO formulation via the OptunaSearchPlanner (TPE/GP/BoTorch samplers; BoTorch requires the optional botorch extra). 'grid' runs a log-spaced 8-step sweep + sla_breach_knee post-process. Recipe-only flag; ignored unless --search-recipe max-concurrency-under-sla is set.
+
+#### `--degradation-threshold` `<float>`
+
+Relative latency degradation threshold for the concurrency-ramp recipe (e.g. 0.20 = 20%). The recipe's post-process handler reports the first concurrency where p99 latency exceeds baseline * (1 + threshold). Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--degradation-metric-tag` `<str>`
+
+ConcurrencyRamp post-process: metric tag for knee detection (default: request_latency). Use, e.g., 'time_to_first_token' to detect the knee on TTFT instead of end-to-end request latency. Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+
+#### `--degradation-stat` `<str>`
+
+ConcurrencyRamp post-process: statistic for knee detection (default: p99). Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+
+#### `--isl-min` `<int>`
+
+Minimum input-sequence-length for the prefill-ttft-curve recipe (default 256 when omitted). The recipe sweeps ISL on a log scale from --isl-min to --isl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--isl-max` `<int>`
+
+Maximum input-sequence-length for the prefill-ttft-curve recipe (default 32768 when omitted). The recipe sweeps ISL on a log scale from --isl-min to --isl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--isl-steps` `<int>`
+
+Number of log-spaced steps for the prefill-ttft-curve recipe's ISL grid (default 8 when omitted). Must be >= 2 — a single-point ramp degenerates and post-process can't compute a baseline. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+#### `--concurrency-min` `<int>`
+
+Lower bound for the concurrency sweep axis used by concurrency-ramp and decode-itl-curve recipes (defaults: 1 for concurrency-ramp, 1 for decode-itl-curve). Must be &lt; --concurrency-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--concurrency-max` `<int>`
+
+Upper bound for the concurrency sweep axis used by concurrency-ramp and decode-itl-curve recipes (defaults: 1000 for concurrency-ramp, 200 for decode-itl-curve). Must be > --concurrency-min. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--concurrency-steps` `<int>`
+
+Number of log-spaced steps for the concurrency sweep axis used by concurrency-ramp (default 8) and decode-itl-curve (default 6). Must be >= 2. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+#### `--osl-min` `<int>`
+
+Minimum output-sequence-length for the decode-itl-curve recipe's OSL grid (default 64 when omitted). The recipe sweeps OSL on a log scale from --osl-min to --osl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--osl-max` `<int>`
+
+Maximum output-sequence-length for the decode-itl-curve recipe's OSL grid (default 1024 when omitted). The recipe sweeps OSL on a log scale from --osl-min to --osl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--osl-steps` `<int>`
+
+Number of log-spaced steps for the decode-itl-curve recipe's OSL grid (default 4 when omitted). Must be >= 2. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+### Accuracy
+
+#### `--accuracy-benchmark` `<str>`
+
+Accuracy benchmark to run (e.g., mmlu, aime, hellaswag). When set, enables accuracy benchmarking mode alongside performance profiling.
+<br/>_Choices: [`mmlu`, `mmlu_pro`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
+
+#### `--accuracy-tasks` `<list>`
+
+Specific tasks or subtasks within the benchmark to evaluate (e.g., specific MMLU subjects). Accepts comma-separated values (e.g. abstract_algebra,anatomy) or repeated flags. If not set, all tasks are included.
+
+#### `--accuracy-n-shots` `<int>`
+
+Number of few-shot examples to include in the prompt. 0 means zero-shot evaluation, None uses the benchmark default (e.g. MMLU=5). Maximum 32.
+<br/>_Constraints: ≥ 0, ≤ 32_
+
+#### `--accuracy-enable-cot`, `--accuracy-no-enable-cot`
+
+Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instructions to the prompt. Defaults to the benchmark's ``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).
+<br/>_Flag (no value required)_
+
+#### `--accuracy-grader` `<str>`
+
+Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
+<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`, `mmlu_pro`]_
+
+#### `--accuracy-system-prompt` `<str>`
+
+Custom system prompt to use for accuracy evaluation. Overrides any benchmark-specific system prompt.
+
+#### `--accuracy-verbose`
+
+Enable verbose output for accuracy evaluation, showing per-problem grading details.
+<br/>_Flag (no value required)_
+
+### Service
+
+#### `--log-level` `<str>`
+
+Set the logging verbosity level. Controls the amount of output displayed during benchmark execution. Use `TRACE` for debugging ZMQ messages, `DEBUG` for detailed operation logs, or `INFO` (default) for standard progress updates.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `TRACE` |  | Most verbose. Logs all operations including ZMQ messages and internal state changes. |
+| `DEBUG` |  | Detailed debugging information. Logs function calls and important state transitions. |
+| `INFO` | _default_ | General informational messages. Default level showing benchmark progress and results. |
+| `NOTICE` |  | Important informational messages that are more significant than INFO but not warnings. |
+| `WARNING` |  | Warning messages for potentially problematic situations that don't prevent execution. |
+| `SUCCESS` |  | Success messages for completed operations and milestones. |
+| `ERROR` |  | Error messages for failures that prevent specific operations but allow continued execution. |
+| `CRITICAL` |  | Critical errors that may cause the benchmark to fail or produce invalid results. |
+
+#### `-v`, `--verbose`
+
+Equivalent to `--log-level DEBUG`. Enables detailed logging output showing function calls and state transitions. Also automatically switches UI to `simple` mode for better console visibility. Does not include raw ZMQ message logging.
+<br/>_Flag (no value required)_
+
+#### `-vv`, `--extra-verbose`
+
+Equivalent to `--log-level TRACE`. Enables the most verbose logging possible, including all ZMQ messages, internal state changes, and low-level operations. Also switches UI to `simple` mode. Use for deep debugging.
+<br/>_Flag (no value required)_
+
+#### `--record-processor-service-count`, `--record-processors` `<int>`
+
+Number of `RecordProcessor` services to spawn for parallel metric computation. Higher request rates require more processors to keep up with incoming records. If not specified, automatically determined based on worker count (typically 1-2 processors per 8 workers).
+<br/>_Constraints: ≥ 1_
+
+#### `--api-port` `<int>`
+
+AIPerf API port (enables HTTP + WebSocket endpoints).
+<br/>_Constraints: ≥ 1, ≤ 65535_
+
+#### `--api-host` `<str>`
+
+AIPerf API host (requires --api-port or AIPERF_API_SERVER_PORT to be set).
+
+#### `--stats-interval` `<float>`
+
+Interval in seconds between realtime stats publishes (dashboards and the per-tick log block). 0 disables the log block while dashboards continue to poll. Defaults to 5s under --ui dashboard, 30s otherwise. Overrides AIPERF_UI_REALTIME_METRICS_INTERVAL.
+<br/>_Constraints: ≥ 0.0, ≤ 1000.0_
+
+### ZMQ Communication
+
+#### `--zmq-host` `<str>`
+
+Host address for internal ZMQ TCP communication between AIPerf services. Defaults to `127.0.0.1` (localhost) for single-machine deployments. For distributed setups, set to a reachable IP address. All internal service-to-service communication (message bus, dataset manager, workers) uses this host for TCP sockets.
+<br/>_Default: `127.0.0.1`_
+
+#### `--zmq-ipc-path` `<str>`
+
+Directory path for ZMQ IPC (Inter-Process Communication) socket files. When using IPC transport instead of TCP, AIPerf creates Unix domain socket files in this directory for faster local communication. Auto-generated in system temp directory if not specified. Only applicable when using IPC communication backend.
+
+#### `--zmq-dual-bind`
+
+Select the ZMQ dual-bind communication backend (IPC + TCP). All dual-bind knobs are cluster-managed; this flag only selects the discriminator and the converter routes downstream to the default.
+<br/>_Flag (no value required)_
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+#### `--name` `<str>`
+
+Human-readable name for the benchmark job (DNS label, max 40 chars).
+
+#### `--image` `<str>`
+
+AIPerf container image to use for Kubernetes deployment.
+<br/>_Constraints: min: 1_
+
+#### `--image-pull-policy` `<str>`
+
+Image pull policy (Always, IfNotPresent, Never). Use 'Never' for minikube (or local clusters) with locally loaded images.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `Always` |  | Every time the kubelet launches a container, it queries the registry to resolve the name to a digest. Uses cached image if digest matches, otherwise pulls the image. |
+| `Never` |  | The kubelet does not try fetching the image. Startup fails if the image is not already present locally. |
+| `IfNotPresent` |  | The image is pulled only if it is not already present locally. |
+
+#### `--total-workers` `<int>`
+
+Total number of workers. Automatically distributed across pods based on --workers-per-pod (default 10). E.g., --total-workers 50 = 5 pods × 10 workers.
+<br/>_Constraints: > 0_
+<br/>_Default: `10`_
+
+#### `--ttl-seconds` `<int>`
+
+Seconds to keep pods after completion (None to disable TTL).
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `300`_
+
+### Kubernetes Node Placement
+
+#### `--node-selector` `<list>`
+
+CLI-only node selector labels (JSON object or repeated key=value).
+
+#### `--tolerations` `<list>`
+
+Pod tolerations as JSON object/array or repeated JSON values.
+
+### Kubernetes Scheduling
+
+#### `--queue-name` `<str>`
+
+Kueue LocalQueue name for gang-scheduling. When set, the JobSet is submitted to Kueue for quota-managed admission.
+
+#### `--priority-class` `<str>`
+
+Kueue WorkloadPriorityClass name for scheduling priority.
+
+### Kubernetes Metadata
+
+#### `--annotations` `<str>`
+
+Additional pod annotations.
+
+#### `--labels` `<str>`
+
+Additional pod labels.
+
+### Kubernetes Secrets
+
+#### `--image-pull-secrets` `<list>`
+
+Image pull secret names.
+
+#### `--env-vars` `<str>`
+
+Extra environment variables (key: value).
+
+#### `--env-from-secrets` `<str>`
+
+Environment variables from secrets (ENV_NAME: secret_name/key).
+
+#### `--secret-mounts` `<list>`
+
+Secret volume mounts.
+
+#### `--service-account` `<str>`
+
+Service account name for pods.
+
+### Parameters
+
+#### `--trials` `<int>`
+
+Multi-run runs per sweep cell; overrides multiRun.numRuns / multi_run.num_runs in the YAML.
+
+#### `--cooldown` `<float>`
+
+Cooldown seconds between multi-run trials (overrides YAML).
+<br/>_Default: `0.0`_
+
+#### `--convergence-metric` `<str>`
+
+Stop multi-run early when this metric converges (e.g. ttft_p99).
+
+#### `--min-runs` `<int>`
+
+Minimum runs before convergence is checked (default 3).
+<br/>_Default: `3`_
+
+#### `--max-runs` `<int>`
+
+Hard cap on runs even if not converged (default 10).
+<br/>_Default: `10`_
+
+#### `--convergence-threshold` `<float>`
+
+Relative convergence threshold (default 0.05 = 5%).
+<br/>_Constraints: > 0, &lt; 1_
+<br/>_Default: `0.05`_
+
+#### `-d`, `--detach`, `--no-detach`
+
+Exit after submitting (don't tail). v1 always behaves as detach=True.
+
+#### `--dry-run`
+
+Print the AIPerfSweep CR as JSON without submitting it.
+<br/>_Flag (no value required)_
+
+<hr/>
+
+## `aiperf kube generate`
+
+Generate Kubernetes YAML manifests
+
+### Endpoint
+
+#### `-m`, `--model-names`, `--model` `<list>`
+
+Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
+
+#### `--model-selection-strategy` `<str>`
+
+When multiple models are specified, this is how a specific model should be assigned to a prompt. round_robin: nth prompt in the list gets assigned to n-mod len(models). random: assignment is uniformly random.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `round_robin` | _default_ | Cycle through models in order. The nth prompt is assigned to model at index (n mod number_of_models). |
+| `random` |  | Randomly select a model for each prompt using uniform distribution. |
+| `weighted` |  | Select a model with probability proportional to a per-model weight. |
+
+#### `--custom-endpoint`, `--endpoint` `<str>`
+
+Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default, endpoints follow OpenAI-compatible paths like `/v1/chat/completions`. Use this option to override the default path for non-standard API implementations.
+
+#### `--endpoint-type` `<str>`
+
+The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
+<br/>_Choices: [`audio_transcription`, `chat`, `cohere_rankings`, `completions`, `responses`, `messages`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
+<br/>_Default: `chat`_
+
+#### `--streaming`
+
+Enable streaming responses. When enabled, the server streams tokens incrementally as they are generated. Automatically disabled if the selected endpoint type does not support streaming. Enables measurement of time-to-first-token (TTFT) and inter-token latency (ITL) metrics.
+<br/>_Flag (no value required)_
+
+#### `-u`, `--url` `<list>`
+
+Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). URLs that do not include a scheme (no `://`) have `http://` prepended automatically.
+<br/>_Constraints: min: 1_
+<br/>_Default: `['http://localhost:8000']`_
+
+#### `--url-strategy` `<str>`
+
+Strategy for selecting URLs when multiple `--url` values are provided. 'round_robin' (default): distribute requests evenly across URLs in sequential order.
+<br/>_Choices: [`round_robin`]_
+<br/>_Default: `round_robin`_
+
+#### `--request-timeout-seconds` `<float>`
+
+Maximum time in seconds to wait for each HTTP request to complete, including connection establishment, request transmission, and response receipt. Applies to both streaming and non-streaming requests. Requests exceeding this timeout are cancelled and recorded as failures.
+<br/>_Constraints: > 0_
+<br/>_Default: `21600`_
+
+#### `--wait-for-model-timeout` `<float>`
+
+Seconds to wait for endpoint readiness before benchmarking (0 = skip). Sends a real inference request to verify the model is loaded and can generate output.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--wait-for-model-mode` `<str>`
+
+How readiness probes the endpoint: 'models' checks /v1/models, 'inference' sends a canned one-token inference request, and 'both' runs the models check before inference.
+<br/>_Default: `inference`_
+
+#### `--wait-for-model-interval` `<float>`
+
+Seconds between endpoint readiness probe attempts.
+<br/>_Constraints: > 0.0_
+<br/>_Default: `5.0`_
+
+#### `--reset-kv-cache`
+
+Enable once-per-cell KV-cache reset via POST to the endpoint.
+<br/>_Flag (no value required)_
+
+#### `--reset-kv-cache-timeout-seconds` `<float>`
+
+Timeout seconds for reset_kv_cache control requests.
+<br/>_Constraints: > 0_
+
+#### `--reset-kv-cache-path` `<str>`
+
+Relative path for reset_kv_cache (default /reset_prefix_cache).
+
+#### `--server-profiler`
+
+Enable server profiler start/stop around profiling phases.
+<br/>_Flag (no value required)_
+
+#### `--server-profiler-timeout-seconds` `<float>`
+
+Timeout seconds for server_profiler control requests.
+<br/>_Constraints: > 0_
+
+#### `--server-profiler-start-path` `<str>`
+
+Relative path for profiler start (default /start_profile).
+
+#### `--server-profiler-stop-path` `<str>`
+
+Relative path for profiler stop (default /stop_profile).
+
+#### `--api-key` `<str>`
+
+API authentication key for the endpoint. When provided, automatically included in request headers as `Authorization: Bearer <api_key>`.
+
+#### `--transport`, `--transport-type` `<str>`
+
+Transport protocol to use for API requests. If not specified, auto-detected from the URL scheme (`http`/`https` -> `TransportType.HTTP`). Currently supports `http` transport using aiohttp with connection pooling, TCP optimization, and Server-Sent Events (SSE) for streaming. Explicit override rarely needed.
+<br/>_Choices: [`http`]_
+
+#### `--use-legacy-max-tokens`
+
+Use the legacy 'max_tokens' field instead of 'max_completion_tokens' in request payloads. The OpenAI API now prefers 'max_completion_tokens', but some older APIs or implementations may require 'max_tokens'.
+<br/>_Flag (no value required)_
+
+#### `--use-server-token-count`
+
+Use server-reported token counts from API usage fields instead of client-side tokenization. When enabled, tokenizers are still loaded (needed for dataset generation) but tokenizer.encode() is not called for computing metrics. Token count fields will be None if the server does not provide usage information. For OpenAI-compatible streaming endpoints (chat/completions), stream_options.include_usage is automatically configured when this flag is enabled.
+<br/>_Flag (no value required)_
+
+#### `--connection-reuse-strategy` `<str>`
+
+Transport connection reuse strategy. 'pooled' (default): connections are pooled and reused across all requests. 'never': new connection for each request, closed after response. 'sticky-user-sessions': connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `pooled` | _default_ | Connections are pooled and reused across all requests |
+| `never` |  | New connection for each request, closed after response |
+| `sticky-user-sessions` |  | Connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing) |
+
+#### `--download-video-content`
+
+For video generation endpoints, download the video content after generation completes. When enabled, request latency includes the video download time. When disabled (default), only generation time is measured.
+<br/>_Flag (no value required)_
+
+#### `--request-content-type` `<str>`
+
+Content type for request body serialization. By default, requests are sent as 'application/json'. Set to 'multipart/form-data' for servers that require form-encoded requests (e.g., vLLM video generation endpoints).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `application/json` |  | Standard JSON encoding. Default for all endpoints. |
+| `multipart/form-data` |  | Multipart form encoding. Required by some video generation servers (e.g., vLLM). |
+
+#### `--session-header` `<str>`
+
+HTTP header name used to carry the per-session affinity identifier. When set, replaces the default `X-Correlation-ID` header with the provided name (e.g., `--session-header X-Session-ID`).
+
+#### `--uuid-and-strip`
+
+Enable AIPerf-managed image stripping for vLLM's multimodal processor cache. Dataset-authored image UUIDs, including UUID-only cache references, always pass through on the chat endpoint; this flag only strips repeated content after AIPerf observes it in the same session. Automatic stripping supports only single_turn datasets with session_id-grouped rows; multi_turn is rejected. The server cache must cover the working set, and requests in a session must reach a replica that retains earlier UUIDs.
+<br/>_Flag (no value required)_
+
+### Tokenizer
+
+#### `--tokenizer` `<str>`
+
+HuggingFace tokenizer identifier, local path, or `builtin` for token counting in prompts and responses. Accepts model names (e.g., `meta-llama/Llama-2-7b-hf`), filesystem paths to tokenizer files, or `builtin` for a zero-network-access tokenizer backed by tiktoken (o200k_base encoding). If not specified, defaults to the value of `--model-names`. If `--tokenizer` is not set and the model name looks like an obvious placeholder (e.g. `mock-model`, `test-model`, `fake-model`), AIPerf substitutes `builtin` automatically and emits a warning. Essential for accurate token-based metrics (input/output token counts, token throughput).
+
+#### `--tokenizer-revision` `<str>`
+
+Specific tokenizer version to load from HuggingFace Hub. Can be a branch name (e.g., `main`), tag name (e.g., `v1.0`), or full commit hash. Ensures reproducible tokenization across runs by pinning to a specific version. Defaults to `main` branch if not specified.
+<br/>_Default: `main`_
+
+#### `--tokenizer-trust-remote-code`
+
+Allow execution of custom Python code from HuggingFace Hub tokenizer repositories. Required for tokenizers with custom implementations not in the standard `transformers` library. **Security Warning**: Only enable for trusted repositories, as this executes arbitrary code. Unnecessary for standard tokenizers.
+<br/>_Flag (no value required)_
+
+#### `--apply-chat-template`
+
+Apply the HuggingFace tokenizer's chat template when counting input tokens. When enabled: synthetic ISL is compensated for chat-template wrapping (BOS, role headers, EOT, generation-prompt suffix) and the record processor reports ISL using `apply_chat_template(tokenize=True, add_generation_prompt=True)` for chat-shape payloads. When disabled (default), both paths use bare-text encoding, so reported ISL matches the prompt content the user asked for and ignores template overhead. Requires an HF tokenizer with a chat template configured; no-ops on tiktoken / un-templated models.
+<br/>_Flag (no value required)_
+
+### Input
+
+#### `--extra-inputs` `<list>`
+
+Additional input parameters to include in every API request payload. Specify as `key:value` pairs (e.g., `--extra-inputs temperature:0.7 top_p:0.9`) or as JSON string (e.g., `'{"temperature": 0.7}'`). These parameters are merged with request-specific inputs and sent directly to the endpoint API.
+
+#### `-H`, `--header` `<list>`
+
+Custom HTTP headers to include with every request. Specify as `Header:Value` pairs (e.g., `--header X-Custom-Header:value`) or as JSON string. Can be specified multiple times. Useful for custom authentication, tracking, or API-specific requirements. Combined with auto-generated headers (e.g., `Authorization` from `--api-key`).
+
+#### `--input-file` `<str>`
+
+Path to file or directory containing benchmark dataset. Required when using `--custom-dataset-type`. Supported formats depend on dataset type: JSONL for `single_turn`/`multi_turn`, JSONL for `mooncake_trace`/`bailian_trace` (timestamped traces), Parquet for `baseten_trace`, directories for `random_pool`. File is parsed according to `--custom-dataset-type` specification.
+
+#### `--public-dataset` `<str>`
+
+Pre-configured public dataset to download and use for benchmarking (e.g., `sharegpt`). AIPerf automatically downloads and parses these datasets. Mutually exclusive with `--custom-dataset-type`. Run `aiperf plugins public_dataset_loader` to list available datasets. Use `--hf-subset` to override the HuggingFace subset/config for HF-backed datasets.
+<br/>_Choices: [`exgentic_v2`, `exgentic`, `sharegpt`, `aimo`, `mmstar`, `mmvu`, `vision_arena`, `llava_onevision`, `aimo_aime`, `aimo_numina_cot`, `aimo_numina_1_5`, `spec_bench`, `spec_al_gsm8k`, `spec_al_math500`, `spec_al_humaneval`, `spec_al_mbpp`, `spec_al_mtbench`, `instruct_coder`, `blazedit_5k`, `blazedit_10k`, `librispeech`, `voxpopuli`, `gigaspeech`, `ami`, `spgispeech`, `semianalysis_cc_traces_weka`, `semianalysis_cc_traces_weka_no_subagents`, `semianalysis_cc_traces_weka_with_subagents`, `semianalysis_cc_traces_weka_with_subagents_256k`, `semianalysis_cc_traces_weka_with_subagents_060226`, `semianalysis_cc_traces_weka_with_subagents_060226_256k`, `semianalysis_cc_traces_weka_with_subagents_060526`, `semianalysis_cc_traces_weka_with_subagents_060526_256k`, `semianalysis_cc_traces_weka_with_subagents_060826`, `semianalysis_cc_traces_weka_with_subagents_060826_256k`, `semianalysis_cc_traces_weka_061326`, `semianalysis_cc_traces_weka_061326_256k`, `semianalysis_cc_traces_weka_061526`, `semianalysis_cc_traces_weka_061526_256k`, `semianalysis_cc_traces_weka_062126`, `semianalysis_cc_traces_weka_062126_256k`, `weka_hf`]_
+
+#### `--hf-subset` `<str>`
+
+HuggingFace dataset subset/config name to override the plugin default (e.g. `sharegpt4o`). Only applies when using `--public-dataset` with a HuggingFace-backed loader. Takes priority over the subset defined in the plugin registry.
+
+#### `--hf-weka-dataset` `<str>`
+
+HuggingFace dataset repo for the generic Weka loader (e.g. `semianalysisai/cc-traces-weka-061526`). Passing this auto-selects `--public-dataset weka_hf`, so the repo flag works on its own; setting it alongside any other `--public-dataset` or `--custom-dataset-type` is an error. Pinned Weka public dataset aliases keep their registry-defined repo names.
+
+#### `--dataset-filter` `<list>`
+
+Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
+
+#### `--custom-dataset-type` `<str>`
+
+Format specification for custom dataset provided via `--input-file`. Determines parsing logic and expected file structure. Options: `single_turn` (JSONL with single exchanges), `multi_turn` (JSONL with conversation history), `tracelab` (TraceLab agentic-coding corpus, JSONL or gzipped JSONL), `mooncake_trace`/`bailian_trace`/`baseten_trace` (timestamped trace files), `random_pool` (directory of reusable prompts; when using `random_pool`, `--conversation-num` defaults to 100 if not specified; batch sizes > 1 sample each modality independently from a flat pool and do not preserve per-entry associations - use `single_turn` if paired modalities must stay together). Requires `--input-file`. Mutually exclusive with `--public-dataset`.
+<br/>_Choices: [`burst_gpt_trace`, `bailian_trace`, `baseten_trace`, `mooncake_trace`, `raw_payload`, `inputs_json`, `dag_jsonl`, `sagemaker_data_capture`, `multi_turn`, `random_pool`, `single_turn`, `speed_bench_qualitative`, `speed_bench_coding`, `speed_bench_humanities`, `speed_bench_math`, `speed_bench_multilingual`, `speed_bench_qa`, `speed_bench_rag`, `speed_bench_reasoning`, `speed_bench_roleplay`, `speed_bench_stem`, `speed_bench_summarization`, `speed_bench_writing`, `speed_bench_throughput_1k`, `speed_bench_throughput_2k`, `speed_bench_throughput_8k`, `speed_bench_throughput_16k`, `speed_bench_throughput_32k`, `speed_bench_throughput_1k_low_entropy`, `speed_bench_throughput_1k_mixed`, `speed_bench_throughput_1k_high_entropy`, `speed_bench_throughput_2k_low_entropy`, `speed_bench_throughput_2k_mixed`, `speed_bench_throughput_2k_high_entropy`, `speed_bench_throughput_8k_low_entropy`, `speed_bench_throughput_8k_mixed`, `speed_bench_throughput_8k_high_entropy`, `speed_bench_throughput_16k_low_entropy`, `speed_bench_throughput_16k_mixed`, `speed_bench_throughput_16k_high_entropy`, `speed_bench_throughput_32k_low_entropy`, `speed_bench_throughput_32k_mixed`, `speed_bench_throughput_32k_high_entropy`, `tracelab`, `weka_trace`]_
+
+#### `--ignore-trace-delays`
+
+Strip per-turn timestamps and inter-turn delays from trace datasets at load time. With this flag, Turn.timestamp and Turn.delay are emitted as None so concurrency / request-rate timing modes dispatch turns back-to-back instead of reproducing the recorded user think-time gaps. No effect under `--fixed-schedule` (timestamps drive that mode before they could be ignored -- combine with `--no-fixed-schedule` if you want both behaviors).
+<br/>_Flag (no value required)_
+
+#### `--use-think-time-only`
+
+For weka_trace inputs, emit Turn.delay using only the recorded per-request `think_time` (client-side delay before each request) instead of the full `t_curr - t_prev` inter-request delta. Compresses replay wall time against zero-latency mocks because the recorded `api_time` portion of each gap is dropped. Mirrors kv-cache-tester's default `--timing-strategy think-only`. Falls back to the full delta for turns whose recorded `think_time` is null. Mutually exclusive with `--ignore-trace-delays`. No effect on non-weka trace loaders.
+<br/>_Flag (no value required)_
+
+#### `--max-context-length` `<int>`
+
+Maximum peak prompt+output context length (tokens) per Weka root trace. Weka loaders (--custom-dataset-type weka_trace or a weka --public-dataset) drop whole traces whose *recorded* peak exceeds this ceiling at load time (filter-then-cap before --num-dataset-entries). Not a DatasetManager tokenize filter; rejected for non-Weka formats.
+<br/>_Constraints: ≥ 1_
+
+#### `--dataset-sampling-strategy` `<str>`
+
+Strategy for selecting entries from dataset during benchmarking. `sequential`: Iterate through dataset in order, wrapping to start after end. `random`: Randomly sample with replacement (entries may repeat before all are used). `shuffle`: Shuffle dataset and iterate without replacement, re-shuffling after exhaustion. Default behavior depends on dataset type (e.g., `sequential` for traces, `shuffle` for synthetic).
+<br/>_Choices: [`random`, `sequential`, `shuffle`]_
+
+#### `--allow-dataset-wrap`, `--no-allow-dataset-wrap`
+
+Allow weka/agentic replay to wrap (reuse distinct eligible traces across concurrency lanes) when concurrency exceeds the loaded pool. Defaults to False: over-subscription fails unless wrapping is explicitly enabled or an active --cache-bust target already keeps repeated-trace traffic distinct.
+
+#### `--random-seed` `<int>`
+
+Random seed for deterministic data generation. When set, makes synthetic prompts, sampling, delays, and other random operations reproducible across runs. Essential for A/B testing and debugging. Uses system entropy if not specified. Initialized globally at config creation.
+<br/>_Constraints: ≥ 0_
+
+#### `--trace-session-sample-ratio` `<float>`
+
+Fraction of trace sessions to keep for replay, sampled whole-session to preserve multi-turn integrity; deterministic when `--random-seed` is set. Only supported by the baseten_trace loader.
+<br/>_Constraints: > 0.0, ≤ 1.0_
+
+#### `-f`, `--config` `<str>`
+
+Path to a YAML configuration file. CLI flags override values from the config file.
+
+### Fixed Schedule
+
+#### `--fixed-schedule`
+
+Run requests according to timestamps specified in the input dataset. When enabled, AIPerf replays the exact timing pattern from the dataset. This mode is automatically enabled for trace datasets.
+<br/>_Flag (no value required)_
+
+#### `--no-fixed-schedule`
+
+Suppress the automatic switch to fixed-schedule mode for trace datasets that carry per-record timestamps. By default a trace input (e.g. mooncake_trace) with timestamps in the first record auto-promotes the profiling phase to fixed_schedule. Pass --no-fixed-schedule to keep the user-selected timing mode (e.g. concurrency, request_rate) and ignore the trace timestamps.
+
+#### `--fixed-schedule-auto-offset`
+
+Automatically normalize timestamps in fixed schedule by shifting all timestamps so the first timestamp becomes 0. When enabled, benchmark starts immediately with the timing pattern preserved. When disabled, timestamps are used as absolute offsets from benchmark start. Mutually exclusive with `--fixed-schedule-start-offset`.
+<br/>_Flag (no value required)_
+
+#### `--fixed-schedule-start-offset` `<int>`
+
+Start offset in milliseconds for fixed schedule replay. Skips all requests before this timestamp, allowing benchmark to start from a specific point in the trace. Requests at exactly the start offset are included. Useful for analyzing specific time windows. Mutually exclusive with `--fixed-schedule-auto-offset`. Must be ≤ `--fixed-schedule-end-offset` if both specified.
+<br/>_Constraints: ≥ 0_
+
+#### `--fixed-schedule-end-offset` `<int>`
+
+End offset in milliseconds for fixed schedule replay. Stops issuing requests after this timestamp, allowing benchmark of specific trace subsets. Requests at exactly the end offset are included. Defaults to last timestamp in dataset. Must be ≥ `--fixed-schedule-start-offset` if both specified.
+<br/>_Constraints: ≥ 0_
+
+### Goodput
+
+#### `--goodput` `<str>`
+
+Specify service level objectives (SLOs) for goodput as space-separated 'KEY:VALUE' pairs, where KEY is a metric tag and VALUE is a number in the metric's display unit (falls back to its base unit if no display unit is defined). Examples: 'request_latency:250' (ms), 'inter_token_latency:10' (ms), `output_token_throughput_per_user:600` (tokens/s). Only metrics applicable to the current endpoint/config are considered. For more context on the definition of goodput, refer to DistServe paper: https://arxiv.org/pdf/2401.09670 and the blog: https://hao-ai-lab.github.io/blogs/distserve.
+
+### Conversation Input
+
+#### `--conversation-num`, `--num-conversations`, `--num-sessions` `<str>`
+
+The total number of unique conversations to generate. Each conversation represents a single request session between client and server. Supported on synthetic mode and the custom random_pool dataset. The number of conversations will be used to determine the number of entries in both the custom random_pool and synthetic datasets and will be reused until benchmarking is complete. Pass a comma-separated list (e.g. `--num-conversations 50,100,200`) to sweep over session-bounded run lengths; the converter promotes the list to a sweep on phases.profiling.sessions before AIPerfConfig validation. The synthetic dataset pool is sized to max(list) so every variation has its full unique-session set.
+
+#### `--num-dataset-entries`, `--num-prompts` `<int>`
+
+Total number of unique entries to generate for the dataset. Each entry represents one user message that can be used as a turn in conversations. Entries are reused across conversations and turns according to `--dataset-sampling-strategy`. Higher values provide more diversity.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `100`_
+
+#### `--conversation-turn-mean`, `--session-turns-mean` `<int>`
+
+Mean number of request-response turns per conversation. Each turn consists of a user message and model response. Turn counts follow normal distribution around this mean (±`--conversation-turn-stddev`). Set to 1 for single-turn interactions. Multi-turn conversations enable testing of context retention and conversation history handling. Pass a comma-separated list (e.g. `--conversation-turn-mean 1,3,8`) to sweep over multiple turn-mean values; the converter promotes the list to a sweep on datasets.main.turns.mean before AIPerfConfig validation.
+<br/>_Default: `1`_
+
+#### `--conversation-turn-stddev`, `--session-turns-stddev` `<int>`
+
+Standard deviation for number of turns per conversation. Creates variability in conversation lengths, simulating diverse interaction patterns (quick questions vs. extended dialogues). Turn counts follow normal distribution. Set to 0 for uniform conversation lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--conversation-turn-delay-mean`, `--session-turn-delay-mean` `<float>`
+
+Mean delay in milliseconds between consecutive turns within a multi-turn conversation. Simulates user think time between receiving a response and sending the next message. Delays follow normal distribution around this mean (±`--conversation-turn-delay-stddev`). Only applies to multi-turn conversations (`--conversation-turn-mean` > 1). Set to 0 for back-to-back turns.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--conversation-turn-delay-stddev`, `--session-turn-delay-stddev` `<float>`
+
+Standard deviation for turn delays in milliseconds. Creates variability in user think time between conversation turns. Delays follow normal distribution. Set to 0 for deterministic delays. Models realistic human interaction patterns with variable response times.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--conversation-turn-delay-ratio`, `--session-delay-ratio` `<float>`
+
+Multiplier for scaling all turn delays within conversations. Applied after mean/stddev calculation: `actual_delay = calculated_delay × ratio`. Use to proportionally adjust timing without changing distribution shape. Values &lt; 1 speed up conversations, > 1 slow them down. Set to 0 to eliminate delays entirely.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1.0`_
+
+#### `--inter-turn-delay-cap-seconds` `<float>`
+
+Clamp per-turn replay delays to at most this many seconds; ``None`` disables the cap. Honored by the DAG JSONL loader and the baseten_trace loader's closed-loop think-times; the clamp count is reported at end of load. Maps to FileDataset ``inter_turn_delay_cap_seconds``.
+<br/>_Constraints: ≥ 0.0_
+
+#### `--max-idle-gap-cap-seconds` `<float>`
+
+Collapse idle gaps between consecutive requests (across all sessions) to at most this many seconds, so a sparse or session-sampled trace does not replay dead air; ``None`` disables the cap. The cap is in replay wall-clock seconds, applied after --replay-speedup compression, so it bounds actual benchmark idle time regardless of speedup. Only supported by the baseten_trace loader. Maps to FileDataset ``max_idle_gap_cap_seconds``.
+<br/>_Constraints: > 0.0_
+
+#### `--replay-speedup` `<float>`
+
+Trace replay wall-clock compression (10 = 10x faster than recorded): divides normalized timestamps and inter-turn delays; ``None`` = real time. Unlike synthesis speedup_ratio, hash_ids stay untouched (KV-cache fidelity). Only supported by the baseten_trace loader. Maps to FileDataset ``replay_speedup``.
+<br/>_Constraints: > 0.0_
+
+#### `--open-loop-replay`, `--no-open-loop-replay`
+
+Open-loop replay (the default): each session starts at its absolute, speedup-scaled recorded timestamp; continuation turns fire at max(recorded timestamp, prior-turn completion). Pass `--no-open-loop-replay` for closed-loop back-pressure: continuation turns fire a think-time (recorded start-to-start gap minus recorded e2e duration) after the prior turn completes, keeping sessions causally ordered when replayed service times differ from recorded (e.g. A/A comparisons). Only honored by the baseten_trace loader. Maps to FileDataset ``open_loop_replay``.
+<br/>_Default: `True`_
+
+#### `--open-loop-strict`
+
+In open-loop replay, fire every trace row at its absolute recorded timestamp as an independent single-turn session, trading away multi-turn grouping and session metrics. Only honored by the baseten_trace loader. Maps to FileDataset ``open_loop_strict``.
+<br/>_Flag (no value required)_
+
+#### `--omit-kv-hints`
+
+Drop recorded KV-cache hints (``hash_ids``, ``block_size``) from replayed request bodies, for strict frontends that reject unknown parameters. Only honored by the baseten_trace loader. Maps to FileDataset ``omit_kv_hints``.
+<br/>_Flag (no value required)_
+
+#### `--force-min-tokens`, `--no-force-min-tokens`
+
+Pin ``min_tokens`` to the recorded output length so replayed generations match recorded lengths; pass `--no-force-min-tokens` to let EOS end generations naturally (some servers reject ``min_tokens``). Only honored by the baseten_trace loader. Maps to FileDataset ``force_min_tokens``.
+<br/>_Default: `True`_
+
+### Prompt
+
+#### `-b`, `--prompt-batch-size`, `--batch-size-text`, `--batch-size` `<int>`
+
+Number of text inputs to include in each request for batch processing endpoints. Supported by `embeddings` and `rankings` endpoint types where models can process multiple inputs simultaneously for efficiency. Set to 1 for single-input requests. Not applicable to `chat` or `completions` endpoints.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--prompt-corpus` `<str>`
+
+Source corpus for synthetic prompt text generation. 'sonnet' uses Shakespeare sonnets. 'coding' uses realistic coding content (code, bash output, JSON, error tracebacks, git diffs). Honored only for synthesized content (synthetic datasets and count/hash-id trace loaders); verbatim formats ignore it. When unset, the active dataset loader's default applies (most loaders default to 'sonnet'; agentic-coding loaders such as weka_trace default to 'coding').
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `sonnet` |  | Shakespeare sonnets (default). Classic prose for filler text. |
+| `coding` |  | Realistic coding content: code, bash output, JSON, error tracebacks, git diffs. |
+
+### Cache Bust
+
+#### `--cache-bust` `<str>`
+
+Where (and how) to inject a cache-bust marker. Two families: (1) RID targets (system_prefix, system_suffix, first_turn_prefix, first_turn_suffix) — inject a per-trajectory unique SHA-256 digest marker that is identical across warmup and profiling, so warmup KV-cache work transfers to profiling while preventing cross-trajectory cache sharing. Prefix variants prepend at token 0; suffix variants append after existing content. (2) Warmup-isolation targets (warmup_isolation_system, warmup_isolation_first_turn) — inject a constant '[warmup]' marker only during the WARMUP phase; profiling sees no marker (fully cold start or system-pre-warmed). Incompatible with agentic_replay timing mode. 'none' disables the feature (default). See [cache-bust.md](reference/cache-bust.md) for detailed semantics, trade-offs, and examples.
+<br/>_Choices: [`none`, `system_prefix`, `system_suffix`, `first_turn_prefix`, `first_turn_suffix`, `warmup_isolation_system`, `warmup_isolation_first_turn`]_
+<br/>_Default: `none`_
+
+### Prefix Prompt
+
+#### `--system-prompt` `<str>`
+
+Verbatim system prompt text, identical across every conversation. Sent as a system-role message ahead of all turns. Works with both synthetic and file/public datasets; when the dataset already carries its own system message, this text is prepended to it. Tokens are additive: `--isl` continues to size the generated user prompt only. Mutually exclusive with `--system-prompt-file`, `--shared-system-prompt-length`, and `--num-prefix-prompts`/`--prefix-prompt-length`.
+
+#### `--system-prompt-file` `<str>`
+
+Path to a UTF-8 text file holding the verbatim system prompt. Preferred over `--system-prompt` for real production prompts, which are long enough that shell quoting mangles them. Read once at startup, so a missing or unreadable file fails immediately rather than mid-run. Mutually exclusive with `--system-prompt`, `--shared-system-prompt-length`, and `--num-prefix-prompts`/`--prefix-prompt-length`.
+
+#### `--prompt-prefix-pool-size`, `--prefix-prompt-pool-size`, `--num-prefix-prompts` `<int>`
+
+Number of distinct prefix prompts to generate for K-V cache testing. Each prefix is prepended to user prompts, simulating cached context scenarios. Prefixes randomly selected from pool per request. Set to 0 to disable prefix prompts. Mutually exclusive with `--shared-system-prompt-length`/`--user-context-prompt-length`.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--prompt-prefix-length`, `--prefix-prompt-length` `<int>`
+
+The number of tokens in each prefix prompt. This is only used if `--num-prefix-prompts` is greater than zero. Note that due to the prefix and user prompts being concatenated, the number of tokens in the final prompt may be off by one.Mutually exclusive with `--shared-system-prompt-length`/`--user-context-prompt-length`.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--shared-system-prompt-length` `<int>`
+
+Length of shared system prompt in tokens. This prompt is identical across all sessions and appears as a system message. Mutually exclusive with `--prefix-prompt-length`/`--prefix-prompt-pool-size`.
+<br/>_Constraints: ≥ 1_
+
+#### `--user-context-prompt-length` `<int>`
+
+Length of per-session user context prompt in tokens. Each dataset entry gets a unique user context prompt. Requires --num-dataset-entries to be specified. Mutually exclusive with --prefix-prompt-length/--prefix-prompt-pool-size.
+<br/>_Constraints: ≥ 1_
+
+### Input Sequence Length (ISL)
+
+#### `--prompt-input-tokens-mean`, `--synthetic-input-tokens-mean`, `--isl` `<int>`
+
+Mean number of tokens for synthetically generated input prompts. AIPerf generates prompts with lengths following a normal distribution around this mean (±`--prompt-input-tokens-stddev`). Applies only to synthetic datasets, not custom or public datasets. Pass a comma-separated list (e.g. `--isl 128,512,2048`) to sweep over multiple input lengths; the converter promotes the list to a sweep on datasets.main.prompts.isl.mean before AIPerfConfig validation.
+<br/>_Default: `550`_
+
+#### `--prompt-input-tokens-stddev`, `--synthetic-input-tokens-stddev`, `--isl-stddev` `<float>`
+
+Standard deviation for synthetic input prompt token lengths. Creates variability in prompt sizes when > 0, simulating realistic workloads with mixed request sizes. Lengths follow normal distribution. Set to 0 for uniform prompt lengths. Applies only to synthetic data generation. Pass a comma-separated list (e.g. `--isl-stddev 10,50,200`) to sweep over multiple stddev values; the converter promotes the list to a sweep on datasets.main.prompts.isl.stddev. Pair with a zip-mode `--isl` sweep to model realistic small/medium/large traffic shapes.
+<br/>_Default: `0.0`_
+
+#### `--prompt-input-tokens-block-size`, `--synthetic-input-tokens-block-size`, `--isl-block-size` `<int>`
+
+Token block size for hash-based prompt synthesis when dataset entries carry `hash_ids`: each `hash_id` maps to a cached block of `block_size` tokens, enabling simulation of KV-cache sharing patterns from production workloads. The total prompt length equals `(num_hash_ids - 1) * block_size + final_block_size`. With `--input-file` this overrides the trace loader's `default_block_size` plugin metadata (16 for `bailian_trace`, 512 for `mooncake_trace`) for loaders that reconstruct prompts from `hash_ids`; it has no effect on `baseten_trace`, which replays literal recorded prompts. Set it when a trace was recorded at a block size different from its loader default (e.g. a Mooncake-format trace recorded at 16).
+<br/>_Constraints: ≥ 1_
+
+#### `--seq-dist`, `--sequence-distribution` `<str>`
+
+Distribution of (ISL, OSL) pairs with probabilities for mixed workload simulation. Format: `ISL,OSL:prob;ISL,OSL:prob` (semicolons separate pairs, probabilities are percentages 0-100 that must sum to 100). Supports optional stddev: `ISL|stddev,OSL|stddev:prob`. Examples: `128,64:25;512,128:50;1024,256:25` or with variance: `256|10,128|5:40;512|20,256|10:60`. Also supports bracket `[(256,128):40,(512,256):60]` and JSON formats.
+
+### Output Sequence Length (OSL)
+
+#### `--prompt-output-tokens-mean`, `--output-tokens-mean`, `--osl` `<str>`
+
+Mean number of tokens to request in model outputs via `max_completion_tokens` field. Controls response length for synthetic and some custom datasets. If specified, included in request payload to limit generation length. When not set, model determines output length. Pass a comma-separated list (e.g. `--osl 128,256,512`) to sweep over multiple output lengths; the converter promotes the list to a sweep on datasets.main.prompts.osl.mean before AIPerfConfig validation.
+
+#### `--prompt-output-tokens-stddev`, `--output-tokens-stddev`, `--osl-stddev` `<int>`
+
+Standard deviation for output token length requests. Creates variability in `max_completion_tokens` field across requests, simulating mixed response length requirements. Lengths follow normal distribution. Only applies when `--prompt-output-tokens-mean` is set. Pass a comma-separated list (e.g. `--osl-stddev 5,25,100`) to sweep over multiple stddev values; the converter promotes the list to a sweep on datasets.main.prompts.osl.stddev. Pair with a zip-mode `--osl` sweep to model realistic output-length variance across traffic tiers.
+<br/>_Default: `0`_
+
+### Audio Input
+
+#### `--audio-batch-size`, `--batch-size-audio` `<int>`
+
+The number of audio inputs to include in each request. Supported with the `chat` endpoint type for multimodal models.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--audio-length-mean` `<float>`
+
+Mean duration in seconds for synthetically generated audio files. Audio lengths follow a normal distribution around this mean (±`--audio-length-stddev`). Used when `--audio-batch-size` > 0 for multimodal benchmarking. Generated audio is random noise with specified sample rate, bit depth, and format.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--audio-length-stddev` `<float>`
+
+Standard deviation for synthetic audio duration in seconds. Creates variability in audio lengths when > 0, simulating mixed-duration audio inputs. Durations follow normal distribution. Set to 0 for uniform audio lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--audio-format` `<str>`
+
+File format for generated audio files. Supports `wav` (uncompressed PCM, larger files) and `mp3` (compressed, smaller files). Format choice affects file size in multimodal requests but not audio characteristics (sample rate, bit depth, duration).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `wav` | _default_ | WAV format. Uncompressed audio, larger file sizes, best quality. |
+| `mp3` |  | MP3 format. Compressed audio, smaller file sizes, good quality. |
+
+#### `--audio-depths` `<list>`
+
+List of audio bit depths in bits to randomly select from when generating audio files. Each audio file is assigned a random depth from this list. Common values: `8` (low quality), `16` (CD quality), `24` (professional), `32` (high-end). Specify multiple values (e.g., `--audio-depths 16 24`) for mixed-quality testing.
+<br/>_Constraints: min: 1_
+<br/>_Default: `[16]`_
+
+#### `--audio-sample-rates` `<list>`
+
+A list of audio sample rates to randomly select from in kHz. Common sample rates are 16, 44.1, 48, 96, etc.
+<br/>_Constraints: min: 1_
+<br/>_Default: `[16.0]`_
+
+#### `--audio-num-channels` `<int>`
+
+Number of audio channels for synthetic audio generation. `1` = mono (single channel), `2` = stereo (left/right channels). Stereo doubles file size but simulates realistic audio for models supporting spatial audio processing. Most speech models use mono.
+<br/>_Constraints: ≥ 1, ≤ 2_
+<br/>_Default: `1`_
+
+### Image Input
+
+#### `--image-width-mean` `<float>`
+
+Mean width in pixels for synthetically generated images. Image widths follow a normal distribution around this mean (±`--image-width-stddev`). Combined with `--image-height-mean` to determine image dimensions and file sizes for multimodal benchmarking.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-width-stddev` `<float>`
+
+Standard deviation for synthetic image widths in pixels. Creates variability in horizontal resolution when > 0, simulating mixed-resolution image inputs. Widths follow normal distribution. Set to 0 for uniform image widths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-height-mean` `<float>`
+
+Mean height in pixels for synthetically generated images. Image heights follow a normal distribution around this mean (±`--image-height-stddev`). Used when `--image-batch-size` > 0 for multimodal vision benchmarking. Generated images are resized from source images in `assets/source_images` directory.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-height-stddev` `<float>`
+
+Standard deviation for synthetic image heights in pixels. Creates variability in vertical resolution when > 0, simulating mixed-resolution image inputs. Heights follow normal distribution. Set to 0 for uniform image heights.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--image-batch-size`, `--batch-size-image` `<int>`
+
+Number of images to include in each multimodal request. Supported with `chat` endpoint type for vision-language models. Each image is generated by randomly sampling and resizing source images from `assets/source_images` directory to specified dimensions. Set to 0 to disable image inputs. Higher batch sizes test multi-image understanding and increase request payload size.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--image-format` `<str>`
+
+Image file format for generated images. Choose `png` for lossless compression (larger files, best quality), `jpeg` for lossy compression (smaller files, good quality), or `random` to randomly select between PNG and JPEG for each image. Format affects file size in multimodal requests and encoding overhead.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `png` | _default_ | PNG format. Lossless compression, larger file sizes, best quality. |
+| `jpeg` |  | JPEG format. Lossy compression, smaller file sizes, good for photos. |
+| `random` |  | Randomly select PNG or JPEG for each image. |
+
+#### `--image-source` `<str>`
+
+Source image generation mode (default `noise`). `noise` generates random noise images on the fly at the requested dimensions — no files on disk required, and the pool is effectively unbounded so servers cannot dedupe on identical inputs. `assets` indexes images from the built-in `assets/source_images` directory (ships with a small set of 4 images) and lazily loads them at the requested dimensions. A path to a directory indexes images from the given directory (e.g. `--image-source ./source_images`). Note: random-noise images are roughly incompressible, so payload bytes are larger than equivalent natural images.
+<br/>_Default: `noise`_
+
+#### `--image-source-sampling` `<str>`
+
+How source images are selected from finite image sources selected by `--image-source assets` or `--image-source <directory>`. `random-with-replacement` draws each source image independently; repeats may occur immediately. `shuffle-cycle` draws every source image once per shuffled cycle, reshuffling after exhaustion. `sequential-cycle` walks source images in sorted load order and wraps after exhaustion. For `noise`, only `random-with-replacement` is valid because there is no finite source pool.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `random-with-replacement` | _default_ | Draw each source image independently; repeats may occur immediately. |
+| `shuffle-cycle` |  | Draw every source image once per shuffled cycle; reshuffle after exhaustion. |
+| `sequential-cycle` |  | Walk source images in sorted load order; wrap after exhaustion. |
+
+### Video Input
+
+#### `--video-batch-size`, `--batch-size-video` `<int>`
+
+Number of video files to include in each multimodal request. Supported with `chat` endpoint type for video understanding models. Each video is generated synthetically with specified duration, FPS, resolution, and codec. Set to 0 to disable video inputs. Higher batch sizes test multi-video understanding and significantly increase request payload size.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `1`_
+
+#### `--video-duration` `<float>`
+
+Duration in seconds for each synthetically generated video clip. Combined with `--video-fps`, determines total frame count (frames = duration × FPS). Longer durations increase file size and processing time. Typical values: 1-10 seconds for testing. Requires FFmpeg for video generation.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `5.0`_
+
+#### `--video-fps` `<int>`
+
+Frames per second for generated video. Higher FPS creates smoother video but increases frame count and file size. Common values: `4` (minimal motion, recommended for Cosmos models), `24` (cinematic), `30` (standard video), `60` (high frame rate). Total frames = `--video-duration` × FPS.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `4`_
+
+#### `--video-width` `<int>`
+
+Video frame width in pixels. Must be specified together with `--video-height` (both or neither). Determines video resolution and file size. Common resolutions: `640×480` (SD), `1280×720` (HD), `1920×1080` (Full HD). If not specified, uses codec/format defaults.
+<br/>_Constraints: ≥ 1_
+
+#### `--video-height` `<int>`
+
+Video frame height in pixels. Must be specified together with `--video-width` (both or neither). Combined with width determines aspect ratio and total pixel count per frame. Higher resolution increases processing demands and file size.
+<br/>_Constraints: ≥ 1_
+
+#### `--video-synth-type` `<str>`
+
+Algorithm for generating synthetic video content. Different types produce different visual patterns for testing. Options: `moving_shapes` (animated geometric shapes), `grid_clock` (grid with rotating clock hands), `noise` (random pixel frames). Content doesn't affect semantic meaning but may impact encoding efficiency and file size.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `moving_shapes` | _default_ | Generate videos with animated geometric shapes moving across the frame |
+| `grid_clock` |  | Generate videos with a grid pattern and frame number overlay for frame-accurate verification |
+| `noise` |  | Generate videos with random noise frames |
+
+#### `--video-format` `<str>`
+
+Container format for generated video files. Supports `webm` (VP9, recommended, BSD-licensed) and `mp4` (widely compatible container, VP9 by default). Format choice affects compatibility, file size, and encoding options. `mp4` is the more portable container, but note that the default VP9 video and Opus audio are less widely supported by players than H.264/AAC would be.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `mp4` |  | MP4 container. Widely compatible, good for H.264/H.265 codecs. |
+| `webm` | _default_ | WebM container. Open format, optimized for web, good for VP9 codec. |
+
+#### `--video-codec` `<str>`
+
+The video codec to use for encoding. Common options: libvpx-vp9 (CPU, BSD-licensed, default), libvpx (CPU, BSD-licensed, VP8). Any codec the local FFmpeg supports can be used, but the AIPerf container ships a minimal FFmpeg build limited to VP8/VP9 video with Vorbis/Opus audio; codecs such as libx264 or h264_nvenc require an FFmpeg build that includes them.
+<br/>_Default: `libvpx-vp9`_
+
+#### `--video-audio-sample-rate` `<float>`
+
+Audio sample rate in Hz or kHz for the embedded audio track. Common values: 8/8000 (telephony), 16/16000 (speech), 44.1/44100 (CD quality), 48/48000 (professional). Higher sample rates increase audio fidelity and file size.
+<br/>_Constraints: ≥ 8, ≤ 96000_
+<br/>_Default: `44100`_
+
+#### `--video-audio-num-channels` `<int>`
+
+Number of audio channels to embed in generated video files. 0 = disabled (no audio track, default), 1 = mono, 2 = stereo. When set to 1 or 2, a Gaussian noise audio track matching the video duration is muxed into each video via FFmpeg.
+<br/>_Constraints: ≥ 0, ≤ 2_
+<br/>_Default: `0`_
+
+#### `--video-audio-codec` `<str>`
+
+Audio codec for the embedded audio track. If not specified, auto-selects based on video format: libopus for MP4, libvorbis for WebM. Options: libvorbis, libopus, aac. The AIPerf container ships only libvorbis and libopus; aac requires an FFmpeg build that includes an AAC encoder. libopus always encodes at 48 kHz, so any --video-audio-sample-rate is resampled during muxing.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `aac` |  | AAC codec. Not built into the AIPerf container's FFmpeg; selecting it requires an FFmpeg build that includes an AAC encoder. |
+| `libvorbis` |  | Vorbis codec. Default for WebM containers. |
+| `libopus` |  | Opus codec. Default for MP4 containers. Always encodes at 48 kHz regardless of the requested sample rate. |
+
+#### `--video-audio-depth` `<str>`
+
+Audio bit depth for the embedded audio track. Supported values: 8, 16, 24, or 32 bits. Higher bit depths provide greater dynamic range but increase file size.
+<br/>_Default: `16`_
+
+### Rankings
+
+#### `--rankings-passages-mean` `<int>`
+
+Mean number of passages to include per ranking request. For `rankings` endpoint type, each request contains a query and multiple passages to rank. Passages follow normal distribution around this mean (±`--rankings-passages-stddev`). Higher values test ranking at scale but increase request payload size and processing time.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `1`_
+
+#### `--rankings-passages-stddev` `<int>`
+
+Standard deviation for number of passages per ranking request. Creates variability in ranking workload complexity. Passage counts follow normal distribution. Set to 0 for uniform passage counts across all requests.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--rankings-passages-prompt-token-mean` `<int>`
+
+Mean token length for each passage in ranking requests. Passages are synthetically generated text with lengths following normal distribution around this mean (±`--rankings-passages-prompt-token-stddev`). Longer passages increase input processing demands and request size.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `550`_
+
+#### `--rankings-passages-prompt-token-stddev` `<int>`
+
+Standard deviation for passage token lengths in ranking requests. Creates variability in passage sizes, simulating realistic heterogeneous document collections. Token lengths follow normal distribution. Set to 0 for uniform passage lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+#### `--rankings-query-prompt-token-mean` `<int>`
+
+Mean token length for query text in ranking requests. Each ranking request contains one query and multiple passages. Queries are synthetically generated with lengths following normal distribution around this mean (±`--rankings-query-prompt-token-stddev`).
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `550`_
+
+#### `--rankings-query-prompt-token-stddev` `<int>`
+
+Standard deviation for query token lengths in ranking requests. Creates variability in query complexity, simulating realistic user search patterns. Token lengths follow normal distribution. Set to 0 for uniform query lengths.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0`_
+
+### Synthesis
+
+#### `--synthesis-speedup-ratio` `<float>`
+
+Multiplier for timestamp scaling in synthesized traces.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-prefix-len-multiplier` `<float>`
+
+Multiplier for core prefix branch lengths in radix tree.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-prefix-root-multiplier` `<int>`
+
+Number of independent radix trees to distribute traces across.
+<br/>_Constraints: ≥ 1_
+<br/>_Default: `1`_
+
+#### `--synthesis-prompt-len-multiplier` `<float>`
+
+Multiplier for leaf path (unique prompt) lengths.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-output-len-multiplier` `<float>`
+
+Multiplier for output lengths in synthesized traces.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `1.0`_
+
+#### `--synthesis-max-isl` `<int>`
+
+Maximum input sequence length for filtering. Traces with input_length > max_isl are skipped.
+<br/>_Constraints: ≥ 1_
+
+#### `--synthesis-max-osl` `<int>`
+
+Maximum output sequence length cap for top-level (parent) turns. Turns with output_length > max_osl are capped to max_osl. Subagent child turns are intentionally uncapped so their decode load stays faithful; flat-chain sidecars still honor the cap.
+<br/>_Constraints: ≥ 1_
+
+### Load Generator
+
+#### `--benchmark-duration` `<str>`
+
+Maximum benchmark runtime in seconds. When set, AIPerf stops issuing new requests after this duration, Responses received within `--benchmark-grace-period` after duration ends are included in metrics. Pass a comma-separated list (e.g. `--benchmark-duration 30,60,120`) to sweep over multiple durations; the converter promotes the list to a sweep on phases.profiling.duration before AIPerfConfig validation.
+
+#### `--benchmark-grace-period` `<float>`
+
+The grace period in seconds to wait for responses after benchmark duration ends. Only applies when --benchmark-duration is set. Responses received within this period are included in metrics. Use 'inf' to wait indefinitely for all responses.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `30.0`_
+
+#### `--concurrency` `<str>`
+
+Number of concurrent requests to maintain. AIPerf issues a new request immediately when one completes, maintaining this level of in-flight requests. Can be combined with `--request-rate` to control the request rate. Pass a comma-separated list (e.g. `--concurrency 10,20,30`) to sweep over multiple concurrencies; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--prefill-concurrency` `<str>`
+
+Max concurrent requests waiting for first token (prefill phase). Limits how many requests can be in the prefill/prompt-processing stage simultaneously. Pass a comma-separated list (e.g. `--prefill-concurrency 1,2,4`) to sweep over multiple values; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--request-rate` `<str>`
+
+Target request rate in requests per second. AIPerf generates request timing according to `--request-rate-mode` to achieve this average rate. Can be combined with `--concurrency` to control the number of concurrent requests. Supports fractional rates (e.g., `0.5` = 1 request every 2 seconds). Pass a comma-separated list (e.g. `--request-rate 10,20,50`) to sweep over multiple rates; the converter promotes the list to a sweep before AIPerfConfig validation.
+
+#### `--arrival-pattern`, `--request-rate-mode` `<str>`
+
+Sets the arrival pattern for the load generated by AIPerf. Valid values: constant, poisson, gamma. `constant`: Generate requests at a fixed rate. `poisson`: Generate requests using a poisson distribution. `gamma`: Generate requests using a gamma distribution with tunable smoothness.
+<br/>_Choices: [`concurrency_burst`, `constant`, `gamma`, `poisson`]_
+<br/>_Default: `poisson`_
+
+#### `--arrival-smoothness`, `--vllm-burstiness` `<float>`
+
+Smoothness parameter for gamma distribution arrivals (--arrival-pattern gamma). Controls the shape of the arrival pattern: - 1.0: Poisson-like (exponential inter-arrivals, default) - &lt;1.0: Bursty/clustered arrivals (higher variance) - >1.0: Smooth/regular arrivals (lower variance) Compatible with vLLM's --burstiness parameter (same value = same distribution).
+<br/>_Constraints: > 0_
+
+#### `--request-count`, `--num-requests` `<str>`
+
+The maximum number of requests to send. If not set, will be automatically determined based on the timing mode and dataset size. For synthetic datasets, this will be `max(10, concurrency * 2)`. Pass a comma-separated list (e.g. `--request-count 100,500,1000`) to sweep over multiple request counts; the converter promotes the list to a sweep on phases.profiling.requests before AIPerfConfig validation.
+
+#### `--concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp session concurrency from 1 to target. Useful for gradual warm-up of the target system.
+<br/>_Constraints: > 0_
+
+#### `--prefill-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp prefill concurrency from 1 to target.
+<br/>_Constraints: > 0_
+
+#### `--request-rate-ramp-duration` `<float>`
+
+Duration in seconds to ramp request rate from a proportional minimum to target. Start rate is calculated as target * (update_interval / duration), ensuring correct behavior for target rates below 1 QPS. Useful for gradual warm-up of the target system.
+<br/>_Constraints: > 0_
+
+#### `--request-rate-series` `<str>`
+
+JSON file containing request-rate points for piecewise-linear request-rate control.
+
+#### `--failed-request-threshold` `<float>`
+
+Abort the run early when (failed_records / total_records) exceeds this ratio. Default None disables the check. Only PROFILING-phase records count toward the ratio. A grace floor of max(concurrency, 10) records must accumulate before the check is armed, so a single early failure cannot kill the run. When the threshold is exceeded a ProfileCancelCommand is broadcast: in-flight requests drain via the normal cancel path, partial results are still aggregated, and the run exits non-zero. Pairs with the AGENTIC_REPLAY context-overflow drop in record_processor_service so the rate measures real failures only.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+
+#### `--trajectory-start-min-ratio` `<float>`
+
+AGENTIC_REPLAY only: lower bound (inclusive) on the random start position within each trajectory, expressed as a fraction of the trace's total turn count. Sampled per trajectory at trajectory-build time; deterministic given --random-seed.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+<br/>_Default: `0.25`_
+
+#### `--trajectory-start-max-ratio` `<float>`
+
+AGENTIC_REPLAY only: upper bound (inclusive) on the random start position within each trajectory, expressed as a fraction of the trace's total turn count. The effective per-trace ceiling is min(int(max_ratio * n), n - 2) so at least one profile turn remains after warmup.
+<br/>_Constraints: ≥ 0.0, ≤ 1.0_
+<br/>_Default: `0.75`_
+
+#### `--burst-phase-starts`
+
+AGENTIC_REPLAY only: collapse the WARMUP-start and PROFILING-start dispatches into synchronized bursts instead of spreading them by each request's recorded offset from t*. By default (False) the phase starts are SPREAD: WARMUP requests are aligned globally so every trajectory reaches its t* at the same instant (the warmup end), and each lane's first PROFILING request waits out its recorded gap after t* -- reproducing the recorded arrival pattern at both phase boundaries. The rest of the replay (inter-turn delays) is timing-faithful regardless of this flag; it governs ONLY the burst-vs-spread of the two phase starts. Pass --burst-phase-starts to fire each phase's first requests together (faster concurrency ramp, synchronized start), e.g. for a throughput-oriented run rather than a faithful arrival replay.
+<br/>_Flag (no value required)_
+
+#### `--trace-idle-gap-cap-seconds` `<float>`
+
+Hard ceiling (seconds) for idle gaps within each individual trace. For Weka trace replay, AIPerf looks at all parent and subagent request submission timestamps within one root trace, compresses long gaps between consecutive request submissions, and derives turn delays from the compressed per-trace timeline. Original request api_time values are not used to decide these idle gaps. When set for Weka, this takes precedence over `--inter-turn-delay-cap-seconds` so individual parent/subagent-line delays are not separately capped. Defaults to None (no per-trace idle-gap compression).
+<br/>_Constraints: ≥ 0.0_
+
+#### `--system-idle-gap-cap-seconds` `<float>`
+
+AGENTIC_REPLAY only: maximum time in seconds the replay may remain globally idle while future requests are scheduled. When no requests are in flight or ready, all pending request timers shift earlier uniformly so the next request arrives within this limit. Per-trace timing is otherwise preserved. None disables the cap.
+<br/>_Constraints: ≥ 0.0_
+
+### Scenario
+
+#### `--scenario` `<str>`
+
+Lock all benchmark invariants for a named scenario (e.g. 'inferencex-agentx-mvp'). Conflicts with the locked invariants raise ScenarioLockError at startup unless --unsafe-override is also passed. Distinct from the sweep ``scenarios`` strategy (hand-picked named runs).
+
+#### `--unsafe-override`
+
+Convert scenario lock errors to warnings; stamps submission_valid=false in the aggregate output. No-op without --scenario.
+<br/>_Flag (no value required)_
+
+### Warmup
+
+#### `--warmup-request-count`, `--num-warmup-requests` `<int>`
+
+The maximum number of warmup requests to send before benchmarking. If not set and no --warmup-duration is set, then no warmup phase will be used.
+<br/>_Constraints: > 0_
+
+#### `--warmup-duration` `<float>`
+
+The maximum duration in seconds for the warmup phase. If not set, it will use the `--warmup-request-count` value. If neither are set, no warmup phase will be used.
+<br/>_Constraints: > 0_
+
+#### `--agentic-cache-warmup-duration` `<float>`
+
+Additional agentic replay warmup duration in seconds. After the normal snapshot warmup drains, AIPerf continues the live trajectories without recorded idle delays and with one-token outputs, then drains and resumes profiling from the resulting trajectory state using each live stream's residual next-turn delay.
+<br/>_Constraints: > 0_
+
+#### `--agentic-warmup-grace-period` `<float>`
+
+AGENTIC_REPLAY only: grace period in seconds the auto-synthesized warmup barrier waits for in-flight priming requests after the warmup burst sends. The agentic warmup is synthesized from the profiling phase rather than a user-declared warmup phase, so it does NOT honor `--warmup-grace-period` (which requires `--warmup-duration`). If not set, the warmup barrier waits indefinitely until every primed trajectory returns.
+<br/>_Constraints: ≥ 0_
+
+#### `--num-warmup-sessions` `<int>`
+
+The number of sessions to use for the warmup phase. If not set, it will use the `--warmup-request-count` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-concurrency` `<int>`
+
+The concurrency value to use for the warmup phase. If not set, it will use the `--concurrency` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-prefill-concurrency` `<int>`
+
+The prefill concurrency value to use for the warmup phase. If not set, it will use the `--prefill-concurrency` value.
+<br/>_Constraints: ≥ 1_
+
+#### `--warmup-request-rate` `<float>`
+
+The request rate to use for the warmup phase. If not set, it will use the `--request-rate` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-arrival-pattern` `<str>`
+
+The arrival pattern to use for the warmup phase. If not set, it will use the `--arrival-pattern` value. Valid values: constant, poisson, gamma.
+
+#### `--warmup-grace-period` `<float>`
+
+The grace period in seconds to wait for responses after warmup phase ends. Only applies when warmup is enabled. Responses received within this period are included in warmup completion. If not set, waits indefinitely for all warmup responses.
+<br/>_Constraints: ≥ 0_
+
+#### `--warmup-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup session concurrency from 1 to target. If not set, uses `--concurrency-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-prefill-concurrency-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup prefill concurrency from 1 to target. If not set, uses `--prefill-concurrency-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+#### `--warmup-request-rate-ramp-duration` `<float>`
+
+Duration in seconds to ramp warmup request rate from a proportional minimum to target. Start rate is calculated as target * (update_interval / duration). If not set, uses `--request-rate-ramp-duration` value.
+<br/>_Constraints: > 0_
+
+### User-Centric Rate
+
+#### `--user-centric-rate` `<float>`
+
+Enable user-centric rate limiting mode with the specified request rate (QPS). Each user has a gap = num_users / qps between turns. Users block on their previous turn (no interleaving within a user). New users are spawned on a fixed schedule to maintain steady-state throughput. Designed for KV cache benchmarking with realistic multi-user patterns. Requires --num-users to be set.
+<br/>_Constraints: > 0_
+
+#### `--num-users` `<str>`
+
+The number of initial users to use for --user-centric-rate mode. Pass a comma-separated list (e.g. `--num-users 4,8,16`) to sweep over user counts; the converter promotes the list to a sweep on phases.profiling.users before AIPerfConfig validation.
+
+### Request Cancellation
+
+#### `--request-cancellation-rate` `<float>`
+
+Percentage (0-100) of requests to cancel for testing cancellation handling. Cancelled requests are sent normally but aborted after `--request-cancellation-delay` seconds. Useful for testing graceful degradation and resource cleanup.
+<br/>_Constraints: > 0.0, ≤ 100.0_
+
+#### `--request-cancellation-delay` `<float>`
+
+Seconds to wait after the request is fully sent before cancelling. A delay of 0 means 'send the full request, then immediately disconnect'. Requires --request-cancellation-rate to be set.
+<br/>_Constraints: ≥ 0.0_
+<br/>_Default: `0.0`_
+
+### Output
+
+#### `--output-artifact-dir`, `--artifact-dir` `<str>`
+
+Output directory for all benchmark artifacts including metrics (`.csv`, `.json`, `.jsonl`), raw data (`_raw.jsonl`), GPU telemetry (`_gpu_telemetry.jsonl`), and time-sliced metrics (`_timeslices.csv/json`). Directory created if it doesn't exist. All output file paths are constructed relative to this directory.
+<br/>_Default: `artifacts`_
+
+#### `--profile-export-prefix`, `--profile-export-file` `<str>`
+
+Base filename for ALL exported files. With prefix='foo' every output becomes `foo.csv`, `foo.json`, `foo_timeslices.{csv,json}`, `foo.jsonl`, `foo_raw.jsonl`, `foo_gpu_telemetry.jsonl`, and `foo_server_metrics.{jsonl,json,csv,parquet}`. When unset (the default), historical per-file names are used: `profile_export_aiperf.{csv,json}` for the summary, `profile_export.jsonl` and `profile_export_raw.jsonl` for records, `gpu_telemetry_export.jsonl`, and `server_metrics_export.*`. Known suffixes (e.g. `_raw.jsonl`, `_timeslices.csv`, `_server_metrics.parquet`) are stripped from the supplied value.
+
+#### `--export-level`, `--profile-export-level` `<str>`
+
+Controls which output files are generated. `summary`: Only aggregate metrics files (`.csv`, `.json`). `records`: Includes per-request metrics (`.jsonl`). `raw`: Includes raw request/response data (`_raw.jsonl`).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `summary` |  | Export only aggregated/summarized metrics (most compact) |
+| `records` | _default_ | Export per-record metrics after aggregation with display unit conversion (CLI default) |
+| `raw` |  | Export raw parsed records with full request/response data (most detailed) |
+
+#### `--slice-duration` `<float>`
+
+Duration in seconds for time-sliced metric analysis. When set, AIPerf divides the benchmark timeline into fixed-length windows and computes metrics separately for each window. This enables analysis of performance trends and variations over time (e.g., warmup effects, degradation under sustained load).
+<br/>_Constraints: > 0_
+
+#### `--auto-plot`, `--no-auto-plot`
+
+Auto-invoke `aiperf plot` against the artifact directory after the benchmark completes. None = defer to recipe default (False if no recipe). True/False = explicit override. Failures are logged but do not fail the command unless --plot-required is set.
+
+#### `--plot-required`
+
+Treat auto-plot failures as fatal: re-raise so `aiperf profile` exits non-zero. Only meaningful when auto-plot is on. Default False = warn and continue.
+<br/>_Flag (no value required)_
+
+#### `--export-outputs-json`
+
+Export generated response text to outputs.json after the run. When enabled, the raw generated-text payload for each request is written to an outputs.json file in the artifact directory.
+<br/>_Flag (no value required)_
+
+#### `--otel-url` `<str>`
+
+OTLP/HTTP metrics endpoint URL.
+
+#### `--stream` `<list>`
+
+Select which AIPerf telemetry domains to stream over OTel. Valid values: 'metrics', 'timing', or 'default'. 'default' streams both metrics and timing. Examples: --stream metrics | --stream timing | --stream metrics timing.
+
+#### `--otel-resource-attributes` `<list>`
+
+Custom OTel resource attributes as key=value pairs. Merged into the default resource attributes on every exported metric.
+
+#### `--gen-ai-provider` `<str>`
+
+GenAI semantic convention provider override.
+
+#### `--mlflow-tracking-uri` `<str>`
+
+MLflow tracking URI.
+
+#### `--mlflow-experiment` `<str>`
+
+MLflow experiment name.
+
+#### `--mlflow-run-name` `<str>`
+
+MLflow run name.
+
+#### `--mlflow-tag` `<list>`
+
+Additional MLflow run tags to attach on upload. Specify as key:value pairs (e.g., --mlflow-tag team:perf) or as JSON string.
+
+#### `--mlflow-parent-run-id` `<str>`
+
+Optional MLflow parent run ID.
+
+#### `--mlflow-artifact-glob` `<list>`
+
+Artifact glob overrides for MLflow upload. Can be specified multiple times or as a comma-separated list.
+
+#### `--wandb-project` `<str>`
+
+Weights & Biases project name. Setting this enables wandb export.
+
+#### `--wandb-entity` `<str>`
+
+Weights & Biases entity (team or user). Defaults to the API key's default entity.
+
+#### `--wandb-run-name` `<str>`
+
+Weights & Biases run name.
+
+#### `--wandb-tag` `<list>`
+
+Additional Weights & Biases run tags to attach on upload. Can be specified multiple times or as a comma-separated list.
+
+### HTTP Trace
+
+#### `--export-http-trace`
+
+Include HTTP trace data (timestamps, chunks, headers, socket info) in profile_export.jsonl. Computed metrics (http_req_duration, http_req_waiting, etc.) are always included regardless of this setting. See the HTTP Trace Metrics guide for details on trace data fields.
+<br/>_Flag (no value required)_
+
+#### `--show-trace-timing`
+
+Display HTTP trace timing metrics in the console at the end of the benchmark. Shows detailed timing breakdown: blocked, DNS, connecting, sending, waiting (TTFB), receiving, and total duration following k6 naming conventions.
+<br/>_Flag (no value required)_
+
+### Server Metrics
+
+#### `--server-metrics` `<list>`
+
+Server metrics collection (ENABLED BY DEFAULT). Automatically collects from inference endpoint base_url + `/metrics`. Optionally specify additional custom Prometheus-compatible endpoint URLs (e.g., http://node1:8081/metrics, http://node2:9090/metrics). Use `--no-server-metrics` to disable collection. Example: `--server-metrics node1:8081 node2:9090/metrics` for additional endpoints.
+
+#### `--no-server-metrics`
+
+Disable server metrics collection entirely.
+
+#### `--server-metrics-formats` `<list>`
+
+Specify which output formats to generate for server metrics. Multiple formats can be specified (e.g., `--server-metrics-formats json csv parquet`).
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `json` | _default_ | Export aggregated statistics in JSON hybrid format with metrics keyed by name. Best for: Programmatic access, CI/CD pipelines, automated analysis. |
+| `csv` | _default_ | Export aggregated statistics in CSV tabular format organized by metric type. Best for: Spreadsheet analysis, Excel/Google Sheets, pandas DataFrames. |
+| `jsonl` |  | Export raw time-series records in line-delimited JSON format. Best for: Time-series analysis, debugging, visualizing metric evolution. Warning: Can generate very large files for long-running benchmarks. |
+| `parquet` |  | Export raw time-series data with delta calculations in Parquet columnar format. Best for: Analytics with DuckDB/pandas/Polars, efficient storage, SQL queries. Includes cumulative deltas from reference point for counters and histograms. |
+
+### Network Latency
+
+#### `--network-latency-automatic`
+
+Automatically measure network latency (DISABLED BY DEFAULT). Opens a fresh TCP connection to the endpoint throughout the run, measures the handshake RTT, and subtracts the mean from request-start-anchored latency metrics (request_latency, time_to_first_token, time_to_first_output_token). Raw metrics are preserved; adjusted values are emitted as separate network_adjusted_* metrics plus a network_rtt summary. Mutually exclusive with --network-latency-mean.
+<br/>_Flag (no value required)_
+
+#### `--network-latency-mean` `<float>`
+
+Set a fixed mean network RTT in milliseconds to subtract, bypassing active probing. Implicitly enables network latency adjustment. Mutually exclusive with --network-latency-automatic.
+<br/>_Constraints: ≥ 0.0_
+
+#### `--network-latency-ping-interval` `<float>`
+
+Seconds between TCP-handshake RTT probes during profiling (default: 1.0s). Only applies with --network-latency-automatic.
+<br/>_Constraints: > 0.0_
+
+### GPU Telemetry
+
+#### `--gpu-telemetry` `<list>`
+
+Enable GPU telemetry console display and optionally specify: (1) 'pynvml' or 'amdsmi' to use a local GPU library instead of DCGM HTTP endpoints, (2) 'dashboard' for realtime dashboard mode, (3) custom DCGM exporter URLs (e.g., http://node1:9401/metrics), (4) custom metrics CSV file (e.g., custom_gpu_metrics.csv). Default: DCGM mode with localhost:9400 and localhost:9401 endpoints. Examples: --gpu-telemetry pynvml | --gpu-telemetry amdsmi | --gpu-telemetry dashboard node1:9400.
+
+#### `--no-gpu-telemetry`
+
+Disable GPU telemetry collection entirely.
+
+### UI
+
+#### `--ui-type`, `--ui` `<str>`
+
+Select the user interface type for displaying benchmark progress. `dashboard` shows real-time metrics in a Textual TUI, `simple` uses TQDM progress bars, `none` disables UI completely. Defaults to `dashboard` in interactive terminals, `none` when not a TTY (e.g., piped or redirected output). Automatically set to `simple` when using `--verbose` or `--extra-verbose` in a TTY.
+<br/>_Choices: [`dashboard`, `none`, `simple`]_
+<br/>_Default: `dashboard`_
+
+### Multi-Run
+
+#### `--num-profile-runs` `<int>`
+
+Number of profile runs to execute for confidence reporting. Must be between 1 and 10. When set to 1 (default), runs a single benchmark. When set to >1, runs multiple benchmarks and computes aggregate statistics (mean, std, confidence intervals, coefficient of variation) across runs. Useful for quantifying variance and establishing confidence in results.
+<br/>_Constraints: ≥ 1, ≤ 10_
+<br/>_Default: `1`_
+
+#### `--profile-run-cooldown-seconds` `<float>`
+
+Cooldown duration in seconds between profile runs. Only applies when --num-profile-runs > 1. Allows the system to stabilize between runs (e.g., clear caches, cool down GPUs). Default is 0 (no cooldown).
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--confidence-level` `<float>`
+
+Confidence level for computing confidence intervals (0-1). Only applies when --num-profile-runs > 1. Common values: 0.90 (90%), 0.95 (95%, default), 0.99 (99%). Higher values produce wider confidence intervals.
+<br/>_Constraints: > 0, &lt; 1_
+<br/>_Default: `0.95`_
+
+#### `--profile-run-disable-warmup-after-first`, `--no-profile-run-disable-warmup-after-first`
+
+Disable warmup for profile runs after the first. Only applies when --num-profile-runs > 1. When True (default), only the first run includes warmup, subsequent runs measure steady-state performance for more accurate aggregate statistics. When False, all runs include warmup (useful for long cooldown periods or when testing cold-start performance).
+<br/>_Default: `True`_
+
+#### `--set-consistent-seed`, `--no-set-consistent-seed`
+
+Automatically set random seed for consistent workloads across runs. Only applies when --num-profile-runs > 1. When True (default), automatically sets --random-seed=42 if not specified, ensuring identical workloads across all runs for valid statistical comparison. When False, preserves None seed, resulting in different workloads per run (not recommended for confidence reporting as it produces invalid statistics). If --random-seed is explicitly set, that value is always used regardless of this setting.
+<br/>_Default: `True`_
+
+#### `--vary-seed-per-trial`, `--no-vary-seed-per-trial`
+
+When True, derive a distinct seed for each trial of a variation via SHA-256 over (envelope_seed, variation.label, trial). When False (default), all trials of a variation share the same seed, giving pure-runtime variance for confidence intervals. Enable when you want trials to also sample different inputs (captures end-to-end variance at the cost of conflating input noise with runtime noise in the resulting confidence statistics).
+
+#### `--convergence-metric` `<str>`
+
+Target metric name for adaptive convergence stopping. When set with --num-profile-runs > 1, enables adaptive mode that stops early once the metric stabilizes according to --convergence-mode. Uses --num-profile-runs as the maximum run cap. Example metrics: time_to_first_token, request_latency, inter_token_latency.
+
+#### `--convergence-stat` `<str>`
+
+Statistic to evaluate for convergence when using ci_width or cv mode. Common values: avg, p50, p90, p95, p99. Only applies when --convergence-metric is set.
+<br/>_Choices: [`avg`, `p50`, `p90`, `p95`, `p99`, `min`, `max`]_
+<br/>_Default: `avg`_
+
+#### `--convergence-threshold` `<float>`
+
+Threshold for convergence detection. For ci_width mode: maximum CI width as a fraction of the mean. For cv mode: maximum coefficient of variation. For distribution mode: KS test p-value threshold. When unset, each mode uses its own algorithm-specific default. Only applies when --convergence-metric is set.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--convergence-mode` `<str>`
+
+Statistical method for convergence detection. ci_width: Stop when Student's t confidence interval width relative to mean is below threshold. cv: Stop when coefficient of variation (std/mean) is below threshold. distribution: Stop when KS test p-value indicates latest run matches prior runs (requires --export-level records or --export-level raw; rejected with --export-level summary). Only applies when --convergence-metric is set.
+<br/>_Choices: [`ci_width`, `cv`, `distribution`]_
+<br/>_Default: `ci_width`_
+
+#### `--parameter-sweep-cooldown-seconds` `<float>`
+
+Cooldown seconds between sweep variations (e.g. between --concurrency 10 and --concurrency 20). Honored by MultiRunOrchestrator when iterating plan.configs. Default 0.
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `0.0`_
+
+#### `--parameter-sweep-same-seed`, `--no-parameter-sweep-same-seed`
+
+If true, every sweep variation reuses the same random seed (correlated comparisons). If false (default), each variation derives a unique seed `base_seed + variation.index` so independent draws exercise different inputs. Requires --random-seed when true.
+
+#### `--parameter-sweep-mode` `<str>`
+
+Execution order for sweep + multi-trial composition. 'repeated' (default) iterates trials as the outer loop and variations as the inner loop, so all variations run within trial 1, then within trial 2, etc. 'independent' inverts the loops: all trials at one variation complete before the next variation starts. Both modes produce the same total runs, only the artifact-path layout and submit order differ.
+<br/>_Choices: [`independent`, `repeated`]_
+<br/>_Default: `repeated`_
+
+#### `--sweep-type` `<str>`
+
+Topology used when multiple CLI magic-list flags (--concurrency, --request-rate, --isl, --osl, ...) are passed together. 'grid' (default) takes the Cartesian product of all lists; 'zip' pairs them element-wise (all lists must have equal length, like the YAML `sweep: {type: zip}` block). Ignored when only one magic-list flag is set or when the sweep is declared in YAML.
+<br/>_Default: `grid`_
+
+#### `--no-sweep-table`
+
+Suppress the per-cell streaming sweep table during multi-variation sweeps. Auto-suppressed when stdout is non-interactive, when the dashboard UI is active, or for single-cell sweeps.
+
+#### `--search-space` `<list>`
+
+Adaptive-search space dimensions. Repeatable. Each value is 'path:lo,hi[:kind]', e.g. 'phases.profiling.concurrency:1,1000:int'. Mutually exclusive with magic-list flags (--concurrency 10,20,30) and with explicit sweep blocks. See docs/sweeping/bayesian-optimization.md.
+
+#### `--search-metric` `<str>`
+
+Metric tag to optimize, e.g. 'output_token_throughput'. Required when --search-space is set. Must match a key in RunResult.summary_metrics produced by the run (NOT the flattened '_avg' / '_p99' aggregator-suffixed key).
+
+#### `--search-stat` `<str>`
+
+Statistic on the metric: avg / p50 / p90 / p95 / p99. Defaults to 'avg' when omitted (set by the CLIConfig -> AIPerfConfig converter).
+
+#### `--search-direction` `<str>`
+
+Optimization direction. Required when --search-space is set.
+
+#### `--search-max-iterations` `<int>`
+
+Maximum number of search iterations. Each iteration runs --num-profile-runs benchmarks. Required when --search-space is set.
+<br/>_Constraints: ≥ 2, ≤ 200_
+
+#### `--search-initial-points` `<int>`
+
+Random Sobol points before fitting the GP. Defaults to 5 when omitted. Must be &lt; --search-max-iterations.
+<br/>_Constraints: ≥ 1_
+
+#### `--search-random-seed` `<int>`
+
+Random seed for reproducible search trajectories. When unset, the planner uses non-deterministic randomness.
+<br/>_Constraints: ≥ 0_
+
+#### `--search-planner` `<str>`
+
+Outer-loop search planner plugin. Default `bayesian` is a curated Optuna preset that uses BoTorch qLogNEI/qLogNEHVI when the optional `botorch` extra is installed and otherwise falls back to Optuna TPE with a warning. `optuna` is the expert-mode alternative exposing `--optuna-sampler` (tpe / gp / botorch) and `--optuna-acquisition`. Explicit unavailable optional samplers raise. Third-party planners registered under the `search_planner` plugin category are accepted here. Only applies when --search-space is set.
+<br/>_Choices: [`bayesian`, `monotonic_sla`, `smooth_isotonic`, `optuna`]_
+
+#### `--optuna-sampler` `<str>`
+
+Optuna sampler selection. Only consulted when --search-planner=optuna. ``botorch`` is the preferred implicit default and requires the optional ``botorch`` extra; when the implicit default is unavailable, the planner warns and falls back to ``tpe``. Explicit ``botorch`` requests raise if the optional stack is unavailable. ``tpe`` is dep-light and ships with Optuna core. ``gp`` is Optuna's native GP-EI with inequality constraints (Optuna 4.2+) but requires ``torch``.
+
+#### `--optuna-acquisition` `<str>`
+
+Acquisition function override for the Optuna BoTorch sampler. Only consulted when --search-planner=optuna AND --optuna-sampler=botorch; rejected otherwise. ``None`` (default) lets Optuna pick (single-objective unconstrained -> LogEI per Optuna v4.x). ``logei``/``qlogei`` make that explicit. ``qnei`` selects plain noisy EI (Letham 2017). ``qlognei`` selects qLogNoisyExpectedImprovement (Ament 2023, https://arxiv.org/abs/2310.20708) -- BoTorch's strongly recommended modern noisy-EI default; requires ``botorch>=0.10``. Multi-objective variants (``qehvi``/``qnehvi``/``qlognehvi``) are accepted when ``objectives`` has length > 1; the planner rejects them on single-objective configs.
+
+#### `--optuna-terminator` `<str>`
+
+Optional posterior-regret stopping rule layered on top of the three-signal convergence check. Only consulted when --search-planner=optuna. ``regret`` selects Optuna's ``RegretBoundEvaluator`` (Makarova et al. 2022, https://proceedings.mlr.press/v188/makarova22a.html). ``emmr`` selects ``EMMREvaluator`` (Ishibashi et al. 2023, https://proceedings.mlr.press/v206/ishibashi23a.html). Both are in the same family as Wilson 2024's PRB stopping rule and ship in Optuna core (no extra dep). ``none`` (default) disables; convergence is then driven by --search-max-iterations / --improvement-patience / --plateau-cv only.
+
+#### `--search-percentile-pooling` `<str>`
+
+Percentile aggregation strategy when --search-stat is a percentile (p50/p90/p95/p99). ``mean`` (default) computes the BO objective as the arithmetic mean of per-trial percentiles across --num-profile-runs trials. ``pooled`` walks each trial's per-request profile_export.jsonl, accumulates raw samples, and computes ``np.percentile`` over the pooled bag -- exposing more tail mass than mean-of-percentiles (correct for SLO claims; same argmax for ranking on monotone problems). ``pooled`` requires --export-level records; if the JSONL is missing the planner falls back to mean with a one-time warning. Rejected when --search-stat is ``avg``.
+
+#### `--bo-constraint-mode` `<str>`
+
+Deprecated and ignored. The bayesian preset and the optuna expert mode both use Optuna's native ``constraints_func`` (Letham et al. 2019, arXiv:1706.07094), which subsumes both the soft-penalty and EIC formulations. Accepted for backwards compatibility but has no effect: the value flows through ``_converter_optionals._SWEEP_OPTIONAL_FIELDS`` to ``AdaptiveSearchSweep.constraint_mode`` (see ``aiperf.config.sweep.config``), and that field is not read by any planner.
+
+#### `--variant`, `--sweep-variant` `<list>`
+
+Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
+
+#### `--search-sla` `<list>`
+
+SLA filter to attach to the adaptive-search or grid path. Format: 'metric_tag:stat:op:threshold'. Stat in {avg, min, max, p1, p5, p10, p25, p50, p75, p90, p95, p99}; op in {lt, le, gt, ge}; threshold is a float in the metric's native unit. For request_error_rate, 1 means 1% (percentage points), unlike --error-rate-sla, which accepts a fraction. Repeatable. Example: --search-sla 'time_to_first_token:p95:lt:200' --search-sla 'request_error_rate:avg:lt:1'. Composes with recipe-named SLA flags (--ttft-sla-ms etc.); the final filter list is recipe filters first, then --search-sla filters in CLI order.
+
+#### `--search-sla-tier` `<list>`
+
+Multi-tier SLO grouping flag. Each invocation defines one tier of SLA filters. Format: 'LABEL:FILTER[,FILTER...]' or 'FILTER[,FILTER...]' (auto-labels tier_1, tier_2, ...). Requires 2-10 invocations. Example: --search-sla-tier 'fast:output_token_throughput:avg:gt:300,time_to_first_token:p95:lt:5000' --search-sla-tier 'standard:output_token_throughput:avg:gt:100,time_to_first_token:p95:lt:10000'. When used, all --search-sla filters are still parsed and compose with tier definitions.
+
+#### `--search-recipe` `<str>`
+
+Named search-recipe preset that expands to an adaptive-search or sweep block. Mutually exclusive with explicit --search-* flags. Recipes are registered under the search_recipe plugin category. Example: --search-recipe max-throughput-ttft-sla --ttft-sla-ms 200.
+
+#### `--ttft-sla-ms` `<float>`
+
+Time-to-first-token SLA threshold in milliseconds. Required by TTFT-SLA recipes (e.g. max-throughput-ttft-sla); ignored otherwise. Must be > 0 — a 0 or negative threshold yields an unsatisfiable filter.
+<br/>_Constraints: > 0_
+
+#### `--isl-osl-pairs` `<str>`
+
+Paired ISL/OSL workload shapes for the pareto-sweep recipe, e.g. '128/128,512/256,2048/512'. Each pair is '&lt;isl>/&lt;osl>' with positive ints; pairs are comma-separated and whitespace-tolerant. Recipe-only flag; ignored unless --search-recipe pareto-sweep is set.
+
+#### `--itl-sla-ms` `<float>`
+
+Inter-token-latency SLA threshold in milliseconds. Required by ITL-SLA recipes (e.g. max-throughput-itl-sla); ignored otherwise. Must be > 0 — a 0 or negative threshold yields an unsatisfiable filter.
+<br/>_Constraints: > 0_
+
+#### `--tpot-sla-ms` `<float>`
+
+Time-per-output-token SLA threshold in milliseconds. Maps to the `inter_token_latency` metric tag (TPOT and ITL are equivalent in this codebase). Consumed by the max-concurrency-under-sla and max-goodput-under-slo recipes; ignored otherwise. Streaming required.
+<br/>_Constraints: > 0_
+
+#### `--e2e-sla-ms` `<float>`
+
+End-to-end request-latency SLA threshold in milliseconds (p99). Maps to the `request_latency` metric tag. Consumed by the max-concurrency-under-sla and max-goodput-under-slo recipes; ignored otherwise. Available without streaming.
+<br/>_Constraints: > 0_
+
+#### `--error-rate-sla` `<float>`
+
+Maximum acceptable request error rate as a fraction in (0, 1) (e.g. 0.05 = 5%). Maps to the `request_error_rate` metric tag (avg), converting the fraction to the metric's percentage-point scale. Consumed by the max-concurrency-under-sla recipe; ignored otherwise. Available without streaming.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--slo-attainment-fraction` `<float>`
+
+Minimum fraction of requests that must satisfy ALL configured per-request SLOs (TTFT/TPOT/E2E) for a configuration to be considered feasible by the goodput recipe. Bounded in (0, 1]. Default 0.95 matches DistServe's canonical attainment-fraction convention (https://arxiv.org/pdf/2401.09670). Consumed by the max-goodput-under-slo recipe; ignored otherwise.
+<br/>_Constraints: > 0, ≤ 1_
+
+#### `--search-style` `<str>`
+
+Search strategy for the max-concurrency-under-sla recipe. 'smooth_isotonic' (default) runs PAVA + PCHIP smooth-isotonic regression-based 1D SLA-saturation search. 'monotonic' runs a 1D binary-search via the MonotonicSLASearchPlanner (~10-20 iterations). 'bo' runs penalty Bayesian Optimization (~30 iterations). 'optuna' runs the same penalty-BO formulation via the OptunaSearchPlanner (TPE/GP/BoTorch samplers; BoTorch requires the optional botorch extra). 'grid' runs a log-spaced 8-step sweep + sla_breach_knee post-process. Recipe-only flag; ignored unless --search-recipe max-concurrency-under-sla is set.
+
+#### `--degradation-threshold` `<float>`
+
+Relative latency degradation threshold for the concurrency-ramp recipe (e.g. 0.20 = 20%). The recipe's post-process handler reports the first concurrency where p99 latency exceeds baseline * (1 + threshold). Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+<br/>_Constraints: > 0, &lt; 1_
+
+#### `--degradation-metric-tag` `<str>`
+
+ConcurrencyRamp post-process: metric tag for knee detection (default: request_latency). Use, e.g., 'time_to_first_token' to detect the knee on TTFT instead of end-to-end request latency. Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+
+#### `--degradation-stat` `<str>`
+
+ConcurrencyRamp post-process: statistic for knee detection (default: p99). Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
+
+#### `--isl-min` `<int>`
+
+Minimum input-sequence-length for the prefill-ttft-curve recipe (default 256 when omitted). The recipe sweeps ISL on a log scale from --isl-min to --isl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--isl-max` `<int>`
+
+Maximum input-sequence-length for the prefill-ttft-curve recipe (default 32768 when omitted). The recipe sweeps ISL on a log scale from --isl-min to --isl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--isl-steps` `<int>`
+
+Number of log-spaced steps for the prefill-ttft-curve recipe's ISL grid (default 8 when omitted). Must be >= 2 — a single-point ramp degenerates and post-process can't compute a baseline. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+#### `--concurrency-min` `<int>`
+
+Lower bound for the concurrency sweep axis used by concurrency-ramp and decode-itl-curve recipes (defaults: 1 for concurrency-ramp, 1 for decode-itl-curve). Must be &lt; --concurrency-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--concurrency-max` `<int>`
+
+Upper bound for the concurrency sweep axis used by concurrency-ramp and decode-itl-curve recipes (defaults: 1000 for concurrency-ramp, 200 for decode-itl-curve). Must be > --concurrency-min. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--concurrency-steps` `<int>`
+
+Number of log-spaced steps for the concurrency sweep axis used by concurrency-ramp (default 8) and decode-itl-curve (default 6). Must be >= 2. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+#### `--osl-min` `<int>`
+
+Minimum output-sequence-length for the decode-itl-curve recipe's OSL grid (default 64 when omitted). The recipe sweeps OSL on a log scale from --osl-min to --osl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--osl-max` `<int>`
+
+Maximum output-sequence-length for the decode-itl-curve recipe's OSL grid (default 1024 when omitted). The recipe sweeps OSL on a log scale from --osl-min to --osl-max. Recipe-only flag.
+<br/>_Constraints: ≥ 1_
+
+#### `--osl-steps` `<int>`
+
+Number of log-spaced steps for the decode-itl-curve recipe's OSL grid (default 4 when omitted). Must be >= 2. Recipe-only flag.
+<br/>_Constraints: ≥ 2_
+
+### Accuracy
+
+#### `--accuracy-benchmark` `<str>`
+
+Accuracy benchmark to run (e.g., mmlu, aime, hellaswag). When set, enables accuracy benchmarking mode alongside performance profiling.
+<br/>_Choices: [`mmlu`, `mmlu_pro`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
+
+#### `--accuracy-tasks` `<list>`
+
+Specific tasks or subtasks within the benchmark to evaluate (e.g., specific MMLU subjects). Accepts comma-separated values (e.g. abstract_algebra,anatomy) or repeated flags. If not set, all tasks are included.
+
+#### `--accuracy-n-shots` `<int>`
+
+Number of few-shot examples to include in the prompt. 0 means zero-shot evaluation, None uses the benchmark default (e.g. MMLU=5). Maximum 32.
+<br/>_Constraints: ≥ 0, ≤ 32_
+
+#### `--accuracy-enable-cot`, `--accuracy-no-enable-cot`
+
+Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instructions to the prompt. Defaults to the benchmark's ``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).
+<br/>_Flag (no value required)_
+
+#### `--accuracy-grader` `<str>`
+
+Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
+<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`, `mmlu_pro`]_
+
+#### `--accuracy-system-prompt` `<str>`
+
+Custom system prompt to use for accuracy evaluation. Overrides any benchmark-specific system prompt.
+
+#### `--accuracy-verbose`
+
+Enable verbose output for accuracy evaluation, showing per-problem grading details.
+<br/>_Flag (no value required)_
+
+### Service
+
+#### `--log-level` `<str>`
+
+Set the logging verbosity level. Controls the amount of output displayed during benchmark execution. Use `TRACE` for debugging ZMQ messages, `DEBUG` for detailed operation logs, or `INFO` (default) for standard progress updates.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `TRACE` |  | Most verbose. Logs all operations including ZMQ messages and internal state changes. |
+| `DEBUG` |  | Detailed debugging information. Logs function calls and important state transitions. |
+| `INFO` | _default_ | General informational messages. Default level showing benchmark progress and results. |
+| `NOTICE` |  | Important informational messages that are more significant than INFO but not warnings. |
+| `WARNING` |  | Warning messages for potentially problematic situations that don't prevent execution. |
+| `SUCCESS` |  | Success messages for completed operations and milestones. |
+| `ERROR` |  | Error messages for failures that prevent specific operations but allow continued execution. |
+| `CRITICAL` |  | Critical errors that may cause the benchmark to fail or produce invalid results. |
+
+#### `-v`, `--verbose`
+
+Equivalent to `--log-level DEBUG`. Enables detailed logging output showing function calls and state transitions. Also automatically switches UI to `simple` mode for better console visibility. Does not include raw ZMQ message logging.
+<br/>_Flag (no value required)_
+
+#### `-vv`, `--extra-verbose`
+
+Equivalent to `--log-level TRACE`. Enables the most verbose logging possible, including all ZMQ messages, internal state changes, and low-level operations. Also switches UI to `simple` mode. Use for deep debugging.
+<br/>_Flag (no value required)_
+
+#### `--record-processor-service-count`, `--record-processors` `<int>`
+
+Number of `RecordProcessor` services to spawn for parallel metric computation. Higher request rates require more processors to keep up with incoming records. If not specified, automatically determined based on worker count (typically 1-2 processors per 8 workers).
+<br/>_Constraints: ≥ 1_
+
+#### `--api-port` `<int>`
+
+AIPerf API port (enables HTTP + WebSocket endpoints).
+<br/>_Constraints: ≥ 1, ≤ 65535_
+
+#### `--api-host` `<str>`
+
+AIPerf API host (requires --api-port or AIPERF_API_SERVER_PORT to be set).
+
+#### `--stats-interval` `<float>`
+
+Interval in seconds between realtime stats publishes (dashboards and the per-tick log block). 0 disables the log block while dashboards continue to poll. Defaults to 5s under --ui dashboard, 30s otherwise. Overrides AIPERF_UI_REALTIME_METRICS_INTERVAL.
+<br/>_Constraints: ≥ 0.0, ≤ 1000.0_
+
+### ZMQ Communication
+
+#### `--zmq-host` `<str>`
+
+Host address for internal ZMQ TCP communication between AIPerf services. Defaults to `127.0.0.1` (localhost) for single-machine deployments. For distributed setups, set to a reachable IP address. All internal service-to-service communication (message bus, dataset manager, workers) uses this host for TCP sockets.
+<br/>_Default: `127.0.0.1`_
+
+#### `--zmq-ipc-path` `<str>`
+
+Directory path for ZMQ IPC (Inter-Process Communication) socket files. When using IPC transport instead of TCP, AIPerf creates Unix domain socket files in this directory for faster local communication. Auto-generated in system temp directory if not specified. Only applicable when using IPC communication backend.
+
+#### `--zmq-dual-bind`
+
+Select the ZMQ dual-bind communication backend (IPC + TCP). All dual-bind knobs are cluster-managed; this flag only selects the discriminator and the converter routes downstream to the default.
+<br/>_Flag (no value required)_
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+#### `--name` `<str>`
+
+Human-readable name for the benchmark job (DNS label, max 40 chars).
+
+#### `--image` `<str>`
+
+AIPerf container image to use for Kubernetes deployment.
+<br/>_Constraints: min: 1_
+
+#### `--image-pull-policy` `<str>`
+
+Image pull policy (Always, IfNotPresent, Never). Use 'Never' for minikube (or local clusters) with locally loaded images.
+
+**Choices:**
+
+| | | |
+|-------|:-------:|-------------|
+| `Always` |  | Every time the kubelet launches a container, it queries the registry to resolve the name to a digest. Uses cached image if digest matches, otherwise pulls the image. |
+| `Never` |  | The kubelet does not try fetching the image. Startup fails if the image is not already present locally. |
+| `IfNotPresent` |  | The image is pulled only if it is not already present locally. |
+
+#### `--total-workers` `<int>`
+
+Total number of workers. Automatically distributed across pods based on --workers-per-pod (default 10). E.g., --total-workers 50 = 5 pods × 10 workers.
+<br/>_Constraints: > 0_
+<br/>_Default: `10`_
+
+#### `--ttl-seconds` `<int>`
+
+Seconds to keep pods after completion (None to disable TTL).
+<br/>_Constraints: ≥ 0_
+<br/>_Default: `300`_
+
+### Kubernetes Node Placement
+
+#### `--node-selector` `<list>`
+
+CLI-only node selector labels (JSON object or repeated key=value).
+
+#### `--tolerations` `<list>`
+
+Pod tolerations as JSON object/array or repeated JSON values.
+
+### Kubernetes Scheduling
+
+#### `--queue-name` `<str>`
+
+Kueue LocalQueue name for gang-scheduling. When set, the JobSet is submitted to Kueue for quota-managed admission.
+
+#### `--priority-class` `<str>`
+
+Kueue WorkloadPriorityClass name for scheduling priority.
+
+### Kubernetes Metadata
+
+#### `--annotations` `<str>`
+
+Additional pod annotations.
+
+#### `--labels` `<str>`
+
+Additional pod labels.
+
+### Kubernetes Secrets
+
+#### `--image-pull-secrets` `<list>`
+
+Image pull secret names.
+
+#### `--env-vars` `<str>`
+
+Extra environment variables (key: value).
+
+#### `--env-from-secrets` `<str>`
+
+Environment variables from secrets (ENV_NAME: secret_name/key).
+
+#### `--secret-mounts` `<list>`
+
+Secret volume mounts.
+
+#### `--service-account` `<str>`
+
+Service account name for pods.
+
+### Parameters
+
+#### `--operator`
+
+Output an AIPerfJob or AIPerfSweep CR (requires the operator).
+<br/>_Flag (no value required)_
+
+#### `--no-operator`
+
+Output raw K8s manifests (Namespace, RBAC, ConfigMap, JobSet).
+
+<hr/>
+
+## `aiperf kube setup`
+
+Install cluster prerequisites (JobSet CRD, namespaces, AIPerf operator)
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+### Parameters
+
+#### `--jobset-version` `<str>`
+
+JobSet release tag to install (default: latest release, falling back to a known-good pin).
+
+#### `--operator-namespace` `<str>`
+
+Namespace for the AIPerf operator (default: aiperf-system).
+
+#### `--chart` `<str>`
+
+Path to an alternate aiperf-operator Helm chart (default: chart bundled with AIPerf).
+
+#### `--skip-operator`, `--no-skip-operator`
+
+Install only the JobSet CRD and namespaces; leave the operator alone.
+
+#### `--dry-run`, `--no-dry-run`
+
+Report what would be installed and exit without changing the cluster.
+
+<hr/>
+
+## `aiperf kube delete`
+
+Delete a benchmark and its backing Kubernetes resources
+
+### Parameters
+
+#### `--job-id` `<str>`
+
+The AIPerf job ID or AIPerfSweep name to delete (default: last deployed job).
+
+#### `-f`, `--force`, `--no-force`
+
+Skip the confirmation prompt.
+
+#### `--delete-namespace`, `--no-delete-namespace`
+
+Also delete the namespace, but only when AIPerf generated it (aiperf-&lt;job_id>).
+
+#### `--kind` `<str>`
+
+Target kind when an AIPerfJob and AIPerfSweep share a name.
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+<hr/>
+
+## `aiperf kube cleanup`
+
+Bulk-remove finished benchmarks from a namespace
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+### Parameters
+
+#### `-a`, `--all`, `--no-all`
+
+Also remove benchmarks that are still running (they are cancelled first).
+
+#### `-f`, `--force`, `--no-force`
+
+Skip the confirmation prompt.
+
+#### `--dry-run`, `--no-dry-run`
+
+List what would be removed and exit without deleting anything.
+
+<hr/>
+
+## `aiperf kube shutdown`
+
+Retire a finished benchmark's controller pod
+
+### Parameters
+
+#### `--job-id` `<str>`
+
+The AIPerf job ID whose controller should shut down (default: last deployed job).
+
+#### `--local-port` `<int>`
+
+Local port for the API port-forward (0 = ephemeral).
+<br/>_Default: `0`_
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+<hr/>
+
+## `aiperf kube cancel`
+
+Cancel a running benchmark (patches spec.cancel on the CR)
+
+### Parameters
+
+#### `--job-id` `<str>`
+
+The AIPerf job ID or AIPerfSweep name to cancel (default: last deployed job).
+
+#### `-v`, `--variation` `<int>`
+
+When job_id is an AIPerfSweep name, target child variation index (0..199). Resolves to &lt;sweep>-v&lt;idx:02d>[-t&lt;trial>].
+
+#### `-t`, `--trial` `<int>`
+
+Trial index (0..9) within a sweep variation. Requires -v.
+
+#### `--kind` `<str>`
+
+Target kind when an AIPerfJob and AIPerfSweep share a name.
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+<hr/>
+
+## `aiperf kube attach`
+
+Attach to a running benchmark and stream progress
+
+### Parameters
+
+#### `--job-id` `<str>`
+
+The AIPerf job ID or AIPerfSweep name to attach to (default: last deployed job).
+
+#### `-p`, `--port` `<int>`
+
+Local port for port-forward (default: 0 = ephemeral).
+<br/>_Default: `0`_
+
+#### `-v`, `--variation` `<int>`
+
+When job_id is an AIPerfSweep name, target child variation index (0..199). Resolves to &lt;sweep>-v&lt;idx:02d>[-t&lt;trial>].
+
+#### `-t`, `--trial` `<int>`
+
+Trial index (0..9) within a sweep variation. Requires -v.
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+<hr/>
+
+## `aiperf kube list`
+
+List benchmark jobs and their status
+
+### Parameters
+
+#### `--job-id` `<str>`
+
+Specific job ID to check.
+
+#### `-A`, `--all-namespaces`, `--no-all-namespaces`
+
+Search in all namespaces (default). Ignored when --namespace is set.
+<br/>_Default: `True`_
+
+#### `--running`, `--no-running`
+
+Show only running jobs.
+
+#### `--completed`, `--no-completed`
+
+Show only completed jobs.
+
+#### `--failed`, `--no-failed`
+
+Show only failed jobs.
+
+#### `-w`, `--wide`, `--no-wide`
+
+Show additional columns (model, endpoint, error).
+
+#### `--watch`, `--no-watch`
+
+Refresh the list every few seconds until interrupted.
+
+#### `--interval` `<int>`
+
+Refresh interval in seconds (used with --watch).
+<br/>_Default: `5`_
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+<hr/>
+
+## `aiperf kube logs`
+
+Retrieve logs from benchmark pods
+
+### Parameters
+
+#### `--job-id` `<str>`
+
+The AIPerf job ID or AIPerfSweep name to get logs from (default: last deployed job).
+
+#### `--container` `<str>`
+
+Specific container name to get logs from.
+
+#### `-f`, `--follow`, `--no-follow`
+
+Follow log output in real-time.
+
+#### `--tail` `<int>`
+
+Number of lines from the end to show.
+
+#### `-o`, `--output` `<str>`
+
+Directory to save log files (one per pod). Prints to stdout if not set.
+
+#### `-v`, `--variation` `<int>`
+
+When job_id is an AIPerfSweep name, target child variation index (0..199). Resolves to &lt;sweep>-v&lt;idx:02d>[-t&lt;trial>].
+
+#### `-t`, `--trial` `<int>`
+
+Trial index (0..9) within a sweep variation. Requires -v.
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+<hr/>
+
+## `aiperf kube results`
+
+Retrieve benchmark results
+
+### Parameters
+
+#### `--job-id` `<str>`
+
+The AIPerf job ID or AIPerfSweep name to get results from (default: last deployed job).
+
+#### `--output` `<str>`
+
+Output directory for results (default: ./artifacts/{name}).
+
+#### `--from-pods`, `--no-from-pods`
+
+Retrieve results from benchmark pods instead of the operator. Tries the controller API first, falls back to kubectl cp.
+
+#### `-a`, `--all`, `--summary-only`
+
+Download all artifacts. Use --summary-only to download only summary results.
+<br/>_Flag (no value required)_
+<br/>_Default: `True`_
+
+#### `--shutdown`, `--no-shutdown`
+
+Shut down the API service after downloading results. Only takes effect with --from-pods.
+
+#### `--port` `<int>`
+
+Local port for API port-forward (default: 0 = ephemeral).
+<br/>_Default: `0`_
+
+#### `--operator-namespace` `<str>`
+
+Namespace where the operator is deployed. Auto-detected (cluster-wide pod search) when omitted.
+
+#### `--run` `<str>`
+
+Pin to a specific historical run (epoch from `aiperf kube results list-runs`). Default: latest.
+
+#### `-v`, `--variation` `<int>`
+
+When job_id is an AIPerfSweep name, target child variation index (0..199). Resolves to &lt;sweep>-v&lt;idx:02d>[-t&lt;trial>] and downloads that single child instead of the whole sweep.
+
+#### `-t`, `--trial` `<int>`
+
+Trial index (0..9) within a sweep variation. Requires -v.
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+<hr/>
+
+## `aiperf kube show`
+
+Render an AIPerfJob CR with Jinja2/env-vars resolved
+
+### `-f`, `--path` `<str>` _(Required)_
+
+Path to an AIPerfJob YAML file.
+
+<hr/>
+
+## `aiperf kube debug`
+
+Run diagnostic analysis on a deployment
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+### Parameters
+
+#### `-j`, `--job-id` `<str>`
+
+Specific AIPerf job ID or AIPerfSweep name to diagnose.
+
+#### `-v`, `--verbose`, `--no-verbose`
+
+Show detailed output including pod logs.
+
+#### `-A`, `--all-namespaces`, `--no-all-namespaces`
+
+Inspect all namespaces with AIPerf deployments.
+
+#### `--variation` `<int>`
+
+When --job-id is an AIPerfSweep name, target child variation index (0..199). Resolves to &lt;sweep>-v&lt;idx:02d>[-t&lt;trial>]. Note: -v is reserved for --verbose; use the long form here.
+
+#### `-t`, `--trial` `<int>`
+
+Trial index (0..9) within a sweep variation. Requires --variation.
+
+<hr/>
+
+## `aiperf kube preflight`
+
+Run pre-flight checks against the target Kubernetes cluster
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+### Parameters
+
+#### `-i`, `--image` `<str>`
+
+Container image to verify accessibility.
+
+#### `--image-pull-secret`, `--image-pull-secrets` `<list>`
+
+Image pull secret name to verify (repeat for multiple secrets).
+
+#### `--secret`, `--secrets` `<list>`
+
+Referenced Kubernetes secret name to verify (repeat for multiple secrets).
+
+#### `-e`, `--endpoint-url` `<str>`
+
+LLM endpoint URL to test connectivity.
+
+#### `-w`, `--workers` `<int>`
+
+Planned number of worker pods (for resource projection).
+<br/>_Default: `1`_
+
+#### `-o`, `--output` `<str>`
+
+Output format: "text" for human-readable, "json" for machine-parseable.
+<br/>_Default: `text`_
+
+<hr/>
+
+## `aiperf kube dashboard`
+
+Open the operator results server UI in your browser
+
+### Kubernetes
+
+#### `--kubeconfig` `<str>`
+
+Path to kubeconfig file (defaults to ~/.kube/config or KUBECONFIG env).
+
+#### `--kube-context` `<str>`
+
+Kubernetes context to use (defaults to current context in kubeconfig).
+
+#### `-n`, `--namespace` `<str>`
+
+Kubernetes namespace (default: aiperf-benchmarks).
+
+### Parameters
+
+#### `--port` `<int>`
+
+Local port to bind (default: 0 = ephemeral).
+<br/>_Default: `0`_
+
+#### `--operator-namespace` `<str>`
+
+Namespace where the operator is deployed. Auto-detected (cluster-wide pod search) when omitted.
+
+#### `--no-browser`, `--no-no-browser`
+
+Print the URL instead of opening a browser.
 
 <hr/>
 
@@ -1866,6 +7259,27 @@ Validate plugins.yaml.
 
 <hr/>
 
+## `aiperf proxy`
+
+Run a single ZMQ proxy in this process until SIGTERM/SIGINT.
+
+_Advanced use only — this command is invoked by the AIPerf Kubernetes sidecar pattern and is not intended for direct human use._
+
+### `--benchmark-run` `<str>` _(Required)_
+
+Path to the BenchmarkRun JSON file. Used to resolve the proxy's bind addresses from the resolved communication config.
+
+### `--kind` `<str>`
+
+Which proxy to run. Currently only 'event_bus' is supported.
+<br/>_Default: `event_bus`_
+
+### `--health-port` `<int>`
+
+HTTP port for /healthz and /readyz. Falls back to AIPERF_SERVICE_HEALTH_PORT.
+
+<hr/>
+
 ## `aiperf service`
 
 Run an AIPerf service in a single process.
@@ -1874,1464 +7288,30 @@ _Advanced use only — intended for developers and Kubernetes/distributed deploy
 
 For standard single-node benchmarking, use the `aiperf profile` command instead.
 
-### Parameters
-
-#### `--type` `<str>` _(Required)_
+### `--type` `<str>` _(Required)_
 
 Service type to run.
-<br/>_Choices: [`api`, `dataset_manager`, `gpu_telemetry_manager`, `network_latency_manager`, `record_processor`, `records_manager`, `server_metrics_manager`, `system_controller`, `timing_manager`, `worker`, `worker_manager`]_
+<br/>_Choices: [`api`, `dataset_manager`, `gpu_telemetry_manager`, `network_latency_manager`, `record_processor`, `records_manager`, `server_metrics_manager`, `system_controller`, `timing_manager`, `worker`, `worker_manager`, `worker_group_manager`]_
 
-#### `--service-id` `<str>`
+### `--benchmark-run` `<str>` _(Required)_
+
+Path to the pre-built BenchmarkRun JSON file. The service bootstraps exclusively from this serialized run. Kubernetes controllers materialize it before starting service containers.
+
+### `--api-port` `<int>`
+
+HTTP port for API endpoints (e.g. /api/dataset, /api/progress). Only used by services that expose HTTP APIs.
+
+### `--service-id` `<str>`
 
 Unique identifier for the service instance. Useful when running multiple instances of the same service type.
 
-#### `--health-host` `<str>`
+### `--health-host` `<str>`
 
 Host to bind the health server to. Falls back to AIPERF_SERVICE_HEALTH_HOST environment variable.
 
-#### `--health-port` `<int>`
+### `--health-port` `<int>`
 
 HTTP port for health endpoints (/healthz, /readyz). Required for Kubernetes liveness and readiness probes. Falls back to AIPERF_SERVICE_HEALTH_PORT environment variable.
-
-### Endpoint
-
-#### `-m`, `--model-names`, `--model` `<list>`
-
-Model name(s) to be benchmarked. Can be a comma-separated list or a single model name.
-
-#### `--model-selection-strategy` `<str>`
-
-When multiple models are specified, this is how a specific model should be assigned to a prompt. round_robin: nth prompt in the list gets assigned to n-mod len(models). random: assignment is uniformly random.
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `round_robin` | _default_ | Cycle through models in order. The nth prompt is assigned to model at index (n mod number_of_models). |
-| `random` |  | Randomly select a model for each prompt using uniform distribution. |
-| `weighted` |  | Select a model with probability proportional to a per-model weight. |
-
-#### `--custom-endpoint`, `--endpoint` `<str>`
-
-Set a custom API endpoint path (e.g., `/v1/custom`, `/my-api/chat`). By default, endpoints follow OpenAI-compatible paths like `/v1/chat/completions`. Use this option to override the default path for non-standard API implementations.
-
-#### `--endpoint-type` `<str>`
-
-The API endpoint type to benchmark. Determines request/response format and supported features. Common types: `chat` (multi-modal conversations), `embeddings` (vector generation), `completions` (text completion). See enum documentation for all supported endpoint types.
-<br/>_Choices: [`audio_transcription`, `chat`, `cohere_rankings`, `completions`, `responses`, `messages`, `chat_embeddings`, `embeddings`, `hf_tei_rankings`, `huggingface_generate`, `image_generation`, `image_edit`, `video_generation`, `image_retrieval`, `nim_embeddings`, `nim_rankings`, `solido_rag`, `raw`, `template`]_
-<br/>_Default: `chat`_
-
-#### `--streaming`
-
-Enable streaming responses. When enabled, the server streams tokens incrementally as they are generated. Automatically disabled if the selected endpoint type does not support streaming. Enables measurement of time-to-first-token (TTFT) and inter-token latency (ITL) metrics.
-<br/>_Flag (no value required)_
-
-#### `-u`, `--url` `<list>`
-
-Base URL(s) of the API server(s) to benchmark. Multiple URLs can be specified for load balancing across multiple instances (e.g., `--url http://server1:8000 --url http://server2:8000`). The endpoint path is automatically appended based on `--endpoint-type` (e.g., `/v1/chat/completions` for `chat`). URLs that do not include a scheme (no `://`) have `http://` prepended automatically.
-<br/>_Constraints: min: 1_
-<br/>_Default: `['http://localhost:8000']`_
-
-#### `--url-strategy` `<str>`
-
-Strategy for selecting URLs when multiple `--url` values are provided. 'round_robin' (default): distribute requests evenly across URLs in sequential order.
-<br/>_Choices: [`round_robin`]_
-<br/>_Default: `round_robin`_
-
-#### `--request-timeout-seconds` `<float>`
-
-Maximum time in seconds to wait for each HTTP request to complete, including connection establishment, request transmission, and response receipt. Applies to both streaming and non-streaming requests. Requests exceeding this timeout are cancelled and recorded as failures.
-<br/>_Constraints: > 0_
-<br/>_Default: `21600`_
-
-#### `--wait-for-model-timeout` `<float>`
-
-Seconds to wait for endpoint readiness before benchmarking (0 = skip). Sends a real inference request to verify the model is loaded and can generate output.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--wait-for-model-mode` `<str>`
-
-How readiness probes the endpoint: 'models' checks /v1/models, 'inference' sends a canned one-token inference request, and 'both' runs the models check before inference.
-<br/>_Default: `inference`_
-
-#### `--wait-for-model-interval` `<float>`
-
-Seconds between endpoint readiness probe attempts.
-<br/>_Constraints: > 0.0_
-<br/>_Default: `5.0`_
-
-#### `--reset-kv-cache`
-
-Enable once-per-cell KV-cache reset via POST to the endpoint.
-<br/>_Flag (no value required)_
-
-#### `--reset-kv-cache-timeout-seconds` `<float>`
-
-Timeout seconds for reset_kv_cache control requests.
-<br/>_Constraints: > 0_
-
-#### `--reset-kv-cache-path` `<str>`
-
-Relative path for reset_kv_cache (default /reset_prefix_cache).
-
-#### `--server-profiler`
-
-Enable server profiler start/stop around profiling phases.
-<br/>_Flag (no value required)_
-
-#### `--server-profiler-timeout-seconds` `<float>`
-
-Timeout seconds for server_profiler control requests.
-<br/>_Constraints: > 0_
-
-#### `--server-profiler-start-path` `<str>`
-
-Relative path for profiler start (default /start_profile).
-
-#### `--server-profiler-stop-path` `<str>`
-
-Relative path for profiler stop (default /stop_profile).
-
-#### `--api-key` `<str>`
-
-API authentication key for the endpoint. When provided, automatically included in request headers as `Authorization: Bearer <api_key>`.
-
-#### `--transport`, `--transport-type` `<str>`
-
-Transport protocol to use for API requests. If not specified, auto-detected from the URL scheme (`http`/`https` -> `TransportType.HTTP`). Currently supports `http` transport using aiohttp with connection pooling, TCP optimization, and Server-Sent Events (SSE) for streaming. Explicit override rarely needed.
-<br/>_Choices: [`http`]_
-
-#### `--use-legacy-max-tokens`
-
-Use the legacy 'max_tokens' field instead of 'max_completion_tokens' in request payloads. The OpenAI API now prefers 'max_completion_tokens', but some older APIs or implementations may require 'max_tokens'.
-<br/>_Flag (no value required)_
-
-#### `--use-server-token-count`
-
-Use server-reported token counts from API usage fields instead of client-side tokenization. When enabled, tokenizers are still loaded (needed for dataset generation) but tokenizer.encode() is not called for computing metrics. Token count fields will be None if the server does not provide usage information. For OpenAI-compatible streaming endpoints (chat/completions), stream_options.include_usage is automatically configured when this flag is enabled.
-<br/>_Flag (no value required)_
-
-#### `--connection-reuse-strategy` `<str>`
-
-Transport connection reuse strategy. 'pooled' (default): connections are pooled and reused across all requests. 'never': new connection for each request, closed after response. 'sticky-user-sessions': connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing).
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `pooled` | _default_ | Connections are pooled and reused across all requests |
-| `never` |  | New connection for each request, closed after response |
-| `sticky-user-sessions` |  | Connection persists across turns of a multi-turn conversation, closed on final turn (enables sticky load balancing) |
-
-#### `--download-video-content`
-
-For video generation endpoints, download the video content after generation completes. When enabled, request latency includes the video download time. When disabled (default), only generation time is measured.
-<br/>_Flag (no value required)_
-
-#### `--request-content-type` `<str>`
-
-Content type for request body serialization. By default, requests are sent as 'application/json'. Set to 'multipart/form-data' for servers that require form-encoded requests (e.g., vLLM video generation endpoints).
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `application/json` |  | Standard JSON encoding. Default for all endpoints. |
-| `multipart/form-data` |  | Multipart form encoding. Required by some video generation servers (e.g., vLLM). |
-
-#### `--session-header` `<str>`
-
-HTTP header name used to carry the per-session affinity identifier. When set, replaces the default `X-Correlation-ID` header with the provided name (e.g., `--session-header X-Session-ID`).
-
-#### `--uuid-and-strip`
-
-Enable AIPerf-managed image stripping for vLLM's multimodal processor cache. Dataset-authored image UUIDs, including UUID-only cache references, always pass through on the chat endpoint; this flag only strips repeated content after AIPerf observes it in the same session. Automatic stripping supports only single_turn datasets with session_id-grouped rows; multi_turn is rejected. The server cache must cover the working set, and requests in a session must reach a replica that retains earlier UUIDs.
-<br/>_Flag (no value required)_
-
-### Tokenizer
-
-#### `--tokenizer` `<str>`
-
-HuggingFace tokenizer identifier, local path, or `builtin` for token counting in prompts and responses. Accepts model names (e.g., `meta-llama/Llama-2-7b-hf`), filesystem paths to tokenizer files, or `builtin` for a zero-network-access tokenizer backed by tiktoken (o200k_base encoding). If not specified, defaults to the value of `--model-names`. If `--tokenizer` is not set and the model name looks like an obvious placeholder (e.g. `mock-model`, `test-model`, `fake-model`), AIPerf substitutes `builtin` automatically and emits a warning. Essential for accurate token-based metrics (input/output token counts, token throughput).
-
-#### `--tokenizer-revision` `<str>`
-
-Specific tokenizer version to load from HuggingFace Hub. Can be a branch name (e.g., `main`), tag name (e.g., `v1.0`), or full commit hash. Ensures reproducible tokenization across runs by pinning to a specific version. Defaults to `main` branch if not specified.
-<br/>_Default: `main`_
-
-#### `--tokenizer-trust-remote-code`
-
-Allow execution of custom Python code from HuggingFace Hub tokenizer repositories. Required for tokenizers with custom implementations not in the standard `transformers` library. **Security Warning**: Only enable for trusted repositories, as this executes arbitrary code. Unnecessary for standard tokenizers.
-<br/>_Flag (no value required)_
-
-#### `--apply-chat-template`
-
-Apply the HuggingFace tokenizer's chat template when counting input tokens. When enabled: synthetic ISL is compensated for chat-template wrapping (BOS, role headers, EOT, generation-prompt suffix) and the record processor reports ISL using `apply_chat_template(tokenize=True, add_generation_prompt=True)` for chat-shape payloads. When disabled (default), both paths use bare-text encoding, so reported ISL matches the prompt content the user asked for and ignores template overhead. Requires an HF tokenizer with a chat template configured; no-ops on tiktoken / un-templated models.
-<br/>_Flag (no value required)_
-
-### Input
-
-#### `--extra-inputs` `<list>`
-
-Additional input parameters to include in every API request payload. Specify as `key:value` pairs (e.g., `--extra-inputs temperature:0.7 top_p:0.9`) or as JSON string (e.g., `'{"temperature": 0.7}'`). These parameters are merged with request-specific inputs and sent directly to the endpoint API.
-
-#### `-H`, `--header` `<list>`
-
-Custom HTTP headers to include with every request. Specify as `Header:Value` pairs (e.g., `--header X-Custom-Header:value`) or as JSON string. Can be specified multiple times. Useful for custom authentication, tracking, or API-specific requirements. Combined with auto-generated headers (e.g., `Authorization` from `--api-key`).
-
-#### `--input-file` `<str>`
-
-Path to file or directory containing benchmark dataset. Required when using `--custom-dataset-type`. Supported formats depend on dataset type: JSONL for `single_turn`/`multi_turn`, JSONL for `mooncake_trace`/`bailian_trace` (timestamped traces), Parquet for `baseten_trace`, directories for `random_pool`. File is parsed according to `--custom-dataset-type` specification.
-
-#### `--public-dataset` `<str>`
-
-Pre-configured public dataset to download and use for benchmarking (e.g., `sharegpt`). AIPerf automatically downloads and parses these datasets. Mutually exclusive with `--custom-dataset-type`. Run `aiperf plugins public_dataset_loader` to list available datasets. Use `--hf-subset` to override the HuggingFace subset/config for HF-backed datasets.
-<br/>_Choices: [`exgentic_v2`, `exgentic`, `sharegpt`, `aimo`, `mmstar`, `mmvu`, `vision_arena`, `llava_onevision`, `aimo_aime`, `aimo_numina_cot`, `aimo_numina_1_5`, `spec_bench`, `spec_al_gsm8k`, `spec_al_math500`, `spec_al_humaneval`, `spec_al_mbpp`, `spec_al_mtbench`, `instruct_coder`, `blazedit_5k`, `blazedit_10k`, `librispeech`, `voxpopuli`, `gigaspeech`, `ami`, `spgispeech`, `semianalysis_cc_traces_weka`, `semianalysis_cc_traces_weka_no_subagents`, `semianalysis_cc_traces_weka_with_subagents`, `semianalysis_cc_traces_weka_with_subagents_256k`, `semianalysis_cc_traces_weka_with_subagents_060226`, `semianalysis_cc_traces_weka_with_subagents_060226_256k`, `semianalysis_cc_traces_weka_with_subagents_060526`, `semianalysis_cc_traces_weka_with_subagents_060526_256k`, `semianalysis_cc_traces_weka_with_subagents_060826`, `semianalysis_cc_traces_weka_with_subagents_060826_256k`, `semianalysis_cc_traces_weka_061326`, `semianalysis_cc_traces_weka_061326_256k`, `semianalysis_cc_traces_weka_061526`, `semianalysis_cc_traces_weka_061526_256k`, `semianalysis_cc_traces_weka_062126`, `semianalysis_cc_traces_weka_062126_256k`, `weka_hf`]_
-
-#### `--hf-subset` `<str>`
-
-HuggingFace dataset subset/config name to override the plugin default (e.g. `sharegpt4o`). Only applies when using `--public-dataset` with a HuggingFace-backed loader. Takes priority over the subset defined in the plugin registry.
-
-#### `--hf-weka-dataset` `<str>`
-
-HuggingFace dataset repo for the generic Weka loader (e.g. `semianalysisai/cc-traces-weka-061526`). Passing this auto-selects `--public-dataset weka_hf`, so the repo flag works on its own; setting it alongside any other `--public-dataset` or `--custom-dataset-type` is an error. Pinned Weka public dataset aliases keep their registry-defined repo names.
-
-#### `--dataset-filter` `<list>`
-
-Dataset-specific filter in key=value form. Repeat for multiple filters. Only supported by public datasets that declare filter support.
-
-#### `--custom-dataset-type` `<str>`
-
-Format specification for custom dataset provided via `--input-file`. Determines parsing logic and expected file structure. Options: `single_turn` (JSONL with single exchanges), `multi_turn` (JSONL with conversation history), `tracelab` (TraceLab agentic-coding corpus, JSONL or gzipped JSONL), `mooncake_trace`/`bailian_trace`/`baseten_trace` (timestamped trace files), `random_pool` (directory of reusable prompts; when using `random_pool`, `--conversation-num` defaults to 100 if not specified; batch sizes > 1 sample each modality independently from a flat pool and do not preserve per-entry associations - use `single_turn` if paired modalities must stay together). Requires `--input-file`. Mutually exclusive with `--public-dataset`.
-<br/>_Choices: [`burst_gpt_trace`, `bailian_trace`, `baseten_trace`, `mooncake_trace`, `raw_payload`, `inputs_json`, `dag_jsonl`, `sagemaker_data_capture`, `multi_turn`, `random_pool`, `single_turn`, `speed_bench_qualitative`, `speed_bench_coding`, `speed_bench_humanities`, `speed_bench_math`, `speed_bench_multilingual`, `speed_bench_qa`, `speed_bench_rag`, `speed_bench_reasoning`, `speed_bench_roleplay`, `speed_bench_stem`, `speed_bench_summarization`, `speed_bench_writing`, `speed_bench_throughput_1k`, `speed_bench_throughput_2k`, `speed_bench_throughput_8k`, `speed_bench_throughput_16k`, `speed_bench_throughput_32k`, `speed_bench_throughput_1k_low_entropy`, `speed_bench_throughput_1k_mixed`, `speed_bench_throughput_1k_high_entropy`, `speed_bench_throughput_2k_low_entropy`, `speed_bench_throughput_2k_mixed`, `speed_bench_throughput_2k_high_entropy`, `speed_bench_throughput_8k_low_entropy`, `speed_bench_throughput_8k_mixed`, `speed_bench_throughput_8k_high_entropy`, `speed_bench_throughput_16k_low_entropy`, `speed_bench_throughput_16k_mixed`, `speed_bench_throughput_16k_high_entropy`, `speed_bench_throughput_32k_low_entropy`, `speed_bench_throughput_32k_mixed`, `speed_bench_throughput_32k_high_entropy`, `tracelab`, `weka_trace`]_
-
-#### `--ignore-trace-delays`
-
-Strip per-turn timestamps and inter-turn delays from trace datasets at load time. With this flag, Turn.timestamp and Turn.delay are emitted as None so concurrency / request-rate timing modes dispatch turns back-to-back instead of reproducing the recorded user think-time gaps. No effect under `--fixed-schedule` (timestamps drive that mode before they could be ignored -- combine with `--no-fixed-schedule` if you want both behaviors).
-<br/>_Flag (no value required)_
-
-#### `--use-think-time-only`
-
-For weka_trace inputs, emit Turn.delay using only the recorded per-request `think_time` (client-side delay before each request) instead of the full `t_curr - t_prev` inter-request delta. Compresses replay wall time against zero-latency mocks because the recorded `api_time` portion of each gap is dropped. Mirrors kv-cache-tester's default `--timing-strategy think-only`. Falls back to the full delta for turns whose recorded `think_time` is null. Mutually exclusive with `--ignore-trace-delays`. No effect on non-weka trace loaders.
-<br/>_Flag (no value required)_
-
-#### `--max-context-length` `<int>`
-
-Maximum peak prompt+output context length (tokens) per Weka root trace. Weka loaders (--custom-dataset-type weka_trace or a weka --public-dataset) drop whole traces whose *recorded* peak exceeds this ceiling at load time (filter-then-cap before --num-dataset-entries). Not a DatasetManager tokenize filter; rejected for non-Weka formats.
-<br/>_Constraints: ≥ 1_
-
-#### `--dataset-sampling-strategy` `<str>`
-
-Strategy for selecting entries from dataset during benchmarking. `sequential`: Iterate through dataset in order, wrapping to start after end. `random`: Randomly sample with replacement (entries may repeat before all are used). `shuffle`: Shuffle dataset and iterate without replacement, re-shuffling after exhaustion. Default behavior depends on dataset type (e.g., `sequential` for traces, `shuffle` for synthetic).
-<br/>_Choices: [`random`, `sequential`, `shuffle`]_
-
-#### `--allow-dataset-wrap`, `--no-allow-dataset-wrap`
-
-Allow weka/agentic replay to wrap (reuse distinct eligible traces across concurrency lanes) when concurrency exceeds the loaded pool. Defaults to False: over-subscription fails unless wrapping is explicitly enabled or an active --cache-bust target already keeps repeated-trace traffic distinct.
-
-#### `--random-seed` `<int>`
-
-Random seed for deterministic data generation. When set, makes synthetic prompts, sampling, delays, and other random operations reproducible across runs. Essential for A/B testing and debugging. Uses system entropy if not specified. Initialized globally at config creation.
-<br/>_Constraints: ≥ 0_
-
-#### `--trace-session-sample-ratio` `<float>`
-
-Fraction of trace sessions to keep for replay, sampled whole-session to preserve multi-turn integrity; deterministic when `--random-seed` is set. Only supported by the baseten_trace loader.
-<br/>_Constraints: > 0.0, ≤ 1.0_
-
-#### `-f`, `--config` `<str>`
-
-Path to a YAML configuration file. CLI flags override values from the config file.
-
-### Fixed Schedule
-
-#### `--fixed-schedule`
-
-Run requests according to timestamps specified in the input dataset. When enabled, AIPerf replays the exact timing pattern from the dataset. This mode is automatically enabled for trace datasets.
-<br/>_Flag (no value required)_
-
-#### `--no-fixed-schedule`
-
-Suppress the automatic switch to fixed-schedule mode for trace datasets that carry per-record timestamps. By default a trace input (e.g. mooncake_trace) with timestamps in the first record auto-promotes the profiling phase to fixed_schedule. Pass --no-fixed-schedule to keep the user-selected timing mode (e.g. concurrency, request_rate) and ignore the trace timestamps.
-
-#### `--fixed-schedule-auto-offset`
-
-Automatically normalize timestamps in fixed schedule by shifting all timestamps so the first timestamp becomes 0. When enabled, benchmark starts immediately with the timing pattern preserved. When disabled, timestamps are used as absolute offsets from benchmark start. Mutually exclusive with `--fixed-schedule-start-offset`.
-<br/>_Flag (no value required)_
-
-#### `--fixed-schedule-start-offset` `<int>`
-
-Start offset in milliseconds for fixed schedule replay. Skips all requests before this timestamp, allowing benchmark to start from a specific point in the trace. Requests at exactly the start offset are included. Useful for analyzing specific time windows. Mutually exclusive with `--fixed-schedule-auto-offset`. Must be ≤ `--fixed-schedule-end-offset` if both specified.
-<br/>_Constraints: ≥ 0_
-
-#### `--fixed-schedule-end-offset` `<int>`
-
-End offset in milliseconds for fixed schedule replay. Stops issuing requests after this timestamp, allowing benchmark of specific trace subsets. Requests at exactly the end offset are included. Defaults to last timestamp in dataset. Must be ≥ `--fixed-schedule-start-offset` if both specified.
-<br/>_Constraints: ≥ 0_
-
-### Goodput
-
-#### `--goodput` `<str>`
-
-Specify service level objectives (SLOs) for goodput as space-separated 'KEY:VALUE' pairs, where KEY is a metric tag and VALUE is a number in the metric's display unit (falls back to its base unit if no display unit is defined). Examples: 'request_latency:250' (ms), 'inter_token_latency:10' (ms), `output_token_throughput_per_user:600` (tokens/s). Only metrics applicable to the current endpoint/config are considered. For more context on the definition of goodput, refer to DistServe paper: https://arxiv.org/pdf/2401.09670 and the blog: https://hao-ai-lab.github.io/blogs/distserve.
-
-### Conversation Input
-
-#### `--conversation-num`, `--num-conversations`, `--num-sessions` `<str>`
-
-The total number of unique conversations to generate. Each conversation represents a single request session between client and server. Supported on synthetic mode and the custom random_pool dataset. The number of conversations will be used to determine the number of entries in both the custom random_pool and synthetic datasets and will be reused until benchmarking is complete. Pass a comma-separated list (e.g. `--num-conversations 50,100,200`) to sweep over session-bounded run lengths; the converter promotes the list to a sweep on phases.profiling.sessions before AIPerfConfig validation. The synthetic dataset pool is sized to max(list) so every variation has its full unique-session set.
-
-#### `--num-dataset-entries`, `--num-prompts` `<int>`
-
-Total number of unique entries to generate for the dataset. Each entry represents one user message that can be used as a turn in conversations. Entries are reused across conversations and turns according to `--dataset-sampling-strategy`. Higher values provide more diversity.
-<br/>_Constraints: ≥ 1_
-<br/>_Default: `100`_
-
-#### `--conversation-turn-mean`, `--session-turns-mean` `<int>`
-
-Mean number of request-response turns per conversation. Each turn consists of a user message and model response. Turn counts follow normal distribution around this mean (±`--conversation-turn-stddev`). Set to 1 for single-turn interactions. Multi-turn conversations enable testing of context retention and conversation history handling. Pass a comma-separated list (e.g. `--conversation-turn-mean 1,3,8`) to sweep over multiple turn-mean values; the converter promotes the list to a sweep on datasets.main.turns.mean before AIPerfConfig validation.
-<br/>_Default: `1`_
-
-#### `--conversation-turn-stddev`, `--session-turns-stddev` `<int>`
-
-Standard deviation for number of turns per conversation. Creates variability in conversation lengths, simulating diverse interaction patterns (quick questions vs. extended dialogues). Turn counts follow normal distribution. Set to 0 for uniform conversation lengths.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0`_
-
-#### `--conversation-turn-delay-mean`, `--session-turn-delay-mean` `<float>`
-
-Mean delay in milliseconds between consecutive turns within a multi-turn conversation. Simulates user think time between receiving a response and sending the next message. Delays follow normal distribution around this mean (±`--conversation-turn-delay-stddev`). Only applies to multi-turn conversations (`--conversation-turn-mean` > 1). Set to 0 for back-to-back turns.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--conversation-turn-delay-stddev`, `--session-turn-delay-stddev` `<float>`
-
-Standard deviation for turn delays in milliseconds. Creates variability in user think time between conversation turns. Delays follow normal distribution. Set to 0 for deterministic delays. Models realistic human interaction patterns with variable response times.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--conversation-turn-delay-ratio`, `--session-delay-ratio` `<float>`
-
-Multiplier for scaling all turn delays within conversations. Applied after mean/stddev calculation: `actual_delay = calculated_delay × ratio`. Use to proportionally adjust timing without changing distribution shape. Values &lt; 1 speed up conversations, > 1 slow them down. Set to 0 to eliminate delays entirely.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `1.0`_
-
-#### `--inter-turn-delay-cap-seconds` `<float>`
-
-Clamp per-turn replay delays to at most this many seconds; ``None`` disables the cap. Honored by the DAG JSONL loader and the baseten_trace loader's closed-loop think-times; the clamp count is reported at end of load. Maps to FileDataset ``inter_turn_delay_cap_seconds``.
-<br/>_Constraints: ≥ 0.0_
-
-#### `--max-idle-gap-cap-seconds` `<float>`
-
-Collapse idle gaps between consecutive requests (across all sessions) to at most this many seconds, so a sparse or session-sampled trace does not replay dead air; ``None`` disables the cap. The cap is in replay wall-clock seconds, applied after --replay-speedup compression, so it bounds actual benchmark idle time regardless of speedup. Only supported by the baseten_trace loader. Maps to FileDataset ``max_idle_gap_cap_seconds``.
-<br/>_Constraints: > 0.0_
-
-#### `--replay-speedup` `<float>`
-
-Trace replay wall-clock compression (10 = 10x faster than recorded): divides normalized timestamps and inter-turn delays; ``None`` = real time. Unlike synthesis speedup_ratio, hash_ids stay untouched (KV-cache fidelity). Only supported by the baseten_trace loader. Maps to FileDataset ``replay_speedup``.
-<br/>_Constraints: > 0.0_
-
-#### `--open-loop-replay`, `--no-open-loop-replay`
-
-Open-loop replay (the default): each session starts at its absolute, speedup-scaled recorded timestamp; continuation turns fire at max(recorded timestamp, prior-turn completion). Pass `--no-open-loop-replay` for closed-loop back-pressure: continuation turns fire a think-time (recorded start-to-start gap minus recorded e2e duration) after the prior turn completes, keeping sessions causally ordered when replayed service times differ from recorded (e.g. A/A comparisons). Only honored by the baseten_trace loader. Maps to FileDataset ``open_loop_replay``.
-<br/>_Default: `True`_
-
-#### `--open-loop-strict`
-
-In open-loop replay, fire every trace row at its absolute recorded timestamp as an independent single-turn session, trading away multi-turn grouping and session metrics. Only honored by the baseten_trace loader. Maps to FileDataset ``open_loop_strict``.
-<br/>_Flag (no value required)_
-
-#### `--omit-kv-hints`
-
-Drop recorded KV-cache hints (``hash_ids``, ``block_size``) from replayed request bodies, for strict frontends that reject unknown parameters. Only honored by the baseten_trace loader. Maps to FileDataset ``omit_kv_hints``.
-<br/>_Flag (no value required)_
-
-#### `--force-min-tokens`, `--no-force-min-tokens`
-
-Pin ``min_tokens`` to the recorded output length so replayed generations match recorded lengths; pass `--no-force-min-tokens` to let EOS end generations naturally (some servers reject ``min_tokens``). Only honored by the baseten_trace loader. Maps to FileDataset ``force_min_tokens``.
-<br/>_Default: `True`_
-
-### Prompt
-
-#### `-b`, `--prompt-batch-size`, `--batch-size-text`, `--batch-size` `<int>`
-
-Number of text inputs to include in each request for batch processing endpoints. Supported by `embeddings` and `rankings` endpoint types where models can process multiple inputs simultaneously for efficiency. Set to 1 for single-input requests. Not applicable to `chat` or `completions` endpoints.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `1`_
-
-#### `--prompt-corpus` `<str>`
-
-Source corpus for synthetic prompt text generation. 'sonnet' uses Shakespeare sonnets. 'coding' uses realistic coding content (code, bash output, JSON, error tracebacks, git diffs). Honored only for synthesized content (synthetic datasets and count/hash-id trace loaders); verbatim formats ignore it. When unset, the active dataset loader's default applies (most loaders default to 'sonnet'; agentic-coding loaders such as weka_trace default to 'coding').
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `sonnet` |  | Shakespeare sonnets (default). Classic prose for filler text. |
-| `coding` |  | Realistic coding content: code, bash output, JSON, error tracebacks, git diffs. |
-
-### Cache Bust
-
-#### `--cache-bust` `<str>`
-
-Where (and how) to inject a cache-bust marker. Two families: (1) RID targets (system_prefix, system_suffix, first_turn_prefix, first_turn_suffix) — inject a per-trajectory unique SHA-256 digest marker that is identical across warmup and profiling, so warmup KV-cache work transfers to profiling while preventing cross-trajectory cache sharing. Prefix variants prepend at token 0; suffix variants append after existing content. (2) Warmup-isolation targets (warmup_isolation_system, warmup_isolation_first_turn) — inject a constant '[warmup]' marker only during the WARMUP phase; profiling sees no marker (fully cold start or system-pre-warmed). Incompatible with agentic_replay timing mode. 'none' disables the feature (default). See [cache-bust.md](reference/cache-bust.md) for detailed semantics, trade-offs, and examples.
-<br/>_Choices: [`none`, `system_prefix`, `system_suffix`, `first_turn_prefix`, `first_turn_suffix`, `warmup_isolation_system`, `warmup_isolation_first_turn`]_
-<br/>_Default: `none`_
-
-### Prefix Prompt
-
-#### `--system-prompt` `<str>`
-
-Verbatim system prompt text, identical across every conversation. Sent as a system-role message ahead of all turns. Works with both synthetic and file/public datasets; when the dataset already carries its own system message, this text is prepended to it. Tokens are additive: `--isl` continues to size the generated user prompt only. Mutually exclusive with `--system-prompt-file`, `--shared-system-prompt-length`, and `--num-prefix-prompts`/`--prefix-prompt-length`.
-
-#### `--system-prompt-file` `<str>`
-
-Path to a UTF-8 text file holding the verbatim system prompt. Preferred over `--system-prompt` for real production prompts, which are long enough that shell quoting mangles them. Read once at startup, so a missing or unreadable file fails immediately rather than mid-run. Mutually exclusive with `--system-prompt`, `--shared-system-prompt-length`, and `--num-prefix-prompts`/`--prefix-prompt-length`.
-
-#### `--prompt-prefix-pool-size`, `--prefix-prompt-pool-size`, `--num-prefix-prompts` `<int>`
-
-Number of distinct prefix prompts to generate for K-V cache testing. Each prefix is prepended to user prompts, simulating cached context scenarios. Prefixes randomly selected from pool per request. Set to 0 to disable prefix prompts. Mutually exclusive with `--shared-system-prompt-length`/`--user-context-prompt-length`.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0`_
-
-#### `--prompt-prefix-length`, `--prefix-prompt-length` `<int>`
-
-The number of tokens in each prefix prompt. This is only used if `--num-prefix-prompts` is greater than zero. Note that due to the prefix and user prompts being concatenated, the number of tokens in the final prompt may be off by one.Mutually exclusive with `--shared-system-prompt-length`/`--user-context-prompt-length`.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0`_
-
-#### `--shared-system-prompt-length` `<int>`
-
-Length of shared system prompt in tokens. This prompt is identical across all sessions and appears as a system message. Mutually exclusive with `--prefix-prompt-length`/`--prefix-prompt-pool-size`.
-<br/>_Constraints: ≥ 1_
-
-#### `--user-context-prompt-length` `<int>`
-
-Length of per-session user context prompt in tokens. Each dataset entry gets a unique user context prompt. Requires --num-dataset-entries to be specified. Mutually exclusive with --prefix-prompt-length/--prefix-prompt-pool-size.
-<br/>_Constraints: ≥ 1_
-
-### Input Sequence Length (ISL)
-
-#### `--prompt-input-tokens-mean`, `--synthetic-input-tokens-mean`, `--isl` `<int>`
-
-Mean number of tokens for synthetically generated input prompts. AIPerf generates prompts with lengths following a normal distribution around this mean (±`--prompt-input-tokens-stddev`). Applies only to synthetic datasets, not custom or public datasets. Pass a comma-separated list (e.g. `--isl 128,512,2048`) to sweep over multiple input lengths; the converter promotes the list to a sweep on datasets.main.prompts.isl.mean before AIPerfConfig validation.
-<br/>_Default: `550`_
-
-#### `--prompt-input-tokens-stddev`, `--synthetic-input-tokens-stddev`, `--isl-stddev` `<float>`
-
-Standard deviation for synthetic input prompt token lengths. Creates variability in prompt sizes when > 0, simulating realistic workloads with mixed request sizes. Lengths follow normal distribution. Set to 0 for uniform prompt lengths. Applies only to synthetic data generation. Pass a comma-separated list (e.g. `--isl-stddev 10,50,200`) to sweep over multiple stddev values; the converter promotes the list to a sweep on datasets.main.prompts.isl.stddev. Pair with a zip-mode `--isl` sweep to model realistic small/medium/large traffic shapes.
-<br/>_Default: `0.0`_
-
-#### `--prompt-input-tokens-block-size`, `--synthetic-input-tokens-block-size`, `--isl-block-size` `<int>`
-
-Token block size for hash-based prompt synthesis when dataset entries carry `hash_ids`: each `hash_id` maps to a cached block of `block_size` tokens, enabling simulation of KV-cache sharing patterns from production workloads. The total prompt length equals `(num_hash_ids - 1) * block_size + final_block_size`. With `--input-file` this overrides the trace loader's `default_block_size` plugin metadata (16 for `bailian_trace`, 512 for `mooncake_trace`) for loaders that reconstruct prompts from `hash_ids`; it has no effect on `baseten_trace`, which replays literal recorded prompts. Set it when a trace was recorded at a block size different from its loader default (e.g. a Mooncake-format trace recorded at 16).
-<br/>_Constraints: ≥ 1_
-
-#### `--seq-dist`, `--sequence-distribution` `<str>`
-
-Distribution of (ISL, OSL) pairs with probabilities for mixed workload simulation. Format: `ISL,OSL:prob;ISL,OSL:prob` (semicolons separate pairs, probabilities are percentages 0-100 that must sum to 100). Supports optional stddev: `ISL|stddev,OSL|stddev:prob`. Examples: `128,64:25;512,128:50;1024,256:25` or with variance: `256|10,128|5:40;512|20,256|10:60`. Also supports bracket `[(256,128):40,(512,256):60]` and JSON formats.
-
-### Output Sequence Length (OSL)
-
-#### `--prompt-output-tokens-mean`, `--output-tokens-mean`, `--osl` `<str>`
-
-Mean number of tokens to request in model outputs via `max_completion_tokens` field. Controls response length for synthetic and some custom datasets. If specified, included in request payload to limit generation length. When not set, model determines output length. Pass a comma-separated list (e.g. `--osl 128,256,512`) to sweep over multiple output lengths; the converter promotes the list to a sweep on datasets.main.prompts.osl.mean before AIPerfConfig validation.
-
-#### `--prompt-output-tokens-stddev`, `--output-tokens-stddev`, `--osl-stddev` `<int>`
-
-Standard deviation for output token length requests. Creates variability in `max_completion_tokens` field across requests, simulating mixed response length requirements. Lengths follow normal distribution. Only applies when `--prompt-output-tokens-mean` is set. Pass a comma-separated list (e.g. `--osl-stddev 5,25,100`) to sweep over multiple stddev values; the converter promotes the list to a sweep on datasets.main.prompts.osl.stddev. Pair with a zip-mode `--osl` sweep to model realistic output-length variance across traffic tiers.
-<br/>_Default: `0`_
-
-### Audio Input
-
-#### `--audio-batch-size`, `--batch-size-audio` `<int>`
-
-The number of audio inputs to include in each request. Supported with the `chat` endpoint type for multimodal models.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `1`_
-
-#### `--audio-length-mean` `<float>`
-
-Mean duration in seconds for synthetically generated audio files. Audio lengths follow a normal distribution around this mean (±`--audio-length-stddev`). Used when `--audio-batch-size` > 0 for multimodal benchmarking. Generated audio is random noise with specified sample rate, bit depth, and format.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--audio-length-stddev` `<float>`
-
-Standard deviation for synthetic audio duration in seconds. Creates variability in audio lengths when > 0, simulating mixed-duration audio inputs. Durations follow normal distribution. Set to 0 for uniform audio lengths.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--audio-format` `<str>`
-
-File format for generated audio files. Supports `wav` (uncompressed PCM, larger files) and `mp3` (compressed, smaller files). Format choice affects file size in multimodal requests but not audio characteristics (sample rate, bit depth, duration).
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `wav` | _default_ | WAV format. Uncompressed audio, larger file sizes, best quality. |
-| `mp3` |  | MP3 format. Compressed audio, smaller file sizes, good quality. |
-
-#### `--audio-depths` `<list>`
-
-List of audio bit depths in bits to randomly select from when generating audio files. Each audio file is assigned a random depth from this list. Common values: `8` (low quality), `16` (CD quality), `24` (professional), `32` (high-end). Specify multiple values (e.g., `--audio-depths 16 24`) for mixed-quality testing.
-<br/>_Constraints: min: 1_
-<br/>_Default: `[16]`_
-
-#### `--audio-sample-rates` `<list>`
-
-A list of audio sample rates to randomly select from in kHz. Common sample rates are 16, 44.1, 48, 96, etc.
-<br/>_Constraints: min: 1_
-<br/>_Default: `[16.0]`_
-
-#### `--audio-num-channels` `<int>`
-
-Number of audio channels for synthetic audio generation. `1` = mono (single channel), `2` = stereo (left/right channels). Stereo doubles file size but simulates realistic audio for models supporting spatial audio processing. Most speech models use mono.
-<br/>_Constraints: ≥ 1, ≤ 2_
-<br/>_Default: `1`_
-
-### Image Input
-
-#### `--image-width-mean` `<float>`
-
-Mean width in pixels for synthetically generated images. Image widths follow a normal distribution around this mean (±`--image-width-stddev`). Combined with `--image-height-mean` to determine image dimensions and file sizes for multimodal benchmarking.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--image-width-stddev` `<float>`
-
-Standard deviation for synthetic image widths in pixels. Creates variability in horizontal resolution when > 0, simulating mixed-resolution image inputs. Widths follow normal distribution. Set to 0 for uniform image widths.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--image-height-mean` `<float>`
-
-Mean height in pixels for synthetically generated images. Image heights follow a normal distribution around this mean (±`--image-height-stddev`). Used when `--image-batch-size` > 0 for multimodal vision benchmarking. Generated images are resized from source images in `assets/source_images` directory.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--image-height-stddev` `<float>`
-
-Standard deviation for synthetic image heights in pixels. Creates variability in vertical resolution when > 0, simulating mixed-resolution image inputs. Heights follow normal distribution. Set to 0 for uniform image heights.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--image-batch-size`, `--batch-size-image` `<int>`
-
-Number of images to include in each multimodal request. Supported with `chat` endpoint type for vision-language models. Each image is generated by randomly sampling and resizing source images from `assets/source_images` directory to specified dimensions. Set to 0 to disable image inputs. Higher batch sizes test multi-image understanding and increase request payload size.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `1`_
-
-#### `--image-format` `<str>`
-
-Image file format for generated images. Choose `png` for lossless compression (larger files, best quality), `jpeg` for lossy compression (smaller files, good quality), or `random` to randomly select between PNG and JPEG for each image. Format affects file size in multimodal requests and encoding overhead.
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `png` | _default_ | PNG format. Lossless compression, larger file sizes, best quality. |
-| `jpeg` |  | JPEG format. Lossy compression, smaller file sizes, good for photos. |
-| `random` |  | Randomly select PNG or JPEG for each image. |
-
-#### `--image-source` `<str>`
-
-Source image generation mode (default `noise`). `noise` generates random noise images on the fly at the requested dimensions — no files on disk required, and the pool is effectively unbounded so servers cannot dedupe on identical inputs. `assets` indexes images from the built-in `assets/source_images` directory (ships with a small set of 4 images) and lazily loads them at the requested dimensions. A path to a directory indexes images from the given directory (e.g. `--image-source ./source_images`). Note: random-noise images are roughly incompressible, so payload bytes are larger than equivalent natural images.
-<br/>_Default: `noise`_
-
-#### `--image-source-sampling` `<str>`
-
-How source images are selected from finite image sources selected by `--image-source assets` or `--image-source <directory>`. `random-with-replacement` draws each source image independently; repeats may occur immediately. `shuffle-cycle` draws every source image once per shuffled cycle, reshuffling after exhaustion. `sequential-cycle` walks source images in sorted load order and wraps after exhaustion. For `noise`, only `random-with-replacement` is valid because there is no finite source pool.
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `random-with-replacement` | _default_ | Draw each source image independently; repeats may occur immediately. |
-| `shuffle-cycle` |  | Draw every source image once per shuffled cycle; reshuffle after exhaustion. |
-| `sequential-cycle` |  | Walk source images in sorted load order; wrap after exhaustion. |
-
-### Video Input
-
-#### `--video-batch-size`, `--batch-size-video` `<int>`
-
-Number of video files to include in each multimodal request. Supported with `chat` endpoint type for video understanding models. Each video is generated synthetically with specified duration, FPS, resolution, and codec. Set to 0 to disable video inputs. Higher batch sizes test multi-video understanding and significantly increase request payload size.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `1`_
-
-#### `--video-duration` `<float>`
-
-Duration in seconds for each synthetically generated video clip. Combined with `--video-fps`, determines total frame count (frames = duration × FPS). Longer durations increase file size and processing time. Typical values: 1-10 seconds for testing. Requires FFmpeg for video generation.
-<br/>_Constraints: ≥ 0.0_
-<br/>_Default: `5.0`_
-
-#### `--video-fps` `<int>`
-
-Frames per second for generated video. Higher FPS creates smoother video but increases frame count and file size. Common values: `4` (minimal motion, recommended for Cosmos models), `24` (cinematic), `30` (standard video), `60` (high frame rate). Total frames = `--video-duration` × FPS.
-<br/>_Constraints: ≥ 1_
-<br/>_Default: `4`_
-
-#### `--video-width` `<int>`
-
-Video frame width in pixels. Must be specified together with `--video-height` (both or neither). Determines video resolution and file size. Common resolutions: `640×480` (SD), `1280×720` (HD), `1920×1080` (Full HD). If not specified, uses codec/format defaults.
-<br/>_Constraints: ≥ 1_
-
-#### `--video-height` `<int>`
-
-Video frame height in pixels. Must be specified together with `--video-width` (both or neither). Combined with width determines aspect ratio and total pixel count per frame. Higher resolution increases processing demands and file size.
-<br/>_Constraints: ≥ 1_
-
-#### `--video-synth-type` `<str>`
-
-Algorithm for generating synthetic video content. Different types produce different visual patterns for testing. Options: `moving_shapes` (animated geometric shapes), `grid_clock` (grid with rotating clock hands), `noise` (random pixel frames). Content doesn't affect semantic meaning but may impact encoding efficiency and file size.
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `moving_shapes` | _default_ | Generate videos with animated geometric shapes moving across the frame |
-| `grid_clock` |  | Generate videos with a grid pattern and frame number overlay for frame-accurate verification |
-| `noise` |  | Generate videos with random noise frames |
-
-#### `--video-format` `<str>`
-
-Container format for generated video files. Supports `webm` (VP9, recommended, BSD-licensed) and `mp4` (widely compatible container, VP9 by default). Format choice affects compatibility, file size, and encoding options. `mp4` is the more portable container, but note that the default VP9 video and Opus audio are less widely supported by players than H.264/AAC would be.
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `mp4` |  | MP4 container. Widely compatible, good for H.264/H.265 codecs. |
-| `webm` | _default_ | WebM container. Open format, optimized for web, good for VP9 codec. |
-
-#### `--video-codec` `<str>`
-
-The video codec to use for encoding. Common options: libvpx-vp9 (CPU, BSD-licensed, default), libvpx (CPU, BSD-licensed, VP8). Any codec the local FFmpeg supports can be used, but the AIPerf container ships a minimal FFmpeg build limited to VP8/VP9 video with Vorbis/Opus audio; codecs such as libx264 or h264_nvenc require an FFmpeg build that includes them.
-<br/>_Default: `libvpx-vp9`_
-
-#### `--video-audio-sample-rate` `<float>`
-
-Audio sample rate in Hz or kHz for the embedded audio track. Common values: 8/8000 (telephony), 16/16000 (speech), 44.1/44100 (CD quality), 48/48000 (professional). Higher sample rates increase audio fidelity and file size.
-<br/>_Constraints: ≥ 8, ≤ 96000_
-<br/>_Default: `44100`_
-
-#### `--video-audio-num-channels` `<int>`
-
-Number of audio channels to embed in generated video files. 0 = disabled (no audio track, default), 1 = mono, 2 = stereo. When set to 1 or 2, a Gaussian noise audio track matching the video duration is muxed into each video via FFmpeg.
-<br/>_Constraints: ≥ 0, ≤ 2_
-<br/>_Default: `0`_
-
-#### `--video-audio-codec` `<str>`
-
-Audio codec for the embedded audio track. If not specified, auto-selects based on video format: libopus for MP4, libvorbis for WebM. Options: libvorbis, libopus, aac. The AIPerf container ships only libvorbis and libopus; aac requires an FFmpeg build that includes an AAC encoder. libopus always encodes at 48 kHz, so any --video-audio-sample-rate is resampled during muxing.
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `aac` |  | AAC codec. Not built into the AIPerf container's FFmpeg; selecting it requires an FFmpeg build that includes an AAC encoder. |
-| `libvorbis` |  | Vorbis codec. Default for WebM containers. |
-| `libopus` |  | Opus codec. Default for MP4 containers. Always encodes at 48 kHz regardless of the requested sample rate. |
-
-#### `--video-audio-depth` `<str>`
-
-Audio bit depth for the embedded audio track. Supported values: 8, 16, 24, or 32 bits. Higher bit depths provide greater dynamic range but increase file size.
-<br/>_Default: `16`_
-
-### Rankings
-
-#### `--rankings-passages-mean` `<int>`
-
-Mean number of passages to include per ranking request. For `rankings` endpoint type, each request contains a query and multiple passages to rank. Passages follow normal distribution around this mean (±`--rankings-passages-stddev`). Higher values test ranking at scale but increase request payload size and processing time.
-<br/>_Constraints: ≥ 1_
-<br/>_Default: `1`_
-
-#### `--rankings-passages-stddev` `<int>`
-
-Standard deviation for number of passages per ranking request. Creates variability in ranking workload complexity. Passage counts follow normal distribution. Set to 0 for uniform passage counts across all requests.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0`_
-
-#### `--rankings-passages-prompt-token-mean` `<int>`
-
-Mean token length for each passage in ranking requests. Passages are synthetically generated text with lengths following normal distribution around this mean (±`--rankings-passages-prompt-token-stddev`). Longer passages increase input processing demands and request size.
-<br/>_Constraints: ≥ 1_
-<br/>_Default: `550`_
-
-#### `--rankings-passages-prompt-token-stddev` `<int>`
-
-Standard deviation for passage token lengths in ranking requests. Creates variability in passage sizes, simulating realistic heterogeneous document collections. Token lengths follow normal distribution. Set to 0 for uniform passage lengths.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0`_
-
-#### `--rankings-query-prompt-token-mean` `<int>`
-
-Mean token length for query text in ranking requests. Each ranking request contains one query and multiple passages. Queries are synthetically generated with lengths following normal distribution around this mean (±`--rankings-query-prompt-token-stddev`).
-<br/>_Constraints: ≥ 1_
-<br/>_Default: `550`_
-
-#### `--rankings-query-prompt-token-stddev` `<int>`
-
-Standard deviation for query token lengths in ranking requests. Creates variability in query complexity, simulating realistic user search patterns. Token lengths follow normal distribution. Set to 0 for uniform query lengths.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0`_
-
-### Synthesis
-
-#### `--synthesis-speedup-ratio` `<float>`
-
-Multiplier for timestamp scaling in synthesized traces.
-<br/>_Constraints: ≥ 0.0_
-<br/>_Default: `1.0`_
-
-#### `--synthesis-prefix-len-multiplier` `<float>`
-
-Multiplier for core prefix branch lengths in radix tree.
-<br/>_Constraints: ≥ 0.0_
-<br/>_Default: `1.0`_
-
-#### `--synthesis-prefix-root-multiplier` `<int>`
-
-Number of independent radix trees to distribute traces across.
-<br/>_Constraints: ≥ 1_
-<br/>_Default: `1`_
-
-#### `--synthesis-prompt-len-multiplier` `<float>`
-
-Multiplier for leaf path (unique prompt) lengths.
-<br/>_Constraints: ≥ 0.0_
-<br/>_Default: `1.0`_
-
-#### `--synthesis-output-len-multiplier` `<float>`
-
-Multiplier for output lengths in synthesized traces.
-<br/>_Constraints: ≥ 0.0_
-<br/>_Default: `1.0`_
-
-#### `--synthesis-max-isl` `<int>`
-
-Maximum input sequence length for filtering. Traces with input_length > max_isl are skipped.
-<br/>_Constraints: ≥ 1_
-
-#### `--synthesis-max-osl` `<int>`
-
-Maximum output sequence length cap for top-level (parent) turns. Turns with output_length > max_osl are capped to max_osl. Subagent child turns are intentionally uncapped so their decode load stays faithful; flat-chain sidecars still honor the cap.
-<br/>_Constraints: ≥ 1_
-
-### Load Generator
-
-#### `--benchmark-duration` `<str>`
-
-Maximum benchmark runtime in seconds. When set, AIPerf stops issuing new requests after this duration, Responses received within `--benchmark-grace-period` after duration ends are included in metrics. Pass a comma-separated list (e.g. `--benchmark-duration 30,60,120`) to sweep over multiple durations; the converter promotes the list to a sweep on phases.profiling.duration before AIPerfConfig validation.
-
-#### `--benchmark-grace-period` `<float>`
-
-The grace period in seconds to wait for responses after benchmark duration ends. Only applies when --benchmark-duration is set. Responses received within this period are included in metrics. Use 'inf' to wait indefinitely for all responses.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `30.0`_
-
-#### `--concurrency` `<str>`
-
-Number of concurrent requests to maintain. AIPerf issues a new request immediately when one completes, maintaining this level of in-flight requests. Can be combined with `--request-rate` to control the request rate. Pass a comma-separated list (e.g. `--concurrency 10,20,30`) to sweep over multiple concurrencies; the converter promotes the list to a sweep before AIPerfConfig validation.
-
-#### `--prefill-concurrency` `<str>`
-
-Max concurrent requests waiting for first token (prefill phase). Limits how many requests can be in the prefill/prompt-processing stage simultaneously. Pass a comma-separated list (e.g. `--prefill-concurrency 1,2,4`) to sweep over multiple values; the converter promotes the list to a sweep before AIPerfConfig validation.
-
-#### `--request-rate` `<str>`
-
-Target request rate in requests per second. AIPerf generates request timing according to `--request-rate-mode` to achieve this average rate. Can be combined with `--concurrency` to control the number of concurrent requests. Supports fractional rates (e.g., `0.5` = 1 request every 2 seconds). Pass a comma-separated list (e.g. `--request-rate 10,20,50`) to sweep over multiple rates; the converter promotes the list to a sweep before AIPerfConfig validation.
-
-#### `--arrival-pattern`, `--request-rate-mode` `<str>`
-
-Sets the arrival pattern for the load generated by AIPerf. Valid values: constant, poisson, gamma. `constant`: Generate requests at a fixed rate. `poisson`: Generate requests using a poisson distribution. `gamma`: Generate requests using a gamma distribution with tunable smoothness.
-<br/>_Choices: [`concurrency_burst`, `constant`, `gamma`, `poisson`]_
-<br/>_Default: `poisson`_
-
-#### `--arrival-smoothness`, `--vllm-burstiness` `<float>`
-
-Smoothness parameter for gamma distribution arrivals (--arrival-pattern gamma). Controls the shape of the arrival pattern: - 1.0: Poisson-like (exponential inter-arrivals, default) - &lt;1.0: Bursty/clustered arrivals (higher variance) - >1.0: Smooth/regular arrivals (lower variance) Compatible with vLLM's --burstiness parameter (same value = same distribution).
-<br/>_Constraints: > 0_
-
-#### `--request-count`, `--num-requests` `<str>`
-
-The maximum number of requests to send. If not set, will be automatically determined based on the timing mode and dataset size. For synthetic datasets, this will be `max(10, concurrency * 2)`. Pass a comma-separated list (e.g. `--request-count 100,500,1000`) to sweep over multiple request counts; the converter promotes the list to a sweep on phases.profiling.requests before AIPerfConfig validation.
-
-#### `--concurrency-ramp-duration` `<float>`
-
-Duration in seconds to ramp session concurrency from 1 to target. Useful for gradual warm-up of the target system.
-<br/>_Constraints: > 0_
-
-#### `--prefill-concurrency-ramp-duration` `<float>`
-
-Duration in seconds to ramp prefill concurrency from 1 to target.
-<br/>_Constraints: > 0_
-
-#### `--request-rate-ramp-duration` `<float>`
-
-Duration in seconds to ramp request rate from a proportional minimum to target. Start rate is calculated as target * (update_interval / duration), ensuring correct behavior for target rates below 1 QPS. Useful for gradual warm-up of the target system.
-<br/>_Constraints: > 0_
-
-#### `--request-rate-series` `<str>`
-
-JSON file containing request-rate points for piecewise-linear request-rate control.
-
-#### `--failed-request-threshold` `<float>`
-
-Abort the run early when (failed_records / total_records) exceeds this ratio. Default None disables the check. Only PROFILING-phase records count toward the ratio. A grace floor of max(concurrency, 10) records must accumulate before the check is armed, so a single early failure cannot kill the run. When the threshold is exceeded a ProfileCancelCommand is broadcast: in-flight requests drain via the normal cancel path, partial results are still aggregated, and the run exits non-zero. Pairs with the AGENTIC_REPLAY context-overflow drop in record_processor_service so the rate measures real failures only.
-<br/>_Constraints: ≥ 0.0, ≤ 1.0_
-
-#### `--trajectory-start-min-ratio` `<float>`
-
-AGENTIC_REPLAY only: lower bound (inclusive) on the random start position within each trajectory, expressed as a fraction of the trace's total turn count. Sampled per trajectory at trajectory-build time; deterministic given --random-seed.
-<br/>_Constraints: ≥ 0.0, ≤ 1.0_
-<br/>_Default: `0.25`_
-
-#### `--trajectory-start-max-ratio` `<float>`
-
-AGENTIC_REPLAY only: upper bound (inclusive) on the random start position within each trajectory, expressed as a fraction of the trace's total turn count. The effective per-trace ceiling is min(int(max_ratio * n), n - 2) so at least one profile turn remains after warmup.
-<br/>_Constraints: ≥ 0.0, ≤ 1.0_
-<br/>_Default: `0.75`_
-
-#### `--burst-phase-starts`
-
-AGENTIC_REPLAY only: collapse the WARMUP-start and PROFILING-start dispatches into synchronized bursts instead of spreading them by each request's recorded offset from t*. By default (False) the phase starts are SPREAD: WARMUP requests are aligned globally so every trajectory reaches its t* at the same instant (the warmup end), and each lane's first PROFILING request waits out its recorded gap after t* -- reproducing the recorded arrival pattern at both phase boundaries. The rest of the replay (inter-turn delays) is timing-faithful regardless of this flag; it governs ONLY the burst-vs-spread of the two phase starts. Pass --burst-phase-starts to fire each phase's first requests together (faster concurrency ramp, synchronized start), e.g. for a throughput-oriented run rather than a faithful arrival replay.
-<br/>_Flag (no value required)_
-
-#### `--trace-idle-gap-cap-seconds` `<float>`
-
-Hard ceiling (seconds) for idle gaps within each individual trace. For Weka trace replay, AIPerf looks at all parent and subagent request submission timestamps within one root trace, compresses long gaps between consecutive request submissions, and derives turn delays from the compressed per-trace timeline. Original request api_time values are not used to decide these idle gaps. When set for Weka, this takes precedence over `--inter-turn-delay-cap-seconds` so individual parent/subagent-line delays are not separately capped. Defaults to None (no per-trace idle-gap compression).
-<br/>_Constraints: ≥ 0.0_
-
-#### `--system-idle-gap-cap-seconds` `<float>`
-
-AGENTIC_REPLAY only: maximum time in seconds the replay may remain globally idle while future requests are scheduled. When no requests are in flight or ready, all pending request timers shift earlier uniformly so the next request arrives within this limit. Per-trace timing is otherwise preserved. None disables the cap.
-<br/>_Constraints: ≥ 0.0_
-
-### Scenario
-
-#### `--scenario` `<str>`
-
-Lock all benchmark invariants for a named scenario (e.g. 'inferencex-agentx-mvp'). Conflicts with the locked invariants raise ScenarioLockError at startup unless --unsafe-override is also passed. Distinct from the sweep ``scenarios`` strategy (hand-picked named runs).
-
-#### `--unsafe-override`
-
-Convert scenario lock errors to warnings; stamps submission_valid=false in the aggregate output. No-op without --scenario.
-<br/>_Flag (no value required)_
-
-### Warmup
-
-#### `--warmup-request-count`, `--num-warmup-requests` `<int>`
-
-The maximum number of warmup requests to send before benchmarking. If not set and no --warmup-duration is set, then no warmup phase will be used.
-<br/>_Constraints: > 0_
-
-#### `--warmup-duration` `<float>`
-
-The maximum duration in seconds for the warmup phase. If not set, it will use the `--warmup-request-count` value. If neither are set, no warmup phase will be used.
-<br/>_Constraints: > 0_
-
-#### `--agentic-cache-warmup-duration` `<float>`
-
-Additional agentic replay warmup duration in seconds. After the normal snapshot warmup drains, AIPerf continues the live trajectories without recorded idle delays and with one-token outputs, then drains and resumes profiling from the resulting trajectory state using each live stream's residual next-turn delay.
-<br/>_Constraints: > 0_
-
-#### `--agentic-warmup-grace-period` `<float>`
-
-AGENTIC_REPLAY only: grace period in seconds the auto-synthesized warmup barrier waits for in-flight priming requests after the warmup burst sends. The agentic warmup is synthesized from the profiling phase rather than a user-declared warmup phase, so it does NOT honor `--warmup-grace-period` (which requires `--warmup-duration`). If not set, the warmup barrier waits indefinitely until every primed trajectory returns.
-<br/>_Constraints: ≥ 0_
-
-#### `--num-warmup-sessions` `<int>`
-
-The number of sessions to use for the warmup phase. If not set, it will use the `--warmup-request-count` value.
-<br/>_Constraints: ≥ 1_
-
-#### `--warmup-concurrency` `<int>`
-
-The concurrency value to use for the warmup phase. If not set, it will use the `--concurrency` value.
-<br/>_Constraints: ≥ 1_
-
-#### `--warmup-prefill-concurrency` `<int>`
-
-The prefill concurrency value to use for the warmup phase. If not set, it will use the `--prefill-concurrency` value.
-<br/>_Constraints: ≥ 1_
-
-#### `--warmup-request-rate` `<float>`
-
-The request rate to use for the warmup phase. If not set, it will use the `--request-rate` value.
-<br/>_Constraints: > 0_
-
-#### `--warmup-arrival-pattern` `<str>`
-
-The arrival pattern to use for the warmup phase. If not set, it will use the `--arrival-pattern` value. Valid values: constant, poisson, gamma.
-
-#### `--warmup-grace-period` `<float>`
-
-The grace period in seconds to wait for responses after warmup phase ends. Only applies when warmup is enabled. Responses received within this period are included in warmup completion. If not set, waits indefinitely for all warmup responses.
-<br/>_Constraints: ≥ 0_
-
-#### `--warmup-concurrency-ramp-duration` `<float>`
-
-Duration in seconds to ramp warmup session concurrency from 1 to target. If not set, uses `--concurrency-ramp-duration` value.
-<br/>_Constraints: > 0_
-
-#### `--warmup-prefill-concurrency-ramp-duration` `<float>`
-
-Duration in seconds to ramp warmup prefill concurrency from 1 to target. If not set, uses `--prefill-concurrency-ramp-duration` value.
-<br/>_Constraints: > 0_
-
-#### `--warmup-request-rate-ramp-duration` `<float>`
-
-Duration in seconds to ramp warmup request rate from a proportional minimum to target. Start rate is calculated as target * (update_interval / duration). If not set, uses `--request-rate-ramp-duration` value.
-<br/>_Constraints: > 0_
-
-### User-Centric Rate
-
-#### `--user-centric-rate` `<float>`
-
-Enable user-centric rate limiting mode with the specified request rate (QPS). Each user has a gap = num_users / qps between turns. Users block on their previous turn (no interleaving within a user). New users are spawned on a fixed schedule to maintain steady-state throughput. Designed for KV cache benchmarking with realistic multi-user patterns. Requires --num-users to be set.
-<br/>_Constraints: > 0_
-
-#### `--num-users` `<str>`
-
-The number of initial users to use for --user-centric-rate mode. Pass a comma-separated list (e.g. `--num-users 4,8,16`) to sweep over user counts; the converter promotes the list to a sweep on phases.profiling.users before AIPerfConfig validation.
-
-### Request Cancellation
-
-#### `--request-cancellation-rate` `<float>`
-
-Percentage (0-100) of requests to cancel for testing cancellation handling. Cancelled requests are sent normally but aborted after `--request-cancellation-delay` seconds. Useful for testing graceful degradation and resource cleanup.
-<br/>_Constraints: > 0.0, ≤ 100.0_
-
-#### `--request-cancellation-delay` `<float>`
-
-Seconds to wait after the request is fully sent before cancelling. A delay of 0 means 'send the full request, then immediately disconnect'. Requires --request-cancellation-rate to be set.
-<br/>_Constraints: ≥ 0.0_
-<br/>_Default: `0.0`_
-
-### Output
-
-#### `--output-artifact-dir`, `--artifact-dir` `<str>`
-
-Output directory for all benchmark artifacts including metrics (`.csv`, `.json`, `.jsonl`), raw data (`_raw.jsonl`), GPU telemetry (`_gpu_telemetry.jsonl`), and time-sliced metrics (`_timeslices.csv/json`). Directory created if it doesn't exist. All output file paths are constructed relative to this directory.
-<br/>_Default: `artifacts`_
-
-#### `--profile-export-prefix`, `--profile-export-file` `<str>`
-
-Base filename for ALL exported files. With prefix='foo' every output becomes `foo.csv`, `foo.json`, `foo_timeslices.{csv,json}`, `foo.jsonl`, `foo_raw.jsonl`, `foo_gpu_telemetry.jsonl`, and `foo_server_metrics.{jsonl,json,csv,parquet}`. When unset (the default), historical per-file names are used: `profile_export_aiperf.{csv,json}` for the summary, `profile_export.jsonl` and `profile_export_raw.jsonl` for records, `gpu_telemetry_export.jsonl`, and `server_metrics_export.*`. Known suffixes (e.g. `_raw.jsonl`, `_timeslices.csv`, `_server_metrics.parquet`) are stripped from the supplied value.
-
-#### `--export-level`, `--profile-export-level` `<str>`
-
-Controls which output files are generated. `summary`: Only aggregate metrics files (`.csv`, `.json`). `records`: Includes per-request metrics (`.jsonl`). `raw`: Includes raw request/response data (`_raw.jsonl`).
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `summary` |  | Export only aggregated/summarized metrics (most compact) |
-| `records` | _default_ | Export per-record metrics after aggregation with display unit conversion (CLI default) |
-| `raw` |  | Export raw parsed records with full request/response data (most detailed) |
-
-#### `--slice-duration` `<float>`
-
-Duration in seconds for time-sliced metric analysis. When set, AIPerf divides the benchmark timeline into fixed-length windows and computes metrics separately for each window. This enables analysis of performance trends and variations over time (e.g., warmup effects, degradation under sustained load).
-<br/>_Constraints: > 0_
-
-#### `--auto-plot`, `--no-auto-plot`
-
-Auto-invoke `aiperf plot` against the artifact directory after the benchmark completes. None = defer to recipe default (False if no recipe). True/False = explicit override. Failures are logged but do not fail the command unless --plot-required is set.
-
-#### `--plot-required`
-
-Treat auto-plot failures as fatal: re-raise so `aiperf profile` exits non-zero. Only meaningful when auto-plot is on. Default False = warn and continue.
-<br/>_Flag (no value required)_
-
-#### `--export-outputs-json`
-
-Export generated response text to outputs.json after the run. When enabled, the raw generated-text payload for each request is written to an outputs.json file in the artifact directory.
-<br/>_Flag (no value required)_
-
-#### `--otel-url` `<str>`
-
-OTLP/HTTP metrics endpoint URL.
-
-#### `--stream` `<list>`
-
-Select which AIPerf telemetry domains to stream over OTel. Valid values: 'metrics', 'timing', or 'default'. 'default' streams both metrics and timing. Examples: --stream metrics | --stream timing | --stream metrics timing.
-
-#### `--otel-resource-attributes` `<list>`
-
-Custom OTel resource attributes as key=value pairs. Merged into the default resource attributes on every exported metric.
-
-#### `--gen-ai-provider` `<str>`
-
-GenAI semantic convention provider override.
-
-#### `--mlflow-tracking-uri` `<str>`
-
-MLflow tracking URI.
-
-#### `--mlflow-experiment` `<str>`
-
-MLflow experiment name.
-
-#### `--mlflow-run-name` `<str>`
-
-MLflow run name.
-
-#### `--mlflow-tag` `<list>`
-
-Additional MLflow run tags to attach on upload. Specify as key:value pairs (e.g., --mlflow-tag team:perf) or as JSON string.
-
-#### `--mlflow-parent-run-id` `<str>`
-
-Optional MLflow parent run ID.
-
-#### `--mlflow-artifact-glob` `<list>`
-
-Artifact glob overrides for MLflow upload. Can be specified multiple times or as a comma-separated list.
-
-#### `--wandb-project` `<str>`
-
-Weights & Biases project name. Setting this enables wandb export.
-
-#### `--wandb-entity` `<str>`
-
-Weights & Biases entity (team or user). Defaults to the API key's default entity.
-
-#### `--wandb-run-name` `<str>`
-
-Weights & Biases run name.
-
-#### `--wandb-tag` `<list>`
-
-Additional Weights & Biases run tags to attach on upload. Can be specified multiple times or as a comma-separated list.
-
-### HTTP Trace
-
-#### `--export-http-trace`
-
-Include HTTP trace data (timestamps, chunks, headers, socket info) in profile_export.jsonl. Computed metrics (http_req_duration, http_req_waiting, etc.) are always included regardless of this setting. See the HTTP Trace Metrics guide for details on trace data fields.
-<br/>_Flag (no value required)_
-
-#### `--show-trace-timing`
-
-Display HTTP trace timing metrics in the console at the end of the benchmark. Shows detailed timing breakdown: blocked, DNS, connecting, sending, waiting (TTFB), receiving, and total duration following k6 naming conventions.
-<br/>_Flag (no value required)_
-
-### Server Metrics
-
-#### `--server-metrics` `<list>`
-
-Server metrics collection (ENABLED BY DEFAULT). Automatically collects from inference endpoint base_url + `/metrics`. Optionally specify additional custom Prometheus-compatible endpoint URLs (e.g., http://node1:8081/metrics, http://node2:9090/metrics). Use `--no-server-metrics` to disable collection. Example: `--server-metrics node1:8081 node2:9090/metrics` for additional endpoints.
-
-#### `--no-server-metrics`
-
-Disable server metrics collection entirely.
-
-#### `--server-metrics-formats` `<list>`
-
-Specify which output formats to generate for server metrics. Multiple formats can be specified (e.g., `--server-metrics-formats json csv parquet`).
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `json` | _default_ | Export aggregated statistics in JSON hybrid format with metrics keyed by name. Best for: Programmatic access, CI/CD pipelines, automated analysis. |
-| `csv` | _default_ | Export aggregated statistics in CSV tabular format organized by metric type. Best for: Spreadsheet analysis, Excel/Google Sheets, pandas DataFrames. |
-| `jsonl` |  | Export raw time-series records in line-delimited JSON format. Best for: Time-series analysis, debugging, visualizing metric evolution. Warning: Can generate very large files for long-running benchmarks. |
-| `parquet` |  | Export raw time-series data with delta calculations in Parquet columnar format. Best for: Analytics with DuckDB/pandas/Polars, efficient storage, SQL queries. Includes cumulative deltas from reference point for counters and histograms. |
-
-### Network Latency
-
-#### `--network-latency-automatic`
-
-Automatically measure network latency (DISABLED BY DEFAULT). Opens a fresh TCP connection to the endpoint throughout the run, measures the handshake RTT, and subtracts the mean from request-start-anchored latency metrics (request_latency, time_to_first_token, time_to_first_output_token). Raw metrics are preserved; adjusted values are emitted as separate network_adjusted_* metrics plus a network_rtt summary. Mutually exclusive with --network-latency-mean.
-<br/>_Flag (no value required)_
-
-#### `--network-latency-mean` `<float>`
-
-Set a fixed mean network RTT in milliseconds to subtract, bypassing active probing. Implicitly enables network latency adjustment. Mutually exclusive with --network-latency-automatic.
-<br/>_Constraints: ≥ 0.0_
-
-#### `--network-latency-ping-interval` `<float>`
-
-Seconds between TCP-handshake RTT probes during profiling (default: 1.0s). Only applies with --network-latency-automatic.
-<br/>_Constraints: > 0.0_
-
-### GPU Telemetry
-
-#### `--gpu-telemetry` `<list>`
-
-Enable GPU telemetry console display and optionally specify: (1) 'pynvml' or 'amdsmi' to use a local GPU library instead of DCGM HTTP endpoints, (2) 'dashboard' for realtime dashboard mode, (3) custom DCGM exporter URLs (e.g., http://node1:9401/metrics), (4) custom metrics CSV file (e.g., custom_gpu_metrics.csv). Default: DCGM mode with localhost:9400 and localhost:9401 endpoints. Examples: --gpu-telemetry pynvml | --gpu-telemetry amdsmi | --gpu-telemetry dashboard node1:9400.
-
-#### `--no-gpu-telemetry`
-
-Disable GPU telemetry collection entirely.
-
-### UI
-
-#### `--ui-type`, `--ui` `<str>`
-
-Select the user interface type for displaying benchmark progress. `dashboard` shows real-time metrics in a Textual TUI, `simple` uses TQDM progress bars, `none` disables UI completely. Defaults to `dashboard` in interactive terminals, `none` when not a TTY (e.g., piped or redirected output). Automatically set to `simple` when using `--verbose` or `--extra-verbose` in a TTY.
-<br/>_Choices: [`dashboard`, `none`, `simple`]_
-<br/>_Default: `dashboard`_
-
-### Multi-Run
-
-#### `--num-profile-runs` `<int>`
-
-Number of profile runs to execute for confidence reporting. Must be between 1 and 10. When set to 1 (default), runs a single benchmark. When set to >1, runs multiple benchmarks and computes aggregate statistics (mean, std, confidence intervals, coefficient of variation) across runs. Useful for quantifying variance and establishing confidence in results.
-<br/>_Constraints: ≥ 1, ≤ 10_
-<br/>_Default: `1`_
-
-#### `--profile-run-cooldown-seconds` `<float>`
-
-Cooldown duration in seconds between profile runs. Only applies when --num-profile-runs > 1. Allows the system to stabilize between runs (e.g., clear caches, cool down GPUs). Default is 0 (no cooldown).
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--confidence-level` `<float>`
-
-Confidence level for computing confidence intervals (0-1). Only applies when --num-profile-runs > 1. Common values: 0.90 (90%), 0.95 (95%, default), 0.99 (99%). Higher values produce wider confidence intervals.
-<br/>_Constraints: > 0, &lt; 1_
-<br/>_Default: `0.95`_
-
-#### `--profile-run-disable-warmup-after-first`, `--no-profile-run-disable-warmup-after-first`
-
-Disable warmup for profile runs after the first. Only applies when --num-profile-runs > 1. When True (default), only the first run includes warmup, subsequent runs measure steady-state performance for more accurate aggregate statistics. When False, all runs include warmup (useful for long cooldown periods or when testing cold-start performance).
-<br/>_Default: `True`_
-
-#### `--set-consistent-seed`, `--no-set-consistent-seed`
-
-Automatically set random seed for consistent workloads across runs. Only applies when --num-profile-runs > 1. When True (default), automatically sets --random-seed=42 if not specified, ensuring identical workloads across all runs for valid statistical comparison. When False, preserves None seed, resulting in different workloads per run (not recommended for confidence reporting as it produces invalid statistics). If --random-seed is explicitly set, that value is always used regardless of this setting.
-<br/>_Default: `True`_
-
-#### `--vary-seed-per-trial`, `--no-vary-seed-per-trial`
-
-When True, derive a distinct seed for each trial of a variation via SHA-256 over (envelope_seed, variation.label, trial). When False (default), all trials of a variation share the same seed, giving pure-runtime variance for confidence intervals. Enable when you want trials to also sample different inputs (captures end-to-end variance at the cost of conflating input noise with runtime noise in the resulting confidence statistics).
-
-#### `--convergence-metric` `<str>`
-
-Target metric name for adaptive convergence stopping. When set with --num-profile-runs > 1, enables adaptive mode that stops early once the metric stabilizes according to --convergence-mode. Uses --num-profile-runs as the maximum run cap. Example metrics: time_to_first_token, request_latency, inter_token_latency.
-
-#### `--convergence-stat` `<str>`
-
-Statistic to evaluate for convergence when using ci_width or cv mode. Common values: avg, p50, p90, p95, p99. Only applies when --convergence-metric is set.
-<br/>_Choices: [`avg`, `p50`, `p90`, `p95`, `p99`, `min`, `max`]_
-<br/>_Default: `avg`_
-
-#### `--convergence-threshold` `<float>`
-
-Threshold for convergence detection. For ci_width mode: maximum CI width as a fraction of the mean. For cv mode: maximum coefficient of variation. For distribution mode: KS test p-value threshold. When unset, each mode uses its own algorithm-specific default. Only applies when --convergence-metric is set.
-<br/>_Constraints: > 0, &lt; 1_
-
-#### `--convergence-mode` `<str>`
-
-Statistical method for convergence detection. ci_width: Stop when Student's t confidence interval width relative to mean is below threshold. cv: Stop when coefficient of variation (std/mean) is below threshold. distribution: Stop when KS test p-value indicates latest run matches prior runs (requires --export-level records or --export-level raw; rejected with --export-level summary). Only applies when --convergence-metric is set.
-<br/>_Choices: [`ci_width`, `cv`, `distribution`]_
-<br/>_Default: `ci_width`_
-
-#### `--parameter-sweep-cooldown-seconds` `<float>`
-
-Cooldown seconds between sweep variations (e.g. between --concurrency 10 and --concurrency 20). Honored by MultiRunOrchestrator when iterating plan.configs. Default 0.
-<br/>_Constraints: ≥ 0_
-<br/>_Default: `0.0`_
-
-#### `--parameter-sweep-same-seed`, `--no-parameter-sweep-same-seed`
-
-If true, every sweep variation reuses the same random seed (correlated comparisons). If false (default), each variation derives a unique seed `base_seed + variation.index` so independent draws exercise different inputs. Requires --random-seed when true.
-
-#### `--parameter-sweep-mode` `<str>`
-
-Execution order for sweep + multi-trial composition. 'repeated' (default) iterates trials as the outer loop and variations as the inner loop, so all variations run within trial 1, then within trial 2, etc. 'independent' inverts the loops: all trials at one variation complete before the next variation starts. Both modes produce the same total runs, only the artifact-path layout and submit order differ.
-<br/>_Choices: [`independent`, `repeated`]_
-<br/>_Default: `repeated`_
-
-#### `--sweep-type` `<str>`
-
-Topology used when multiple CLI magic-list flags (--concurrency, --request-rate, --isl, --osl, ...) are passed together. 'grid' (default) takes the Cartesian product of all lists; 'zip' pairs them element-wise (all lists must have equal length, like the YAML `sweep: {type: zip}` block). Ignored when only one magic-list flag is set or when the sweep is declared in YAML.
-<br/>_Default: `grid`_
-
-#### `--no-sweep-table`
-
-Suppress the per-cell streaming sweep table during multi-variation sweeps. Auto-suppressed when stdout is non-interactive, when the dashboard UI is active, or for single-cell sweeps.
-
-#### `--search-space` `<list>`
-
-Adaptive-search space dimensions. Repeatable. Each value is 'path:lo,hi[:kind]', e.g. 'phases.profiling.concurrency:1,1000:int'. Mutually exclusive with magic-list flags (--concurrency 10,20,30) and with explicit sweep blocks. See docs/sweeping/bayesian-optimization.md.
-
-#### `--search-metric` `<str>`
-
-Metric tag to optimize, e.g. 'output_token_throughput'. Required when --search-space is set. Must match a key in RunResult.summary_metrics produced by the run (NOT the flattened '_avg' / '_p99' aggregator-suffixed key).
-
-#### `--search-stat` `<str>`
-
-Statistic on the metric: avg / p50 / p90 / p95 / p99. Defaults to 'avg' when omitted (set by the CLIConfig -> AIPerfConfig converter).
-
-#### `--search-direction` `<str>`
-
-Optimization direction. Required when --search-space is set.
-
-#### `--search-max-iterations` `<int>`
-
-Maximum number of search iterations. Each iteration runs --num-profile-runs benchmarks. Required when --search-space is set.
-<br/>_Constraints: ≥ 2, ≤ 200_
-
-#### `--search-initial-points` `<int>`
-
-Random Sobol points before fitting the GP. Defaults to 5 when omitted. Must be &lt; --search-max-iterations.
-<br/>_Constraints: ≥ 1_
-
-#### `--search-random-seed` `<int>`
-
-Random seed for reproducible search trajectories. When unset, the planner uses non-deterministic randomness.
-<br/>_Constraints: ≥ 0_
-
-#### `--search-planner` `<str>`
-
-Outer-loop search planner plugin. Default `bayesian` is a curated Optuna preset that uses BoTorch qLogNEI/qLogNEHVI when the optional `botorch` extra is installed and otherwise falls back to Optuna TPE with a warning. `optuna` is the expert-mode alternative exposing `--optuna-sampler` (tpe / gp / botorch) and `--optuna-acquisition`. Explicit unavailable optional samplers raise. Third-party planners registered under the `search_planner` plugin category are accepted here. Only applies when --search-space is set.
-<br/>_Choices: [`bayesian`, `monotonic_sla`, `smooth_isotonic`, `optuna`]_
-
-#### `--optuna-sampler` `<str>`
-
-Optuna sampler selection. Only consulted when --search-planner=optuna. ``botorch`` is the preferred implicit default and requires the optional ``botorch`` extra; when the implicit default is unavailable, the planner warns and falls back to ``tpe``. Explicit ``botorch`` requests raise if the optional stack is unavailable. ``tpe`` is dep-light and ships with Optuna core. ``gp`` is Optuna's native GP-EI with inequality constraints (Optuna 4.2+) but requires ``torch``.
-
-#### `--optuna-acquisition` `<str>`
-
-Acquisition function override for the Optuna BoTorch sampler. Only consulted when --search-planner=optuna AND --optuna-sampler=botorch; rejected otherwise. ``None`` (default) lets Optuna pick (single-objective unconstrained -> LogEI per Optuna v4.x). ``logei``/``qlogei`` make that explicit. ``qnei`` selects plain noisy EI (Letham 2017). ``qlognei`` selects qLogNoisyExpectedImprovement (Ament 2023, https://arxiv.org/abs/2310.20708) -- BoTorch's strongly recommended modern noisy-EI default; requires ``botorch>=0.10``. Multi-objective variants (``qehvi``/``qnehvi``/``qlognehvi``) are accepted when ``objectives`` has length > 1; the planner rejects them on single-objective configs.
-
-#### `--optuna-terminator` `<str>`
-
-Optional posterior-regret stopping rule layered on top of the three-signal convergence check. Only consulted when --search-planner=optuna. ``regret`` selects Optuna's ``RegretBoundEvaluator`` (Makarova et al. 2022, https://proceedings.mlr.press/v188/makarova22a.html). ``emmr`` selects ``EMMREvaluator`` (Ishibashi et al. 2023, https://proceedings.mlr.press/v206/ishibashi23a.html). Both are in the same family as Wilson 2024's PRB stopping rule and ship in Optuna core (no extra dep). ``none`` (default) disables; convergence is then driven by --search-max-iterations / --improvement-patience / --plateau-cv only.
-
-#### `--search-percentile-pooling` `<str>`
-
-Percentile aggregation strategy when --search-stat is a percentile (p50/p90/p95/p99). ``mean`` (default) computes the BO objective as the arithmetic mean of per-trial percentiles across --num-profile-runs trials. ``pooled`` walks each trial's per-request profile_export.jsonl, accumulates raw samples, and computes ``np.percentile`` over the pooled bag -- exposing more tail mass than mean-of-percentiles (correct for SLO claims; same argmax for ranking on monotone problems). ``pooled`` requires --export-level records; if the JSONL is missing the planner falls back to mean with a one-time warning. Rejected when --search-stat is ``avg``.
-
-#### `--bo-constraint-mode` `<str>`
-
-Deprecated and ignored. The bayesian preset and the optuna expert mode both use Optuna's native ``constraints_func`` (Letham et al. 2019, arXiv:1706.07094), which subsumes both the soft-penalty and EIC formulations. Accepted for backwards compatibility but has no effect: the value flows through ``_converter_optionals._SWEEP_OPTIONAL_FIELDS`` to ``AdaptiveSearchSweep.constraint_mode`` (see ``aiperf.config.sweep.config``), and that field is not read by any planner.
-
-#### `--variant`, `--sweep-variant` `<list>`
-
-Repeatable: each occurrence describes one sweep variation. Format: '[name:] key=value, key=value, ...'. Keys are CLI flag names with the leading '--' stripped, in either kebab-case or snake_case (isl, osl, concurrency, request-rate / request_rate, request-count / request_count, benchmark-duration / benchmark_duration, ...). Multi-occurrence emits a ScenarioSweep. Mutually exclusive with magic-list flags, --search-recipe, and YAML-declared sweeps. Single-occurrence is rejected -- use the standalone --isl / --osl / --concurrency flags for a one-off.
-
-#### `--search-sla` `<list>`
-
-SLA filter to attach to the adaptive-search or grid path. Format: 'metric_tag:stat:op:threshold'. Stat in {avg, min, max, p1, p5, p10, p25, p50, p75, p90, p95, p99}; op in {lt, le, gt, ge}; threshold is a float in the metric's native unit. For request_error_rate, 1 means 1% (percentage points), unlike --error-rate-sla, which accepts a fraction. Repeatable. Example: --search-sla 'time_to_first_token:p95:lt:200' --search-sla 'request_error_rate:avg:lt:1'. Composes with recipe-named SLA flags (--ttft-sla-ms etc.); the final filter list is recipe filters first, then --search-sla filters in CLI order.
-
-#### `--search-sla-tier` `<list>`
-
-Multi-tier SLO grouping flag. Each invocation defines one tier of SLA filters. Format: 'LABEL:FILTER[,FILTER...]' or 'FILTER[,FILTER...]' (auto-labels tier_1, tier_2, ...). Requires 2-10 invocations. Example: --search-sla-tier 'fast:output_token_throughput:avg:gt:300,time_to_first_token:p95:lt:5000' --search-sla-tier 'standard:output_token_throughput:avg:gt:100,time_to_first_token:p95:lt:10000'. When used, all --search-sla filters are still parsed and compose with tier definitions.
-
-#### `--search-recipe` `<str>`
-
-Named search-recipe preset that expands to an adaptive-search or sweep block. Mutually exclusive with explicit --search-* flags. Recipes are registered under the search_recipe plugin category. Example: --search-recipe max-throughput-ttft-sla --ttft-sla-ms 200.
-
-#### `--ttft-sla-ms` `<float>`
-
-Time-to-first-token SLA threshold in milliseconds. Required by TTFT-SLA recipes (e.g. max-throughput-ttft-sla); ignored otherwise. Must be > 0 — a 0 or negative threshold yields an unsatisfiable filter.
-<br/>_Constraints: > 0_
-
-#### `--isl-osl-pairs` `<str>`
-
-Paired ISL/OSL workload shapes for the pareto-sweep recipe, e.g. '128/128,512/256,2048/512'. Each pair is '&lt;isl>/&lt;osl>' with positive ints; pairs are comma-separated and whitespace-tolerant. Recipe-only flag; ignored unless --search-recipe pareto-sweep is set.
-
-#### `--itl-sla-ms` `<float>`
-
-Inter-token-latency SLA threshold in milliseconds. Required by ITL-SLA recipes (e.g. max-throughput-itl-sla); ignored otherwise. Must be > 0 — a 0 or negative threshold yields an unsatisfiable filter.
-<br/>_Constraints: > 0_
-
-#### `--tpot-sla-ms` `<float>`
-
-Time-per-output-token SLA threshold in milliseconds. Maps to the `inter_token_latency` metric tag (TPOT and ITL are equivalent in this codebase). Consumed by the max-concurrency-under-sla and max-goodput-under-slo recipes; ignored otherwise. Streaming required.
-<br/>_Constraints: > 0_
-
-#### `--e2e-sla-ms` `<float>`
-
-End-to-end request-latency SLA threshold in milliseconds (p99). Maps to the `request_latency` metric tag. Consumed by the max-concurrency-under-sla and max-goodput-under-slo recipes; ignored otherwise. Available without streaming.
-<br/>_Constraints: > 0_
-
-#### `--error-rate-sla` `<float>`
-
-Maximum acceptable request error rate as a fraction in (0, 1) (e.g. 0.05 = 5%). Maps to the `request_error_rate` metric tag (avg), converting the fraction to the metric's percentage-point scale. Consumed by the max-concurrency-under-sla recipe; ignored otherwise. Available without streaming.
-<br/>_Constraints: > 0, &lt; 1_
-
-#### `--slo-attainment-fraction` `<float>`
-
-Minimum fraction of requests that must satisfy ALL configured per-request SLOs (TTFT/TPOT/E2E) for a configuration to be considered feasible by the goodput recipe. Bounded in (0, 1]. Default 0.95 matches DistServe's canonical attainment-fraction convention (https://arxiv.org/pdf/2401.09670). Consumed by the max-goodput-under-slo recipe; ignored otherwise.
-<br/>_Constraints: > 0, ≤ 1_
-
-#### `--search-style` `<str>`
-
-Search strategy for the max-concurrency-under-sla recipe. 'smooth_isotonic' (default) runs PAVA + PCHIP smooth-isotonic regression-based 1D SLA-saturation search. 'monotonic' runs a 1D binary-search via the MonotonicSLASearchPlanner (~10-20 iterations). 'bo' runs penalty Bayesian Optimization (~30 iterations). 'optuna' runs the same penalty-BO formulation via the OptunaSearchPlanner (TPE/GP/BoTorch samplers; BoTorch requires the optional botorch extra). 'grid' runs a log-spaced 8-step sweep + sla_breach_knee post-process. Recipe-only flag; ignored unless --search-recipe max-concurrency-under-sla is set.
-
-#### `--degradation-threshold` `<float>`
-
-Relative latency degradation threshold for the concurrency-ramp recipe (e.g. 0.20 = 20%). The recipe's post-process handler reports the first concurrency where p99 latency exceeds baseline * (1 + threshold). Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
-<br/>_Constraints: > 0, &lt; 1_
-
-#### `--degradation-metric-tag` `<str>`
-
-ConcurrencyRamp post-process: metric tag for knee detection (default: request_latency). Use, e.g., 'time_to_first_token' to detect the knee on TTFT instead of end-to-end request latency. Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
-
-#### `--degradation-stat` `<str>`
-
-ConcurrencyRamp post-process: statistic for knee detection (default: p99). Recipe-only flag; ignored unless --search-recipe concurrency-ramp is set.
-
-#### `--isl-min` `<int>`
-
-Minimum input-sequence-length for the prefill-ttft-curve recipe (default 256 when omitted). The recipe sweeps ISL on a log scale from --isl-min to --isl-max. Recipe-only flag.
-<br/>_Constraints: ≥ 1_
-
-#### `--isl-max` `<int>`
-
-Maximum input-sequence-length for the prefill-ttft-curve recipe (default 32768 when omitted). The recipe sweeps ISL on a log scale from --isl-min to --isl-max. Recipe-only flag.
-<br/>_Constraints: ≥ 1_
-
-#### `--isl-steps` `<int>`
-
-Number of log-spaced steps for the prefill-ttft-curve recipe's ISL grid (default 8 when omitted). Must be >= 2 — a single-point ramp degenerates and post-process can't compute a baseline. Recipe-only flag.
-<br/>_Constraints: ≥ 2_
-
-#### `--concurrency-min` `<int>`
-
-Lower bound for the concurrency sweep axis used by concurrency-ramp and decode-itl-curve recipes (defaults: 1 for concurrency-ramp, 1 for decode-itl-curve). Must be &lt; --concurrency-max. Recipe-only flag.
-<br/>_Constraints: ≥ 1_
-
-#### `--concurrency-max` `<int>`
-
-Upper bound for the concurrency sweep axis used by concurrency-ramp and decode-itl-curve recipes (defaults: 1000 for concurrency-ramp, 200 for decode-itl-curve). Must be > --concurrency-min. Recipe-only flag.
-<br/>_Constraints: ≥ 1_
-
-#### `--concurrency-steps` `<int>`
-
-Number of log-spaced steps for the concurrency sweep axis used by concurrency-ramp (default 8) and decode-itl-curve (default 6). Must be >= 2. Recipe-only flag.
-<br/>_Constraints: ≥ 2_
-
-#### `--osl-min` `<int>`
-
-Minimum output-sequence-length for the decode-itl-curve recipe's OSL grid (default 64 when omitted). The recipe sweeps OSL on a log scale from --osl-min to --osl-max. Recipe-only flag.
-<br/>_Constraints: ≥ 1_
-
-#### `--osl-max` `<int>`
-
-Maximum output-sequence-length for the decode-itl-curve recipe's OSL grid (default 1024 when omitted). The recipe sweeps OSL on a log scale from --osl-min to --osl-max. Recipe-only flag.
-<br/>_Constraints: ≥ 1_
-
-#### `--osl-steps` `<int>`
-
-Number of log-spaced steps for the decode-itl-curve recipe's OSL grid (default 4 when omitted). Must be >= 2. Recipe-only flag.
-<br/>_Constraints: ≥ 2_
-
-### Accuracy
-
-#### `--accuracy-benchmark` `<str>`
-
-Accuracy benchmark to run (e.g., mmlu, aime, hellaswag). When set, enables accuracy benchmarking mode alongside performance profiling.
-<br/>_Choices: [`mmlu`, `mmlu_pro`, `aime`, `hellaswag`, `bigbench`, `aime24`, `aime25`, `math_500`, `gsm8k`, `gpqa_diamond`, `lcb_codegeneration`]_
-
-#### `--accuracy-tasks` `<list>`
-
-Specific tasks or subtasks within the benchmark to evaluate (e.g., specific MMLU subjects). Accepts comma-separated values (e.g. abstract_algebra,anatomy) or repeated flags. If not set, all tasks are included.
-
-#### `--accuracy-n-shots` `<int>`
-
-Number of few-shot examples to include in the prompt. 0 means zero-shot evaluation, None uses the benchmark default (e.g. MMLU=5). Maximum 32.
-<br/>_Constraints: ≥ 0, ≤ 32_
-
-#### `--accuracy-enable-cot`, `--accuracy-no-enable-cot`
-
-Enable chain-of-thought prompting for accuracy evaluation. Adds reasoning instructions to the prompt. Defaults to the benchmark's ``default_enable_cot`` metadata when unset (e.g. AIME defaults to True).
-<br/>_Flag (no value required)_
-
-#### `--accuracy-grader` `<str>`
-
-Override the default grader for the selected benchmark (e.g., exact_match, math, multiple_choice, code_execution). If not set, uses the benchmark's default grader.
-<br/>_Choices: [`exact_match`, `math`, `multiple_choice`, `code_execution`, `lighteval_expr`, `lighteval_latex`, `lighteval_gpqa`, `lighteval_gsm8k`, `mmlu_pro`]_
-
-#### `--accuracy-system-prompt` `<str>`
-
-Custom system prompt to use for accuracy evaluation. Overrides any benchmark-specific system prompt.
-
-#### `--accuracy-verbose`
-
-Enable verbose output for accuracy evaluation, showing per-problem grading details.
-<br/>_Flag (no value required)_
-
-### Service
-
-#### `--log-level` `<str>`
-
-Set the logging verbosity level. Controls the amount of output displayed during benchmark execution. Use `TRACE` for debugging ZMQ messages, `DEBUG` for detailed operation logs, or `INFO` (default) for standard progress updates.
-
-**Choices:**
-
-| | | |
-|-------|:-------:|-------------|
-| `TRACE` |  | Most verbose. Logs all operations including ZMQ messages and internal state changes. |
-| `DEBUG` |  | Detailed debugging information. Logs function calls and important state transitions. |
-| `INFO` | _default_ | General informational messages. Default level showing benchmark progress and results. |
-| `NOTICE` |  | Important informational messages that are more significant than INFO but not warnings. |
-| `WARNING` |  | Warning messages for potentially problematic situations that don't prevent execution. |
-| `SUCCESS` |  | Success messages for completed operations and milestones. |
-| `ERROR` |  | Error messages for failures that prevent specific operations but allow continued execution. |
-| `CRITICAL` |  | Critical errors that may cause the benchmark to fail or produce invalid results. |
-
-#### `-v`, `--verbose`
-
-Equivalent to `--log-level DEBUG`. Enables detailed logging output showing function calls and state transitions. Also automatically switches UI to `simple` mode for better console visibility. Does not include raw ZMQ message logging.
-<br/>_Flag (no value required)_
-
-#### `-vv`, `--extra-verbose`
-
-Equivalent to `--log-level TRACE`. Enables the most verbose logging possible, including all ZMQ messages, internal state changes, and low-level operations. Also switches UI to `simple` mode. Use for deep debugging.
-<br/>_Flag (no value required)_
-
-#### `--record-processor-service-count`, `--record-processors` `<int>`
-
-Number of `RecordProcessor` services to spawn for parallel metric computation. Higher request rates require more processors to keep up with incoming records. If not specified, automatically determined based on worker count (typically 1-2 processors per 8 workers).
-<br/>_Constraints: ≥ 1_
-
-#### `--api-port` `<int>`
-
-AIPerf API port (enables HTTP + WebSocket endpoints).
-<br/>_Constraints: ≥ 1, ≤ 65535_
-
-#### `--api-host` `<str>`
-
-AIPerf API host (requires --api-port or AIPERF_API_SERVER_PORT to be set).
-
-#### `--stats-interval` `<float>`
-
-Interval in seconds between realtime stats publishes (dashboards and the per-tick log block). 0 disables the log block while dashboards continue to poll. Defaults to 5s under --ui dashboard, 30s otherwise. Overrides AIPERF_UI_REALTIME_METRICS_INTERVAL.
-<br/>_Constraints: ≥ 0.0, ≤ 1000.0_
-
-### Workers
-
-#### `--workers-max`, `--max-workers` `<int>`
-
-Maximum number of workers to create. If not specified, the number of workers will be determined by the formula `min(concurrency, (num CPUs * 0.75) - 1)`, with a default max cap of 32. Any value provided will still be capped by the concurrency value (if specified), but not by the max cap.
-<br/>_Constraints: ≥ 1_
-
-### ZMQ Communication
-
-#### `--zmq-host` `<str>`
-
-Host address for internal ZMQ TCP communication between AIPerf services. Defaults to `127.0.0.1` (localhost) for single-machine deployments. For distributed setups, set to a reachable IP address. All internal service-to-service communication (message bus, dataset manager, workers) uses this host for TCP sockets.
-<br/>_Default: `127.0.0.1`_
-
-#### `--zmq-ipc-path` `<str>`
-
-Directory path for ZMQ IPC (Inter-Process Communication) socket files. When using IPC transport instead of TCP, AIPerf creates Unix domain socket files in this directory for faster local communication. Auto-generated in system temp directory if not specified. Only applicable when using IPC communication backend.
-
-#### `--zmq-dual-bind`
-
-Select the ZMQ dual-bind communication backend (IPC + TCP). All dual-bind knobs are cluster-managed; this flag only selects the discriminator and the converter routes downstream to the default.
-<br/>_Flag (no value required)_
 
 <hr/>
 

--- a/docs/dev/kubernetes-flow.md
+++ b/docs/dev/kubernetes-flow.md
@@ -1,0 +1,755 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Kubernetes Flow
+---
+
+# Kubernetes Flow End-to-End
+
+This document describes the complete flow from user command to benchmark completion when running AIPerf on Kubernetes.
+
+## Overview
+
+```mermaid
+flowchart TB
+    subgraph WS["User workstation"]
+        CLI["aiperf kube profile --model Qwen/Qwen3-0.6B --total-workers 10"]
+        SUB["Submit AIPerfJob CR<br/>(or direct manifests if no operator)"]
+        CLI --> SUB
+    end
+
+    SUB -->|kubernetes_asyncio API| JS
+
+    subgraph K8S["Kubernetes cluster"]
+        subgraph JS["JobSet: aiperf-{job_id}"]
+            CTRL["Controller pod<br/>SystemController / TimingMgr<br/>DatasetMgr / RecordsMgr / API"]
+            W0["Worker pod 0"]
+            W1["Worker pod 1"]
+            WN["Worker pod N"]
+            W0 --> CTRL
+            W1 --> CTRL
+            WN --> CTRL
+        end
+        CM["ConfigMap: benchmark config"]
+        CM --> CTRL
+    end
+```
+
+`WorkerGroupManager` is the universal readiness and capacity authority for worker groups across local and Kubernetes mode. This document focuses on the Kubernetes deployment, where each worker group maps to one worker pod, but the group-local startup and dataset contract is intentionally the same one used by local worker groups.
+
+## 1. CLI Entry Point
+
+```bash
+aiperf kube profile --model Qwen/Qwen3-0.6B --url http://server:8000 --image aiperf:latest --total-workers 10
+```
+
+CLI commands defined in `src/aiperf/cli_commands/kube/`:
+
+| Command | Purpose |
+|---------|---------|
+| `init` | Generate a starter configuration template |
+| `validate` | Validate AIPerfJob and AIPerfSweep YAML files against the CRD schema |
+| `profile` | Run a benchmark in Kubernetes |
+| `sweep` | Run a parameter sweep or multi-run benchmark in Kubernetes |
+| `generate` | Generate Kubernetes YAML manifests |
+| `attach` | Attach to a running benchmark and stream progress |
+| `list` | List benchmark jobs and their status; pass `--watch` for live updates |
+| `logs` | Retrieve logs from benchmark pods |
+| `results` | Retrieve benchmark results |
+| `show` | Render an AIPerfJob CR with Jinja2/env-vars resolved |
+| `debug` | Run diagnostic analysis on a deployment |
+| `preflight` | Run pre-flight checks against the target cluster |
+| `dashboard` | Open the operator results server UI in your browser |
+
+## 2. Deployment Generation
+
+The deployment logic in `src/aiperf/cli_commands/kube/profile.py` auto-detects whether the AIPerfJob CRD is installed. If the operator is present, `deploy_via_operator()` (in `profile_deploy.py`) submits an `AIPerfJob` custom resource and the operator reconciles it; otherwise `deploy_direct()` (in `profile_deploy_direct.py`) creates the manifests (ConfigMap, Role, RoleBinding, JobSet) directly. `--operator` forces operator mode without the cluster-scoped CRD probe; `--no-operator` forces direct mode. The operator path creates the default CLI-owned namespace when no namespace flag is supplied, but treats an explicit `--namespace` as pre-provisioned and performs only namespaced custom-resource operations.
+
+```mermaid
+flowchart TD
+    A["1. Resolve benchmark config<br/>from CLI flags or AIPerfJob CR YAML"] --> B
+    B["2. Configure ServiceConfig<br/>service_run_type = KUBERNETES<br/>dataset API base URL = controller DNS"] --> C
+    C{"3. AIPerfJob CRD present?"}
+    C -->|yes, or --operator| D["Operator mode:<br/>create AIPerfJob CR, operator reconciles"]
+    C -->|no, or --no-operator| E["Direct mode:<br/>create ConfigMap + RBAC + JobSet directly"]
+```
+
+`ServiceRunType.KUBERNETES` is a generated plugin enum member — it comes from
+`src/aiperf/plugin/plugins.yaml` via the generated `src/aiperf/plugin/enums.py`,
+which is never hand-edited.
+
+## 3. Kubernetes Resources
+
+### Resource Creation Order
+
+```mermaid
+flowchart TD
+    NS["Namespace (if auto-generated)"] --> ROLE[Role]
+    ROLE --> RB[RoleBinding]
+    ROLE --> CM[ConfigMap]
+    RB --> CM
+    CM --> JS[JobSet]
+    JS --> CTRL["controller (1 pod)"]
+    JS --> W["workers (N pods)"]
+```
+
+### Same-name recreation fencing
+
+Operator-managed RBAC, ConfigMaps, and JobSets are adopted after an
+`AlreadyExists` response only when their controller owner reference matches the
+current AIPerfJob or AIPerfSweep name and immutable UID. A resource owned by an
+older incarnation, or a matching resource already being deleted, remains on a
+retry path until Kubernetes garbage collection finishes. A deterministic name
+occupied by an unrelated or ownerless resource fails permanently instead of
+being adopted.
+
+Sweep child rollups and the sweep-controller pod apply the same UID fence to
+parent status writes. Resource-version and JSON Patch test operations prevent a
+delayed child event or stale controller pod from updating a newly recreated,
+same-named AIPerfSweep.
+
+AIPerfJob recovery callbacks also pin the parent resource version and accept
+JobSet state only when its controller owner API version, kind, name, and UID
+match the callback's immutable parent UID. Timeout, startup-failure, and result
+salvage cleanup re-read that ownership and delete with the JobSet UID as a
+precondition. A stable startup-blocker deadline first atomically adds
+`aiperf.nvidia.com/startup-failure-claimed` with JSON Patch tests for the
+parent UID, resource version, spec cancellation state, phase, exact
+`status.startupIssue`, and annotation map. The annotation-map test makes this
+failure-cleanup claim mutually exclusive with the durable completion claim;
+only the winner may enter JobSet deletion. A matching persisted failure claim
+resumes cleanup after an operator restart. Pod watches and stale-heartbeat
+recovery only persist critical startup diagnosis; the cached-state deadline is
+the sole path that may claim, delete, and terminalize that blocker. JobSet
+failure events use the same ownership fence before a direct status patch.
+Event status changes are rebased onto the fenced live status so every condition
+type not demonstrably changed by the event survives concurrent controller
+writes. Pod events resolve the full Pod to batch Job to JobSet to AIPerfJob
+controller-owner chain before restart reporting, startup diagnosis, or
+controller-termination salvage; transient owner-read failures request a
+bounded kopf retry instead of dropping the one-shot event.
+
+For an operator-managed AIPerfJob, the immutable owner UID is injected into
+controller-pod services as `AIPERF_JOB_UID`. Completion and progress writers
+read the live target, verify ownership, and use JSON Patch `test` operations on
+the AIPerfJob or JobSet UID before adding annotations. If the named resource was
+recreated between the read and patch, the API server rejects the whole atomic
+patch and the stale controller cannot mutate the replacement.
+
+Cancellation and completion callbacks use the same UID in their process-local
+cancellation, progress-client, and completion-claim keys. JobSet deletion uses
+the validated JobSet UID as a precondition, and terminal status merge patches
+carry the live parent resource version. Ready/latest and runs-index publication
+recheck the parent UID; the SQLite latest row advances only when `latest.txt`
+accepted the same epoch. A delayed callback therefore cannot close a
+replacement job's client, delete its JobSet, or publish terminal state for it.
+
+AIPerfSweep deletion uses sweep-name, sweep-UID, and, when available, run-epoch
+labels only to discover candidate child jobs. Before setting
+`spec.cancel=true`, the handler requires an `AIPerfSweep` owner reference whose
+name and immutable UID match the deleting parent. A standalone AIPerfJob cannot
+be cancelled merely by carrying user-writable sweep tracking labels.
+
+### Pod Architecture
+
+Each control-plane service runs in its own container in the controller pod
+(sibling containers, not subprocesses). Workers and record processors
+likewise each run in their own container inside a worker pod.
+
+**Controller pod** (container names from the `Containers` class in `src/aiperf/kubernetes/constants.py`):
+
+| Container | Role |
+|---|---|
+| `control-plane` | SystemController (orchestration) |
+| `dataset-manager` | Generates prompts, serves dataset |
+| `timing-manager` | Schedules requests, issues credits |
+| `records-manager` | Aggregates results from workers |
+| `api` | WebSocket + HTTP on port 9090 |
+| `gpu-telemetry-manager` | GPU metrics via DCGM (optional) |
+| `server-metrics-manager` | Prometheus metrics (optional) |
+| `results-sidecar` | Serves exported results after controller exit (port 9091) |
+| `event-bus-proxy` | XPUB/XSUB ZMQ proxy sidecar (`AIPERF_K8S_EVENT_BUS_SIDECAR_ENABLED=true` by default; isolates pub/sub I/O from the SystemController process) |
+
+Per-container health ports run 8080-8088 (`AIPERF_K8S_PORT_*_HEALTH`); the API
+service is on 9090 and the results sidecar on 9091.
+
+**Worker pod (x N):**
+
+| Container | Role |
+|---|---|
+| `worker-group-manager` | Group-local readiness, dataset download, proxy |
+| `worker-0` .. `worker-{N}` | One worker per container; each makes LLM API calls |
+| `record-processor-0` .. `record-processor-{M}` | One record processor per container; each computes metrics per record |
+
+### RBAC Permissions
+
+The Role rules are the `_RULES` class-var on the resource builder in
+`src/aiperf/kubernetes/resources.py`:
+
+| API group | Resources | Verbs |
+|---|---|---|
+| `aiperf.nvidia.com` | `aiperfjobs`, `aiperfjobs/status` | get, list, watch, patch, update |
+| `""` (core) | `configmaps` | get, list, watch, create, update, patch, delete |
+| `""` (core) | `pods`, `pods/log` | get, list, watch |
+| `""` (core) | `services`, `endpoints` | get, list, watch, create, delete |
+| `""` (core) | `events` | get, list, watch, create, patch |
+| `batch` | `jobs` | get, list, watch |
+| `jobset.x-k8s.io` | `jobsets` | get, list, watch, create, update, patch, delete |
+| `jobset.x-k8s.io` | `jobsets/status` | get, list, watch |
+
+## 4. Inter-Pod Communication
+
+### Network Topology
+
+```mermaid
+flowchart TD
+    DNS["Kubernetes DNS<br/>{jobset}-controller-0-0.{jobset}.{ns}.svc.cluster.local"]
+    DNS --> W0["Worker pod 0"]
+    DNS --> W1["Worker pod 1"]
+    DNS --> WN["Worker pod N"]
+```
+
+Each worker pod resolves the controller through that headless-service DNS name,
+injected via the ZMQ controller-host environment variable
+(`AIPERF_K8S_PORT_*` settings in `src/aiperf/kubernetes/environment.py`).
+
+### Communication Channels
+
+| Channel | Port | Protocol | Purpose |
+|---------|------|----------|---------|
+| ZMQ Event Bus | IPC + TCP | ZMQ PUB/SUB | Message broadcasting |
+| API Service | 9090 | HTTP/WS | WebSocket streaming, Dataset API |
+| Health | 8080 | HTTP | Kubernetes probes |
+
+### Dual-Bind ZMQ Configuration
+
+```mermaid
+flowchart TD
+    CP["Controller pod"]
+    CP --> IPC["IPC socket: event_bus_proxy_frontend.ipc<br/>used by control-plane services in the same pod"]
+    CP --> TCP["TCP sockets: 0.0.0.0:5663 (frontend), :5664 (backend)<br/>used by worker pods (external)"]
+```
+
+Port defaults live on the `AIPERF_K8S_PORT_` settings in
+`src/aiperf/kubernetes/environment.py`.
+
+## 5. Dataset Transfer
+
+In Kubernetes mode, the DatasetManager streams conversations directly to zstd-compressed files.
+Workers download the compressed files via HTTP and decompress locally for memory-mapped access.
+
+### Metadata Synchronization
+
+The API Service waits for dataset metadata before serving files:
+
+```mermaid
+sequenceDiagram
+    participant DM as DatasetManager
+    participant API as API Service
+    participant WGM as WorkerGroupManager
+
+    DM->>DM: stream_writer.write() (zstd streaming to .zst)
+    DM->>DM: finalize() + compress index
+    DM->>API: DatasetConfiguredNotification (ZMQ pub/sub)
+    Note over API: sets the dataset-configured event<br/>and caches the client metadata
+    WGM->>API: GET /api/dataset/data (Accept-Encoding: zstd)
+    Note over API: waits on the dataset-configured event,<br/>serves paths from the metadata
+    API-->>WGM: stream .zst as-is (Content-Encoding: zstd)
+    Note over WGM: decompress, then mmap locally
+    WGM->>API: GET /api/dataset/index
+    API-->>WGM: stream .zst as-is
+    Note over WGM: decompress
+```
+
+Net effect: only `.zst` files exist on the control plane, file serving is
+metadata-driven, and each worker pod ends up with local `.dat` files for mmap
+access.
+
+### Key Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| **DatasetManager** | Streams to `.zst`, broadcasts `DatasetConfiguredNotification` with `MemoryMapClientMetadata` |
+| **API Service** | Waits for notification via `asyncio.Event`, serves files using paths from metadata |
+| **WorkerGroupManager** | Downloads via HTTP, decompresses locally, then exposes group-local dataset readiness and current-state snapshots to sibling workers using the same readiness contract local mode uses |
+
+### Benefits
+
+| Approach | Disk on Controller | Transfer | CPU Overhead |
+|----------|-------------------|----------|--------------|
+| **compress_only mode** | Compressed only | Passthrough | Compress once, decompress distributed |
+| On-the-fly compression | Uncompressed + compressed | Re-compress per request | High on controller |
+
+### Files Created
+
+**Controller (DatasetManager):**
+```
+{mmap_base}/aiperf_mmap_{benchmark_id}/
+├── dataset.dat.zst   # zstd-compressed conversations (streaming write)
+└── index.dat.zst     # zstd-compressed byte offset index
+```
+
+**Workers (after download):**
+```
+{mmap_base}/aiperf_mmap_{benchmark_id}/
+├── dataset.dat       # Decompressed conversations (mmap target)
+└── index.dat         # Decompressed index
+```
+
+## 6. Benchmark Execution Flow
+
+```mermaid
+flowchart LR
+    A[Pods start] --> B[Dataset ready]
+    B --> C[Timing credits]
+    C --> D[Workers execute]
+    D --> E[Metrics compute]
+    E --> F[Records aggregate]
+    F --> G[Results export]
+```
+
+### Detailed Steps
+
+1. **Pods Start** - Control-plane services register with `SystemController`, and each worker pod brings up one `WorkerGroupManager` as the controller-facing authority for that group
+2. **DatasetManager** - Generates prompts, serves via HTTP at `/api/dataset`
+3. **WorkerGroupManager** - Downloads dataset files once per group, publishes group-local current state, and makes sibling workers dispatchable only after group readiness converges
+4. **TimingManager** - Schedules requests, issues credits to workers
+5. **Workers** - Make LLM API calls once their `WorkerGroupManager` reports group-local readiness, then generate raw records
+6. **RecordProcessor** - Computes metrics (latency, TTFT, throughput)
+7. **RecordsManager** - Aggregates results from all workers
+
+### Service Discovery
+
+`KubernetesServiceManager` in `src/aiperf/controller/kubernetes_service_manager.py`:
+
+| Method | Behavior |
+|--------|----------|
+| `run_service()` | For service types in `EXTERNAL_K8S_SERVICES`, spawns nothing — records the expected instance count with `ServiceRegistry` and waits for the sibling container/worker pod to register. Anything else falls through to `MultiProcessServiceManager.run_service` and spawns a subprocess. |
+| `stop_service()` | No-op for externally managed pods (they get shutdown over the control channel and exit on their own); otherwise delegates to the multiprocess manager. |
+| `shutdown_all_services()` | Stops any locally managed subprocesses and releases the `kubernetes_asyncio` API client. |
+| `check_pods_healthy()` / `_monitor_worker_pods()` | Polls worker-pod status so a crash-looping or evicted pod surfaces as a controller-side failure. |
+
+`wait_for_all_services_registration()` is inherited from `BaseServiceManager` and is what actually blocks until every expected service has registered over ZMQ.
+
+`SystemController` consumes both halves: `_verify_pods_healthy()` gates `PROFILE_START` on `check_pods_healthy()` (catching a pod that registered and then died), and `_watch_pod_failure_abort()` waits on `pod_failure_abort_event` so a mid-run breach of `AIPERF_POD_FAILURE_ABORT_THRESHOLD_PERCENT` cancels the benchmark through the same path as Ctrl+C. `BaseServiceManager` supplies inert defaults, so non-Kubernetes modes need no branch at the call site.
+
+### Cross-Pod Clock Correction
+
+Controller and worker pods have independent clocks. Every credit carries the controller's `issued_at_ns`, so each receipt is a one-way offset sample (`received - issued`) fed to `ClockOffsetTracker`, which min-filters a 20-sample window (NTP RFC 5905 clock filter) to reject transit jitter. At startup a worker sends `TimePing` on its credit DEALER; `StickyCreditRouter._handle_time_ping` echoes `TimePong` verbatim so RTT is measured entirely against the worker's own clock. Every `RequestRecord` leaving a worker is stamped with `clock_offset_ns`; the contract is `controller_time = worker_time - clock_offset_ns`. Both sampling and probing are gated on Kubernetes mode (`Worker._tracks_clock_offset`) — in local mode both sides share one clock, so records carry `None`.
+
+## 7. Results Collection
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    W["Workers (raw records)"] --> RP[RecordProcessor]
+    RP --> RM[RecordsManager]
+    RM --> API["API Service (port 9090)"]
+```
+
+In operator mode, results are served by the `results-server` container inside the operator deployment (port 8081), which reads from the operator PVC. In direct mode (no operator) or when the operator PVC is unavailable, results can be copied from the controller pod's `results-sidecar` or via `kubectl cp`.
+
+The same `results-server` container also hosts every `/api/v1/*` router for the operator (jobs, sweeps, results, config, admin, analytics, dashboard_proxy) — there is no separate FastAPI app in the operator container, which only runs kopf (`/healthz` on port 8080 and the Prometheus `/metrics` endpoint on port 9090). The sweep-controller's empty-summary fallback (`K8sChildJobExecutor._fetch_summary_from_operator`) targets this container too via `AIPERF_OPERATOR_BASE_URL` (default `http://aiperf-operator.aiperf-system:8081`); it does not point at the operator container's port 8080.
+
+### Retrieval Methods
+
+```bash
+# Operator mode (default): fetch via operator results-server
+aiperf kube results {job_id}
+
+# Direct mode / fallback: copy from the controller pod
+aiperf kube results {job_id} --from-pods
+kubectl cp <controller-pod>:/results ./results -n <namespace>
+```
+
+## Results layout and history
+
+Each AIPerfJob submission lands in its own artifact directory keyed by the CR's
+**creationTimestamp epoch** (seconds since 1970). Re-creating a CR with the
+same name never overwrites prior results.
+
+On-disk shape under the operator's results PVC (`AIPERF_RESULTS_DIR`, default
+`/data`):
+
+```text
+<base>/<namespace>/<name>/
+  <epoch-A>/   ← run A artifacts
+  <epoch-B>/   ← run B artifacts
+  latest.txt   ← pointer to the epoch of the most recent successful run
+```
+
+The pointer file is written atomically (staged write + `os.replace`) at the
+single success gate in `handlers/completion.py`, alongside `status.resultsPath`
+and `status.runEpoch`. A retention pass (env `AIPERF_RESULTS_RETAIN_RUNS`,
+default 10) trims older run dirs on every successful completion; the just-written
+epoch is always protected from deletion.
+
+### HTTP API
+
+Non-epoch routes now require an explicit run epoch and return `409 Conflict` if
+omitted. Callers must use the `/runs/<epoch>` form; there is no implicit
+"latest run" fallback (`_require_epoch_for_results` raises `HTTPException(409)`
+for all non-epoch routes in `src/aiperf/operator/routers/results_files.py`).
+
+| Route | Behavior |
+|---|---|
+| `GET /api/v1/results/<ns>/<name>` | **409** — epoch required |
+| `GET /api/v1/results/<ns>/<name>.zip` | **409** — epoch required |
+| `GET /api/v1/results/<ns>/<name>/<filename>` | **409** — epoch required |
+| `GET /api/v1/results/<ns>/<name>/runs/<epoch>` | List files from the pinned run |
+| `GET /api/v1/results/<ns>/<name>/runs/<epoch>.zip` | Zip bundle of the pinned run |
+| `GET /api/v1/results/<ns>/<name>/runs/<epoch>/<filename>` | Download one file from the pinned run |
+
+`<epoch>` is validated against `EPOCH_RE` (`^\d{9,20}$`, in `src/aiperf/operator/results_layout.py`) before any disk access.
+
+### Edge cases
+
+- **Rapid delete + resubmit within the same wall-clock second** produces colliding
+  epoch keys; the second submission overwrites the first. This matches the
+  legacy `EPOCH=$(date +%s)` semantics and is intentional.
+- **A delayed older completion never rolls the pointer backward.**
+  `write_latest` reads the current pointer first and no-ops when it already
+  names a numerically newer epoch.
+- **`latest.txt` points at a missing directory** (corruption, manual delete):
+  default-route requests return 404 until the next successful completion
+  rewrites the pointer. Historical routes still work.
+
+### Runs/sweep index writes
+
+The operator maintains a SQLite index at `<RESULTS.DIR>/.aiperf_index.sqlite` that mirrors disk state for fast queries. Writes happen at fixed handler points:
+
+```mermaid
+sequenceDiagram
+    participant K as kopf
+    participant O as operator
+    participant FS as PVC
+    participant DB as runs_index
+
+    K->>O: on_create(AIPerfJob)
+    O->>FS: save_job_spec_file
+    O->>DB: upsert_run_created (Pending)
+
+    Note over O: phase transitions (Running, Aggregating, ...)
+    O->>DB: upsert_run_phase
+
+    K->>O: completion observed
+    O->>FS: download results, write ready marker
+    O->>DB: upsert_run_completed + set_latest
+
+    K->>O: on_delete or retention
+    O->>FS: rm -rf run dir
+    O->>DB: delete_run
+```
+
+Read sites (`results_layout.list_runs_async`, `results_db.ResultsDB`, `routers/results_files.py`) consult the index first and fall back to disk only when a row is missing, firing a lazy backfill in the background.
+
+CR deletion wins every race with completion. The delete handler first records a
+sticky cancellation event. The result harvester waits on that event alongside
+metrics requests, primary and sidecar downloads, and retry backoff, so deletion
+interrupts long I/O instead of waiting for its timeout. Metrics and completed
+downloads from earlier boundaries remain available for recovery, but completion
+does not publish terminal status or a latest pointer after cancellation.
+Completion also rechecks cancellation after retention and every index await. If
+cancellation lands while an upsert is in flight, the completion writer deletes
+that exact epoch after the upsert returns; it cannot recreate an orphan row after
+delete cleanup has already passed. Set cancellation flags are never evicted to
+satisfy the progress-client cache bound, including when a large sweep deletes
+thousands of children concurrently.
+
+## 8. Completion & Cleanup
+
+### Lifecycle
+
+```mermaid
+flowchart LR
+    Deploy --> Running --> Complete --> TTL[TTL expires] --> Deleted
+```
+
+### Pending pod reconciliation
+
+The Pod watch classifies each changed Pod body directly and records the
+highest-priority startup blocker in `status.startupIssue` without listing the
+JobSet's Pods. A healthy update for the same Pod clears the blocker. The
+fingerprint and `firstObservedTime` make the grace period survive operator
+restarts. The same diagnostic is exposed through `WorkersReady=False`, and a
+Kubernetes warning event is emitted after
+`AIPERF_K8S_WATCHDOG_PENDING_THRESHOLD_SECONDS`.
+
+A bounded deadline handler re-evaluates only an already-cached
+`status.startupIssue`; it does not list Pods or run the broad recovery engine.
+This lets an unchanged blocker reach its warning or failure threshold even
+when the controller heartbeat remains healthy and no further Pod event occurs.
+Before deleting the JobSet it re-reads and validates the exact parent UID,
+resource version, non-terminal phase, cancellation state, and blocker
+fingerprint. It revalidates again after deletion and commits through an atomic
+UID/resource-version/phase/full-startup-issue JSON fence, so a concurrent
+recovery or terminal transition remains authoritative.
+
+Image pull, container configuration, repeated crash-loop, and structural
+scheduling failures may transition the AIPerfJob to `Failed` only after the
+blocker remains unchanged for
+`AIPERF_K8S_WATCHDOG_PENDING_CRITICAL_THRESHOLD_SECONDS`. Capacity shortages,
+pending PVC binding, unknown scheduler reasons, and Kueue suspension remain
+retryable: they are visible in status but do not auto-fail when the job timeout
+is disabled. The operator checks both regular and init-container statuses and
+`PodScheduled=False` conditions, using its shared `k8s_client` context.
+
+### Lifecycle surface: `status.subPhase`
+
+The controller pushes `status.subPhase` from its `SystemState`
+(`src/aiperf/common/enums/enums.py`) directly to the AIPerfJob at least every
+10 seconds, including quiet states with unchanged progress. It is distinct
+from `status.phase` (the operator's own view) and `status.currentPhase` (the
+per-benchmark stage), and is cleared on terminal transitions.
+
+Focused watches maintain the operator-owned coarse lifecycle while the broad
+recovery engine is gated. JobSet `replicatedJobsStatus` changes update worker
+counts and `WorkersReady`, promoting Pending or Queued jobs to Initializing
+when workers start. Controller `subPhase` transitions promote the job to
+Running at profiling or later states. Event-authored status commits re-read the
+live parent, reject terminal or cancelled jobs, and JSON-patch-test both the
+resource version and expected live phase so a stale JobSet or Pod callback
+cannot reverse a concurrent completion or cancellation. Resource-version or
+JSON-test conflicts raise a bounded Kopf retry; the retried watch handler
+re-reads the parent and rebuilds its status update, so one-shot readiness and
+healthy-Pod clears are not lost to controller heartbeat writes. The subphase
+watch uses this same direct fence and never writes through an ordinary Kopf
+merge patch.
+
+`status.currentPhase` preserves the user-provided phase name, such as
+`cache_prime` or `steady_state_profile`; it is not restricted to the legacy
+`warmup` and `profiling` names. Each `status.phases.<name>` entry includes
+`phaseName`, the closed semantic `phaseKind` (`warmup` or `profiling`),
+`phaseIndex`, and `profilingIndex`. The operator uses `phaseKind` for lifecycle
+behavior: warmup-kind phases remain in Initializing, while a profiling-kind
+phase promotes the job to Running and gates completion regardless of its name.
+For stable `kubectl get` columns, the operator also projects the latest
+profiling-kind phase's counters to top-level `status.requestsCompleted`,
+`status.requestsTotal`, and `status.requestsPerSecond`; printer columns never
+assume a phase is literally named `profiling`.
+
+The controller-side `ProgressRouter` mirrors progress annotations to both the
+JobSet and AIPerfJob and merge-patches the AIPerfJob status. It also refreshes
+the UID-fenced `aiperf.nvidia.com/controller-heartbeat` annotation on every
+push. The operator's recurring watchdog inspects only this cached parent body
+while the heartbeat is fresh; broad JobSet, Pod, sidecar, and results recovery
+runs only after heartbeat expiry or when an explicit `timeoutSeconds` deadline
+is due. A controller service error is pushed as `status.controllerFailure`
+before that controller exits; the operator fences and terminalizes the exact
+parent as Failed, and never lets a later sidecar artifact salvage reinterpret
+that explicit failure as a successful completion.
+
+One transition is easy to misread: `SystemState.PROCESSING` is set when the
+SystemController handles `CreditsCompleteMessage` — that is, when request
+*dispatch* finishes and only record aggregation remains. It is **not** set at
+profile completion; the whole aggregation phase happens while `subPhase` reads
+`processing`.
+
+### Completion Signals
+
+- Controller receives `ALL_RECORDS_RECEIVED` message
+- Results available via API service
+- Services shut down cleanly
+
+For `exportLevel: raw`, result publication has an additional acknowledged
+barrier before shutdown. While ZMQ and the group-local lifecycle channels are
+still live, `SystemController` sends `FINALIZE_ARTIFACTS` to the exact set of
+registered `WorkerGroupManager` service IDs. Each manager requires its exact
+declared record-processor set to flush successfully, stops those processors,
+waits for their exact shutdown notices, and uploads every materialized RAW
+JSONL file. The controller API stages each upload under a temporary name,
+fsyncs it, and atomically renames it before returning the size acknowledgement.
+Only then does the manager acknowledge the controller command.
+
+Any missing service, rejected RAW row, timeout, flush error, HTTP failure, or
+size mismatch fails the barrier. The controller skips aggregation/export and
+withholds both the
+results-ready marker and `ResultsExportedMessage`, so an incomplete RAW result
+set cannot be advertised as authoritative. Empty processors are valid and may
+produce no file; completion is proven by service acknowledgements rather than
+filename counts or file-size stability polling.
+
+The controller performs final export before broadcasting service shutdown or
+stopping its message bus. After the durable marker commits, the still-running
+API service can therefore receive `ResultsExportedMessage`; the marker remains
+the authoritative recovery signal if that live notification is lost.
+
+### Cleanup Options
+
+```bash
+# Automatic (TTL-based)
+ttlSecondsAfterFinished: 300  # Pods auto-delete after 5 minutes
+
+# Manual cleanup (operator mode): delete the AIPerfJob CR
+kubectl delete aiperfjob <name> -n <namespace>
+
+# Manual cleanup (direct mode): delete the JobSet
+kubectl delete jobset <name> -n <namespace>
+```
+
+## 9. Configuration
+
+### CLI Options
+
+```bash
+aiperf kube profile \
+  --image myregistry.io/aiperf:latest \
+  --namespace benchmarks \
+  --total-workers 10 \
+  --ttl-seconds 300 \
+  --kubeconfig ~/.kube/prod-config \
+  --node-selector '{"nvidia.com/gpu": "A100"}' \
+  --tolerations '[{"key":"nvidia.com/gpu","operator":"Exists"}]' \
+  --image-pull-secrets registry-creds \
+  --env-from-secrets 'OPENAI_API_KEY=llm-api-key/api-key'
+```
+
+Sensitive endpoint fields never rely on the ConfigMap copy. JSON
+serialization redacts them, and `aiperf service --benchmark-run` restores them
+from the Secret-backed `AIPERF_INJECTED_API_KEY`/`OPENAI_API_KEY`,
+`AIPERF_INJECTED_HEADERS`, and `AIPERF_INJECTED_ENDPOINT_URLS` environment
+variables. Generation and operator reconciliation fail closed when the
+corresponding `valueFrom.secretKeyRef` mapping is absent.
+`aiperf service` requires `--benchmark-run` and never resolves per-container
+benchmark flags.
+
+### Environment Variables
+
+Resource limits configured via `src/aiperf/kubernetes/environment.py`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AIPERF_K8S_SYSTEM_CONTROLLER_CPU` | 75m | System controller container CPU (request and limit) |
+| `AIPERF_K8S_DATASET_MANAGER_MEMORY` | 256Mi | Dataset manager container memory (request and limit) |
+| `AIPERF_K8S_WORKER_POD_CPU` | 150m | Worker pod CPU (request and limit) |
+| `AIPERF_K8S_WORKER_POD_MEMORY` | 4Gi | Worker pod memory (request and limit) |
+| `AIPERF_K8S_PORT_API_SERVICE` | 9090 | API service port |
+| `AIPERF_K8S_JOBSET_TTL_SECONDS_AFTER_FINISHED` | 300 | TTL after completion |
+
+### AIPerfSweep handlers
+
+The kopf operator registers sweep-lifecycle handlers in `src/aiperf/operator/main.py`. Seven registrations are on the parent `AIPerfSweep` CRD; one more watches child `AIPerfJob`s to roll their status up into the parent:
+
+- `@kopf.on.create AIPerfSweep` (handler in `handlers/sweep/create.py`) — validates the workload through the canonical Config-v2 mapping loader and `AIPerfSweepSpec`, computes `totalVariations`/`maxTotalRuns`, sets `status.runEpoch` to a collision-safe decimal key derived from `metadata.creationTimestamp` and immutable `metadata.uid`, provisions a namespace-scoped ServiceAccount/Role/RoleBinding for the sweep-controller pod, and creates a single-replica JobSet that runs `python -m aiperf.sweep_controller.main`.
+- `@kopf.on.update AIPerfSweep field=spec.cancel` (handler in `handlers/sweep/lifecycle.py`) — mirrors the cancel signal into `status.conditions[Cancelling]` and advances `status.observedGeneration`, including terminal/no-op updates, so GitOps clients can distinguish an acknowledged spec change. The sweep-controller pod observes `spec.cancel` directly via its own poll and propagates it to the current child.
+- `@kopf.on.update AIPerfSweep field=spec.ttlSecondsAfterFinished` — acknowledges the other mutable parent control immediately. The reaper timer reads the latest TTL; create-time execution fields are immutable after admission.
+- `@kopf.on.field AIPerfSweep field=status.aggregation.phase new=Complete` plus `@kopf.on.resume` — triggers `handlers/sweep/_aggregate_fetch.fetch_sweep_aggregate_to_disk` to pull the cross-variation aggregate off the sweep-controller's `emptyDir` results-sidecar before the JobSet is reaped, and resumes an interrupted harvest after an operator restart. The fetch reports `(downloaded, listed)` counts; a partial harvest (`downloaded < listed`) or a missing/unparsable `aggregate.json` raises `kopf.TemporaryError` so the JobSet — and with it the only other copy of the artifacts — stays alive for re-harvest. During commit, the operator materializes every child `sweep.json` backlink on its PVC from the canonical `children.json` manifest before status publication. Delayed callbacks carry the parent CR's immutable UID, verify the live parent and exact JobSet owner API version/kind/name/UID with `controller: true`, and publish status with a JSON Patch UID test before advancing `latest.txt` or the runs index. Only a full harvest with a parseable `aggregate.json` and durable child lineage on the PVC publishes the operator-backed `aggregateRef`, flips `resultsAvailable` to true, and deletes that exact JobSet with its resource UID as a delete precondition. A same-name replacement makes the old callback a no-op; transient reads and status-validation failures against the current owner retry.
+- `@kopf.on.delete AIPerfSweep` — cooperatively cancels only AIPerfJobs whose exact owner kind/name/UID matches the deleting sweep; sweep labels narrow discovery but never establish ownership. Kubernetes owner-reference GC tears down the sweep-controller JobSet and RBAC.
+- `@kopf.timer` `cleanup_old_sweeps` — TTL reaper for terminal `AIPerfSweep`s, evaluated at the operator monitor cadence rather than the daily result-retention cadence. A completed aggregate is not eligible until the operator-backed result reference is published, so even `ttlSecondsAfterFinished: 0` cannot delete the only `emptyDir` copy during harvest. Parent deletion uses the timer body's immutable UID as a Kubernetes delete precondition, so a stale timer cannot reap a same-name replacement.
+- `@kopf.on.field AIPerfJob field=status.phase` (handler in `handlers/sweep/child_rollup.py`) — this one is on **child AIPerfJobs**, not the AIPerfSweep CRD: for AIPerfJob children whose `ownerReferences` include an `AIPerfSweep`, it recomputes the parent's `runStates`/`currentChildRef`/`lastChildEvent`. Standalone AIPerfJobs are no-ops.
+
+Sweep **result** retention is process-level rather than a CR timer. After the
+runs-index bootstrap and once per day, the operator scans durable sweep epoch
+directories, reads `aggregate.json.specSnapshot.resultsTtlDays` (falling back
+to `AIPERF_RESULTS_TTL_DAYS` for legacy archives), removes expired archives
+and SQLite rows, and reconciles `latest.txt`. This continues after the parent
+CR's default 300-second lifecycle TTL has elapsed; bootstrap reverse-pruning
+repairs an index delete interrupted by an operator crash.
+
+The AIPerfJob CRD likewise permits only runtime-control edits after creation:
+`spec.cancel` and `spec.timeoutSeconds`. Their dedicated field handlers advance
+`status.observedGeneration` only after the edit is consumed successfully; a
+failed JobSet deletion leaves a cancel edit unacknowledged for kopf to retry.
+
+### Sweep plan convergence
+
+Kubernetes and local sweeps use the same Config-v2 planning path. The kube CLI
+keeps the post-environment, pre-Jinja template leaves in the submitted CR. The
+operator and sweep-controller validate a rendered copy through
+`load_config_from_mapping`, while retaining that raw envelope so each variation
+can render its own values. The sweep-controller then calls
+`build_benchmark_plan`; its only plan adaptation is attaching the
+Kubernetes-only `failurePolicy`. Adaptive sweeps instantiate their planner
+through the shared `build_search_planner` factory, and
+`K8sChildJobExecutor` supplies the cluster execution backend behind the same
+`RunExecutor` protocol used by local sweeps.
+
+## CRD Generator
+
+Both CRDs (`aiperfjobs.aiperf.nvidia.com`, `aiperfsweeps.aiperf.nvidia.com`)
+are auto-generated by `tools/generate_crd.py` from the `AIPerfJobSpec` and
+`AIPerfSweepSpec` Pydantic models (`src/aiperf/kubernetes/crd_models.py`).
+Both inherit `AIPerfWorkloadSpec`, which composes the complete `AIPerfConfig`
+envelope (`benchmark`, `sweep`, `multiRun`, `variables`, and related fields)
+with the Kubernetes deployment surface. **Never edit the rendered YAML in
+`deploy/helm/aiperf-operator/templates/crd*.yaml` directly** — the next
+regeneration overwrites it.
+
+### Generator pipeline
+
+1. **JSON Schema walk** (`_convert_schema`) — recursively converts the
+   Pydantic-emitted JSON Schema into K8s-compatible OpenAPI v3, resolving
+   `$ref`, collapsing `anyOf`-with-null into nullables, and falling back to
+   `x-kubernetes-preserve-unknown-fields: true` at narrow shorthand
+   boundaries (`models`, `endpoint.urls`, top-level
+   `model`/`dataset`/`warmup`/`profiling`, `sweep`).
+2. **Type-on-marker pass** (`_ensure_type_on_preserve_unknown`) — defaults
+   `type: object` on every node carrying `x-kubernetes-preserve-unknown-fields:
+   true`. K8s structural-schema validation rejects the marker without a
+   declared type, AND CEL field access compiles only on typed nodes.
+3. **Shape-detector decorators** (`_decorate_*_node`) — each helper detects
+   its target node by a unique fingerprint of property keys (e.g. an
+   endpoint node has `urls` + `apiKey` + `connectionReuse`; a runtime node
+   has `apiPort` + `apiHost` + `workersPerPod`). The walker
+   (`_walk_dict_apply`) calls every decorator on every dict node, so the
+   same set of CEL rules fires on both AIPerfJob's `spec.benchmark` and
+   AIPerfSweep's `spec.benchmark` from a single pass.
+4. **Kind-specific attachment** — sweep-only rules are added in
+   `_build_aiperfsweep_crd_from_schema` by direct property indexing after the
+   walker runs: `has(self.sweep)` makes the sweep block required on AIPerfSweep
+   (the inverse `!has(self.sweep)` fires on AIPerfJob), plus `oldSelf == self`
+   immutability on `spec.sweep` / `spec.multiRun`. The old Tier-1D rule that
+   forbade `sweep`/`multi_run` inside the per-child benchmark was removed —
+   `AIPerfJobSpec.benchmark` is typed as `BenchmarkConfig` (no such fields), so
+   the generated structural schema enforces it at the apiserver without CEL.
+
+### Adding a CEL rule
+
+The user-facing catalog of every rule lives in
+[`docs/kubernetes/crd-validation.md`](../kubernetes/crd-validation.md). To
+add a new one:
+
+1. Identify the **shape** the rule applies to (benchmark, endpoint,
+   runtime, multiRun) and pick the matching `_decorate_*_node`
+   helper. If your target is a brand new shape, write a new shape detector
+   modelled on the existing ones.
+2. Append a `{"rule": ..., "message": ...}` entry to that helper's
+   `_add_validation_rules(...)` call. Tag the rule with the tier label
+   (1A/1B/.../4O) in a comment so future-you can grep back to the
+   brainstorm in `docs/kubernetes/crd-validation.md`.
+3. Add a structural assertion in
+   `tests/unit/operator/test_aiperfsweep_crd_generation.py` (the existing
+   tests follow a "rule string is in `rules` set" pattern).
+4. Regenerate with `uv run python tools/generate_crd.py` and confirm
+   idempotency with `tools/generate_crd.py --check`.
+5. Round-trip on a real apiserver (`kind create cluster && kubectl apply
+   --dry-run=server -f crd.yaml`). The K8s apiserver compiles CEL at
+   CRD-install time and rejects rules that reference undeclared fields
+   (`undefined field 'X'`) or opaque preserve-unknown items.
+
+CEL constraints worth remembering:
+
+- `has(self.X)` requires X to be declared in the schema. Anything hidden
+  inside a `x-kubernetes-preserve-unknown-fields: true` blob is invisible.
+- Array items emitted as opaque preserve-unknown blobs cannot be
+  dereferenced. Heterogeneous Pydantic discriminated unions
+  (`phases[]`, `datasets[]`) end up opaque, so item-internal invariants
+  (phase-name uniqueness, phase→dataset reference integrity, "seamless not
+  on first") stay enforced in the operator's `@model_validator` decorators
+  on `AIPerfConfig` rather than at the apiserver.
+- `oldSelf` is only available in transition rules and triggers on
+  `kubectl edit` / `kubectl patch`. Use `!has(oldSelf.X) || oldSelf.X ==
+  self.X` for "first-set freezes after that" semantics (e.g.
+  `artifacts.benchmarkId`, `scheduling.queueName`).
+
+## Key Architecture Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **JobSet API** | Orchestrates controller + workers as atomic unit |
+| **Dual-bind ZMQ** | IPC for in-pod speed, TCP for cross-pod reach |
+| **API-based results** | Retrievable via API service or kubectl cp |
+| **Dataset HTTP API** | Avoids shared volume complexity |
+| **WebSocket streaming** | Real-time progress to local CLI |
+| **Container-per-service** | One container per service; failure isolation and per-container resources |

--- a/docs/dev/patterns.md
+++ b/docs/dev/patterns.md
@@ -99,12 +99,16 @@ Then:
 2. If the flag maps to an existing `AIPerfConfig` key, add an entry to that section's
    field map (e.g. `_ENDPOINT_FIELD_MAP` in `_converter_endpoint.py`).
    Otherwise, read it directly in the relevant `_converter_*.py` builder.
-3. Run `make generate-cli-docs` to regen `docs/cli-options.md`. Run
+3. Add the same explicit-field route to
+   `config.flags.resolver.build_cli_overrides` when the flag is valid with
+   `--config`. Test CLI-only and YAML-plus-CLI resolution against the same
+   affected `AIPerfConfig` subtree; unrelated YAML must remain intact.
+4. Run `make generate-cli-docs` to regen `docs/cli-options.md`. Run
    `make generate-env-vars-docs` if you also added a corresponding env var.
-4. Add a unit test under `tests/unit/config/` constructing
+5. Add a unit test under `tests/unit/config/` constructing
    `CLIConfig(my_new_flag=...)` and asserting the converter emits the
    right `AIPerfConfig` shape.
-5. The disjointedness invariant in
+6. The disjointedness invariant in
    `tests/unit/config/v1/test_section_fields.py` will catch any
    cross-section name collision automatically.
 
@@ -112,8 +116,26 @@ Then:
 - No validators on CLIConfig fields. `BeforeValidator(parse_str_or_list)` for
   CLI input coercion is fine; domain validation (range checks across fields,
   cross-field constraints) lives on `AIPerfConfig`, not CLIConfig.
-- The CLI-to-envelope converter is the only module outside `cli_commands/` that may
-  read `CLIConfig` attributes.
+- The CLI-to-envelope converter and config-file resolver are the only modules
+  outside `cli_commands/` that may read `CLIConfig` attributes.
+
+### Config-file override envelope invariant
+
+`resolve_config` keeps two Config-v2 dictionaries aligned when combining
+`--config` with explicit CLI flags:
+
+- The rendered dictionary is post-environment and post-Jinja; it feeds
+  `AIPerfConfig.model_validate`.
+- The raw envelope is post-environment but pre-Jinja; it is retained on
+  `AIPerfConfig._raw_envelope` so `build_benchmark_plan` can render each
+  `sweep.parameters` variation independently.
+
+Every config-file override transformation must run through
+`_merge_overrides_into_envelope`, which applies the same deep merge, dataset
+filtering, phase targeting, and magic-list promotion to both dictionaries. Do
+not mutate only the rendered dictionary: a CLI override of a templated field
+would appear correct on the base config and then be replaced by the old Jinja
+template during sweep expansion.
 
 ### Bool|object nested endpoint fields + flat CLI lowering
 

--- a/docs/dev/sweep-orchestrator.md
+++ b/docs/dev/sweep-orchestrator.md
@@ -30,19 +30,16 @@ flowchart LR
     cfg --> exp --> run --> agg
 
     subgraph BACKENDS["RunExecutor backend (swap point)"]
-        local["LocalSubprocessExecutor<br/>(today)"]
-        k8s["K8sChildJobExecutor<br/><i>coming soon</i>"]
+        local["LocalSubprocessExecutor<br/>(local process)"]
+        k8s["K8sChildJobExecutor<br/>(sweep-controller pod)"]
     end
     run -. selects .-> local
     run -. selects .-> k8s
 
     classDef stage fill:#e3f2fd,stroke:#1565c0,stroke-width:1.5px,color:#0d47a1
     classDef shipping fill:#e8f5e9,stroke:#2e7d32,stroke-width:1.5px,color:#1b5e20
-    classDef coming fill:#fafafa,stroke:#9e9e9e,stroke-width:1.5px,stroke-dasharray:5 3,color:#616161
-
     class cfg,exp,run,agg stage
-    class local shipping
-    class k8s coming
+    class local,k8s shipping
 
     style BACKENDS fill:transparent,stroke:#78909c,stroke-width:2px,stroke-dasharray:2 2
 ```
@@ -69,7 +66,7 @@ flowchart LR
 > orchestrator and executors don't change. Want to run the whole
 > thing on Kubernetes? Implement `RunExecutor.execute` to create an
 > `AIPerfJob` CR and HTTP-pull its results instead of forking a
-> subprocess (this is the *coming-soon* `K8sChildJobExecutor`) — the
+> subprocess (`K8sChildJobExecutor`) — the
 > plan, orchestrator, planner, analyzer, and exporters are reused
 > byte-for-byte. The progression from a single-shot `aiperf profile`
 > to a cluster-distributed BO search isn't a rewrite; it's the same
@@ -78,10 +75,11 @@ flowchart LR
 
 ### Execution
 
-Today only `LocalSubprocessExecutor` ships: `aiperf profile -f config.yaml` runs the orchestrator in the same Python process and forks `aiperf.orchestrator.subprocess_runner` per cell.
-
-> [!NOTE]
-> **Cluster execution (coming soon).** `K8sChildJobExecutor` lives on the K8s integration branch (not `main` yet). It runs in-cluster in a `sweep-controller` pod (from an `AIPerfSweep` CR). Each cell becomes an `AIPerfJob` CR, watched to completion; the operator results server supplies the child export (same shape as local). Orchestrator logic is unchanged—only `RunExecutor` differs. CLI: `aiperf kube sweep` (alongside `aiperf kube profile`).
+`LocalSubprocessExecutor` powers `aiperf profile -f config.yaml` and forks
+`aiperf.orchestrator.subprocess_runner` per cell. `K8sChildJobExecutor` runs the
+same plan in a sweep-controller pod created from an `AIPerfSweep` CR. Each cell
+becomes an `AIPerfJob` CR, watched to completion; the operator results server
+supplies the child export in the same `RunResult` shape as local execution.
 
 ### Key types
 
@@ -99,7 +97,7 @@ The whole flow uses about a dozen types. If you know these, you can read any swe
 | **`BenchmarkRun`** | One cell: `(cfg, variation, trial, artifact_dir)`. The smallest unit of work. |
 | **`RunResult`** | `{success, summary_metrics, artifacts_path, variation_label, variation_values, trial_index, error}`. One per `BenchmarkRun`. |
 | **`MultiRunOrchestrator`** | Drives the N×M loop. Picks REPEATED (trials outer) or INDEPENDENT (variations outer) based on `sweep.iteration_order`; dispatches to `execute_adaptive_search` if the sweep is adaptive. |
-| **`RunExecutor`** | ABC with `execute(run) -> RunResult` plus a second abstract `derive_id(plan, var_idx, trial) -> str` for stable per-cell identifiers. `LocalSubprocessExecutor` is the only shipping implementation today; `K8sChildJobExecutor` (one child `AIPerfJob` CR per call) is finalized but unmerged — see Execution above. |
+| **`RunExecutor`** | ABC with `execute(run) -> RunResult` plus `derive_id(plan, var_idx, trial) -> str` for stable per-cell identifiers. `LocalSubprocessExecutor` launches local subprocesses; `K8sChildJobExecutor` creates one child `AIPerfJob` CR per call. |
 | **`SweepAnalyzer`** | Post-hoc aggregator. CLI helpers group `list[RunResult]` by `variation_values` into `per_combination_stats`; `SweepAnalyzer.compute()` then produces `best_configurations`, `pareto_optimal`, `per_combination_metrics`. Written to `sweep_aggregate/profile_export_aiperf_sweep.{json,csv}`. |
 
 ### End-to-end pipeline (canonical)
@@ -134,7 +132,7 @@ flowchart TD
     subgraph S6["6. execute one cell"]
         re["**RunExecutor** (ABC)"]
         loc["**LocalSubprocessExecutor**<br/>forks subprocess_runner"]
-        k8s["**K8sChildJobExecutor**<br/><i>coming soon</i>"]
+        k8s["**K8sChildJobExecutor**<br/>creates child AIPerfJob CRs"]
         run["aiperf workload run<br/><i>full service mesh — see<br/>docs/architecture.md</i>"]
         rr["**RunResult**<br/>metrics · variation_values · artifacts_path"]
     end
@@ -149,14 +147,13 @@ flowchart TD
     uc -->|convert_cli_to_aiperf| ac
     ac --> es --> bp --> mo --> strategy --> br --> re
     re --> loc
-    re -.coming soon.-> k8s
+    re --> k8s
     loc --> run --> rr
     rr --> sa --> out
 
     classDef data fill:#e3f2fd,stroke:#1565c0,stroke-width:1.5px,color:#0d47a1
     classDef proc fill:#fff3e0,stroke:#e65100,stroke-width:1.5px,color:#bf360c
     classDef art fill:#e8f5e9,stroke:#2e7d32,stroke-width:1.5px,color:#1b5e20
-    classDef coming fill:#fafafa,stroke:#9e9e9e,stroke-width:1.5px,stroke-dasharray:5 3,color:#616161
     classDef decision fill:#f3e5f5,stroke:#6a1b9a,stroke-width:1.5px,color:#4a148c
 
     class yaml,cli,uc data
@@ -164,7 +161,7 @@ flowchart TD
     class es,sa,run proc
     class mo,strategy,br,re,loc decision
     class rr,out art
-    class k8s coming
+    class k8s decision
 
     style S1 fill:transparent,stroke:#78909c,stroke-width:2px,stroke-dasharray:5 3
     style S2 fill:transparent,stroke:#78909c,stroke-width:2px,stroke-dasharray:5 3
@@ -175,7 +172,12 @@ flowchart TD
     style S7 fill:transparent,stroke:#78909c,stroke-width:2px,stroke-dasharray:5 3
 ```
 
-The orchestrator forks a subprocess per cell at stage 6; aggregation is pure post-hoc compute over the collected `RunResult`s. YAML configs reach `AIPerfConfig` directly through `load_config` → `AIPerfConfig.model_validate`; only CLI flags travel through `CLIConfig` first so cyclopts can parse magic-list affordances (`--concurrency 1,2,4`) before they're lifted into a typed `SweepConfig`.
+At stage 6 the selected executor either forks a local subprocess or creates a
+child `AIPerfJob`; aggregation is pure post-hoc compute over the collected
+`RunResult`s. YAML configs reach `AIPerfConfig` through the Config-v2 loader;
+only CLI flags travel through `CLIConfig` first so cyclopts can parse
+magic-list affordances (`--concurrency 1,2,4`) before they are lifted into a
+typed `SweepConfig`.
 
 ### What happens between runs (per-cell loop)
 
@@ -389,7 +391,7 @@ For adaptive search, `N` is the iteration count: bounded above by `max_iteration
 | Plan loader (CLI/YAML -> plan) | `src/aiperf/config/loader/plan.py` |
 | `BenchmarkPlan` / `BenchmarkRun` models | `src/aiperf/config/resolution/plan.py` |
 | Orchestrator | `src/aiperf/orchestrator/orchestrator.py` |
-| Executors | `src/aiperf/orchestrator/{executor,local_executor}.py` |
+| Executors | `src/aiperf/orchestrator/{executor,local_executor}.py`, `src/aiperf/sweep_controller/k8s_executor.py` |
 | Aggregation | `src/aiperf/orchestrator/aggregation/sweep.py` |
 | Search planners + recipes | `src/aiperf/orchestrator/search_planner/`, `src/aiperf/search_recipes/` |
 
@@ -619,6 +621,13 @@ variation (for adaptive runs and for no-sweep runs) or calls `expand_sweep`
 also Sobol / Latin-hypercube for QMC sweeps), then renders any per-variation
 Jinja and emits one `BenchmarkConfig` per variation.
 
+Local files and `AIPerfSweep` CRs converge before this stage. Kubernetes
+projects the Config-v2 fields out of `spec`, loads that mapping with the same
+Config-v2 loader, and calls `build_benchmark_plan`. The Kubernetes adapter only
+attaches the CR's `failurePolicy` afterward. This keeps Jinja overlays, seed
+derivation, `multi_run`, `plot`, and future `AIPerfConfig` envelope fields on
+origin/main's canonical plan path.
+
 ```mermaid
 %%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'htmlLabels': true}, 'themeVariables': {'fontSize': '14px'}}}%%
 flowchart TB
@@ -847,7 +856,7 @@ Three collaborators inside the cell — two ABCs and one Pydantic model:
 | Type | Implementations | Job |
 | :--- | :--- | :--- |
 | **`ExecutionStrategy`** (ABC) | `FixedTrialsStrategy`, `AdaptiveStrategy` | Decide whether to run another trial in this cell. |
-| **`RunExecutor`** (ABC) | `LocalSubprocessExecutor` (only one shipping) | Turn one `BenchmarkRun` into one `RunResult` by spawning a fresh subprocess of `aiperf.orchestrator.subprocess_runner`. |
+| **`RunExecutor`** (ABC) | `LocalSubprocessExecutor`, `K8sChildJobExecutor` | Turn one `BenchmarkRun` into one `RunResult`; the backend either spawns a local subprocess or creates and watches a child `AIPerfJob`. |
 | **`BenchmarkRun`** (Pydantic model) | — | The smallest unit of work — essentially `(cfg, variation, trial, artifact_dir)`, plus identity fields (`benchmark_id`, `sweep_id`, `label`, `cli_command`, `random_seed`) that the orchestrator uses for the artifact tree and sweep grouping. |
 
 `FixedTrialsStrategy` runs exactly `M` trials. `AdaptiveStrategy` runs until a
@@ -1064,7 +1073,7 @@ other class in the sweep code is glue or helper.
 | **`MultiRunOrchestrator`** | Drives the cell loop; dispatches grid vs adaptive.                 | Stage 4                   |
 | **`ExecutionStrategy`**  | Per-cell "should I keep going?" — `FixedTrialsStrategy` / `AdaptiveStrategy`. | Stages 5–6        |
 | **`BenchmarkRun`**       | One `(cfg, variation, trial)` plus identity (`benchmark_id`, `sweep_id`, `label`, `cli_command`, `random_seed`). Smallest unit of work. | Stage 6 in                |
-| **`RunExecutor`**        | ABC. Only impl: `LocalSubprocessExecutor`.                           | Stage 6                   |
+| **`RunExecutor`**        | ABC implemented by `LocalSubprocessExecutor` and `K8sChildJobExecutor`. | Stage 6                 |
 | **`RunResult`**          | One `BenchmarkRun`'s output (metrics + variation metadata).          | Stage 6 out -> 7 in       |
 | **`SweepAnalyzer`**      | Pure compute: `list[RunResult]` -> grouped / best / Pareto JSON.     | Stage 7                   |
 
@@ -1104,7 +1113,7 @@ flowchart LR
     class E art
 ```
 
-### 10,000 ft — local end-to-end (with cluster path *coming soon*)
+### 10,000 ft — local and cluster execution
 
 ```mermaid
 %%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'htmlLabels': true}, 'themeVariables': {'fontSize': '14px'}}}%%
@@ -1113,7 +1122,7 @@ flowchart TD
 
     subgraph INPUTS["inputs"]
         cli["**aiperf profile** -c config.yaml"]
-        kube["**aiperf kube sweep** --config sweep.yaml<br/><i>coming soon</i>"]
+        kube["**aiperf kube sweep** --config sweep.yaml"]
     end
 
     subgraph CORE["plan / orchestration"]
@@ -1123,12 +1132,12 @@ flowchart TD
 
     subgraph EXEC["executors"]
         local["**LocalSubprocessExecutor**"]
-        k8s["**K8sChildJobExecutor**<br/><i>(in sweep-controller pod)</i><br/><i>coming soon</i>"]
+        k8s["**K8sChildJobExecutor**<br/><i>(in sweep-controller pod)</i>"]
     end
 
     subgraph RUNTIME["runtime"]
         sysctrl["**SystemController** + services"]
-        child["child **AIPerfJob** CRs<br/><i>(one per cell, deterministic names)</i><br/><i>coming soon</i>"]
+        child["child **AIPerfJob** CRs<br/><i>(one per cell, deterministic names)</i>"]
     end
 
     subgraph RESULTS["results"]
@@ -1136,28 +1145,27 @@ flowchart TD
     end
 
     user --> cli --> plan
-    user -.->|"coming soon"| kube -.-> plan
+    user --> kube --> plan
 
     plan --> orch
     orch --> local
-    orch -.->|"coming soon"| k8s
+    orch --> k8s
     local --> sysctrl
-    k8s -.-> child
-    child -.->|"HTTP pull<br/>profile_export_aiperf.json"| out
+    k8s --> child
+    child -->|"HTTP pull<br/>profile_export_aiperf.json"| out
     sysctrl --> out
 
     classDef data fill:#e3f2fd,stroke:#1565c0,stroke-width:1.5px,color:#0d47a1
     classDef proc fill:#fff3e0,stroke:#e65100,stroke-width:1.5px,color:#bf360c
     classDef decision fill:#f3e5f5,stroke:#6a1b9a,stroke-width:1.5px,color:#4a148c
     classDef art fill:#e8f5e9,stroke:#2e7d32,stroke-width:1.5px,color:#1b5e20
-    classDef coming fill:#fafafa,stroke:#9e9e9e,stroke-width:1.5px,stroke-dasharray:5 3,color:#616161
 
-    class user,cli data
+    class user,cli,kube data
     class plan data
-    class orch,local decision
+    class orch,local,k8s decision
     class sysctrl proc
     class out art
-    class kube,k8s,child coming
+    class child proc
 
     style INPUTS fill:transparent,stroke:#78909c,stroke-width:2px,stroke-dasharray:5 3
     style CORE fill:transparent,stroke:#78909c,stroke-width:2px,stroke-dasharray:5 3
@@ -1272,7 +1280,7 @@ flowchart TD
 
 ### Sub-flow — RunExecutor backends
 
-`RunExecutor` is a 2-method ABC: `execute(run) -> RunResult` and `derive_id(plan, var_idx, trial) -> str`. The local executor derives a stable id from the plan/variation/trial tuple for artifact naming; the cluster executor (**coming soon — finalized on the K8s integration branch, not yet on `main`**) derives a deterministic K8s-name-safe id from `(plan, var_idx, trial)` so child `AIPerfJob` creation is idempotent.
+`RunExecutor` is a 2-method ABC: `execute(run) -> RunResult` and `derive_id(plan, var_idx, trial) -> str`. The local executor derives a stable id from the plan/variation/trial tuple for artifact naming; the cluster executor derives a deterministic K8s-name-safe id from `(plan, var_idx, trial)` so child `AIPerfJob` creation is idempotent.
 
 ```mermaid
 %%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'htmlLabels': true}, 'themeVariables': {'fontSize': '14px'}}}%%
@@ -1286,7 +1294,7 @@ flowchart TD
         rrl["**RunResult**<br/>label · success ·<br/>summary_metrics · error ·<br/>artifacts_path · variation_label ·<br/>variation_values · trial_index"]
     end
 
-    subgraph K8S_BACKEND["cluster backend &mdash; <i>coming soon</i>"]
+    subgraph K8S_BACKEND["cluster backend"]
         k8s["**K8sChildJobExecutor**<br/><i>(runs inside sweep-controller pod)</i>"]
         cr["create **AIPerfJob** CR<br/><i>(deterministic name:<br/>&lt;sweep&gt;-v{idx:04d}-t{trial:02d})</i>"]
         watch["kubernetes_asyncio:<br/>watch child to terminal phase"]
@@ -1295,7 +1303,7 @@ flowchart TD
     end
 
     abc --> loc
-    abc -.->|"coming soon"| k8s
+    abc --> k8s
 
     loc -->|spawn subprocess| sub
     sub --> jr
@@ -1310,13 +1318,14 @@ flowchart TD
     classDef decision fill:#f3e5f5,stroke:#6a1b9a,stroke-width:1.5px,color:#4a148c
     classDef proc fill:#fff3e0,stroke:#e65100,stroke-width:1.5px,color:#bf360c
     classDef art fill:#e8f5e9,stroke:#2e7d32,stroke-width:1.5px,color:#1b5e20
-    classDef coming fill:#fafafa,stroke:#9e9e9e,stroke-width:1.5px,stroke-dasharray:5 3,color:#616161
 
     class run data
     class abc,loc decision
     class sub,jr proc
     class rrl art
-    class k8s,cr,watch,pull,rrk coming
+    class k8s decision
+    class cr,watch,pull proc
+    class rrk art
 
     style LOCAL_BACKEND fill:transparent,stroke:#78909c,stroke-width:2px,stroke-dasharray:5 3
     style K8S_BACKEND fill:transparent,stroke:#9e9e9e,stroke-width:2px,stroke-dasharray:5 3
@@ -1461,7 +1470,6 @@ classDiagram
     }
     class LocalSubprocessExecutor
     class K8sChildJobExecutor {
-        <<coming soon>>
         runs in sweep-controller pod
         creates child AIPerfJob CR per call
     }
@@ -1492,7 +1500,7 @@ classDiagram
     MultiRunOrchestrator ..> BenchmarkRun : builds
     MultiRunOrchestrator ..> RunExecutor : delegates
     RunExecutor <|-- LocalSubprocessExecutor
-    RunExecutor <|.. K8sChildJobExecutor : coming soon
+    RunExecutor <|-- K8sChildJobExecutor
     RunExecutor ..> RunResult : returns
 
     SweepAnalyzer ..> RunResult : aggregates
@@ -1939,7 +1947,7 @@ sequenceDiagram
     participant PP as PostProcessHandler
     participant Out as search_history.json /<br/>sweep_aggregate
 
-    Orch->>Pl: planner instantiated upstream<br/>(via _build_search_planner)<br/>and passed into execute
+    Orch->>Pl: planner instantiated upstream<br/>(via build_search_planner)<br/>and passed into execute
 
     loop until converged or max_iterations
         Orch->>Pl: ask
@@ -2293,8 +2301,8 @@ flowchart TB
 
 #### Notes on extension points
 
-- **Adding a new planner backend** (random-search baseline, etc.): subclass `SearchPlanner`, implement the four abstract methods (`ask`/`tell`/`is_converged`/`history`); optionally override `convergence_reason` (default returns `None`) and `boundary_summary` (1D feasibility planners only). No orchestrator changes required — `MonotonicSLASearchPlanner`, `SmoothIsotonicSLAPlanner`, and `OptunaSearchPlanner` are existing examples reusing the same ABC. Wiring is already generic: `AdaptiveSearchSweep.planner` is a `SearchPlannerType` (`ExtensibleStrEnum` in `src/aiperf/plugin/enums.pyi`), and `cli_runner._run_multi_benchmark` instantiates the planner via `plugins.get_class(PluginType.SEARCH_PLANNER, sweep.planner)`. To register a new backend, add an entry under `search_planner:` in `src/aiperf/plugin/plugins.yaml` and a matching enum value — no dispatch code changes.
-- **Adding a new executor backend**: subclass `RunExecutor`. `LocalSubprocessExecutor` iterates one (variation, trial) at a time via `execute(BenchmarkRun)` — the seam is adaptive-shaped by construction.
+- **Adding a new planner backend** (random-search baseline, etc.): subclass `SearchPlanner`, implement the four abstract methods (`ask`/`tell`/`is_converged`/`history`); optionally override `convergence_reason` (default returns `None`) and `boundary_summary` (1D feasibility planners only). No orchestrator changes required — `MonotonicSLASearchPlanner`, `SmoothIsotonicSLAPlanner`, and `OptunaSearchPlanner` are existing examples reusing the same ABC. Wiring is already generic: `AdaptiveSearchSweep.planner` is a `SearchPlannerType` (`ExtensibleStrEnum` in `src/aiperf/plugin/enums.pyi`), and the shared `build_search_planner` factory dispatches through `plugins.get_class(PluginType.SEARCH_PLANNER, sweep.planner)`. To register a new backend, add an entry under `search_planner:` in `src/aiperf/plugin/plugins.yaml` and a matching enum value — no dispatch code changes.
+- **Adding a new executor backend**: subclass `RunExecutor`. `LocalSubprocessExecutor` and `K8sChildJobExecutor` both execute one `(variation, trial)` at a time via `execute(BenchmarkRun)` — the seam is adaptive-shaped by construction.
 - **Replacing the BO backend.** The `OptunaSearchPlanner` boundary (and its `BayesianSearchPlanner` curated-preset subclass) is the only Optuna-aware code in the project. BoTorch-specific acquisitions live behind the optional `botorch` extra in `pyproject.toml`. The `qlognei` / `qlognehvi` acquisitions, posterior-regret stopping (`--optuna-terminator regret`/`emmr`), pooled-percentile aggregation (`--search-percentile-pooling pooled`), and the Hvarfner-DSP Matern-5/2 kernel ([arXiv:2402.02229](https://arxiv.org/abs/2402.02229)) are all plumbed through `_optuna_helpers.py`. The remaining principled upgrade path is wiring per-iteration heteroscedastic noise estimates from the pooled-percentile JSONL helper into a `HeteroskedasticSingleTaskGP`-based custom `candidates_func`. Evidence-gated: ship only if observed within-trial variance varies meaningfully across the search space on real workloads.
 
 #### `smooth_isotonic` as novel-in-composition

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -30,6 +30,22 @@ CLI runner post-run callback behavior. Controls whether OnComplete callback exce
 |----------------------|---------|-------------|-------------|
 | `AIPERF_RAISE_ON_CALLBACK_ERROR` | `False` | — | When true, re-raise the first OnComplete callback exception after running all remaining callbacks but before os._exit. Provides a strict-mode contract where a callback raise propagates out of the runner. When false (default) the exception is logged with full traceback, the exit code is forced non-zero, and the process still terminates via os._exit so leftover ZMQ/multiprocessing state cannot hang the interpreter. |
 
+## OPERATOR ENVIRONMENT
+
+Root operator environment configuration. Loads from environment variables. Nested settings use their own prefixes.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_JOB_TIMEOUT_SECONDS` | `0` | ≥ 0 | Job timeout in seconds (0 = no timeout) |
+| `AIPERF_POD_RESTART_THRESHOLD` | `3` | ≥ 0, ≤ 100 | Pod restart count before emitting a warning event |
+| `AIPERF_METRICS_PORT` | `9090` | ≥ 0, ≤ 65535 | Port for the Prometheus /metrics endpoint exposed by the kopf operator process. Set to 0 to disable. Scraped by ServiceMonitor. |
+| `AIPERF_ENDPOINT_CHECK_TIMEOUT` | `10.0` | > 0, ≤ 300 | Seconds to wait for endpoint health check |
+| `AIPERF_PREFLIGHT_TIMEOUT` | `30.0` | > 0, ≤ 120 | Seconds to wait for all pre-flight checks to complete |
+| `AIPERF_CONFIGMAP_PROPAGATION_DELAY_SECONDS` | `10.0` | ≥ 0, ≤ 60 | Seconds to wait after creating the benchmark ConfigMap before creating the JobSet. Allows kubelet caches on worker nodes to sync the ConfigMap before pods start mounting it, preventing FailedMount races on first deployment with a freshly pulled image. |
+| `AIPERF_MUTATING_ROUTES_ENABLED` | `False` | — | Enable results-server HTTP routes that mutate Kubernetes state. Defaults false so read-only results APIs remain exposed while POST routes fail closed unless an operator explicitly opts in. |
+| `AIPERF_MUTATING_ROUTES_TOKEN` | `''` | — | Bearer token required by enabled results-server mutating routes. Leave empty to fail closed even when MUTATING_ROUTES_ENABLED is true. |
+| `AIPERF_CLUSTER_NAME` | `''` | — | Optional human-readable cluster name surfaced in the UI top banner (e.g. 'dgx-prod', 'kind-aiperf'). When unset the banner falls back to the Kubernetes server version. Set via AIPERF_CLUSTER_NAME on the operator deployment. |
+
 ## ACCURACY
 
 Accuracy benchmark settings. Tunables for accuracy benchmarking: the cancel-path result-wait timeout and the LiveCodeBench dataset release pin, so accuracy behavior and numbers are reproducible across runs without requiring source edits.
@@ -60,7 +76,8 @@ API server settings. Controls the host and port of the API server.
 | `AIPERF_API_SERVER_PORT` | `None` | ≥ 1, ≤ 65535 | Port to bind the API server to |
 | `AIPERF_API_SERVER_CORS_ORIGINS` | `[]` | — | List of CORS origins to allow (empty = no CORS, ['*'] = all origins) |
 | `AIPERF_API_SERVER_SHUTDOWN_TIMEOUT` | `5.0` | ≥ 1.0, ≤ 300.0 | Timeout in seconds for graceful API server shutdown before force-cancelling |
-| `AIPERF_API_SERVER_POST_COMPLETE_GRACE` | `5.0` | ≥ 0.0, ≤ 300.0 | Seconds the API listener stays open after a benchmark terminates so polling clients can observe the final status before the server shuts down. Set to 0 to skip the grace window and shut down immediately. |
+| `AIPERF_API_SERVER_GET_POD_STATES_TIMEOUT` | `2.0` | ≥ 0.1, ≤ 60.0 | Timeout in seconds for API worker-state queries to the SystemController. A short timeout lets progress and debug endpoints fall back to their bus-fed cache while the controller is unavailable. |
+| `AIPERF_API_SERVER_POST_COMPLETE_GRACE` | `5.0` | ≥ 0.0, ≤ 300.0 | Seconds the API listener stays open after a benchmark terminates so polling clients can observe the final status before the server shuts down. Set to 0 to skip the grace window and shut down immediately. Not used under ServiceRunType.KUBERNETES, where the controller pod outlives its benchmark and is retired explicitly via POST /api/shutdown instead -- see FastAPIService._on_shutdown_command. A fixed window there is shorter than the operator's monitor interval and strands the AIPerfJob in a pre-terminal phase. |
 
 ## CHAT
 
@@ -89,6 +106,15 @@ Settings for DAG benchmark mode (`dag_jsonl` input type).
 |----------------------|---------|-------------|-------------|
 | `AIPERF_DAG_FAIL_FAST` | `False` | — | When True, a single DAG child error aborts the parent and every orphan sibling under the same branch (releases sticky refcounts and calls issuer.abort_session); unrelated root sessions continue. Default False - the orchestrator counts the error in BranchStats.children_errored, releases the join slot, drains pending siblings, and continues. Set via AIPERF_DAG_FAIL_FAST=1 for strict CI assertions. |
 
+## DASHBOARD
+
+Plotly Dashboard sidecar wiring (operator + results-server). The dashboard is an opt-in third container in the operator Pod; these settings let other containers locate it.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_DASHBOARD_PORT` | `0` | ≥ 0, ≤ 65535 | Pod-local HTTP port the dashboard sidecar listens on. 0 means the sidecar is disabled / absent. results-server uses this to reverse-proxy /dashboard/*; the operator uses it to fire fire-and-forget refresh POSTs after a benchmark completion claim. |
+| `AIPERF_DASHBOARD_PROXY_ENABLED` | `False` | — | When true, results-server forwards /dashboard/* to the sidecar at localhost:PORT and the SPA shows the 'Plots ↗' top-nav entry. When false, /dashboard/* returns 503 and the link is hidden. Set independently from PORT so a misconfigured chart fails closed. |
+
 ## DATASET
 
 Dataset loading and configuration. Controls timeouts and behavior for dataset loading operations, as well as memory-mapped dataset storage settings.
@@ -96,11 +122,16 @@ Dataset loading and configuration. Controls timeouts and behavior for dataset lo
 | Environment Variable | Default | Constraints | Description |
 |----------------------|---------|-------------|-------------|
 | `AIPERF_DATASET_CONFIGURATION_TIMEOUT` | `300.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for dataset configuration operations |
+| `AIPERF_DATASET_REBROADCAST_INTERVAL` | `2.0` | > 0.0, ≤ 60.0 | Seconds between re-announcements of the dataset-configured notification in Kubernetes. The notification is a one-shot broadcast and sibling worker pods start seconds apart, so a pod that subscribes late would otherwise never learn a dataset exists. |
+| `AIPERF_DATASET_REBROADCAST_WINDOW` | `120.0` | ≥ 0.0, ≤ 3600.0 | Total seconds to keep re-announcing the dataset-configured notification for late-joining worker pods. Set 0 to disable. |
 | `AIPERF_DATASET_BASETEN_SESSION_COLUMN` | `'provided_session_id'` | one of: 'provided_session_id' / 'poor_man_session_id' | Session column used by the Baseten trace loader when both supported columns exist. Set to poor_man_session_id for legacy traces. If the selected column is absent, the loader uses the available column. |
+| `AIPERF_DATASET_STATE_POLL_INTERVAL` | `1.0` | > 0.0, ≤ 60.0 | Seconds between polls of pod-local dataset state while a worker waits to become dispatchable. The dataset arrives via one-shot broadcasts; a worker container that subscribes after they fire recovers by polling its WorkerGroupManager at this interval instead of waiting forever. |
 | `AIPERF_DATASET_MMAP_BASE_PATH` | `None` | — | Base path for memory-mapped dataset files. If None, uses system temp directory. Set to a shared filesystem path for Kubernetes mounted volumes. Example: AIPERF_DATASET_MMAP_BASE_PATH=/mnt/shared-pvc creates files at /mnt/shared-pvc/aiperf_mmap_{benchmark_id}/ |
 | `AIPERF_DATASET_MMAP_CACHE_ENABLED` | `True` | — | If True, AIPerf reuses memory-mapped dataset files across runs whose input bytes, tokenizer identity, and prompt/input settings are byte-identical. Set to False to force every run to re-tokenize and re-write its mmap files. Cache misses still produce byte-identical mmap files to a non-cached run. |
 | `AIPERF_DATASET_MMAP_CACHE_DIR` | `None` | — | Directory holding the content-addressed mmap cache. If None, defaults to ~/.cache/aiperf/dataset_mmap. Each cache entry lives under a `dir/key` subpath and contains dataset.dat, index.dat, manifest.json, and (when produced) inputs.json. No automatic eviction is implemented yet -- delete the directory to reclaim disk. |
 | `AIPERF_DATASET_PREFORMAT_PAYLOADS` | `False` | — | If True, pre-encode single-turn / self-contained synthetic conversations to the PAYLOAD_BYTES mmap fast path at dataset-build time so workers stream the bytes verbatim and skip per-request encoding. This is a throughput optimization that DROPS input-tokenization metrics (input_sequence_length, image counts) because the structured prompt is discarded. Default False keeps the structured-turns (CONVERSATION) path so those metrics are computed. Datasets that natively ship raw payloads (raw_payload / inputs_json / mooncake-with-payload) always use PAYLOAD_BYTES regardless of this flag; cache-bust runs always use CONVERSATION regardless. |
+| `AIPERF_DATASET_DOWNLOAD_MAX_RETRIES` | `3` | ≥ 0, ≤ 20 | Maximum number of retries for dataset download in Kubernetes worker pods |
+| `AIPERF_DATASET_DOWNLOAD_RETRY_DELAY` | `2.0` | ≥ 0.1, ≤ 60.0 | Initial delay in seconds between dataset download retries (doubles each retry) |
 | `AIPERF_DATASET_PUBLIC_DATASET_TIMEOUT` | `300.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for public dataset loading operations |
 | `AIPERF_DATASET_MEDIA_DOWNLOAD_TIMEOUT` | `60.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds per media URL download when inline encoding is required |
 | `AIPERF_DATASET_MEDIA_DOWNLOAD_MAX_CONCURRENCY` | `10` | ≥ 1, ≤ 100 | Maximum number of concurrent media URL downloads |
@@ -170,6 +201,226 @@ HTTP client socket and connection configuration. Controls low-level socket optio
 | `AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID` | `False` | — | Also send X-Dynamo-Session-ID with the stable X-Correlation-ID value, plus X-Dynamo-Parent-Session-ID on subagent children. This transport setting is the supported affinity path for a Dynamo frontend running --router-session-affinity-ttl-secs, pinning every turn of a session to the replica holding its KV prefix. |
 | `AIPERF_HTTP_VIDEO_POLL_INTERVAL` | `0.1` | ≥ 0.001, ≤ 10.0 | Interval in seconds between status polls for async video generation jobs. Lower values provide faster completion detection but increase server load. Applies to the aiohttp transport. |
 
+## K8S
+
+Root Kubernetes environment configuration. Loads configuration from environment variables with the AIPERF_K8S_ prefix. Resource settings per container type are created via _resource_settings() with service-specific env prefixes and defaults.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_RECORD_PROCESSOR_CPU_REQUEST` | `None` | — | Optional per-record-processor CPU request override inside worker pods |
+| `AIPERF_K8S_RECORD_PROCESSOR_SCALE_FACTOR` | `1` | ≥ 1, ≤ 100 | Kubernetes-only default scale factor for record processors per worker pod. Formula: 1 record processor for every X workers. Default: 1 record processor per worker. |
+| `AIPERF_K8S_EVENT_BUS_SIDECAR_ENABLED` | `True` | — | Run the XPUB/XSUB event-bus proxy as a dedicated sidecar container in the controller pod rather than inside the control-plane (SystemController) container. Isolates pub/sub socket accept/forward from the control plane's event loop so large fan-ins (hundreds of simultaneous RP/worker connections) at startup don't starve the SystemController. Set to false to revert to the pre-sidecar behavior where SystemController owns the event-bus proxy. |
+| `AIPERF_K8S_SHARE_PROCESS_NAMESPACE` | `False` | — | When true, JobSet pods spawned by the operator set podSpec.shareProcessNamespace=true so all containers share a PID namespace. Enables cross-container `kubectl exec kill -9 <pid>` for chaos-testing workflows. Keep false in production; chaos fixtures flip it on via AIPERF_K8S_SHARE_PROCESS_NAMESPACE=true. |
+| `AIPERF_K8S_CONTROLLER_HTTP_URL_OVERRIDE` | `None` | — | Chaos-test hook: when set, the operator's progress-client uses this base URL (scheme+host+port, e.g. http://toxiproxy.aiperf-chaos-toxiproxy.svc:20002) instead of the per-CR JobSet pod DNS + API_SERVICE port for controller HTTP calls. Production MUST leave unset — it collapses multi-job isolation because every CR funnels through the same URL. Chaos fixtures set it via AIPERF_K8S_CONTROLLER_HTTP_URL_OVERRIDE to steer traffic through toxiproxy for latency/blackhole injection. |
+| `AIPERF_K8S_APISERVER_TLS_SERVER_NAME_OVERRIDE` | `None` | — | Chaos-test hook: when KUBERNETES_SERVICE_HOST points at an L4 proxy rather than kubernetes.default.svc, verify the apiserver certificate against this hostname while still dialing the proxy. Production MUST leave unset; C15 sets it to kubernetes.default.svc. |
+
+## K8SAPI
+
+Api container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_API_CPU` | `75m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_API_MEMORY` | `256Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SDATASETMANAGER
+
+Dataset Manager container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_DATASET_MANAGER_CPU` | `50m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_DATASET_MANAGER_MEMORY` | `256Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SDIAGNOSIS
+
+Thresholds for ``aiperf.kubernetes.benchmark_diagnosis`` heuristics.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_DIAGNOSIS_STALLED_PENDING_THRESHOLD_SECONDS` | `60.0` | ≥ 1.0, ≤ 3600.0 | Pending job is flagged as stalled after this many seconds. |
+| `AIPERF_K8S_DIAGNOSIS_STALLED_RUNNING_THRESHOLD_SECONDS` | `30.0` | ≥ 1.0, ≤ 3600.0 | Running job with no throughput and no completed requests is flagged as stalled after this many seconds. |
+| `AIPERF_K8S_DIAGNOSIS_HIGH_ERROR_RATE_THRESHOLD` | `0.05` | ≥ 0.0, ≤ 1.0 | Error rate (0.0-1.0) above which a high-error-rate finding is reported. |
+| `AIPERF_K8S_DIAGNOSIS_FAIL_ABOVE_ERROR_RATE` | `1.0` | > 0.0, ≤ 1.0 | Error rate (0.0-1.0) at or above which a finished benchmark is reported as Failed instead of Completed. Defaults to 1.0, so only a run in which every single request errored is failed outright; a run that merely errored heavily still completes and is flagged by the high-error-rate diagnosis. Lower it to enforce a stricter success bar. |
+| `AIPERF_K8S_DIAGNOSIS_HIGH_LATENCY_P99_MULTIPLIER` | `10.0` | ≥ 1.0, ≤ 1000.0 | Multiplier on average latency above which p99 is flagged as a tail-latency outlier. |
+
+## K8SEVENTBUSPROXY
+
+Event Bus Proxy container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_EVENT_BUS_PROXY_CPU` | `50m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_EVENT_BUS_PROXY_MEMORY` | `64Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SGPUTELEMETRYMANAGER
+
+Gpu Telemetry Manager container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_GPU_TELEMETRY_MANAGER_CPU` | `25m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_GPU_TELEMETRY_MANAGER_MEMORY` | `192Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SHEALTH
+
+Health probe configuration for all containers.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_HEALTH_INITIAL_DELAY_SECONDS` | `5` | ≥ 0, ≤ 300 | Seconds before starting probes after container starts |
+| `AIPERF_K8S_HEALTH_PERIOD_SECONDS` | `10` | ≥ 1, ≤ 300 | Interval in seconds between probe checks |
+| `AIPERF_K8S_HEALTH_TIMEOUT_SECONDS` | `5` | ≥ 1, ≤ 60 | Seconds before probe times out |
+| `AIPERF_K8S_HEALTH_FAILURE_THRESHOLD` | `10` | ≥ 1, ≤ 20 | Consecutive failures before container is restarted/marked unready |
+| `AIPERF_K8S_HEALTH_SUCCESS_THRESHOLD` | `1` | ≥ 1, ≤ 10 | Consecutive successes before container is marked healthy |
+| `AIPERF_K8S_HEALTH_STARTUP_PERIOD_SECONDS` | `5` | ≥ 1, ≤ 30 | Interval between startup probe checks |
+| `AIPERF_K8S_HEALTH_STARTUP_FAILURE_THRESHOLD` | `30` | ≥ 1, ≤ 120 | Consecutive startup probe failures before pod is killed. Total startup time = STARTUP_PERIOD_SECONDS * STARTUP_FAILURE_THRESHOLD |
+
+## K8SJOBSET
+
+JobSet-level configuration.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_JOBSET_TTL_SECONDS_AFTER_FINISHED` | `300` | ≥ 0 | Seconds to keep JobSet after completion (None to disable) |
+| `AIPERF_K8S_JOBSET_DIRECT_MODE_TTL_SECONDS` | `28800` | ≥ 0 | TTL for operator-less (direct) deployments. Pods stay alive for manual results retrieval. Default 8 hours (28800s). |
+| `AIPERF_K8S_JOBSET_CONTROLLER_BACKOFF_LIMIT` | `0` | ≥ 0, ≤ 10 | Job backoff limit for controller (0 = no retries) |
+| `AIPERF_K8S_JOBSET_WORKER_BACKOFF_LIMIT` | `20` | ≥ 0, ≤ 20 | Job backoff limit for workers (allows retries for transient failures) |
+| `AIPERF_K8S_JOBSET_WORKER_CONNECTION_PROBE_TIMEOUT` | `60.0` | ≥ 30.0, ≤ 600.0 | Seconds worker pods wait for the PUB/SUB connection probe to succeed. Overrides AIPERF_SERVICE_CONNECTION_PROBE_TIMEOUT for k8s worker containers only. Pods that cannot connect exit cleanly so Kubernetes restarts them with a fresh ZMQ context; WORKER_BACKOFF_LIMIT absorbs transient first-deploy flakes. |
+| `AIPERF_K8S_JOBSET_CONFIG_MOUNT_PATH` | `'/etc/aiperf'` | — | Path to mount ConfigMap with configs |
+| `AIPERF_K8S_JOBSET_DATASETS_PATH` | `'/aiperf/datasets'` | — | Shared path for dataset files (dataset-manager writes, API serves) |
+| `AIPERF_K8S_JOBSET_SWEEP_AGGREGATE_INLINE_MAX_BYTES` | `600000` | ≥ 10000, ≤ 900000 | Max encoded size of the AIPerfSweep aggregate bundle inlined into status.aggregate. K8s rejects CR patches over ~1 MiB with HTTP 413; if the bundle exceeds this cap, the sweep-controller drops `confidence` (the largest contributor on big sweeps) and relies on the disk-backed results sidecar to serve the full document. Default 600 KB leaves headroom for status fields and apiserver framing under the 1 MiB ceiling. |
+| `AIPERF_K8S_JOBSET_KUEUE_DEFAULT_QUEUE_NAME` | `''` | — | Operator-side default for Kueue gang-scheduling. When the AIPerfJob CR's spec.scheduling.queue_name is unset, the JobSet manifest falls back to this value. When non-empty, the JobSet gets the kueue.x-k8s.io/queue-name label, which Kueue's JobSet integration uses to admit the workload as a unit (gang-scheduling: controller + all worker pods admitted atomically, or none). Safe to leave unset on clusters without Kueue — the label is then never added. Set to e.g. 'aiperf-lq' on clusters where Kueue is installed and a LocalQueue of that name exists in the benchmark namespace. |
+| `AIPERF_K8S_JOBSET_KUEUE_DEFAULT_PRIORITY_CLASS` | `''` | — | Operator-side default for Kueue WorkloadPriorityClass. Companion to KUEUE_DEFAULT_QUEUE_NAME. When unset, the JobSet gets no kueue.x-k8s.io/priority-class label and Kueue's default fairness applies. |
+
+## K8SPORT
+
+Container port assignments.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_PORT_SYSTEM_CONTROLLER_HEALTH` | `8080` | ≥ 1, ≤ 65535 | System controller health port |
+| `AIPERF_K8S_PORT_WORKER_MANAGER_HEALTH` | `8081` | ≥ 1, ≤ 65535 | Worker manager health port |
+| `AIPERF_K8S_PORT_TIMING_MANAGER_HEALTH` | `8082` | ≥ 1, ≤ 65535 | Timing manager health port |
+| `AIPERF_K8S_PORT_DATASET_MANAGER_HEALTH` | `8083` | ≥ 1, ≤ 65535 | Dataset manager health port |
+| `AIPERF_K8S_PORT_RECORDS_MANAGER_HEALTH` | `8084` | ≥ 1, ≤ 65535 | Records manager health port |
+| `AIPERF_K8S_PORT_API_SERVICE` | `9090` | ≥ 1, ≤ 65535 | API service port |
+| `AIPERF_K8S_PORT_RESULTS_SIDECAR` | `9091` | ≥ 1, ≤ 65535 | Results sidecar port for serving exported files after controller failure |
+| `AIPERF_K8S_PORT_API_SERVICE_HEALTH` | `8085` | ≥ 1, ≤ 65535 | API service health port |
+| `AIPERF_K8S_PORT_GPU_TELEMETRY_MANAGER_HEALTH` | `8086` | ≥ 1, ≤ 65535 | GPU telemetry manager health port |
+| `AIPERF_K8S_PORT_SERVER_METRICS_MANAGER_HEALTH` | `8087` | ≥ 1, ≤ 65535 | Server metrics manager health port |
+| `AIPERF_K8S_PORT_EVENT_BUS_PROXY_HEALTH` | `8088` | ≥ 1, ≤ 65535 | Event-bus proxy sidecar health port |
+| `AIPERF_K8S_PORT_EVENT_BUS_PROXY_PUB_FRONTEND` | `5663` | ≥ 1, ≤ 65535 | Event-bus XPUB/XSUB proxy publisher-frontend bind port (producers connect to this). |
+| `AIPERF_K8S_PORT_EVENT_BUS_PROXY_SUB_BACKEND` | `5664` | ≥ 1, ≤ 65535 | Event-bus XPUB/XSUB proxy subscriber-backend bind port (subscribers connect to this). |
+| `AIPERF_K8S_PORT_WORKER_HEALTH` | `8080` | ≥ 1, ≤ 65535 | Worker health port |
+| `AIPERF_K8S_PORT_RECORD_PROCESSOR_HEALTH` | `8081` | ≥ 1, ≤ 65535 | Record processor health port |
+
+## K8SPORTFORWARD
+
+Tunables for ``aiperf.kubernetes.port_forward`` kubectl-based forwards.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_PORT_FORWARD_TIMEOUT_SECONDS` | `60.0` | ≥ 1.0, ≤ 600.0 | Total seconds to wait for kubectl port-forward to start and (optionally) for the API to respond. |
+| `AIPERF_K8S_PORT_FORWARD_API_INITIAL_DELAY_SECONDS` | `0.5` | ≥ 0.0, ≤ 10.0 | Seconds to wait after the tunnel comes up before the first API health check. |
+| `AIPERF_K8S_PORT_FORWARD_API_RETRY_DELAY_SECONDS` | `2.0` | ≥ 0.1, ≤ 30.0 | Seconds to back off between port-forward restart attempts while the API isn't ready. |
+| `AIPERF_K8S_PORT_FORWARD_API_MAX_RETRIES` | `10` | ≥ 0, ≤ 50 | Maximum number of port-forward restarts before giving up on the API readiness probe. |
+| `AIPERF_K8S_PORT_FORWARD_PROCESS_CLEANUP_TIMEOUT_SECONDS` | `5.0` | ≥ 0.1, ≤ 60.0 | Seconds to wait for graceful kubectl termination before escalating to SIGKILL. |
+
+## K8SPROGRESSSTREAM
+
+Tunables for ``aiperf.kubernetes.progress_stream`` WebSocket reconnects.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_PROGRESS_STREAM_WS_INITIAL_BACKOFF_SECONDS` | `1.0` | ≥ 0.1, ≤ 60.0 | Initial reconnect backoff after a WebSocket transport error. |
+| `AIPERF_K8S_PROGRESS_STREAM_WS_MAX_BACKOFF_SECONDS` | `30.0` | ≥ 1.0, ≤ 300.0 | Cap on the exponential reconnect backoff. |
+| `AIPERF_K8S_PROGRESS_STREAM_WS_HEARTBEAT_SECONDS` | `30` | ≥ 1, ≤ 300 | Seconds between aiohttp WebSocket heartbeats. |
+
+## K8SRECORDSMANAGER
+
+Records Manager container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_RECORDS_MANAGER_CPU` | `75m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_RECORDS_MANAGER_MEMORY` | `256Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SRESULTSSIDECAR
+
+Results Sidecar container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_RESULTS_SIDECAR_CPU` | `25m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_RESULTS_SIDECAR_MEMORY` | `192Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SSERVERMETRICSMANAGER
+
+Server Metrics Manager container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_SERVER_METRICS_MANAGER_CPU` | `25m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_SERVER_METRICS_MANAGER_MEMORY` | `192Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SSWEEPCONTROLLER
+
+Sweep Controller container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_SWEEP_CONTROLLER_CPU` | `75m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_SWEEP_CONTROLLER_MEMORY` | `512Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SSYSTEMCONTROLLER
+
+System Controller container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_SYSTEM_CONTROLLER_CPU` | `75m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_SYSTEM_CONTROLLER_MEMORY` | `192Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8STIMINGMANAGER
+
+Timing Manager container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_TIMING_MANAGER_CPU` | `50m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_TIMING_MANAGER_MEMORY` | `192Mi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SWATCHDOG
+
+Thresholds for ``aiperf.kubernetes.watchdog`` pod-health heuristics. These were plain keyword defaults on ``BenchmarkWatchdog.__init__`` with no environment binding, so a cluster with slow image pulls or an intentionally restart-tolerant workload had no way to raise them.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_WATCHDOG_POLL_INTERVAL_SECONDS` | `5.0` | ≥ 0.0, ≤ 300.0 | Seconds between watchdog pod-state polls. |
+| `AIPERF_K8S_WATCHDOG_STATUS_INTERVAL_SECONDS` | `10.0` | ≥ 0.0, ≤ 3600.0 | Seconds between watchdog status log lines. |
+| `AIPERF_K8S_WATCHDOG_PENDING_THRESHOLD_SECONDS` | `30.0` | ≥ 1.0, ≤ 3600.0 | Seconds a pod startup blocker may remain stable before the CLI watchdog or operator raises a warning. |
+| `AIPERF_K8S_WATCHDOG_PENDING_CRITICAL_THRESHOLD_SECONDS` | `90.0` | ≥ 1.0, ≤ 3600.0 | Seconds a pod startup blocker may remain stable before escalation to critical. The operator fails only known non-recoverable image, configuration, crash-loop, or structural scheduling blockers; capacity-related scheduling remains retryable. |
+| `AIPERF_K8S_WATCHDOG_CRASHLOOP_RESTART_THRESHOLD` | `2` | ≥ 1, ≤ 100 | Container restart count at which a crash-loop warning is raised and the operator may treat a stable CrashLoopBackOff as terminal. |
+
+## K8SWORKERPOD
+
+Worker Pod container CPU and memory (Guaranteed QoS).
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_WORKER_POD_CPU` | `150m` | — | CPU request and limit (Guaranteed QoS) |
+| `AIPERF_K8S_WORKER_POD_MEMORY` | `4Gi` | — | Memory request and limit (Guaranteed QoS) |
+
+## K8SZMQ
+
+ZMQ communication settings for Kubernetes deployments.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_K8S_ZMQ_CONTROLLER_HOST` | `None` | — | Controller hostname for ZMQ dual-bind mode. Set on worker pods to connect via TCP to controller. When None, services use IPC (controller mode). |
+| `AIPERF_K8S_ZMQ_IPC_PATH` | `'/aiperf/ipc'` | — | Path for IPC socket files in pods |
+
 ## LOGGING
 
 Logging system configuration. Controls multiprocessing log queue size and other logging behavior.
@@ -212,6 +463,33 @@ Network latency calibration configuration. Controls the TCP-handshake RTT probes
 | `AIPERF_NETWORK_LATENCY_COMPLETE_TOPUP_TIMEOUT` | `3.0` | ≥ 0.0, ≤ 30.0 | Wall-clock budget in seconds for the final MIN_SAMPLES top-up probes at PROFILE_COMPLETE, kept well under the command-response budget so a slow endpoint cannot stall completion |
 | `AIPERF_NETWORK_LATENCY_EXPORT_BATCH_SIZE` | `100` | ≥ 1, ≤ 1000000 | Batch size for the network latency jsonl writer export results processor |
 
+## OPERATOR
+
+Operator-service network identity. The operator Pod has three containers but only ONE FastAPI app: the ``results-server`` sidecar on ``resultsServer.port`` (8081 in the chart) hosts every ``/api/v1/*`` router (jobs, sweeps, results, config, admin, analytics, dashboard_proxy). The ``operator`` container on port 8080 runs kopf only — its sole HTTP surface is ``/healthz`` plus Prometheus ``/metrics``. So there is no separate "sweeps API URL" and "results API URL" — there is one base URL for everything, pointing at the results-server. Used when the operator stamps absolute URLs onto CR status (e.g. ``AIPerfSweep.status.apiUrl``, ``AIPerfSweep.status.runsTruncated.fetchURL``) that external clients dereference to fetch results, and when in-pod consumers (e.g. the sweep-controller's empty-summary fallback) need the operator's API endpoint.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_OPERATOR_BASE_URL` | `'http://aiperf-operator.aiperf-system:8081'` | — | Base URL (no trailing slash) for the operator's HTTP API. All ``/api/v1/*`` routers — jobs, sweeps, results, config, admin, analytics, dashboard_proxy — are served by the ``results-server`` container on this port; the operator container exposes only ``/healthz`` + ``/metrics`` on port 8080. Stamped onto ``AIPerfSweep.status.apiUrl`` and ``AIPerfSweep.status.runsTruncated.fetchURL`` so external clients can fetch per-sweep summaries; also consumed by the sweep-controller's per-child summary fallback. Override via ``AIPERF_OPERATOR_BASE_URL`` when the operator's Service+Namespace differ from the Helm chart defaults (e.g. a non-default ``Release.Name`` or an alternate namespace). |
+
+## OPERATORMONITOR
+
+Timer settings for the kopf monitor handler.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_OPERATOR_MONITOR_INTERVAL` | `10.0` | > 0, ≤ 3600 | Seconds between progress checks |
+| `AIPERF_OPERATOR_MONITOR_INITIAL_DELAY` | `5.0` | ≥ 0, ≤ 300 | Seconds before first progress check after job creation |
+
+## OPERATORPROGRESS
+
+Operator progress-client retry settings. Used by ``aiperf.operator.progress_client.ProgressClient`` when polling the controller pod's HTTP progress API. Retries apply to transient failures (connection errors, retryable HTTP statuses); other errors propagate.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_OPERATOR_PROGRESS_MAX_RETRIES` | `3` | ≥ 0, ≤ 20 | Max retry attempts on transient progress-API failures. |
+| `AIPERF_OPERATOR_PROGRESS_INITIAL_BACKOFF_SEC` | `0.5` | > 0, ≤ 60 | Initial backoff (seconds) between progress-API retries. |
+| `AIPERF_OPERATOR_PROGRESS_BACKOFF_MULTIPLIER` | `2.0` | ≥ 1.0, ≤ 10.0 | Multiplicative backoff factor between progress-API retries. |
+
 ## OTEL
 
 OpenTelemetry metrics streaming configuration. Controls buffering and flush behavior for OTLP metric streaming.
@@ -223,18 +501,49 @@ OpenTelemetry metrics streaming configuration. Controls buffering and flush beha
 | `AIPERF_OTEL_MAX_BUFFERED_RECORDS` | `10000` | ≥ 1, ≤ 10000000 | Maximum number of buffered metric records before oldest records are dropped |
 | `AIPERF_OTEL_REQUEST_TIMEOUT_SECONDS` | `10.0` | ≥ 0.1, ≤ 300.0 | Timeout in seconds for OTel collector HTTP requests |
 
+## POD
+
+Kubernetes worker-pod monitoring configuration. Consumed by the Kubernetes service manager, which polls the Kubernetes API for worker-pod phases and container-level failures.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_POD_MONITOR_INTERVAL` | `5.0` | ≥ 0.1, ≤ 100000.0 | Interval in seconds between worker-pod monitoring sweeps. Bounds how quickly a Failed/Unknown worker pod is detected via the Kubernetes API |
+| `AIPERF_POD_FAILURE_ABORT_THRESHOLD_PERCENT` | `50.0` | ≥ 0.0, ≤ 100.0 | Percentage of failed worker pods at which the Kubernetes service manager signals the controller to abort the benchmark. Set to 0 to never abort on pod failures |
+
 ## RECORD
 
 Record processing and export configuration. Controls batch sizes, processor scaling, and progress reporting for record processing.
 
 | Environment Variable | Default | Constraints | Description |
 |----------------------|---------|-------------|-------------|
+| `AIPERF_RECORD_CHECKPOINT_INTERVAL` | `30.0` | ≥ 0.0, ≤ 3600.0 | Seconds between partial-checkpoint writes during a Kubernetes run. The results sidecar serves these before the results-ready marker exists, and the operator treats a growing checkpoint as evidence the controller is alive. Set to 0 to disable. |
 | `AIPERF_RECORD_EXPORT_BATCH_SIZE` | `100` | ≥ 1, ≤ 1000000 | Batch size for record export results processor |
+| `AIPERF_RECORD_COMPLETION_STALL_TIMEOUT` | `300.0` | ≥ 0.0, ≤ 86400.0 | Seconds of ZERO record progress, after all credits are complete, before the RecordsManager stops waiting and finalizes the run as degraded. The completion barrier is event-driven: it needs one record per completed request, so a request that completes without ever emitting a record leaves the barrier permanently short and nothing re-triggers it. This bounds that into a loud failure instead of an unbounded hang. The timer measures time since the last record arrived, not total elapsed, so legitimately slow aggregation is never cut short. Set 0 to disable. |
+| `AIPERF_RECORD_COMPLETION_STALL_CHECK_INTERVAL` | `10.0` | > 0.0, ≤ 3600.0 | Seconds between record-progress stall checks after credits complete. |
 | `AIPERF_RECORD_RAW_EXPORT_BATCH_SIZE` | `10` | ≥ 1, ≤ 1000000 | Batch size for raw record writer processor |
-| `AIPERF_RECORD_PROCESSOR_SCALE_FACTOR` | `4` | ≥ 1, ≤ 100 | Scale factor for number of record processors to spawn based on worker count. Formula: 1 record processor for every X workers |
+| `AIPERF_RECORD_PROCESSOR_SCALE_FACTOR` | `4` | ≥ 1, ≤ 100 | Scale factor for number of record processors to spawn based on worker count. Formula: 1 record processor for every X workers. The default of 4 is the ratio the Kubernetes pod-sizing design was built around, alongside ~500 concurrent connections per worker; see RuntimeConfig.record_processors_per_pod |
 | `AIPERF_RECORD_PROGRESS_REPORT_INTERVAL` | `2.0` | ≥ 0.1, ≤ 600.0 | Interval in seconds between records progress report messages |
 | `AIPERF_RECORD_PROCESS_RECORDS_TIMEOUT` | `300.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for processing record results |
 | `AIPERF_RECORD_STRIP_PAYLOAD_BYTES` | `None` | — | Tri-state control for omitting canonical request payload bytes from RecordContext after a request is sent, which substantially reduces record-pipeline memory for very large prompts. None (default) auto-detects: bytes are stripped only when no downstream record consumer needs them (client-side input tokenization disabled, no synthetic image/audio/video inputs, and raw payload export off). True forces stripping even when a consumer wants the bytes, disabling client-side input tokenization, media counting from request bodies, and raw request payload export. False always retains them. Auto-detection does not see media embedded in custom dataset payloads under server-token-count mode; set False explicitly for that case. |
+
+## RESULTS
+
+Results fetching and storage settings.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_RESULTS_DIR` | `Path('/data')` | — | Base directory for storing benchmark results (mounted PVC) |
+| `AIPERF_RESULTS_K8S_INIT_TIMEOUT_SEC` | `10.0` | > 0, ≤ 120 | Seconds the results-server waits for its Kubernetes client to initialize at startup before giving up and serving PVC-only. The live-job endpoints need a cluster, but every results, sweeps, and artifact route reads the disk, so an unreachable apiserver must degrade the server rather than prevent it from starting. |
+| `AIPERF_RESULTS_MAX_RETRIES` | `5` | ≥ 0, ≤ 50 | Max retries when fetching results from controller |
+| `AIPERF_RESULTS_RETRY_DELAY` | `2.0` | ≥ 0, ≤ 60 | Seconds between result fetch retries |
+| `AIPERF_RESULTS_TTL_DAYS` | `30` | ≥ 0, ≤ 3650 | Days to keep results before cleanup (0 = never clean) |
+| `AIPERF_RESULTS_COMPRESS_ON_DISK` | `True` | — | Store downloaded result files as zstd-compressed (.zst) on disk |
+| `AIPERF_RESULTS_RETAIN_RUNS` | `10` | ≥ 1, ≤ 10000 | Max per-run result dirs to keep under <namespace>/<name>/ before retention trimming. Applied after every successful completion; the just-written epoch is always protected from deletion. |
+| `AIPERF_RESULTS_RETAIN_DAYS` | `0` | ≥ 0, ≤ 36500 | Age-based retention cap in days. 0 disables age policy. A run is deleted only when BOTH this age cap AND RETAIN_RUNS agree the run is outside the keep window; protect_epoch still wins. |
+| `AIPERF_RESULTS_TRANSIENT_FETCH_RETRY_BUDGET_SEC` | `60.0` | ≥ 0.0, ≤ 600.0 | Wall-clock budget (seconds, measured from the completion-claim annotation timestamp) within which a transient HTTP fetch failure is converted to a kopf.TemporaryError so the next monitor tick retries via the orphan-claim recovery path. Past this budget the operator gives up and marks the AIPerfJob Failed with the ResultsFetchFailed condition. WHY: sub-second benchmarks can race the controller's post-export shutdown — the marker has been written and key files exist on the controller PVC, but the operator's HTTP fetch hits a connection-refused or empty list as the controller container terminates. Set 0 to disable retries. |
+| `AIPERF_RESULTS_TRANSIENT_FETCH_RETRY_DELAY_SEC` | `5.0` | ≥ 0.5, ≤ 60.0 | Delay (seconds) passed to ``kopf.TemporaryError`` when retrying a transient results-fetch failure. Each retry runs through the orphan-claim recovery path on the next monitor tick. |
+| `AIPERF_RESULTS_PHASE_SETTLE_ATTEMPTS` | `3` | ≥ 0, ≤ 20 | How many times the completion handler re-samples controller progress while a phase reports its requests finished but its records still aggregating. Record aggregation trails the last request by a beat, so a single sample can leave status.phases showing isRecordsComplete=false on a run whose exports are complete. Set 0 to take exactly one sample. |
+| `AIPERF_RESULTS_PHASE_SETTLE_DELAY_SEC` | `2.0` | ≥ 0.1, ≤ 30.0 | Delay between the re-samples controlled by ``PHASE_SETTLE_ATTEMPTS``. The total wait is a hard ceiling on how long completion is delayed for a cosmetic status mirror. |
 
 ## SEARCHPLANNER
 
@@ -255,6 +564,7 @@ Server metrics collection configuration. Controls server metrics collection freq
 | Environment Variable | Default | Constraints | Description |
 |----------------------|---------|-------------|-------------|
 | `AIPERF_SERVER_METRICS_COLLECTION_FLUSH_PERIOD` | `2.0` | ≥ 0.0, ≤ 30.0 | Time in seconds to continue collecting metrics after profiling completes, allowing server-side metrics to flush/finalize before shutting down (default: 2.0s) |
+| `AIPERF_SERVER_METRICS_PROFILE_COMPLETE_RELAY_TIMEOUT` | `60.0` | ≥ 1.0, ≤ 600.0 | Seconds RecordsManager waits for the final server-metrics scrape command response. A timeout is non-fatal because the controller's result join remains the authoritative completion barrier. |
 | `AIPERF_SERVER_METRICS_COLLECTION_INTERVAL` | `0.333` | ≥ 0.001, ≤ 300.0 | Server metrics collection interval in seconds (default: 333ms, ~3Hz) |
 | `AIPERF_SERVER_METRICS_EXPORT_BATCH_SIZE` | `100` | ≥ 1, ≤ 1000000 | Batch size for server metrics jsonl writer export results processor |
 | `AIPERF_SERVER_METRICS_REACHABILITY_TIMEOUT` | `10` | ≥ 1, ≤ 300 | Timeout in seconds for checking server metrics endpoint reachability during init |
@@ -268,20 +578,28 @@ Service lifecycle and inter-service communication configuration. Controls timeou
 |----------------------|---------|-------------|-------------|
 | `AIPERF_SERVICE_COMMAND_RESPONSE_TIMEOUT` | `30.0` | ≥ 1.0, ≤ 1000.0 | Timeout in seconds for command responses |
 | `AIPERF_SERVICE_COMMS_REQUEST_TIMEOUT` | `90.0` | ≥ 1.0, ≤ 1000.0 | Timeout in seconds for requests from req_clients to rep_clients |
+| `AIPERF_SERVICE_PARENT_LIVENESS_POLL_INTERVAL` | `2.0` | ≥ 0.1, ≤ 60.0 | Interval in seconds at which a child service polls whether the SystemController is still alive. Only used when the direct parent is not the controller (forkserver/spawn start methods), where the kernel's PR_SET_PDEATHSIG cannot cover controller death. |
 | `AIPERF_SERVICE_CONNECTION_PROBE_INTERVAL` | `0.1` | ≥ 0.1, ≤ 600.0 | Interval in seconds for connection probes while waiting for initial connection to the zmq message bus |
 | `AIPERF_SERVICE_CONNECTION_PROBE_TIMEOUT` | `90.0` | ≥ 1.0, ≤ 100000.0 | Maximum time in seconds to wait for connection probe response while waiting for initial connection to the zmq message bus |
 | `AIPERF_SERVICE_CREDIT_PROGRESS_REPORT_INTERVAL` | `2.0` | ≥ 1, ≤ 100000.0 | Interval in seconds between credit progress report messages |
 | `AIPERF_SERVICE_WARMUP_PROGRESS_LOG_INTERVAL` | `30.0` | ≥ 0.0, ≤ 100000.0 | Interval in seconds between warmup progress heartbeat log messages. Set to 0 to disable. |
 | `AIPERF_SERVICE_DISABLE_UVLOOP` | `False` | — | Disable uvloop and use default asyncio event loop instead |
 | `AIPERF_SERVICE_HEARTBEAT_INTERVAL` | `5.0` | ≥ 1.0, ≤ 100000.0 | Interval in seconds between heartbeat messages for component services |
+| `AIPERF_SERVICE_HEARTBEAT_MISSED_THRESHOLD` | `3` | ≥ 1, ≤ 100 | Consecutive heartbeat intervals a registered service may miss before the watchdog suspects it. A service is only failed after appearing stale on two consecutive watchdog ticks, so worst-case detection is HEARTBEAT_INTERVAL * (threshold + 1) seconds. |
+| `AIPERF_SERVICE_FAILURE_SHUTDOWN_TIMEOUT` | `30.0` | ≥ 1.0, ≤ 300.0 | Wall-clock cap on the shutdown path inside AIPerfLifecycleMixin._fail. If cleanup (on_stop hooks, task cancellation) does not complete within this window after a failed on_init/on_start transition, a containerized (operator-managed) service hard-exits via os._exit(1), preventing silent zombie containers when cleanup blocks on a cancelled C-extension call. A local run logs the wedged shutdown and reports the failure normally instead, so the traceback and artifact export are not discarded. |
 | `AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT` | `600.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for profile configure command |
 | `AIPERF_SERVICE_PROFILE_START_TIMEOUT` | `60.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for profile start command |
 | `AIPERF_SERVICE_PROFILE_CANCEL_TIMEOUT` | `10.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for profile cancel command |
 | `AIPERF_SERVICE_REGISTRATION_INTERVAL` | `1.0` | ≥ 1.0, ≤ 100000.0 | Interval in seconds between registration attempts for component services |
 | `AIPERF_SERVICE_REGISTRATION_MAX_ATTEMPTS` | `10` | ≥ 1, ≤ 100000 | Maximum number of registration attempts before giving up |
 | `AIPERF_SERVICE_REGISTRATION_TIMEOUT` | `30.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for service registration |
+| `AIPERF_SERVICE_REGISTRATION_PROGRESS_LOG_INTERVAL` | `5.0` | ≥ 0.1, ≤ 100000.0 | Interval in seconds between 'still waiting for services to register' progress logs emitted by the service registry while blocked |
+| `AIPERF_SERVICE_GROUP_HELLO_ATTEMPT_TIMEOUT` | `2.0` | ≥ 0.1, ≤ 1000.0 | Timeout in seconds for a single group-local GroupPeerHello attempt before it is retried against the worker group manager |
+| `AIPERF_SERVICE_GROUP_HELLO_TOTAL_TIMEOUT` | `120.0` | ≥ 1.0, ≤ 100000.0 | Total deadline in seconds for a group-local peer to get its GroupPeerHello acknowledged before startup is failed |
 | `AIPERF_SERVICE_START_TIMEOUT` | `30.0` | ≥ 1.0, ≤ 100000.0 | Timeout in seconds for service start operations. Also bounds the per-phase wait for the first worker to register with the credit router before credit issuance begins; exceeding it fails the phase. |
 | `AIPERF_SERVICE_TASK_CANCEL_TIMEOUT_SHORT` | `2.0` | ≥ 1.0, ≤ 100000.0 | Maximum time in seconds to wait for simple tasks to complete when cancelling |
+| `AIPERF_SERVICE_SPAWN_TIMEOUT` | `60.0` | ≥ 1.0, ≤ 100000.0 | Safety-net timeout in seconds for multiprocessing Process.start(). Normal spawns complete in milliseconds; this guards against extreme system conditions (memory pressure, exhausted forkserver) blocking the event loop indefinitely. |
+| `AIPERF_SERVICE_ERROR_QUEUE_MAXSIZE` | `256` | ≥ 1, ≤ 65536 | Maximum number of pending subprocess error reports held in the multiprocessing error queue before further reports are dropped. |
 | `AIPERF_SERVICE_EVENT_LOOP_HEALTH_ENABLED` | `True` | — | Enable event loop health monitoring to detect blocked event loops. When enabled, TimingManager and Worker services periodically check if the event loop is responsive and log warnings when latency exceeds the threshold. |
 | `AIPERF_SERVICE_EVENT_LOOP_HEALTH_INTERVAL` | `0.25` | ≥ 0.05, ≤ 10.0 | Interval in seconds between event loop health checks (default: 250ms). The monitor sleeps for this duration and measures actual elapsed time to detect blocking. |
 | `AIPERF_SERVICE_EVENT_LOOP_HEALTH_WARN_THRESHOLD_MS` | `25.0` | > 1.0, ≤ 10000.0 | Warning threshold in milliseconds for event loop latency (default: 25ms). If the actual sleep duration exceeds the expected duration by this amount, a warning is logged. |
@@ -291,6 +609,17 @@ Service lifecycle and inter-service communication configuration. Controls timeou
 | `AIPERF_SERVICE_HEALTH_REQUEST_TIMEOUT` | `5.0` | ≥ 0.1, ≤ 60.0 | Timeout in seconds for reading health check HTTP requests. |
 | `AIPERF_SERVICE_WINDOWS_TCP_BASE_PORT` | `28000` | ≥ 1024, ≤ 65535 | Windows-only: starting port for the ZMQ IPC TCP-loopback fallback range. Per-endpoint ports are derived as ``base + (sha256_hash mod range)``. No-op on POSIX where ipc:// is used directly. |
 | `AIPERF_SERVICE_WINDOWS_TCP_PORT_RANGE` | `20000` | ≥ 64, ≤ 60000 | Windows-only: size of the TCP-loopback port window for the ZMQ IPC fallback. Birthday-paradox collision probability for n sockets is ``1 - exp(-n*n/(2*range))``. Widen if AIPerf grows to many more sockets per run, or relocate via ``AIPERF_SERVICE_WINDOWS_TCP_BASE_PORT`` if 28000-48000 conflicts. |
+
+## SWEEPCONTROLLER
+
+Sweep-controller pod settings. Used by the sweep-controller pod (`aiperf.sweep_controller.k8s_executor`) when creating child AIPerfJob CRs.
+
+| Environment Variable | Default | Constraints | Description |
+|----------------------|---------|-------------|-------------|
+| `AIPERF_SWEEP_CONTROLLER_STALE_CHILD_DELETION_TIMEOUT_SECONDS` | `60.0` | > 0, ≤ 600 | Max seconds the sweep-controller will wait for a same-named AIPerfJob from a prior sweep run to finish cascade-deletion before raising ChildNameConflictError. Hit when a user deletes and recreates a sweep with the same name while old children are still terminating. |
+| `AIPERF_SWEEP_CONTROLLER_STALE_CHILD_POLL_INTERVAL_SECONDS` | `2.0` | > 0, ≤ 30 | Poll interval (seconds) while waiting for a deleting same-named AIPerfJob to disappear. See STALE_CHILD_DELETION_TIMEOUT_SECONDS. |
+| `AIPERF_SWEEP_CONTROLLER_CANCEL_GRACE_SECONDS` | `120.0` | > 0, ≤ 3600 | Max seconds the sweep-controller will keep polling a child AIPerfJob for a terminal phase after requesting cancel before giving up and advancing the sweep. Bounds the post-cancel wait so a stuck child (stalled operator cancel path, wedged pod, repeatedly-failing JobSet delete) cannot wedge the whole sweep indefinitely. |
+| `AIPERF_SWEEP_CONTROLLER_CHILD_MISSING_TIMEOUT_SECONDS` | `300.0` | > 0, ≤ 3600 | Max seconds the sweep-controller will keep polling for a child AIPerfJob that has gone missing (404) before its terminal phase, with no cancel requested, before giving up and advancing the sweep. Hit when a user (or the kube garbage collector) deletes a child AIPerfJob out-of-band mid-run; without this bound the sequential sweep wedges forever on the deleted variation. |
 
 ## TIMING
 
@@ -340,14 +669,19 @@ Worker management and auto-scaling configuration. Controls worker pool sizing, h
 | Environment Variable | Default | Constraints | Description |
 |----------------------|---------|-------------|-------------|
 | `AIPERF_WORKER_CHECK_INTERVAL` | `1.0` | ≥ 0.1, ≤ 100000.0 | Interval in seconds between worker status checks by WorkerManager |
+| `AIPERF_WORKER_CLOCK_PROBE_TIMEOUT` | `1.0` | ≥ 0.1, ≤ 100000.0 | Per-probe timeout in seconds for a single startup TimePing/TimePong round trip. Kept short so an unreachable credit ROUTER costs a fast retry instead of consuming AIPERF_WORKER_CLOCK_PROBE_BUDGET on one probe. Kubernetes mode only. |
+| `AIPERF_WORKER_CLOCK_PROBE_BUDGET` | `30.0` | ≥ 0.1, ≤ 100000.0 | Total seconds a worker may spend on startup TimePing/TimePong clock-offset RTT probes before giving up and announcing readiness uncalibrated. Hard ceiling on the whole probe sequence, not per probe, so a router that never echoes cannot stall worker registration past AIPERF_SERVICE_REGISTRATION_TIMEOUT. Sized for real cluster startup, where the credit ROUTER is commonly not echoing for the first several seconds after a worker container starts. Kubernetes mode only. |
 | `AIPERF_WORKER_CPU_UTILIZATION_FACTOR` | `0.75` | ≥ 0.1, ≤ 1.0 | Factor multiplied by CPU count to determine default max workers (0.0-1.0). Formula: max(1, min(int(cpu_count * factor) - 1, MAX_WORKERS_CAP)) |
 | `AIPERF_WORKER_ERROR_RECOVERY_TIME` | `3.0` | ≥ 0.1, ≤ 1000.0 | Time in seconds from last error before worker is considered healthy again |
 | `AIPERF_WORKER_HEALTH_CHECK_INTERVAL` | `2.0` | ≥ 0.1, ≤ 1000.0 | Interval in seconds between worker health check messages |
 | `AIPERF_WORKER_HIGH_LOAD_CPU_USAGE` | `85.0` | ≥ 50.0, ≤ 100.0 | CPU usage percentage threshold for considering a worker under high load |
 | `AIPERF_WORKER_HIGH_LOAD_RECOVERY_TIME` | `5.0` | ≥ 0.1, ≤ 1000.0 | Time in seconds from last high load before worker is considered recovered |
 | `AIPERF_WORKER_MAX_WORKERS_CAP` | `32` | ≥ 1, ≤ 10000 | Absolute maximum number of workers to spawn, regardless of CPU count |
+| `AIPERF_WORKER_MIN_ALIVE_FRACTION` | `0.0` | ≥ 0.0, ≤ 1.0 | Fail the benchmark when the number of dispatchable workers remains below this fraction of the peak ever registered for one worker staleness interval. TimingManager evaluates the count after worker deregistration, so Kubernetes replacement pods can become dispatchable before a transient loss is fatal. 0 disables the check. |
 | `AIPERF_WORKER_STALE_TIME` | `10.0` | ≥ 0.1, ≤ 1000.0 | Time in seconds from last status report before worker is considered stale |
 | `AIPERF_WORKER_STATUS_SUMMARY_INTERVAL` | `0.5` | ≥ 0.1, ≤ 1000.0 | Interval in seconds between worker status summary messages |
+| `AIPERF_WORKER_RAW_RECORD_UPLOAD_TIMEOUT` | `60.0` | ≥ 1.0, ≤ 600.0 | Timeout in seconds to wait for worker pods to upload raw record files to the controller API after benchmark completion. |
+| `AIPERF_WORKER_DEFAULT_WORKERS_PER_POD` | `10` | ≥ 1, ≤ 100 | Default number of worker subprocesses per Kubernetes worker pod. Each pod downloads the dataset once and shares it across workers via mmap. Packing exists because a node holds only ~65k ephemeral ports, which caps concurrent connections per node; see RuntimeConfig.workers_per_pod |
 
 ## ZMQ
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -206,6 +206,59 @@ navigation:
   - page: Conversation DAG Benchmarks
     path: benchmark-modes/dag.md
 
+- section: Kubernetes
+  collapsed: true
+  contents:
+  - page: Getting Started on Kubernetes
+    path: kubernetes/getting-started.md
+  - page: Deploy from Source Checkout
+    path: kubernetes/source-checkout-deploy.md
+  - page: End-to-End Workflow
+    path: kubernetes/workflow.md
+  - page: Config Init and Manifest Generation
+    path: kubernetes/init-and-generate.md
+  - page: Kubernetes Configuration Reference
+    path: kubernetes/configuration.md
+  - page: Production Deployment
+    path: kubernetes/production.md
+  - page: RBAC and Security
+    path: kubernetes/rbac-security.md
+  - page: Monitoring and Observability
+    path: kubernetes/monitoring.md
+  - page: Config Validation
+    path: kubernetes/validate.md
+  - page: CRD Validation Rules
+    path: kubernetes/crd-validation.md
+  - page: Preflight Checks
+    path: kubernetes/preflight.md
+  - page: Debug Command
+    path: kubernetes/debug-command.md
+  - page: Attach to a Running Benchmark
+    path: kubernetes/attach.md
+  - page: Logs
+    path: kubernetes/logs.md
+  - page: Results Server API Reference
+    path: kubernetes/results-api.md
+  - page: Web Dashboard
+    path: kubernetes/dashboard-ui.md
+  - page: Controller Pod Sidecars
+    path: kubernetes/sidecars.md
+  - page: Memory Estimator
+    path: kubernetes/memory-estimator.md
+  - page: Kueue Integration
+    path: kubernetes/kueue.md
+  - page: GPU Telemetry on Kubernetes
+    path: kubernetes/gpu-telemetry.md
+  - page: Direct Mode (no operator)
+    path: kubernetes/direct-mode.md
+  - page: Adaptive Search on Kubernetes
+    path: kubernetes/adaptive-search.md
+  - page: User-Defined Output Files
+    path: kubernetes/user-files.md
+  - page: AI-Assisted Debugging Guide
+    path: kubernetes/ai-debugging-guide.md
+
+
 - section: Accuracy
   collapsed: true
   contents:
@@ -301,6 +354,8 @@ navigation:
     path: dev/sweep-orchestrator.md
   - page: YAML Config Future Goals
     path: dev/yaml-config-future-goals.md
+  - page: Kubernetes Flow
+    path: dev/kubernetes-flow.md
 
 - section: Troubleshooting
   collapsed: true

--- a/docs/kubernetes/adaptive-search.md
+++ b/docs/kubernetes/adaptive-search.md
@@ -1,0 +1,327 @@
+<!--
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+-->
+
+# Adaptive Search on Kubernetes
+
+Adaptive search lets the cluster choose its own sweep points instead of
+exhausting a grid. The same `BayesianSearchPlanner` (Optuna-backed, with
+the Gaussian-process path supplied by BoTorch via the `[botorch]` extra) used
+in-process by `aiperf profile --search-*` runs cluster-side when an
+`AIPerfSweep` CR sets `spec.sweep.type: adaptive_search`. The planner
+proposes one variation at a time; the sweep-controller pod creates a child
+`AIPerfJob` for that variation, waits for it to terminate, scores the
+objective, and asks for the next point. Convergence detection (max iterations,
+improvement-patience plateau, or coefficient-of-variation plateau) terminates
+the loop early when further evaluations stop helping.
+
+Reach for adaptive search when the search space is too large to grid
+enumerate (e.g. concurrency 1–1000), when a single scalar objective
+captures what you care about, and when you want one `AIPerfJob` per
+proposed point so each iteration is durable, cancellable, and visible
+through normal `kubectl get aiperfjob` workflows. For the algorithm
+details, flag grammar, and `search_history.json` schema, defer to
+[Bayesian-Optimization Outer Loop](../sweeping/bayesian-optimization.md);
+for the in-process tutorial, see
+[Adaptive Search](../tutorials/adaptive-search.md).
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as kube-apiserver
+    participant Op as kopf operator<br/>(BO-agnostic)
+    participant Ctrl as sweep-controller pod<br/>BayesianSearchPlanner
+    participant Job as AIPerfJob iter N
+    participant Disk as PVC<br/>search_history.json
+
+    User->>API: kubectl apply AIPerfSweep<br/>sweep.type: adaptive_search
+    API->>Op: watch event
+    Op->>API: create JobSet for sweep-controller
+    API->>Ctrl: pod scheduled
+    Ctrl->>Ctrl: planner.ask() -> variation
+    Ctrl->>API: create AIPerfJob iter N
+    API->>Op: watch event
+    Op->>Job: spawn worker pods
+    Job-->>Ctrl: terminal phase + RunResults
+    Ctrl->>Ctrl: planner.tell(results)
+    Ctrl->>Disk: write search_history.json
+    Ctrl->>Ctrl: planner.ask() -> next or None
+    Note over Ctrl: loop until convergence<br/>or maxIterations
+```
+
+The kopf operator stays unaware of Bayesian Optimization: it only sees
+ordinary `AIPerfJob` create/delete events. Planner state — the Gaussian
+process model, trial history, and convergence accumulators — lives in the
+controller process. After a restart, the controller constructs a fresh planner
+and deterministically replays terminal child results through the canonical
+`ask()` / `tell()` loop before proposing a new point. `search_history.json`
+remains an output record rather than an input checkpoint; replay rebuilds it
+from the Kubernetes-owned children.
+
+If `sweep.randomSeed` is omitted, the Kubernetes plan builder derives a stable
+planner seed from the immutable `AIPerfSweep` `metadata.uid`. An explicit
+`randomSeed` always wins. Every child also carries
+`aiperf.nvidia.com/run-identity`, a SHA-256 hash of its exact generated
+`AIPerfJob.spec`. A deterministic child name is reused only when both ownership
+and this execution contract match. A missing or mismatched identity fails the
+sweep instead of feeding metrics from a different configuration into planner
+history.
+
+The optimization stack is pulled in through the AIPerf `[botorch]` extra
+(alias `[optuna]`) and is present on the controller-pod image; operator
+pods do not need it.
+
+## Minimal `AIPerfSweep` CR
+
+A single-dimension search over `phases.profiling.concurrency`. Dimension
+paths are rooted **inside** the `benchmark:` block, so the `benchmark.`
+prefix is redundant and rejected by the validator. This example optimizes
+output token throughput on Llama 3.1 8B Instruct served by vLLM:
+
+```yaml
+apiVersion: aiperf.nvidia.com/v1alpha1
+kind: AIPerfSweep
+metadata:
+  name: bo-concurrency-llama8b
+  namespace: bench
+spec:
+  benchmark:
+    models: [meta-llama/Llama-3.1-8B-Instruct]
+    endpoint:
+      urls: [http://vllm.bench.svc.cluster.local:8000/v1/chat/completions]
+      type: chat
+      streaming: true
+    datasets:
+      - name: main
+        type: synthetic
+    phases:
+      - name: profiling
+        type: poisson
+        rate: 1.0  # placeholder: overridden per-iteration by searchSpace below
+        duration: 120
+  sweep:
+    type: adaptive_search
+    planner: bayesian
+    searchSpace:
+      - path: phases.profiling.concurrency
+        lo: 1
+        hi: 1000
+        kind: int
+    objectives:
+      - metric: output_token_throughput
+        stat: avg
+        direction: maximize
+    maxIterations: 30
+    nInitialPoints: 5
+    improvementPatience: 8
+    plateauWindow: 5
+    plateauThreshold: 0.01
+    randomSeed: 42
+  multiRun:
+    numRuns: 3
+    cooldownSeconds: 30
+```
+
+`numRuns: 3` runs three benchmarks per proposed point and feeds their
+average objective back to the planner — confidence per point at the cost
+of triple the wall clock. Drop to `numRuns: 1` for fastest iteration.
+
+## Multi-dimensional search
+
+Search over concurrency and Poisson rate jointly:
+
+```yaml
+spec:
+  sweep:
+    type: adaptive_search
+    planner: bayesian
+    searchSpace:
+      - path: phases.profiling.concurrency
+        lo: 1
+        hi: 500
+        kind: int
+      - path: phases.profiling.rate
+        lo: 1.0
+        hi: 50.0
+        kind: real
+    objectives:
+      - metric: output_token_throughput
+        stat: avg
+        direction: maximize
+    maxIterations: 40
+    nInitialPoints: 8
+  multiRun:
+    numRuns: 2
+```
+
+`kind: int` declares an integer dimension — Optuna suggests integer
+parameters natively, no rounding step — while `kind: real` keeps
+floats. `nInitialPoints` Sobol-quasirandom draws fit before the GP
+takes over — bump it for higher-dimensional spaces (rule of thumb:
+`>= 2 * len(searchSpace)`).
+
+## Status fields you can watch
+
+The CRD declares typed counters in `status`:
+
+| Field | Meaning under adaptive search |
+|---|---|
+| `status.phase` | `Pending` -> `Running` -> `Aggregating` -> `Succeeded` / `Failed` / `PartiallyFailed` / `Cancelled`. |
+| `status.totalVariations` | Upper bound: equal to `maxIterations`. Actual count may be lower on early stop. |
+| `status.maxTotalRuns` | Upper bound: `maxIterations * multiRun.numRuns`. |
+| `status.completedRuns` | Authoritative count of finished child `AIPerfJob`s. |
+| `status.failedRuns` | Authoritative failure count, fed by `failurePolicy`. |
+| `status.runEpoch` | Decimal sweep-run key used in the on-disk path. Whole-second Kubernetes timestamps carry a deterministic six-digit UID suffix so rapid same-name recreation cannot reuse an archive. |
+
+`status` is a preserve-unknown object, so the operator also stamps
+untyped extras there (`runStates`, `currentChildRef`, `currentCell`,
+`aggregation`).
+
+Both `totalVariations` and `maxTotalRuns` are upper bounds — early
+plateau or improvement-patience convergence shrinks the actual count.
+This mirrors how the trial-level convergence rule
+(`multiRun.numRuns`) caps trials on grid sweeps.
+
+```bash
+$ kubectl -n bench get aiperfsweep bo-concurrency-llama8b
+NAME                     PHASE       COMPLETED   TOTAL   FAILED   CURRENT   AGE
+bo-concurrency-llama8b   Succeeded   54          90      0                  12m
+```
+
+The full BO trajectory — every proposed point, the per-iteration
+objective, the running best, and the convergence reason — lives in
+`search_history.json`, not on the CR. See
+[Output layout](#output-layout) below and the
+[search_history.json schema](../api/search-history.md).
+
+A compact projection of that artifact is served on the sweep detail route
+as `search_summary`, so the dashboard and any API client can read the
+planner's own verdict without downloading the trajectory:
+
+```bash
+$ curl -s http://aiperf-operator.aiperf-system:8081/api/v1/sweeps/bench/bo-concurrency-llama8b \
+    | jq '.search_summary | {convergence_reason, stop_kind, iteration_count,
+                             sla_filter_count, best_trials, boundary_summary}'
+```
+
+| Field | Meaning |
+|---|---|
+| `convergence_reason` | Verbatim planner stop reason; `null` mid-loop or after an abnormal exit. |
+| `stop_kind` | `converged` / `budget_exhausted` / `incomplete` — the classification of that reason, so clients need not track a growing string enum. |
+| `iteration_count`, `feasible_iteration_count` | Iterations recorded, and how many met every SLA filter. |
+| `sla_filter_count` | How many SLA filters were configured. **Zero makes every `feasible` flag vacuously true** — check it before rendering any feasibility claim. |
+| `objectives` | The optimized targets, with `direction` normalized to lowercase. |
+| `best_trials` | Planner-selected winner (Pareto front for multi-objective), capped at 20 with `best_trials_truncated`. Each entry's `objective_values` is **positional against `objectives`** and is never compacted: an objective the scorer could not produce keeps its slot as an explicit `null`, so `objective_values[i]` always belongs to `objectives[i]`. A `null` there means "not measured for this trial" and must be rendered as such — substituting a neighbouring value silently relabels it. The whole field is `null` when the trial was not scored at all. |
+| `boundary_summary` | The empirical SLA boundary: `feasible_max`, `infeasible_min`, and the `first_breach` that defined it. `null` for multi-dimensional searches. |
+
+`search_summary` is `null` for grid-family sweeps, for adaptive sweeps
+whose trajectory has not been harvested to the operator PVC yet, and
+whenever the artifact is unreadable — a missing verdict degrades the
+response, it never fails it. The complete `search_history.json` remains
+downloadable from the per-epoch sweep artifacts routes.
+
+## Mutual exclusion rules
+
+In the flat spec envelope, `adaptive_search` is one of the
+`sweep.type` discriminator values (alongside `grid`, `zip`, `scenarios`,
+`sobol`, and `latin_hypercube`), so "adaptive plus grid" is not even
+expressible — the discriminator picks one. The remaining gates protect
+the cardinality contract:
+
+| Combination | Outcome | Enforced by |
+|---|---|---|
+| `kind: AIPerfJob` + `spec.sweep` (any type) | Rejected at admission — single benchmarks must use `kind: AIPerfJob` with `spec.sweep` unset | CRD `x-kubernetes-validations` rule (`!has(self.sweep)` on AIPerfJob) |
+| `kind: AIPerfSweep` without `spec.sweep` | Rejected at admission — sweeps must declare a `sweep` block | CRD `x-kubernetes-validations` rule (`has(self.sweep)` on AIPerfSweep) |
+| `sweep.type: adaptive_search` + `spec.benchmark.sweep` | Rejected on reconcile (not at admission — `spec.benchmark` is a preserve-unknown node, so CEL cannot see the key) — sweep axes belong on the parent CR, not embedded in the per-iteration body | `BenchmarkConfig` has no `sweep` field and forbids extras |
+| Per-iteration `AIPerfJob` containing magic-list flags (`--concurrency 10,20,30`) | Rejected inside each child by `_reject_in_process_sweep_under_operator` | `src/aiperf/cli_runner/_multi_run.py` |
+
+These prevent sweeping on top of sweeping and keep a single source of
+truth for variation generation.
+
+## Operator-managed gate exception
+
+The operator sets `AIPERF_OPERATOR_MANAGED=1` in every controller and
+worker pod, and `cli_runner._reject_in_process_sweep_under_operator`
+hard-fails any in-process magic-list sweep under that flag — so the
+cluster never sweeps on top of a sweep. **Adaptive search is the
+exception**: the controller pod is the BO driver, and each per-iteration
+child `AIPerfJob` sees a single-config plan (no `is_sweep` shape), so the
+gate never fires for adaptive runs. The exemption is documented in the
+`_reject_in_process_sweep_under_operator` docstring
+(`src/aiperf/cli_runner/_multi_run.py`).
+
+## Cancellation behaviour
+
+Patching the parent `AIPerfSweep` with `spec.cancel: true` is cooperative
+end to end:
+
+1. A background poller in the sweep-controller pod
+   (`_poll_cancel_flag` in `sweep_controller/main.py`) re-reads the parent
+   CR and flips an in-process cancel flag when `spec.cancel` is true.
+2. The adaptive loop and the child-wait loop both consult that flag as a
+   `cancel_check` callable at their `await` boundaries.
+3. The currently-running child `AIPerfJob` is patched with
+   `spec.cancel: true` (`K8sChildJobExecutor._patch_child_cancel`), drains
+   to a terminal phase, and contributes its results.
+4. The controller skips remaining iterations, runs aggregation over the
+   children that did complete, and flushes `search_history.json` with
+   `convergence_reason: "cancelled"`.
+
+`search_history.json` is rewritten after every iteration. Cancellation keeps
+the completed prefix immediately; after a controller restart, the same prefix
+is reconstructed by reusing terminal children and replaying their metrics into
+the restart-stable planner before execution advances.
+
+## Output layout
+
+Artifacts land under the `RESULTS_DIR` PVC, scoped by namespace, sweep
+name, and the sweep run-epoch:
+
+```
+<RESULTS_DIR>/
+  <namespace>/
+    sweeps/
+      <sweep-name>/
+        <sweep-run-epoch>/
+          search_history.json          # BO trajectory + convergence_reason
+          aggregate.json               # durable parent aggregate
+          children.json                # child manifest
+          sweep_aggregate/             # mode-agnostic per-combination aggregate
+            profile_export_aiperf_sweep.json
+            profile_export_aiperf_sweep.csv
+    <sweep-name>-v00-t0/               # per-iteration child AIPerfJob
+      <child-run-epoch>/
+        profile_export_aiperf.json     # full per-trial artifacts
+        ...
+    <sweep-name>-v00-t1/
+    <sweep-name>-v01-t0/
+    ...
+```
+
+The operator harvests the whole tree from the sweep-controller's results
+sidecar before the JobSet is deleted (the controller pod's `/results` is
+an `emptyDir`), re-rooting it onto the operator PVC.
+
+Per-iteration child names follow the same `<sweep>-v<NN>[-t<N>]` budget
+as grid sweeps (`build_child_name` in `sweep_controller/_naming.py`):
+the variation index is the BO iteration index (`-v00` is the first
+proposed point), and the trial suffix is present whenever
+`multiRun.numRuns > 1`. Each child sits at the same path layer as a
+standalone `AIPerfJob` and is reachable through the standard
+`/api/v1/results/<ns>/<sweep>-v00-t1/` endpoints.
+
+`sweep_aggregate/` carries the same per-combination CSV/JSON schema
+produced by grid sweeps — `aggregate_sweep_and_export` groups by stamped
+`variation_values` and is mode-agnostic, so downstream readers do not
+need to know the sweep was adaptive.
+
+## Where to read more
+
+- [Bayesian-Optimization Outer Loop](../sweeping/bayesian-optimization.md) — algorithm, flag grammar, `search_history.json` schema, convergence reasons.
+- [Adaptive Search tutorial](../tutorials/adaptive-search.md) — in-process walkthrough with `aiperf profile --search-*`.
+- [Parameter Sweeps and Multi-Run on Kubernetes](../tutorials/sweeps.md#running-sweeps-on-kubernetes) — grid sweeps, multi-run confidence, cancellation, failure policy.
+- [search_history.json schema](../api/search-history.md) — exact JSON shape consumed by post-run tooling.
+- [AIPerfSweep CRD validation rules](./crd-validation.md) — full catalog of admission-time invariants.

--- a/docs/kubernetes/ai-debugging-guide.md
+++ b/docs/kubernetes/ai-debugging-guide.md
@@ -1,0 +1,479 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: AI Agent Debugging Guide
+---
+
+# AI Agent Debugging Guide for AIPerf on Kubernetes
+
+This guide is written for AI coding agents (Claude, Copilot, Cursor, etc.) that need to diagnose and fix AIPerf Kubernetes benchmark issues. Every command produces machine-parseable output. Every decision point has explicit criteria. No ambiguity.
+
+---
+
+## How to Use This Guide
+
+1. Start at [Triage](#triage) to classify the problem
+2. Follow the decision tree for your problem class
+3. Each section gives you the exact command, the JSON schema of the output, and the decision logic
+4. All commands use `--output json` or equivalent for structured output
+
+---
+
+## Triage
+
+Run this command first. It gives you everything you need to classify the problem:
+
+```bash
+kubectl get aiperfjob <NAME> -n <NS> -o json | python3 -c "
+import sys, json
+st = json.load(sys.stdin).get('status', {})
+w = st.get('workers', {})
+print(json.dumps({
+    'phase': st.get('phase'),
+    'subPhase': st.get('subPhase'),
+    'currentPhase': st.get('currentPhase'),
+    'workers_ready': w.get('ready', 0),
+    'workers_total': w.get('total', 0),
+    'conditions': st.get('conditions', []),
+    'error': st.get('error'),
+}, indent=2))
+"
+
+# Pod-level triage (container states, recent events, node pressure)
+aiperf kube debug --job <NAME> --namespace <NS>
+```
+
+### Decision Tree
+
+Branch on `status.phase` from the CR, then on what `aiperf kube debug` reports.
+(The `health` / `error_rate` rollups came from the removed live-watch command;
+derive the equivalent from pod state and metrics as shown below.)
+
+```
+phase == "Completed"
+  -> Benchmark finished. Go to [Collect Results](#collect-results).
+
+phase == "Failed"
+  -> Go to [Failed Job](#failed-job).
+
+phase == "Cancelled"
+  -> Job was cancelled. Check if intentional. No action needed.
+
+phase == "Pending" for more than ~60s
+  -> Go to [Stuck in Pending](#stuck-in-pending).
+
+phase == "Queued"
+  -> Job is waiting for Kueue admission. Go to [Kueue Issues](#kueue-issues).
+
+phase == "Initializing" for more than ~120s
+  -> Go to [Stuck Initializing](#stuck-initializing).
+
+phase == "Running", and `aiperf kube debug` shows a pod with restarts > 3
+  -> Go to [Crash Loop](#crash-loop).
+
+phase == "Running", and `aiperf kube debug` reports an OOM-killed pod
+  -> Go to [OOM Kills](#problem-oom-kills).
+
+phase == "Running", but status.phases.*.requestsCompleted is not advancing
+  -> Go to [Stalled Benchmark](#stalled-benchmark).
+
+phase == "Running", and error_count / request_count > 0.05 in
+status.liveMetrics.metrics
+  -> Go to [High Error Rate](#high-error-rate).
+
+phase == "Running" and none of the above
+  -> Benchmark is running normally. Monitor with:
+     aiperf kube attach
+```
+
+---
+
+## Problem: Failed Job
+
+### Gather Information
+
+```bash
+# Get the error message from the CR status
+kubectl get aiperfjob <JOB_NAME> -n <NAMESPACE> -o json | \
+  python3 -c "import sys,json; s=json.load(sys.stdin)['status']; print(json.dumps({'phase':s.get('phase'),'error':s.get('error'),'conditions':s.get('conditions',[])}, indent=2))"
+```
+
+```bash
+# Get controller pod logs (last 50 lines)
+aiperf kube logs <JOB_ID> --container control-plane --tail 50
+```
+
+```bash
+# Run full diagnostics
+aiperf kube debug --job-id <JOB_ID> --verbose
+```
+
+### Common Failure Patterns
+
+| Error contains | Root cause | Fix |
+|---|---|---|
+| `preflight` | Cluster validation failed | Run `aiperf kube preflight -o json` and fix failing checks |
+| `endpoint` or `health check` | Inference server unreachable | Verify endpoint URL resolves from inside the cluster |
+| `timeout` | Benchmark exceeded `timeoutSeconds` | Increase `spec.timeoutSeconds` or set to `0` |
+| `ConfigMap` or `size` | Config too large for K8s 1MiB limit | Reduce config size |
+| `image` or `pull` | Container image not accessible | Check image name and pull secrets |
+| `RBAC` or `forbidden` | Missing permissions | Check service account and role bindings |
+
+---
+
+## Problem: Stuck in Pending
+
+Pods cannot be scheduled. Get the reason:
+
+```bash
+# Check pod events for scheduling failures
+kubectl get pods -n <NAMESPACE> -l aiperf.nvidia.com/job-id=<JOB_ID> -o json | \
+  python3 -c "
+import sys, json
+pods = json.load(sys.stdin)['items']
+for pod in pods:
+    name = pod['metadata']['name']
+    conditions = pod['status'].get('conditions', [])
+    for c in conditions:
+        if c.get('type') == 'PodScheduled' and c.get('status') == 'False':
+            print(json.dumps({'pod': name, 'reason': c.get('reason'), 'message': c.get('message')}))
+"
+```
+
+```bash
+# Check node resources
+kubectl get nodes -o json | python3 -c "
+import sys, json
+nodes = json.load(sys.stdin)['items']
+for n in nodes:
+    alloc = n['status']['allocatable']
+    print(json.dumps({
+        'node': n['metadata']['name'],
+        'cpu': alloc.get('cpu'),
+        'memory': alloc.get('memory'),
+        'gpu': alloc.get('nvidia.com/gpu', '0'),
+    }))
+"
+```
+
+### Decision Logic
+
+| Scheduling message contains | Fix |
+|---|---|
+| `Insufficient cpu` or `Insufficient memory` | Reduce worker count: `--total-workers <lower_number>` |
+| `nvidia.com/gpu` | No available GPU nodes. Wait or add capacity. |
+| `didn't match Pod's node affinity/selector` | Fix `spec.podTemplate.nodeSelector` to match existing nodes |
+| `had untolerated taint` | Add tolerations to `spec.podTemplate.tolerations` |
+| `quota` | Namespace ResourceQuota exhausted. Request more or use different namespace. |
+
+---
+
+## Problem: Kueue Issues
+
+```bash
+# Check if the workload is admitted
+kubectl get workloads -n <NAMESPACE> -o json | python3 -c "
+import sys, json
+items = json.load(sys.stdin)['items']
+for w in items:
+    name = w['metadata']['name']
+    conditions = w.get('status', {}).get('conditions', [])
+    admitted = any(c['type'] == 'Admitted' and c['status'] == 'True' for c in conditions)
+    print(json.dumps({'workload': name, 'admitted': admitted, 'conditions': [{'type': c['type'], 'status': c['status'], 'message': c.get('message','')} for c in conditions]}))
+"
+```
+
+```bash
+# Check ClusterQueue capacity
+kubectl get clusterqueues -o json | python3 -c "
+import sys, json
+items = json.load(sys.stdin)['items']
+for q in items:
+    print(json.dumps({
+        'name': q['metadata']['name'],
+        'flavors': q.get('status', {}).get('flavorsReservation', []),
+        'pending': q.get('status', {}).get('pendingWorkloads', 0),
+    }))
+"
+```
+
+If the workload is not admitted, the queue is full. Wait for other workloads to complete, or adjust priority with `spec.scheduling.priorityClass`.
+
+---
+
+## Problem: Stuck Initializing
+
+Workers are starting but not all are ready yet.
+
+```bash
+# Check which pods are not ready
+kubectl get pods -n <NAMESPACE> -l aiperf.nvidia.com/job-id=<JOB_ID> -o json | \
+  python3 -c "
+import sys, json
+pods = json.load(sys.stdin)['items']
+for pod in pods:
+    containers = pod['status'].get('containerStatuses', [])
+    for c in containers:
+        if not c.get('ready', False):
+            waiting = c.get('state', {}).get('waiting', {})
+            print(json.dumps({
+                'pod': pod['metadata']['name'],
+                'container': c['name'],
+                'ready': False,
+                'waiting_reason': waiting.get('reason', 'unknown'),
+                'waiting_message': waiting.get('message', ''),
+                'restarts': c.get('restartCount', 0),
+            }))
+"
+```
+
+| Waiting reason | Fix |
+|---|---|
+| `ContainerCreating` | Normal -- image is pulling. Wait. |
+| `ImagePullBackOff` | Image does not exist or no pull secret. Fix image or add `--image-pull-secrets`. |
+| `CrashLoopBackOff` | Container crashes on startup. Check logs with `aiperf kube logs --container <name>`. |
+| `CreateContainerConfigError` | Missing ConfigMap, Secret, or volume. Check the pod events. |
+
+---
+
+## Problem: Crash Loop
+
+A pod is restarting repeatedly (>3 restarts).
+
+```bash
+# Get logs from the previous (crashed) container
+kubectl logs -n <NAMESPACE> <POD_NAME> --previous -c <CONTAINER_NAME> --tail=50
+```
+
+```bash
+# Get the exit code
+kubectl get pod -n <NAMESPACE> <POD_NAME> -o json | python3 -c "
+import sys, json
+pod = json.load(sys.stdin)
+for c in pod['status'].get('containerStatuses', []):
+    term = c.get('lastState', {}).get('terminated', {})
+    if term:
+        print(json.dumps({
+            'container': c['name'],
+            'exit_code': term.get('exitCode'),
+            'reason': term.get('reason'),
+            'message': term.get('message', ''),
+        }))
+"
+```
+
+| Exit code | Meaning | Fix |
+|---|---|---|
+| 137 | SIGKILL (OOM or external kill) | Increase memory limits. See [OOM Kills](#problem-oom-kills). |
+| 1 | Application error | Read the logs. Common: bad config, missing model, endpoint unreachable. |
+| 2 | Python syntax/import error | Image may be wrong version. Verify `--image`. |
+
+---
+
+## Problem: OOM Kills
+
+A pod was killed because it exceeded its memory limit.
+
+```bash
+# Confirm OOM and get memory limits
+kubectl get pod -n <NAMESPACE> <POD_NAME> -o json | python3 -c "
+import sys, json
+pod = json.load(sys.stdin)
+for c in pod['spec']['containers']:
+    limits = c.get('resources', {}).get('limits', {})
+    print(json.dumps({'container': c['name'], 'memory_limit': limits.get('memory', 'none')}))
+for c in pod['status'].get('containerStatuses', []):
+    term = c.get('lastState', {}).get('terminated', {})
+    if term.get('reason') == 'OOMKilled':
+        print(json.dumps({'container': c['name'], 'oom_killed': True}))
+"
+```
+
+### Fixes (in priority order)
+
+1. **Reduce connections per worker** -- Lower `spec.connectionsPerWorker` (default: 100). Each connection holds request/response buffers in memory.
+
+2. **Increase workers, reduce per-pod** -- Use more pods with fewer workers each. Lower `spec.benchmark.runtime.workersPerPod` in the CR (the cluster-wide worker total stays `--total-workers`; this knob only controls how that total is fanned across pods).
+
+3. **Override memory limits** via environment variables:
+   ```yaml
+   spec:
+     podTemplate:
+       env:
+         - name: AIPERF_K8S_WORKER_POD_MEMORY
+           value: "8192Mi"
+   ```
+
+---
+
+## Problem: Stalled Benchmark
+
+Running phase but no progress (0 throughput, 0 requests completed).
+
+```bash
+# Check Dynamo endpoint reachability from inside the cluster
+# URL pattern: http://{deploy-name}-frontend.{namespace}.svc:8000/v1/models
+kubectl run aiperf-curl-test --rm -it --restart=Never \
+  --image=curlimages/curl -- \
+  curl -s -o /dev/null -w '{"http_code":%{http_code},"time_total":%{time_total}}' \
+  <ENDPOINT_URL>/models
+```
+
+```bash
+# Check controller logs for endpoint errors
+aiperf kube logs <JOB_ID> --container control-plane --tail 30 2>&1 | grep -i "error\|timeout\|refused\|unreachable"
+```
+
+| Symptom | Fix |
+|---|---|
+| `curl` returns `http_code: 0` or `Connection refused` | Endpoint URL wrong or Dynamo frontend not running. Verify URL pattern: `http://{deploy-name}-frontend.{namespace}.svc:8000/v1`. Check Dynamo pods: `kubectl get pods -n dynamo-server`. |
+| `curl` returns `http_code: 200` but benchmark stalled | Workers may not be connecting. Check ZMQ connectivity in controller logs. |
+| `curl` times out | Network policy blocking traffic, or Dynamo workers are still loading the model. Check pod logs: `kubectl logs -n dynamo-server -l app.kubernetes.io/managed-by=dynamo-operator`. |
+
+---
+
+## Problem: High Error Rate
+
+More than 5% of requests are failing.
+
+```bash
+# Get live metrics with error breakdown
+kubectl get aiperfjob <NAME> -n <NS> \
+  -o jsonpath='{.status.liveMetrics.metrics}' | python3 -m json.tool
+```
+
+| Error rate range | Likely cause | Fix |
+|---|---|---|
+| 5-20% | Endpoint overloaded | Reduce `concurrency` in the phase config |
+| 20-50% | Model or endpoint errors | Check endpoint logs for 500/503 errors |
+| >50% | Endpoint down or misconfigured | Verify model name matches what the server is serving |
+| 100% | Wrong endpoint URL or auth required | Fix URL or add API key via `--env-from-secrets` |
+
+---
+
+## Collect Results
+
+```bash
+# Download all artifacts (default: fetched from operator storage,
+# which works even after pods are deleted)
+aiperf kube results <JOB_ID> --output ./artifacts
+
+# Retrieve directly from benchmark pods instead of operator storage
+aiperf kube results <JOB_ID> --from-pods --output ./artifacts
+
+# Read the summary metrics
+cat ./artifacts/profile_export_aiperf.json | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(json.dumps({
+    'request_throughput': data.get('request_throughput'),
+    'request_latency_avg': data.get('request_latency_avg'),
+    'request_latency_p99': data.get('request_latency_p99'),
+    'ttft_avg': data.get('time_to_first_token_avg'),
+    'ttft_p99': data.get('time_to_first_token_p99'),
+    'itl_avg': data.get('inter_token_latency_avg'),
+    'output_token_throughput': data.get('output_token_throughput'),
+    'total_requests': data.get('request_count'),
+    'error_count': data.get('error_count'),
+}, indent=2))
+"
+```
+
+## Preflight JSON Schema
+
+Output from `aiperf kube preflight -o json`:
+
+```json
+{
+  "passed": true,
+  "has_warnings": false,
+  "checks": [
+    {
+      "name": "Cluster Connectivity",
+      "status": "pass",
+      "message": "Connected to cluster",
+      "details": [],
+      "hints": [],
+      "duration_ms": 45.2
+    },
+    {
+      "name": "JobSet CRD",
+      "status": "fail",
+      "message": "JobSet CRD not found",
+      "details": ["API group jobset.x-k8s.io not registered"],
+      "hints": ["Install JobSet: kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/download/v0.5.2/manifests.yaml"],
+      "duration_ms": 12.1
+    }
+  ]
+}
+```
+
+### Check Statuses
+
+| Status | Meaning | Agent action |
+|---|---|---|
+| `pass` | Check passed | No action |
+| `fail` | Check failed, deployment will fail | Must fix before deploying. Read `hints`. |
+| `warn` | Potential issue | Review but not blocking |
+| `skip` | Check not applicable | Ignore |
+| `info` | Informational | Log for context |
+
+### Agent Decision Logic
+
+```python
+preflight = json.loads(subprocess.check_output(["aiperf", "kube", "preflight", "-o", "json"]))
+if not preflight["passed"]:
+    for check in preflight["checks"]:
+        if check["status"] == "fail":
+            # Apply hints[0] if available, otherwise report to user
+            if check["hints"]:
+                print(f"Fix: {check['hints'][0]}")
+            else:
+                print(f"BLOCKED: {check['name']}: {check['message']}")
+    sys.exit(1)
+```
+
+---
+
+## Validate JSON Schema
+
+Output from `aiperf kube validate -o json benchmark.yaml`:
+
+```json
+[
+  {
+    "path": "benchmark.yaml",
+    "passed": true,
+    "errors": [],
+    "warnings": ["Unknown spec field: foo"]
+  }
+]
+```
+
+---
+
+## Quick Command Reference
+
+| Task | Command |
+|------|---------|
+| Get structured triage snapshot | `kubectl get aiperfjob <NAME> -n <NS> -o json` |
+| Get job phase and error | `kubectl get aiperfjob <NAME> -n <NS> -o jsonpath='{.status.phase} {.status.error}'` |
+| Check preflight (JSON) | `aiperf kube preflight -o json` |
+| Validate config (JSON) | `aiperf kube validate -o json <FILE>` |
+| List all jobs (kubectl) | `kubectl get aiperfjobs -A -o json` |
+| Get pod statuses | `kubectl get pods -n <NS> -l aiperf.nvidia.com/job-id=<ID> -o json` |
+| Get controller logs | `aiperf kube logs <ID> --container control-plane --tail 50` |
+| Get worker logs | `aiperf kube logs <ID> --container worker-group-manager --tail 50` |
+| Get events | `kubectl get events -n <NS> --sort-by=.lastTimestamp -o json` |
+| Cancel a job | `kubectl patch aiperfjob <NAME> -n <NS> --type=merge -p '{"spec":{"cancel":true}}'` |
+| Delete a job | `kubectl delete aiperfjob <NAME> -n <NS>` |
+| Download results (from operator, default) | `aiperf kube results <ID> --output ./artifacts` |
+| Download directly from pods | `aiperf kube results <ID> --from-pods --output ./artifacts` |
+
+---
+
+## Related Documentation
+
+- [Getting Started](getting-started.md) -- First benchmark walkthrough
+- [Monitoring and Troubleshooting](monitoring.md) -- Human-readable monitoring guide
+- [Kubernetes Configuration](configuration.md) -- All CRD fields and deployment options

--- a/docs/kubernetes/attach.md
+++ b/docs/kubernetes/attach.md
@@ -1,0 +1,198 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Attach to a Running Benchmark
+---
+
+# Attach to a Running Benchmark
+
+`aiperf kube attach` re-connects to an `AIPerfJob` that is already running in the cluster and streams its progress to your terminal until the benchmark finishes. It is the command you reach for when an earlier `aiperf kube profile` invocation was detached (Ctrl-C, closed laptop, disconnected VPN, separate deploy host) and you want to pick the session back up from another shell.
+
+Attach is intentionally narrow:
+
+- It does **not** deploy, modify, or cancel the `AIPerfJob`.
+- It does **not** download results after completion. Use `aiperf kube results` for that.
+- It does **not** poll the Kubernetes API for snapshots. Use `aiperf kube list` or `aiperf kube debug` for that.
+
+Contrast with the neighbouring commands:
+
+| Command | Shape | When to use |
+|---|---|---|
+| `aiperf kube attach` | Live WebSocket stream, exits on completion | Re-join a detached run in progress |
+| `aiperf kube list` | Polled CR summary | See phase / pod status at a glance |
+| `aiperf kube logs` | Raw container log stream | Debug a misbehaving container |
+| `aiperf kube results` | Artifact download | After the run has completed |
+
+---
+
+## Quick Reference
+
+```bash
+# Attach to the most recently deployed benchmark
+aiperf kube attach
+
+# Attach to a specific job by ID
+aiperf kube attach aiperf-bench-7f2a
+
+# Attach in a specific namespace
+aiperf kube attach aiperf-bench-7f2a --namespace aiperf-bench
+
+# Use a fixed local port instead of an ephemeral one
+aiperf kube attach aiperf-bench-7f2a --port 9091
+
+# Attach to one variation (and trial) of an AIPerfSweep
+aiperf kube attach my-sweep -v 7
+aiperf kube attach my-sweep -v 5 -t 0
+```
+
+---
+
+## CLI Reference
+
+```text
+aiperf kube attach [JOB_ID] [OPTIONS]
+```
+
+| Argument / Flag | Default | Description |
+|---|---|---|
+| `JOB_ID` (positional) | last deployed job | The `AIPerfJob` CR name — or an `AIPerfSweep` name, when combined with `-v` — to attach to. If omitted, the CLI reads `~/.aiperf/last_kube_benchmark.json`. |
+| `-p`, `--port` | `0` | Local port for the `kubectl port-forward` tunnel. `0` asks the kernel for an ephemeral port, which avoids conflicts with other `aiperf kube` sessions on the same machine. |
+| `-v`, `--variation` | unset | When `JOB_ID` names an `AIPerfSweep`, the child variation index (`0`..`199`). Resolves to the child `AIPerfJob` named `<sweep>-v<idx:02d>`. |
+| `-t`, `--trial` | unset | Trial index (`0`..`9`) within a sweep variation, resolving to `<sweep>-v<idx:02d>-t<trial>`. Requires `-v`. |
+| `--namespace` | last-benchmark namespace, else `aiperf-benchmarks` | Kubernetes namespace containing the `AIPerfJob`. |
+| `--kubeconfig` | unset | Path to a kubeconfig file. When unset, the CLI first tries in-cluster config, then the default kubeconfig resolution. |
+| `--kube-context` | unset | Context name to select inside the kubeconfig. |
+
+`--namespace`, `--kubeconfig`, and `--kube-context` are the composite options declared on `KubeManageOptions` and are shared with every other `aiperf kube` subcommand.
+
+---
+
+## Default Job-ID Resolution
+
+If you do not pass a positional `job_id`, the CLI resolves it from the file written by the most recent `aiperf kube profile` (or `aiperf kube sweep`):
+
+```text
+~/.aiperf/last_kube_benchmark.json
+```
+
+The file stores a `{"job_id", "namespace", "name"}` record (see `save_last_benchmark` / `get_last_benchmark` in `aiperf.kubernetes.console`). `resolve_job_id_and_namespace` reads it and prints a one-line info banner so you can confirm which job you are attaching to.
+
+**Multi-cluster pitfall.** The last-benchmark file is keyed by nothing except "the last `aiperf kube` deploy that ran on this workstation". If you routinely switch between clusters or kubeconfig contexts, the stored `job_id` / `namespace` may belong to a *different* cluster than the one your current `--kube-context` targets. The symptom is "No AIPerf job found with ID: ..." even though you just deployed successfully — the job exists, but not on the cluster you are now pointing at. Pass the `job_id` explicitly, or re-confirm your context with `kubectl config current-context` before attaching.
+
+---
+
+## Execution Flow
+
+```mermaid
+sequenceDiagram
+    participant CLI as aiperf kube attach
+    participant Helpers as cli_helpers.resolve_job
+    participant K8s as Kubernetes API
+    participant PF as kubectl port-forward
+    participant WS as Controller /ws
+
+    CLI->>Helpers: resolve_job(job_id, namespace)
+    Helpers->>Helpers: fallback to last_kube_benchmark.json
+    Helpers->>K8s: find_aiperf_job
+    alt CR not found
+        Helpers->>K8s: find_jobset (fallback)
+    end
+    Helpers-->>CLI: ResolvedJob(api, job_info)
+    CLI->>CLI: short-circuit if phase Completed / Failed
+    CLI->>K8s: find_controller_pod
+    CLI->>PF: start port-forward -> API_SERVICE:9090
+    PF-->>CLI: local ephemeral port
+    CLI->>WS: ws://localhost:PORT/ws subscribe
+    loop until ALL_RECORDS_RECEIVED
+        WS-->>CLI: progress / metrics / worker status
+    end
+    CLI->>PF: terminate
+    CLI-->>User: exit 0
+```
+
+The concrete steps performed by `attach_to_benchmark` (in `aiperf/kubernetes/attach.py`) are:
+
+1. **Resolve the job.** `resolve_job` queries `AIPerfJob` CRs first. If the CR is missing, it falls back to `find_jobset` so that jobs deployed in direct-mode (JobSet-only, no operator) are still reachable. See [Direct-mode vs operator-mode](#direct-mode-vs-operator-mode).
+2. **Short-circuit on terminal phase.** If the CR's `status.phase` is already `Completed` or `Failed`, `attach` exits early with a pointer at `aiperf kube results` or `aiperf kube logs` respectively. On failure, it best-effort prints the controller pod's last 30 log lines.
+3. **Locate the controller pod.** `find_controller_pod` returns the `(pod_name, phase)` pair for the control-plane pod. If no pod exists, or the pod is not `Running`, attach prints a warning and exits cleanly (exit code 0) — this is the normal outcome when the CR is still `Pending` and pods have not been scheduled yet.
+4. **Port-forward to the controller API.** `port_forward_with_status` spawns `kubectl port-forward -n NS pod/POD LOCAL:9090` (where `9090` is `K8sEnvironment.PORTS.API_SERVICE`). When `--port 0` is passed, `LOCAL` is `0`, and the actual port is parsed from kubectl's `"Forwarding from 127.0.0.1:NNNN"` stdout line.
+5. **Open the progress WebSocket.** `stream_progress` builds `ws://localhost:PORT/ws`, subscribes to the progress message types enumerated in `WS_MESSAGE_TYPES` (phase start/progress/complete, realtime metrics, worker status summary, all-records-received), and logs each frame to the `aiperf.kube` rich logger.
+6. **Exit on terminal message.** The subscription stops as soon as an `ALL_RECORDS_RECEIVED` frame is observed. The port-forward is then terminated by the `async with` exit handler.
+
+---
+
+## Port-Forward Behavior
+
+The port-forward is managed by `aiperf.kubernetes.port_forward` and is shared by all `aiperf kube` commands that need to talk to the controller API. Key tunables (all seconds):
+
+| Parameter | Value | Purpose |
+|---|---|---|
+| `_PORT_FORWARD_TIMEOUT` | `60.0` | Total budget for `kubectl port-forward` to print its `"Forwarding from ..."` ready line. |
+| `_API_INITIAL_DELAY` | `0.5` | Grace delay before the first `GET /health` probe, giving kubectl time to wire the tunnel. |
+| `_API_RETRY_DELAY` | `2.0` | Sleep between port-forward restart attempts when `/health` fails. |
+| `_API_MAX_RETRIES` | `10` | Maximum number of port-forward restarts while waiting for the API to answer. |
+| `_PROCESS_CLEANUP_TIMEOUT` | `5.0` | Graceful-shutdown grace period for the `kubectl port-forward` child process. |
+| pod-liveness probe interval | `10.0` | Background task runs `kubectl get pod ... -o name` every 10 s; if it returns non-zero, the port-forward is terminated. |
+
+On top of the port-forward, `stream_progress_from_api` applies **WebSocket reconnection** with exponential backoff:
+
+- `_WS_INITIAL_BACKOFF` = `1.0` s
+- `_WS_MAX_BACKOFF` = `30.0` s (doubling per failure)
+- `_WS_HEARTBEAT` = `30` s (aiohttp heartbeat ping)
+- `max_retries` = `10` (`WS_MAX_RETRIES` in `ui_dispatch.py`)
+
+After 10 consecutive failed reconnects, `ConnectionError` is raised with the underlying `aiohttp.ClientError` / `asyncio.TimeoutError` preserved as `__cause__`, and `cli_utils.exit_on_error` converts that into a non-zero exit.
+
+---
+
+## Signals and Exit Codes
+
+| Scenario | Exit code | Notes |
+|---|---|---|
+| Benchmark completes (`ALL_RECORDS_RECEIVED`) | `0` | Port-forward is torn down cleanly; the `AIPerfJob` continues running to completion on the cluster. |
+| Short-circuit on `phase=Completed` / `phase=Failed` | `0` | No port-forward is opened; the CLI prints a pointer to `results` / `logs`. |
+| `Ctrl-C` during streaming (`KeyboardInterrupt`) | non-zero | `exit_on_error` deliberately re-raises `KeyboardInterrupt` rather than swallowing it. **The remote benchmark is not affected** — attach only tears down its own port-forward and WebSocket. |
+| `resolve_job` could not find the CR or JobSet | `1` | Printed via `print_error`; re-run `aiperf kube list` to enumerate available jobs. |
+| WebSocket reconnection budget exhausted | `1` | Wrapped by `cli_utils.exit_on_error(title="Error Attaching to Benchmark")`. |
+| `kubectl port-forward` budget exhausted | `1` | Same error wrapper; stderr from `kubectl` is surfaced in the message. |
+
+Attach is safe to interrupt at any time. The CR, JobSet, and pods are owned by the cluster — the CLI only holds a read-only WebSocket subscription.
+
+---
+
+## Direct-Mode vs Operator-Mode
+
+`resolve_job` is dual-mode by design:
+
+- **Operator-mode** (the default): `aiperf kube profile` creates an `AIPerfJob` CR, and the in-cluster operator reconciles it into a JobSet. `find_aiperf_job` matches the CR directly.
+- **Direct-mode**: `aiperf kube profile --no-operator` skips the CR and creates a JobSet. When no `AIPerfJob` exists, `resolve_job` falls back to `find_jobset` and wraps the returned `JobSetInfo` as a minimal `AIPerfJobInfo` so the rest of the attach flow is identical.
+
+You do not need to tell `attach` which mode the job was deployed in — the fallback is automatic. The only visible difference is that direct-mode jobs will never report `phase=Completed` via the CR (there is no CR), so the short-circuit branch that suggests `aiperf kube results` does not trigger for them; the attach flow detects completion via the `ALL_RECORDS_RECEIVED` WebSocket message instead.
+
+---
+
+## Troubleshooting
+
+**"No AIPerf job found with ID: ..."**
+The `job_id` you passed (or the one stored in `~/.aiperf/last_kube_benchmark.json`) does not exist in the requested namespace, or in any namespace if `--namespace` was omitted. Run `aiperf kube list` to see what is actually deployed, and confirm your current kubeconfig context matches the cluster you deployed to.
+
+**"Port-forward did not become ready within 60.0s"**
+`kubectl port-forward` never printed its ready line. Common causes: the controller pod is `CrashLoopBackOff`, the pod was evicted, or a network policy is blocking pod-to-apiserver traffic. Check `aiperf kube debug` for pod phases and `aiperf kube logs --container control-plane` for the controller's startup errors.
+
+**"Port-forward failed after 10 retries"**
+The tunnel connected but `GET /health` on the API port never returned. Most commonly this means the controller is alive but has not yet bound the API server (still executing the `INITIALIZING` phase) — retry after 30 s. If the problem persists, inspect the controller pod logs for API-service binding errors.
+
+**"Connection lost, retrying in Ns..."**
+The progress WebSocket dropped and is being re-opened. A handful of these during a long run are expected (e.g. when the apiserver throttles the port-forward). Only after 10 consecutive failures will attach give up; at that point the underlying `aiohttp.ClientError` is surfaced in the exception chain.
+
+**Local port conflict (`bind: address already in use`)**
+You passed `--port N` and something else on your machine is already listening on `N`. Either free the port, pick a different one, or drop the flag to get an ephemeral port.
+
+**Auth errors (`Unauthorized` / `forbidden`)**
+In an interactive terminal, `Unauthorized` (HTTP 401) causes AIPerf to wait while
+you complete your normal Kubernetes login in another terminal, then reload the
+selected kubeconfig and retry. Press **Ctrl+C** to stop waiting. `Forbidden`
+(HTTP 403) means the current identity is authenticated but lacks permissions and
+is not retried. At minimum attach needs `get/list/watch` on `aiperfjobs` (or
+`jobsets`), `pods`, and `pods/portforward`. See [RBAC and Security](rbac-security.md)
+for the full CLI-user role.

--- a/docs/kubernetes/configuration.md
+++ b/docs/kubernetes/configuration.md
@@ -1,0 +1,600 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Kubernetes Configuration
+---
+
+# Kubernetes Configuration Reference
+
+This guide covers all the ways to configure AIPerf benchmarks on Kubernetes -- from the AIPerfJob custom resource fields to CLI flags and Helm chart settings.
+
+---
+
+## AIPerfJob Custom Resource
+
+An `AIPerfJob` is a Kubernetes custom resource that tells the operator what benchmark to run. Here is the full structure:
+
+```yaml
+apiVersion: aiperf.nvidia.com/v1alpha1
+kind: AIPerfJob
+metadata:
+  name: my-benchmark
+  namespace: aiperf-benchmarks  # optional, defaults to aiperf-benchmarks
+spec:
+  # Benchmark configuration (what to measure)
+  benchmark:
+    models: ["Qwen/Qwen3-0.6B"]
+    endpoint:
+      urls: ["http://dynamo-agg-frontend.dynamo-server.svc:8000/v1"]
+      streaming: true
+    datasets:
+      - name: main
+        type: synthetic
+        entries: 1000
+        prompts:
+          isl: { mean: 512, stddev: 0 }
+          osl: { mean: 128, stddev: 0 }
+    phases:
+      - name: profiling
+        type: concurrency
+        concurrency: 50
+        requests: 500
+    artifacts:
+      autoPlot: true
+      plotRequired: false
+
+  # Config-v2 envelope field (a sibling of benchmark, not nested inside it)
+  plot:
+    visualization:
+      single_run_defaults: [ttft_over_time]
+      single_run_plots:
+        ttft_over_time:
+          type: scatter
+          x: request_number
+          y: time_to_first_token
+          title: TTFT over time
+
+  # Container image (defaults to the chart/AIPerf image when omitted)
+  image: "nvcr.io/nvidia/aiperf:latest"
+
+  # Pod resource mode
+  resourceMode: burstable        # "burstable" (default), "guaranteed", or "none"
+
+  # Worker scaling
+  connectionsPerWorker: 100       # max concurrent connections per worker process
+
+  # Lifecycle
+  ttlSecondsAfterFinished: 300    # seconds to keep pods after completion
+  timeoutSeconds: 0               # benchmark timeout (0 = no timeout)
+
+  # Cancel a running benchmark
+  cancel: false                   # set to true to cancel
+
+  # Pod customization
+  podTemplate:
+    nodeSelector:
+      nvidia.com/gpu.product: "A100"
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+    imagePullSecrets:
+      - {name: my-registry-secret}
+    env:
+      - name: AIPERF_HTTP_CONNECTION_LIMIT
+        value: "200"
+    volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache
+    volumeMounts:
+      - name: model-cache
+        mountPath: /root/.cache/huggingface
+
+  # Kueue scheduling
+  scheduling:
+    queueName: my-queue
+    priorityClass: high-priority
+```
+
+---
+
+## Spec Fields Reference
+
+### Benchmark Configuration (`spec.benchmark`)
+
+The `benchmark` section mirrors the standard AIPerf YAML config. Any field you use in a local `aiperf profile` run works here.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `models` | list[string] | Model name(s) served by the endpoint |
+| `endpoint.urls` | list[string] | Inference server URLs |
+| `endpoint.streaming` | bool | Enable streaming responses |
+| `endpoint.type` | string | Endpoint type (default: `chat`) |
+| `datasets` | list | Named dataset configurations (each entry has a `name`) |
+| `phases` | list | Ordered load phases (warmup, profiling, etc.), each with a `name` |
+
+See the [YAML Config Reference](../tutorials/yaml-config.md) for the complete set of benchmark fields.
+
+> **Shorthand siblings.** The apiserver also accepts the singular shortcuts
+> from AIPerf CLI YAML — `model:` (string/list/object), `dataset:` (single
+> dict), and top-level `warmup:` / `profiling:` (phase dicts) — and the
+> operator hoists them into the canonical `models`/`datasets`/`phases`
+> shapes before validation. Mixing the canonical and shorthand form for the
+> same slot (e.g. both `datasets:` and `dataset:`) is rejected at admission.
+> Full rule catalog: [CRD Validation Rules](crd-validation.md).
+
+`datasets` and `phases` are lists, not maps. Kubernetes alphabetizes the keys
+of object-typed CRD fields at storage time, so phase ordering is only
+preserved because it is expressed as a list.
+
+### Plot envelope (`spec.plot`)
+
+Kubernetes preserves the Config-v2 `plot:` envelope field and runs it after
+the benchmark's exporters have finished, before the results-sidecar ready
+marker is written. The resolved envelope is saved as
+`.aiperf-plot-config.yaml` beside the run artifacts, so a later
+`aiperf plot <run-directory>` uses the same visualization configuration.
+
+Setting `plot:` implies `spec.benchmark.artifacts.autoPlot: true` unless
+`autoPlot: false` was explicitly authored. With the default
+`plotRequired: false`, rendering failures produce a warning and the exported
+benchmark artifacts still become ready. With `plotRequired: true`, rendering
+is part of the completion transaction: a failure leaves results unready and
+the controller exits non-zero. Inline plot mappings are the portable form for
+hand-authored CRs; `aiperf kube generate -f config.yaml` resolves a file-backed
+`plot: ./plots/config.yaml` before submitting the CR.
+
+### Load Phases (`spec.benchmark.phases`)
+
+Each phase defines a load pattern:
+
+```yaml
+phases:
+  - name: warmup
+    kind: warmup
+    type: concurrency
+    concurrency: 10
+    requests: 10
+  - name: profiling
+    kind: profiling
+    type: concurrency
+    concurrency: 50
+    requests: 500
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | required | Unique phase identity used in status and artifact paths |
+| `kind` | string | inferred for canonical names | Semantic role: `warmup` or `profiling`; warmup metrics are kept phase-scoped and excluded from profiling aggregates |
+| `type` | string | required | Load type: `concurrency`, `constant`, `poisson`, `gamma`, `user_centric`, or `fixed_schedule` |
+| `concurrency` | int | - | Number of concurrent requests |
+| `requests` | int | - | Total requests to send |
+| `duration` | float | - | Phase duration in seconds (alternative to `requests`) |
+
+### Deployment Options (spec top level)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `image` | string | Installed chart image (operator) or `nvcr.io/nvidia/aiperf:latest` (direct mode) | AIPerf container image |
+| `imagePullPolicy` | string | - | `Always`, `IfNotPresent`, or `Never` (Helm default: `IfNotPresent`) |
+| `resourceMode` | string | `burstable` | Pod CPU/memory mode. `burstable` (default) sets requests only, no limits (Burstable QoS) so the controller can grow during aggregation without being OOM-killed by cgroup; `guaranteed` keeps requests==limits (Guaranteed QoS); `none` omits CPU/memory requests and limits for both controller and worker pods. |
+| `connectionsPerWorker` | int | 100 | Max concurrent connections per worker process |
+| `ttlSecondsAfterFinished` | int | 300 | Seconds to keep pods after completion |
+| `timeoutSeconds` | int | 0 | Benchmark timeout in seconds (0 = no timeout) |
+| `cancel` | bool | `false` | Set to `true` to cancel a running benchmark |
+| `keepFailedPods` | bool | `false` | Preserve pods on failure for debugging (overrides `ttlSecondsAfterFinished`) |
+| `resultsTtlDays` | int | - | Override operator-level `AIPERF_RESULTS_TTL_DAYS` for this job or sweep archive |
+| `skipEndpointCheck` | bool | `false` | Skip the operator-side endpoint reachability probe before deploying |
+
+### Pod Template (`spec.podTemplate`)
+
+Customize the pods that run your benchmark:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `nodeSelector` | map | Node labels to constrain scheduling |
+| `tolerations` | list | Tolerations for tainted nodes |
+| `imagePullSecrets` | list[object] | Secret references for private registries, K8s `LocalObjectReference` shape: `[{name: my-secret}]` |
+| `env` | list | Extra environment variables |
+| `volumes` | list | Additional volume definitions |
+| `volumeMounts` | list | Additional volume mounts |
+| `annotations` | map | Extra pod annotations |
+| `labels` | map | Extra pod labels |
+| `serviceAccountName` | string | Custom service account |
+| `containerSecurityContext` | map | SecurityContext applied to every container in the controller and worker pods |
+
+### Scheduling (`spec.scheduling`)
+
+For clusters using [Kueue](https://kueue.sigs.k8s.io/) for resource management:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `queueName` | string | Kueue LocalQueue name for gang-scheduling |
+| `priorityClass` | string | Kueue WorkloadPriorityClass for scheduling priority |
+
+---
+
+## CLI Flags
+
+When using `aiperf kube profile`, you can set deployment options via CLI flags. These override values in a config file:
+
+| Flag | Maps To | Default | Description |
+|------|---------|---------|-------------|
+| `--image` | `spec.image` | YAML, installed chart, or direct-mode default | Explicit container-image override; an image authored in workload YAML remains authoritative when this flag is omitted |
+| `--image-pull-policy` | `spec.imagePullPolicy` | - | Image pull policy (Helm default: `IfNotPresent`) |
+| `--total-workers` | `spec.benchmark.runtime.workers` | 10 | Exact worker target (distributed across pods); when omitted, a YAML-authored `runtime.workers` wins before automatic sizing |
+| `--name` | `metadata.name` | auto-generated | Job name (DNS label, max 40 chars) |
+| `--namespace` | `metadata.namespace` | `aiperf-benchmarks` | Target namespace |
+| `--ttl-seconds` | `spec.ttlSecondsAfterFinished` | 300 | TTL after completion |
+| `--node-selector` | `spec.podTemplate.nodeSelector` | `{}` | Node selector labels |
+| `--tolerations` | `spec.podTemplate.tolerations` | `[]` | Pod tolerations |
+| `--queue-name` | `spec.scheduling.queueName` | - | Kueue queue name |
+| `--priority-class` | `spec.scheduling.priorityClass` | - | Kueue priority class |
+| `--image-pull-secrets` | `spec.podTemplate.imagePullSecrets` | `[]` | Pull secret names |
+| `--env-vars` | `spec.podTemplate.env` | `{}` | Non-sensitive extra env vars |
+| `--env-from-secrets` | `spec.podTemplate.env` | `{}` | Env vars from Kubernetes Secrets; required for endpoint API keys, sensitive headers, and credentialed URLs |
+| `--service-account` | `spec.podTemplate.serviceAccountName` | - | Pod service account |
+| `--detach` | - | `false` | Exit after deploying |
+| `--dry-run` | - | `false` | Print CR without submitting |
+| `--operator` | - | `false` | Deploy through the operator without probing the cluster-scoped AIPerfJob CRD |
+| `--no-operator` | - | `false` | Deploy without operator |
+| `--skip-endpoint-check` | - | `false` | Skip endpoint health check |
+| `--no-wait` | - | `false` | Don't wait for pods ready |
+| `--attach-port` | - | 0 (ephemeral) | Local port for port-forward |
+
+Benchmark CLI flags use the same precedence for plain AIPerf config files and
+`AIPerfJob` CR input: explicitly passed flags override YAML, while omitted CLI
+defaults do not rewrite authored values. This applies to `profile` and
+`generate`; `kube sweep` applies the same benchmark overrides before it builds
+the `AIPerfSweep` template. Kubernetes deployment flags merge into the CR
+deployment subtree, so, for example, `--node-selector gpu=true` does not erase
+an unrelated YAML `podTemplate.affinity` or `podTemplate.volumes` block. An
+explicit list-valued flag still replaces the corresponding YAML list.
+
+Operator mode is auto-detected when neither mode flag is passed. On a
+multi-tenant cluster where users can create namespaced `AIPerfJob` resources
+but cannot read cluster-scoped CRDs, pass `--operator` explicitly. When an
+explicit `--namespace` is also supplied, `profile` assumes the namespace was
+pre-provisioned and does not attempt to create it. `--operator` and
+`--no-operator` are mutually exclusive.
+
+When an `AIPerfJob` CR is passed to `profile --no-operator` or
+`generate --no-operator`, direct mode preserves the fields that JobSet can
+represent, including `imagePullPolicy`, `resourceMode`, `keepFailedPods`,
+`ttlSecondsAfterFinished`, `podTemplate`, and `scheduling`. The operator still
+owns CR lifecycle fields such as `timeoutSeconds`, `resultsTtlDays`, `cancel`,
+and `failurePolicy`; they have no direct-mode reconciler.
+
+Some benchmark runtime fields are intentionally Kubernetes-managed:
+`artifacts.dir` is fixed to the mounted `/results` volume, and the operator
+sets the service run type, API bind, dataset-service URL, UI, and ZMQ transport
+needed for cross-pod operation. Other runtime fields, including
+`workers`, `workersPerPod`, `recordProcessors`,
+`recordProcessorsPerPod`, and `statsInterval`, remain user-configurable. A
+total `recordProcessors` value must divide evenly across identical worker pods;
+otherwise set `recordProcessorsPerPod` explicitly.
+
+---
+
+## Helm Chart Configuration
+
+The operator Helm chart is configured via `values.yaml`. Key settings:
+
+### Operator
+
+```yaml
+operator:
+  replicas: 1
+  resources:
+    requests: { cpu: 250m, memory: 256Mi }
+    # No limits set by default (burstable QoS) so the operator can scale
+    # memory/CPU with high-concurrency runs.
+  env:
+    monitorInterval: "10.0"         # seconds between status checks
+    monitorInitialDelay: "5.0"      # delay before first status check
+    jobTimeoutSeconds: "0"          # 0 = no timeout
+    podRestartThreshold: "3"        # restarts before warning events
+    resultsTtlDays: "30"            # days to keep results on PVC
+    resultsMaxRetries: "5"          # retries for fetching results
+    resultsRetryDelay: "2.0"        # delay between result fetch retries
+    endpointCheckTimeout: "10.0"    # endpoint health check timeout
+    resultsCompressOnDisk: "true"   # store results as zstd on PVC
+```
+
+`operator.replicas` is fixed at `1`. The kopf process and runs index have one
+authoritative writer and do not use leader election, so the chart rejects
+multi-replica values instead of presenting unsafe pseudo-HA.
+
+### Storage
+
+Results are stored on a PVC so they survive pod deletion:
+
+```yaml
+storage:
+  enabled: true           # default — PVC-backed; set false for ephemeral emptyDir
+  size: 1Ti
+  storageClassName: ""    # empty = cluster default
+  accessMode: "ReadWriteOnce"
+```
+
+### Results Server
+
+A sidecar that serves stored results via HTTP (used by `aiperf kube results` by default):
+
+```yaml
+resultsServer:
+  port: 8081
+  resources:
+    requests: { cpu: 100m, memory: 512Mi }
+    limits: { cpu: 500m, memory: 1Gi }
+```
+
+The `resultsServer` chart block only exposes `port` and `resources` today.
+
+The results-server also hosts optional POST routes that create or cancel
+`AIPerfJob` resources. These are governed by two environment variables read on
+the results-server container: `AIPERF_OPERATOR_MUTATING_ROUTES_ENABLED`
+(default `false`) and `AIPERF_OPERATOR_MUTATING_ROUTES_TOKEN` (default empty —
+fails closed). When disabled, the read-only APIs stay exposed while those
+mutating POSTs return 403, so serving the results-server does not grant write
+access through the operator ServiceAccount. The index-rebuild route is mounted
+disabled and always returns 503; restart the operator pod to run the single-writer
+startup rebuild.
+
+The bundled chart does **not** template these two variables (there is no `resultsServer.mutatingRoutes` value and no token-secret projection). To turn the routes on, set both env vars directly on the `results-server` container — e.g. via a deployment patch or a customized chart template — then have clients send `Authorization: Bearer <token>` on protected POST requests. The browser dashboard never receives this token and keeps create/cancel controls disabled; use `aiperf kube` or `kubectl` from an authenticated terminal for those mutations.
+
+### `dashboard`
+
+Optional Plotly Dash sidecar for the operator Pod. Default off.
+
+| Key                              | Default      | Description                                                                   |
+|----------------------------------|--------------|-------------------------------------------------------------------------------|
+| `dashboard.enabled`              | `false`      | Whether to add the dashboard container and surface the "Plots ↗" SPA link.   |
+| `dashboard.port`                 | `8082`       | Pod-local HTTP port. `results-server` reverse-proxies `/dashboard/*` here.    |
+| `dashboard.resources.requests`   | `cpu: 100m, memory: 1Gi` | Resource requests. Leave generous so the build has memory.        |
+| `dashboard.resources.limits`     | `{}`         | Empty by default = no limit. Set `memory:` to enforce a ceiling.             |
+
+See [`dashboard-ui.md`](dashboard-ui.md#isolated-plotly-dashboard-sidecar-opt-in) for the full architecture.
+
+### Benchmark Namespace
+
+```yaml
+benchmarkNamespace:
+  create: true
+  name: "aiperf-benchmarks"
+```
+
+`benchmarkNamespace.create` controls only whether the chart creates the
+namespace. The chart always installs its benchmark `Role` and `RoleBinding` in
+`benchmarkNamespace.name`, including when the namespace already exists and
+`create` is `false`. `aiperf kube setup` uses that mode because it creates the
+resolved `--namespace` before invoking Helm.
+
+### Default Image
+
+The default image used for benchmark jobs if not specified in the CR:
+
+```yaml
+defaults:
+  image: "" # empty = "<image.repository>:<image.tag|Chart.AppVersion>"
+  imagePullPolicy: "IfNotPresent"
+```
+
+When `defaults.image` is empty (the chart default), the chart computes the
+benchmark image as `<image.repository>:<image.tag | Chart.AppVersion>`, so
+overriding `image.tag` automatically propagates to benchmark pods. Set
+`defaults.image` explicitly to decouple the benchmark image from the operator
+image.
+
+### Ingress
+
+Expose the results-server HTTP API outside the cluster via a Kubernetes `Ingress`. Disabled by default -- results are reachable via `ClusterIP` + `kubectl port-forward`.
+
+```yaml
+ingress:
+  enabled: false
+  className: ""                    # IngressClass name (e.g. "nginx"); empty uses cluster default
+  annotations: {}                  # annotations applied to the Ingress
+  hosts:
+    - host: aiperf.example.com
+      paths:
+        - path: /
+          pathType: Prefix         # backend port defaults to resultsServer.port; override with portNumber
+  tls: []                          # optional list of {hosts, secretName}
+```
+
+### NetworkPolicy
+
+Restrict pod traffic to/from the operator. Disabled by default -- no restrictions applied. When enabled, ingress is allowed from the benchmark namespace on the health (8080) and results (`resultsServer.port`) ports, plus DNS, the K8s API server, and the benchmark namespace on egress.
+
+```yaml
+networkPolicy:
+  enabled: false
+  allowedNamespaces: []            # extra namespaces allowed to reach the operator and reachable on egress
+  allowedIngressCIDRs: []          # CIDR allow-list for external scrapers (Prometheus, ingress controllers)
+```
+
+### Kueue
+
+```yaml
+kueue:
+  # When set, the benchmark namespace is annotated with
+  # kueue.x-k8s.io/default-queue-name so all AIPerf jobs are admitted through
+  # Kueue even without an explicit --queue-name flag. Left empty, it falls
+  # back to kueue.localQueueName when createQueues is true.
+  defaultQueueName: ""
+
+  # Optionally let the chart provision the Kueue objects themselves
+  # (ResourceFlavor + ClusterQueue + LocalQueue). Off by default so the
+  # chart renders on clusters without Kueue CRDs.
+  createQueues: false
+  flavorName: "default-flavor"
+  clusterQueueName: "aiperf-cluster-queue"
+  localQueueName: "aiperf-local-queue"
+  resources:
+    cpu: "1000"
+    memory: "4Ti"
+    gpu: ""            # empty = omit nvidia.com/gpu from the quota entirely
+```
+
+See [Kueue Integration](kueue.md) for the full gang-scheduling walkthrough.
+
+---
+
+## Configuration Patterns
+
+### Combining CLI Flags with Config Files
+
+CLI flags override config file values. This is useful for changing deployment settings without editing the YAML:
+
+```bash
+# Use config file for benchmark settings, override image and workers
+aiperf kube profile \
+  --config benchmark.yaml \
+  --image my-registry/aiperf:v2.0 \
+  --total-workers 20 \
+  --namespace production
+```
+
+### Validating Before Deploying
+
+Check your config file for errors before submitting:
+
+```bash
+# Validate YAML structure and fields
+aiperf kube validate benchmark.yaml
+
+# Strict mode fails on unknown fields
+aiperf kube validate --strict benchmark.yaml
+
+# JSON output for CI
+aiperf kube validate -o json benchmark.yaml
+```
+
+Preview what will be submitted without deploying:
+
+```bash
+aiperf kube profile --config benchmark.yaml --image aiperf:latest --dry-run
+```
+
+### Memory Estimation
+
+AIPerf prints a memory estimate before deploying. This helps you right-size your pods:
+
+```bash
+aiperf kube generate --operator --config benchmark.yaml --image aiperf:latest
+```
+
+The memory estimate is printed to stderr. It accounts for dataset size, number of workers, connection pools, and record buffers.
+
+### Multiple Phases
+
+Use multiple phases to warm up before measuring:
+
+```yaml
+phases:
+  - name: warmup
+    kind: warmup
+    type: concurrency
+    concurrency: 10
+    requests: 20
+  - name: low_load
+    kind: profiling
+    type: concurrency
+    concurrency: 25
+    requests: 250
+  - name: high_load
+    kind: profiling
+    type: concurrency
+    concurrency: 100
+    requests: 500
+```
+
+Phases run in order. Every phase keeps phase-scoped results; only phases with
+`kind: profiling` contribute to profiling aggregates. Canonical names
+`warmup` and `profiling` infer their matching kinds, while custom names require
+an explicit `kind`.
+
+---
+
+## Resource Mode
+
+`spec.resourceMode` controls the QoS class Kubernetes assigns to benchmark pods. The three modes differ only in how `requests` and `limits` are emitted onto the manifest — the underlying resource budget is the same in every case.
+
+| Mode | Behavior | K8s QoS class | When to use |
+|---|---|---|---|
+| `burstable` (default) | `requests` only; no `limits`. | Burstable | Default. Cost-sensitive clusters, development, and any benchmark where the controller's aggregation phase may temporarily allocate beyond the request — limits-free pods are not OOM-killed by cgroup. Controller pods stay Burstable by default in the operator's own `values.yaml` for the same reason. |
+| `guaranteed` | `requests == limits` for CPU and memory. | Guaranteed | Production benchmarks where pods must not be evicted under pressure and noisy-neighbor behavior is unacceptable. Use this mode when you have measured the controller's peak memory and want a hard ceiling. |
+| `none` | Neither `requests` nor `limits`. | BestEffort | Environments where CPU/memory admission control is disabled (e.g. CI `kind` clusters with tight node budgets, or when an external scheduler handles admission). The resource-dependent preflight checks ("Node Resources", "Per-Node Schedulability", "Resource Quotas", "Memory Estimation") are auto-skipped.** |
+
+The mode applies to both controller-pod and worker-pod containers; there is no per-container override. OOMKill semantics follow the QoS class — `guaranteed` pods will not be evicted for resource pressure, `burstable` pods may be throttled, and `none`/BestEffort pods can be evicted first.
+
+---
+
+## Tunable Environment Variables (`AIPERF_K8S_*`)
+
+These variables tune the operator and individual benchmark pods. Set them on the operator deployment (`operator.env.*` in `values.yaml`) to affect every subsequent job, or on `spec.podTemplate.env` to affect one CR only.
+
+### Resource sizing (per-container CPU / memory)
+
+Every control-plane container, the event-bus proxy sidecar, the results sidecar, and the worker pod have a paired `_CPU` / `_MEMORY` variable. Defaults are low burstable requests so many tiny jobs can start concurrently; raise them for very large concurrency or high-token workloads.
+
+| Variable | Default | Applies to |
+|---|---|---|
+| `AIPERF_K8S_SYSTEM_CONTROLLER_CPU` / `_MEMORY` | `75m` / `192Mi` | SystemController container |
+| `AIPERF_K8S_TIMING_MANAGER_CPU` / `_MEMORY` | `50m` / `192Mi` | TimingManager container |
+| `AIPERF_K8S_DATASET_MANAGER_CPU` / `_MEMORY` | `50m` / `256Mi` | DatasetManager container |
+| `AIPERF_K8S_RECORDS_MANAGER_CPU` / `_MEMORY` | `75m` / `256Mi` | RecordsManager container (raise to 4000m+ for >500k concurrency) |
+| `AIPERF_K8S_API_CPU` / `_MEMORY` | `75m` / `256Mi` | API container (WebSocket + HTTP) |
+| `AIPERF_K8S_GPU_TELEMETRY_MANAGER_CPU` / `_MEMORY` | `25m` / `192Mi` | GPU telemetry container |
+| `AIPERF_K8S_SERVER_METRICS_MANAGER_CPU` / `_MEMORY` | `25m` / `192Mi` | Server-metrics container |
+| `AIPERF_K8S_RESULTS_SIDECAR_CPU` / `_MEMORY` | `25m` / `192Mi` | Results sidecar (fallback retrieval path) |
+| `AIPERF_K8S_EVENT_BUS_PROXY_CPU` / `_MEMORY` | `50m` / `64Mi` | Event-bus XPUB/XSUB proxy sidecar |
+| `AIPERF_K8S_WORKER_POD_CPU` / `_MEMORY` | `150m` / `4Gi` | Worker pod (workers + record processors + WPM) |
+
+### Architecture toggles
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AIPERF_K8S_EVENT_BUS_SIDECAR_ENABLED` | `true` | Run the XPUB/XSUB event-bus proxy as a dedicated sidecar container. Set to `false` to revert to the pre-sidecar behavior where `SystemController` hosts the proxy in-process. Only disable if you are explicitly testing the legacy path. |
+| `AIPERF_K8S_RECORD_PROCESSOR_SCALE_FACTOR` | `1` | Workers per record processor inside each worker pod. `1` means one RP per worker (maximum fairness); higher values amortize RP overhead across more workers. |
+| `AIPERF_K8S_RECORD_PROCESSOR_CPU_REQUEST` | (unset) | Optional per-RP CPU request override. When unset, RP CPU is derived from the worker-pod budget. |
+
+### JobSet and lifecycle
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AIPERF_K8S_JOBSET_TTL_SECONDS_AFTER_FINISHED` | `300` | Seconds to keep pods after JobSet completion. Override per-CR via `spec.ttlSecondsAfterFinished`. |
+| `AIPERF_K8S_JOBSET_DIRECT_MODE_TTL_SECONDS` | `28800` (8h) | TTL applied when `--no-operator` is used, giving you time to pull results from pod-local storage. |
+| `AIPERF_K8S_JOBSET_CONTROLLER_BACKOFF_LIMIT` | `0` | Controller-job retry count. Default `0` — fail fast when the controller crashes. |
+| `AIPERF_K8S_JOBSET_WORKER_BACKOFF_LIMIT` | `20` | Worker-job retry count. Higher than controller to absorb transient pod-startup flakes. |
+| `AIPERF_K8S_JOBSET_WORKER_CONNECTION_PROBE_TIMEOUT` | `60.0` | Seconds a worker waits for the PUB/SUB connection probe before exiting so K8s restarts it. |
+
+### Health probes
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AIPERF_K8S_HEALTH_STARTUP_PERIOD_SECONDS` | `5` | Startup probe interval. |
+| `AIPERF_K8S_HEALTH_STARTUP_FAILURE_THRESHOLD` | `30` | Consecutive failures before the container is killed during startup. Raise for slow-starting workloads (large tokenizers, cold container images). |
+| Other `AIPERF_K8S_HEALTH_*` | see code | Liveness/readiness intervals, timeouts, thresholds. |
+
+### Ports
+
+All health and service ports are overridable via `AIPERF_K8S_PORT_*` (e.g. `AIPERF_K8S_PORT_API_SERVICE=9090`, `AIPERF_K8S_PORT_RESULTS_SIDECAR=9091`, `AIPERF_K8S_PORT_SYSTEM_CONTROLLER_HEALTH=8080`). Consult `src/aiperf/kubernetes/environment.py::_PortSettings` for the full list — changing these is rarely necessary.
+
+The complete, generated reference for every `AIPERF_*` variable (including non-k8s ones) lives in [`../environment-variables.md`](../environment-variables.md).
+
+---
+
+## Related Documentation
+
+- [Getting Started](getting-started.md) -- First benchmark walkthrough
+- [Monitoring and Troubleshooting](monitoring.md) -- Live monitoring and debugging
+- [Production Deployments](production.md) -- CI/CD, Kueue, and GitOps workflows
+- [CRD Validation Rules](crd-validation.md) -- Apiserver-side CEL invariants and shorthand acceptance
+- [Preflight Checks](preflight.md) -- What the operator validates before admitting a CR
+- [Memory Estimator](memory-estimator.md) -- How per-component memory estimates drive resource requests
+- [Direct Mode](direct-mode.md) -- Trade-offs when running `--no-operator`
+- [User-defined output files](user-files.md) -- `artifacts.user_files` for templated sidecar files
+- [YAML Config Reference](../tutorials/yaml-config.md) -- Complete benchmark configuration options

--- a/docs/kubernetes/crd-validation.md
+++ b/docs/kubernetes/crd-validation.md
@@ -1,0 +1,268 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: CRD Validation Rules
+---
+
+# CRD Validation Rules
+
+When you `kubectl apply` an `AIPerfJob` or `AIPerfSweep` CR, the Kubernetes
+apiserver runs two layers of validation **before** the operator ever sees the
+resource:
+
+1. **Structural schema** — types, enums, `minimum`/`maximum`, `required`. If
+   this layer rejects, the resource is never persisted.
+2. **CEL `x-kubernetes-validations`** — cross-field invariants compiled into
+   the CRD. These mirror the Pydantic `@model_validator` rules on
+   `AIPerfConfig` and `AIPerfSweepSpec`, but fire at admission time so a bad
+   CR is rejected with a clear message before any pod is scheduled.
+
+The CRD that defines both layers is auto-generated from the AIPerfConfig
+Pydantic models — see [the dev flow doc](../dev/kubernetes-flow.md#crd-generator)
+for how to add new rules.
+
+The lifecycle fields `spec.cancel` and `spec.skipEndpointCheck` are native
+booleans, and `spec.ttlSecondsAfterFinished` is a nonnegative integer. Quoted
+forms such as `cancel: "false"` or `ttlSecondsAfterFinished: "300"` are rejected
+at admission. Cancellation and retention handlers consume raw Kubernetes spec
+values, so native schema typing is part of the lifecycle safety boundary.
+
+## Shorthand acceptance
+
+The structural `required` list on `spec.benchmark` is just `[endpoint]`, and
+`spec.benchmark` carries an **empty** `x-kubernetes-validations: []` block — the
+canonical fields (`models`, `datasets`, `phases`) and their shorthand siblings
+(`model`, `dataset`, `warmup`, `profiling`) are all typeless
+preserve-unknown fields, so no CEL rule requires or excludes any of them. The
+apiserver accepts either idiom purely because none is `required` and unknown
+keys are preserved; the operator's before-validator does the actual
+shorthand↔canonical normalization on reconcile. This means **kubectl apply
+accepts the CLI-YAML idiom** without rewriting:
+
+```yaml
+# Shorthand form — accepted by the apiserver, normalized by the operator's
+# before-validator on reconcile.
+spec:
+  benchmark:
+    endpoint:
+      urls: ["http://server:8000/v1/chat/completions"]
+      type: chat
+    model: meta-llama/Llama-3.1-8B-Instruct  # singular, scalar
+    dataset:                                 # singular, dict
+      type: synthetic
+    profiling:                               # phase shorthand
+      type: concurrency
+```
+
+```yaml
+# Canonical form — also accepted; identical post-normalization shape.
+spec:
+  benchmark:
+    endpoint:
+      urls: ["http://server:8000/v1/chat/completions"]
+      type: chat
+    models: [meta-llama/Llama-3.1-8B-Instruct]
+    datasets:
+    - name: main
+      type: synthetic
+    phases:
+    - name: profiling
+      type: concurrency
+```
+
+You **cannot** mix the two forms for the same slot — the operator's
+`normalize_before_validation` raises a Pydantic ``ValueError`` on reconcile
+(`status.phase=Failed` with `'dataset' cannot be used with 'datasets'. Use
+'dataset' for a single dataset or 'datasets' for multiple named datasets.`).
+The check can't move to CEL because the shorthand fields are typeless
+preserve-unknown siblings — see the "Rules NOT enforced at apiserver level"
+table below.
+
+## Rule catalog
+
+The tables below list **only the CEL rules `tools/generate_crd.py` actually
+emits** (verified against the generated `crd-aiperfjob.yaml` /
+`crd-aiperfsweep.yaml`). Each entry gives the verbatim CEL expression and the
+message users see on rejection. Cross-field invariants that CEL cannot express
+are enforced by Pydantic on the operator side instead — see
+[Operator-side (Pydantic) invariants](#operator-side-pydantic-invariants) below.
+
+### Endpoint rules — `spec.benchmark.endpoint` (both kinds)
+
+| CEL rule | Message |
+|---|---|
+| `!has(self.type) \|\| self.type != 'template' \|\| has(self.template)` | `endpoint.template is required when endpoint.type='template'` |
+| `!has(self.template) \|\| !has(self.type) \|\| self.type == 'template'` | `endpoint.template is only used when endpoint.type='template' (omit type to auto-detect)` |
+| `!has(self.requestContentType) \|\| self.requestContentType != 'multipart/form-data' \|\| !has(self.type) \|\| self.type in ['image_edit', 'video_generation']` | `requestContentType='multipart/form-data' is only supported on form-data endpoint types` |
+| `!has(self.path) \|\| self.path.startsWith('/')` | `endpoint.path must start with '/' (e.g. '/v1/chat/completions', not 'v1/chat/completions')` |
+
+### Runtime rules — `spec.benchmark.runtime` (both kinds)
+
+| CEL rule | Message |
+|---|---|
+| `!has(self.apiHost) \|\| has(self.apiPort)` | `runtime.apiHost requires runtime.apiPort to be set` |
+| `!has(self.workersMin) \|\| !has(self.workers) \|\| int(self.workersMin) <= int(self.workers)` | `runtime.workersMin must be <= runtime.workers` |
+
+### MultiRun rules — `spec.multiRun` (both kinds)
+
+| CEL rule | Message |
+|---|---|
+| `!has(self.convergence) \|\| !has(self.convergence.minRuns) \|\| !has(self.numRuns) \|\| self.convergence.minRuns <= self.numRuns` | `multiRun.convergence.minRuns must be <= multiRun.numRuns; either lower minRuns or raise numRuns` |
+
+> No CEL rule is attached to `spec.benchmark.artifacts` on either kind.
+
+### AIPerfJob spec-level rules
+
+| CEL rule | Path | Message |
+|---|---|---|
+| `!has(self.sweep)` | `spec` | `AIPerfJob.spec.sweep must be null/omitted. Use kind: AIPerfSweep for parameter sweeps.` |
+| `!has(self.multiRun) \|\| ((!has(self.multiRun.numRuns) \|\| self.multiRun.numRuns <= 1) && !has(self.multiRun.convergence))` | `spec` | `AIPerfJob.spec.multiRun must describe one run without convergence. Use kind: AIPerfSweep for multi-run orchestration.` |
+
+### AIPerfSweep spec-level rules
+
+| CEL rule | Path | Message |
+|---|---|---|
+| `has(self.sweep)` | `spec` | `AIPerfSweep.spec.sweep is required. Use kind: AIPerfJob for single benchmarks.` |
+
+### Workload update rules
+
+Create-time workload fields use this presence-safe transition rule on the
+parent `spec` node:
+
+| CEL rule template | Path | Message template |
+|---|---|---|
+| `has(oldSelf.<field>) == has(self.<field>) && (!has(self.<field>) \|\| oldSelf.<field> == self.<field>)` | `spec` | `spec.<field> is immutable after creation; create a new <kind> to change it` |
+
+Keeping the rule on `spec`, which exists on every update, is intentional.
+A transition rule attached to an optional field is not evaluated when that
+field is added or removed. The explicit `has` parity rejects a value change,
+first-set-after-create, and removal. Kubernetes evaluates rules using
+`oldSelf` only on updates, so initial creation remains unrestricted.
+
+The exact update contract is:
+
+| Kind | Mutable after creation | Immutable after creation |
+|---|---|---|
+| `AIPerfJob` | `cancel`, `timeoutSeconds` | `image`, `imagePullPolicy`, `resourceMode`, `connectionsPerWorker`, `ttlSecondsAfterFinished`, `resultsTtlDays`, `keepFailedPods`, `podTemplate`, `scheduling`, `schemaVersion`, `benchmark`, `sweep`, `multiRun`, `plot`, `variables`, `randomSeed`, `noSweepTable`, `skipEndpointCheck`, `failurePolicy` |
+| `AIPerfSweep` | `cancel`, `ttlSecondsAfterFinished` | `image`, `imagePullPolicy`, `resourceMode`, `connectionsPerWorker`, `timeoutSeconds`, `resultsTtlDays`, `keepFailedPods`, `podTemplate`, `scheduling`, `schemaVersion`, `benchmark`, `sweep`, `multiRun`, `plot`, `variables`, `randomSeed`, `noSweepTable`, `skipEndpointCheck`, `failurePolicy`, `childMetadata` |
+
+The mutable whitelist follows the live reconciliation paths. The AIPerfJob
+monitor rereads `timeoutSeconds`; both kinds watch or poll `cancel`; and the
+operator's parent-sweep reaper rereads `ttlSecondsAfterFinished`. Every other
+field is rendered into the ConfigMap, JobSet, serialized sweep plan, or child
+template during creation. Accepting updates to those fields would change the
+CR without changing the running workload and could make
+`status.observedGeneration` falsely acknowledge a configuration the pods never
+received.
+
+> The `spec.sweep` absence rule is **AIPerfJob-only**; the AIPerfSweep CRD
+> instead asserts `spec.sweep` is present. `spec.benchmark` carries an empty
+> `x-kubernetes-validations: []` on both kinds.
+
+## Operator-side (Pydantic) invariants
+
+Several cross-field invariants **cannot** be expressed in CEL — either the
+fields they reference are typeless preserve-unknown siblings (`model`,
+`dataset`, `warmup`, `profiling`), or the `phases[]` / `datasets[]` array items
+are emitted as opaque `x-kubernetes-preserve-unknown-fields` blobs (they are
+heterogeneous Pydantic discriminated unions). CEL `has(self.X)` won't compile
+against a typeless field, and opaque array items cannot be dereferenced. These
+checks stay in the operator's `@model_validator` decorators and surface only on
+reconcile (they are also run client-side by `aiperf kube validate`):
+
+| Python validator (`src/aiperf/config/config.py` unless noted) | What it enforces |
+|---|---|
+| `normalize_before_validation` (via `normalizers._check_mutual_exclusivity`) | shorthand↔canonical mutual exclusion (`model`/`models`, `dataset`/`datasets`, `warmup`+`profiling`/`phases`) |
+| `parse_datasets` / `parse_datasets_input` (`loader/normalizers.py`) | each `datasets[]` entry is a mapping with a required `name` |
+| `validate_phase_names_unique` | duplicate phase names within `phases` |
+| `validate_profiling_phase_required` | at least one non-warmup profiling phase |
+| `validate_seamless_not_on_first_phase` | first phase may not set `seamless=true` |
+| `validate_phase_dataset_compatibility` | each phase is compatible with its resolved dataset |
+| `validate_prefill_requires_streaming` | a phase with `prefill_concurrency` requires `endpoint.streaming=true` |
+| `validate_sweep_no_dashboard_ui` | `sweep` set ⇒ `runtime.ui` is not `dashboard` |
+| `_apply_consistent_seed_default` | auto-fills a consistent random seed for cross-trial sweeps when none is given |
+| `_reject_orchestration_on_aiperfjob` (`kubernetes/crd_models.py`) | AIPerfJob rejects sweep and multi-run orchestration (mirrors its two kind-specific CEL rules) |
+| `_require_sweep_on_aiperfsweep` (`kubernetes/crd_models.py`) | AIPerfSweep requires a `sweep` block (mirrors the `has(self.sweep)` CEL rule) |
+| `_reject_non_finite_sweep_knobs` (`kubernetes/crd_models.py`) | rejects NaN/inf on sweep tuning knobs |
+
+> There is no `validate_datasets_unique_names` or `validate_dataset_references`
+> validator — dataset-name presence is checked by `parse_datasets_input` and
+> phase↔dataset coupling by `validate_phase_dataset_compatibility`.
+
+If you submit a CR that the apiserver accepts but the operator later rejects,
+the failure shows up as `status.phase=Failed` with the validation error in
+`status.error` (or in operator pod logs).
+
+## Example error messages
+
+Each CEL rejection names the rule that fired, so the failure points directly
+at what to fix.
+
+```text
+$ kubectl apply -f bad-template.yaml
+The AIPerfJob "x" is invalid: spec.benchmark.endpoint: Invalid value: "object":
+  endpoint.template is required when endpoint.type='template'
+
+$ kubectl apply -f sweep-as-job.yaml
+The AIPerfJob "x" is invalid: spec: Invalid value: "object":
+  AIPerfJob.spec.sweep must be null/omitted. Use kind: AIPerfSweep for
+  parameter sweeps.
+
+$ kubectl apply -f job-as-sweep.yaml
+The AIPerfSweep "x" is invalid: spec: Invalid value: "object":
+  AIPerfSweep.spec.sweep is required. Use kind: AIPerfJob for single
+  benchmarks.
+```
+
+The shorthand↔canonical mutual-exclusion error is **not** a CEL rejection at
+`kubectl apply`; it surfaces on reconcile as `status.phase=Failed` with the
+Pydantic message `'dataset' cannot be used with 'datasets'. Use 'dataset' for
+a single dataset or 'datasets' for multiple named datasets.`
+
+## Extending the rule set
+
+Adding a new CEL rule is a small change in `tools/generate_crd.py`:
+
+1. Decide which **shape** the rule applies to (benchmark, endpoint, runtime,
+   multiRun) and pick the matching `_decorate_*_node` helper, or add a new
+   shape detector if your target node has a unique property fingerprint.
+2. Append a `{"rule": ..., "message": ...}` entry to that helper's
+   `_add_validation_rules(...)` call.
+3. Add a structural assertion to
+   `tests/unit/operator/test_aiperfsweep_crd_generation.py`.
+
+A shape detector keys off property names, so **renaming a field silently
+retires every rule attached to its node** — the detector stops matching and
+the generator reports nothing. Two decorators had been inert this way. When
+you rename or nest a spec field, re-read the detector that fingerprints it,
+and prefer a structural test that asserts the rule is present on both kinds
+over one that only asserts a rule's text.
+4. Regenerate (`uv run python tools/generate_crd.py`) and verify the regen
+   is idempotent (`tools/generate_crd.py --check`).
+5. Round-trip against a real apiserver (kind cluster + `kubectl apply
+   --dry-run=server`) — the CEL compiler runs at CRD-install time and will
+   reject rules that reference undeclared fields or opaque items.
+
+CEL constraints that aren't obvious from the Pydantic side:
+
+- `has(self.X)` only works on properties that are **declared** in the
+  schema. Properties under `x-kubernetes-preserve-unknown-fields` are
+  invisible to CEL.
+- Array items emitted as opaque preserve-unknown blobs cannot be
+  dereferenced (no `phases[].name`, no `datasets[0].seamless`).
+- `oldSelf` is only available in transition rules and triggers on update.
+  Use `!has(oldSelf.X) || oldSelf.X == self.X` for "first-set freezes"
+  semantics.
+- The K8s apiserver compiles CEL at CRD install time; rule errors fail
+  the install with a clear `compilation failed: undefined field 'X'`
+  message.
+
+## See also
+
+- [`docs/dev/kubernetes-flow.md`](../dev/kubernetes-flow.md) — operator/CR
+  lifecycle, including how the CRD generator decorator pattern is wired.
+- [`docs/kubernetes/validate.md`](validate.md) — `aiperf kube validate` runs
+  the same schema check **client-side** so CI catches violations before
+  `kubectl apply`.
+- [`docs/kubernetes/configuration.md`](configuration.md) — full CR-field
+  reference.

--- a/docs/kubernetes/dashboard-ui.md
+++ b/docs/kubernetes/dashboard-ui.md
@@ -1,0 +1,501 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Web Dashboard
+---
+
+# Web Dashboard
+
+The operator ships a browser-based dashboard for inspecting benchmark jobs,
+comparing runs, and browsing historical analytics. It is a lightweight Preact
+single-page application served directly from the operator's Results API
+deployment — no separate service to deploy, no build step, just static assets
+loaded from `src/aiperf/operator/ui/`.
+
+This page documents every page, interaction, and keyboard shortcut in the UI.
+For the HTTP endpoints that power it, see [`results-api.md`](results-api.md).
+
+---
+
+## Accessing the Dashboard
+
+The dashboard and the Results API are served by the same FastAPI process and
+share port **8081** inside the cluster. The SPA is mounted as a catch-all
+`StaticFiles` handler, so any path that isn't an `/api/v1/...` route returns
+`index.html` and lets the client-side router take over.
+
+### Recommended: `aiperf kube dashboard`
+
+```bash
+aiperf kube dashboard
+```
+
+This command locates the operator pod, opens a `kubectl port-forward` directly
+to that pod on the results server port (`RESULTS_SERVER_PORT = 8081`), and
+launches your default browser at the forwarded URL. The port-forward stays
+open until you press `Ctrl+C`.
+
+Useful flags:
+
+| Flag | Purpose |
+|---|---|
+| `--port 8081` | Bind to a specific local port (default: ephemeral). |
+| `--no-browser` | Print the URL instead of opening a browser — useful in SSH sessions. |
+| `--operator-namespace aiperf-system` | Override the namespace to look in. |
+
+### Manual port-forward (enterprise clusters)
+
+If your cluster policy forbids the `aiperf` CLI from spawning `kubectl`, or you
+want a long-lived forward managed by your own tooling, forward the Service
+directly:
+
+```bash
+kubectl port-forward -n aiperf-system svc/aiperf-operator 8081:results
+# open http://localhost:8081
+```
+
+The Service name is whatever Helm's `aiperf-operator.fullname` template
+renders — by default `aiperf-operator`, or `<release>-aiperf-operator` if your
+release name differs from the chart name. The port is exposed under the
+`results` named port (default 8081, see `resultsServer.port` in `values.yaml`).
+
+### Local no-build UI development
+
+For fast iteration on the static operator UI without adding a frontend build
+step, run the local proxy against a forwarded or otherwise reachable operator
+Results API:
+
+```bash
+uv run python tools/operator_ui_proxy.py --dev-reload --port 8123 --upstream http://127.0.0.1:8081
+```
+
+Open `http://127.0.0.1:8123/live/`. The proxy serves
+`src/aiperf/operator/ui/`, forwards `/api/v1/*` to the configured upstream, and
+reloads the browser when `.html`, `.js`, or `.css` files change.
+
+### Authentication
+
+The dashboard inherits the Results API's read-only access model: **no per-user
+authentication** is performed for reads. Access control is the port-forward
+itself — whoever can reach port 8081 inside the cluster (or through a forward)
+can view every job and every result. Browser mutating actions are disabled by
+default because the static SPA has no safe bearer-token delivery path; create
+and cancel jobs from an authenticated terminal with `aiperf kube` or `kubectl`.
+Do not expose this port via an unauthenticated Ingress.
+
+---
+
+## Navigation
+
+The UI is a **flat, dark-mode single-page app** with a text-led operator
+sidebar — there is no namespace-picker landing page and no per-namespace URL
+tier. Namespace is only ever a path
+parameter (`:ns`) on a job/sweep detail route or a `?ns=` query filter on the
+list pages; it is never a routing gate, and nothing about the last namespace is
+persisted.
+
+Routes are hash-based, so reloading any page works without server-side route
+configuration. The full route table (`src/aiperf/operator/ui/app.js:51-83`):
+
+| Route | Page | Purpose |
+|---|---|---|
+| `/` | `Dashboard` | Cluster-wide overview: cluster-stats banner, active-jobs cards, throughput-vs-latency scatter, KPI tiles, recent-jobs table. |
+| `/jobs` | `Jobs` | Filterable/sortable table of every AIPerfJob (phase tabs, search, model/endpoint/namespace filters — all synced to the URL query). |
+| `/jobs/:ns/:name` | `JobDetail` | Single-run workbench (see below). |
+| `/jobs/:ns/:name/runs/:epoch` | `JobDetail` | Same workbench pinned to one epoch of a multi-epoch run. |
+| `/sweeps` | `Sweeps` | Filterable/sortable table of every AIPerfSweep. |
+| `/sweeps/:ns/:name` | `SweepDetail` | Sweep workbench (variation curves, Pareto, children). |
+| `/sweeps/:ns/:name/runs/:epoch` | `SweepDetail` | Sweep workbench pinned to one sweep epoch. |
+| `/leaderboard` | `Leaderboard` | Cross-run ranking for a chosen metric. |
+| `/compare` | `Compare` | Multi-run comparison (metric table, bar/Pareto charts). |
+| `/compare/:ns/:name/:epochA/:epochB` | `CompareEpochs` | Two-epoch diff of one run. |
+| `/history` | `History` | A metric's value over time across runs. |
+| `/launch` | `Launch` | Read-only YAML helper (copy-only; see below). |
+
+Any other path renders a "Not Found" stub.
+
+```mermaid
+flowchart TB
+    dash["/"] --> Dashboard
+    jobs["/jobs"] --> JobDetail["/jobs/:ns/:name(/runs/:epoch)"]
+    sweeps["/sweeps"] --> SweepDetail["/sweeps/:ns/:name(/runs/:epoch)"]
+    lb["/leaderboard"]
+    cmp["/compare"] --> CompareEpochs["/compare/:ns/:name/:a/:b"]
+    hist["/history"]
+    launch["/launch"]
+```
+
+### Operator sidebar
+
+`TopNav` (`components/top-nav.js`) renders two text groups in the left-hand
+sidebar:
+
+- **Operate:** Dashboard, Jobs, Sweeps, Launch.
+- **Analyze:** Leaderboard, Compare, History.
+
+When `/api/v1/config/features` reports `dashboard_enabled: true`, a third group
+adds an external **"Plots ↗"** link (see below). The workspace uses a fixed
+graphite dark palette; NVIDIA green is reserved for deliberate actions and live
+or successful status. Search is available at the base of the sidebar with
+`Ctrl+K`.
+
+### Breadcrumb
+
+Below the top bar, `Breadcrumb` (`components/breadcrumb.js`) renders a
+**route-path** breadcrumb derived from the current hash — e.g. `Jobs / <ns> /
+<name> / runs / <epoch>` on a job-epoch route. It is a plain path trail with
+clickable ancestors; there is **no** namespace dropdown or namespace switcher.
+
+### Read-only launch helper
+
+`/launch` (`pages/launch.js`) is a YAML editor with template pills. Browser
+job submission is **hard-disabled** — `lib/api.js` sets
+`DASHBOARD_MUTATIONS_ENABLED = false`, so `api.createJob()` throws and the
+"Launch" button stays disabled; the working action is **Copy**. Copy the YAML,
+then apply it from an authenticated terminal:
+
+```bash
+kubectl apply -f benchmark.yaml
+```
+
+The page can be pre-filled from a completed run via the "Re-launch" button on
+the job workbench (handed off through `sessionStorage`, not a POST).
+
+### External Plots link
+
+The "Plots ↗" link points at `/dashboard/` — the optional Plotly Dash sidecar.
+The results server mounts an **httpx reverse-proxy router**
+(`operator/routers/dashboard_proxy.py`, wired in `results_server.py:219-223`)
+that forwards `/dashboard/*` to the dashboard sidecar. The link is gated by
+`/api/v1/config/features`'s `dashboard_enabled` flag, and the proxy returns
+`503` when the sidecar is disabled or unreachable. (The Dash app itself uses
+`WSGIMiddleware` inside the sidecar's own `dashboard_server.py`, not on the
+results server.)
+
+---
+
+## Pages
+
+### Dashboard (`/`)
+
+The cluster-wide landing view (`pages/dashboard.js`).
+
+**What it shows:**
+
+- **Cluster-stats banner** — GPUs used/total + free, utilization %, GPU-node
+  breakdown, and a Kubernetes/cluster tile.
+- **Active-jobs cards** — one card per running/initializing/pending job with a
+  live metric strip (TTFT, output tok/s, P99, ITL, requests, error %) and a
+  progress bar. Click a card to open the workbench.
+- **Throughput-vs-latency scatter** — completed jobs, with TPS/P99, TPS/TTFT,
+  tok-s/P99 axis toggles and a log-scale toggle.
+- **KPI tiles** — Running, Completed, Peak Throughput, Best TTFT, Token
+  Throughput.
+- **Recent-jobs table** — newest completed/failed runs with headline metrics.
+
+**Endpoints consumed:** `GET /api/v1/jobs` (5s), `GET /api/v1/cluster` (10s),
+`GET /api/v1/analytics/leaderboard` + per-entry
+`GET /api/v1/analytics/summary/{ns}/{jobId}` (15s).
+
+### Jobs (`/jobs`)
+
+Filterable, sortable table of every AIPerfJob (`pages/jobs.js`). Phase tabs
+(All / Running / Completed / Failed), free-text search, and model / endpoint /
+namespace filters — all persisted to the URL query string. `GET /api/v1/jobs`
+polled every 5s. Clicking a row opens the workbench.
+
+### Job workbench (`/jobs/:ns/:name`)
+
+The deepest page, scoped to one AIPerfJob (`pages/job-detail.js`). Sections
+depend on whether the run is live or finished.
+
+**Always visible:** header (name, phase badge, namespace/model pills, epoch
+selector), conditions, a `PhaseBar` (Phases), record-processing, and a
+`PodsBar` (per-pod JobSet status).
+
+**While running:** a live-throughput line chart, a latency-distribution
+histogram, a realtime KPI grid, and a diagnostics panel (Events / Logs /
+Conditions / Pods tabs). A per-job WebSocket feeds live data. A cancel button
+exists but is **disabled** (`DASHBOARD_MUTATIONS_ENABLED = false`); it renders a
+read-only notice pointing to `aiperf kube` / `kubectl`.
+
+**After completion:** SLA compliance, server metrics, job configuration (with a
+View-YAML modal), run metadata, per-record analysis (from
+`profile_export.jsonl`), concurrency-vs-throughput, latency-percentile and
+latency-timeline charts, ISL distribution, a full metrics-breakdown table, and
+a result-files card.
+
+**Endpoints consumed:** `GET /api/v1/jobs/{ns}/{name}[?epoch=]` (3s),
+`.../epochs`, `GET /api/v1/config/{ns}/{name}`,
+`GET /api/v1/results/{ns}/{name}/runs/{epoch}/...` (file listing +
+`server_metrics_export.json` + `profile_export.jsonl`), and a per-job
+WebSocket.
+
+### Job epoch view (`/jobs/:ns/:name/runs/:epoch`)
+
+The same workbench pinned to a specific epoch of a multi-epoch run
+(concurrency/request-rate sweeps). Header widgets walk epochs and update the
+URL; a no-epoch URL auto-redirects to the resolved current epoch.
+
+### Sweeps (`/sweeps`)
+
+Filterable, sortable table of every AIPerfSweep (`pages/sweeps.js`) — phase
+tabs, progress, failed count, variation count, model, source, and age.
+`GET /api/v1/sweeps` polled every 5s. Row click → sweep detail.
+
+### Sweep detail (`/sweeps/:ns/:name`)
+
+One AIPerfSweep workbench (`pages/sweep-detail.js`): header (phase, model,
+epoch selector, and the currently executing variation), conditions, a KPI row
+(variations / completed / failed plus headline peak metrics), an
+aggregate-artifacts card, a live trial board while running, a variation curve
+(metric selector + chart + table), a children table, and a diagnostics panel
+while live.
+
+Adaptive search has a deliberately state-aware surface:
+
+| State | Surface | Claim the UI may make |
+|---|---|---|
+| Live adaptive search | **Optimization study** with a **Current leader** | The best observation seen so far is provisional; the planner is still sampling and no final recommendation is shown. |
+| Successful terminal adaptive search with `search_summary.best_trials` | **Planner verdict** | The planner's final operating point, stopping evidence, and any SLA boundary. |
+| Failed, cancelled, unknown, or terminal adaptive search without a verdict | **No final recommendation** | The UI directs the reader to the trial history and search artifact; it never promotes a partial result to a winner. |
+| Grid/generator sweep | **Variation analysis** | The curve and table are the result; no browser-derived winner summary is shown. |
+
+Pareto analysis appears only for a sweep that declared more than one objective.
+It is not used as a decorative throughput-versus-latency chart for a
+single-objective or grid sweep.
+
+The headline peak tiles (`Peak output tok/s`, `Peak req/s`, `Best TTFT p50`,
+`Best req lat p99`) report the extremum across **every** variation, feasible or
+not — "how much can this serve if I ignore latency" is a real question, and the
+variation table below the tiles is unfiltered too. So that a peak the
+constrained search *rejected* cannot be mistaken for the sweep's answer, each
+tile states which SLA regime its number is from:
+
+| Tile shows | When |
+|---|---|
+| `breaches SLA`, amber, no gold "award" tone | The variation that produced this extremum fails at least one `spec_summary.sla_filters` entry. Hover names the constraint, the observed value, and the best SLA-feasible alternative among the charted variations. |
+| `meets SLA`, green | The variation satisfies every declared filter. |
+| no feasibility line at all | Either the sweep declared no constraints (`search_summary.sla_filter_count == 0`, which makes every `feasible` flag in the API vacuously true), or it declared some that this page cannot check — `spec_summary.sla_filters` absent on an older archive, or a constraint on a metric the page does not collect. In the second case the tooltip says the tile is **not** filtered for feasibility, rather than leaving its silence to be read as a pass. |
+
+The final verdict comes from `search_summary.best_trials[0]`, the search
+planner's own result recorded from trial-level data. Its headline metric label,
+unit, and direction all come from the objective itself, never from the chart
+selector. An objective the planner could not score on the chosen trial renders
+as `not measured` rather than borrowing a neighbouring objective's number.
+
+**Endpoints consumed:** `GET /api/v1/sweeps/{ns}/{name}[?epoch=]` (5s),
+`.../cells`, `.../epochs`, `.../children`,
+`.../epochs/{epoch}/artifacts`, and per-child `GET /api/v1/jobs/{ns}/{name}`.
+
+### Leaderboard (`/leaderboard`)
+
+Cross-run ranking for a chosen metric + stat (`pages/leaderboard.js`): a
+top-10 horizontal bar chart plus a ranked table, with namespace / model /
+endpoint cross-filters. `GET /api/v1/analytics/leaderboard?metric=&stat=&limit=1000`
+(fetched per selection, not polled). Rows link to the run workbench.
+
+### Compare (`/compare`)
+
+Multi-run comparison (`pages/compare.js`). Left: a job selector with search,
+namespace/model/endpoint facet chips, and quick-pick buttons. Right: a
+metric-comparison table (direction-aware best-value highlight), a grouped bar
+chart, and throughput/latency Pareto scatters. Loads the run list from
+`GET /api/v1/results`, then `GET /api/v1/analytics/compare?jobs=...` on compare.
+Deep-linkable via a `?cluster=` query param. Requires ≥2 selections.
+
+### Compare epochs (`/compare/:ns/:name/:epochA/:epochB`)
+
+A fixed nine-metric diff of two epoch-pinned run summaries of a single run
+(`pages/compare-epochs.js`) — columns Metric / Run A / Run B / Δ.
+`GET /api/v1/results/{ns}/{name}/runs/{epoch}/profile_export_aiperf.json` for
+each side.
+
+### History (`/history`)
+
+One metric's value over time across runs (`pages/history.js`): a line chart
+plus a data-points table, with namespace / model / endpoint filters synced to
+the URL. `GET /api/v1/analytics/history?metric=&stat=`.
+
+### Launch (`/launch`)
+
+Read-only YAML helper — see [Read-only launch helper](#read-only-launch-helper)
+under Navigation. Copy-only; browser submission is disabled.
+
+### Log strip (bottom bar)
+
+`LogStrip` (`components/log-strip.js`) is an always-on strip pinned to the
+bottom of every page. It derives lifecycle events **client-side** by diffing
+successive `/api/v1/jobs` snapshots (new run detected, phase transition,
+worker-ready change) — it consumes **no** endpoint of its own and keeps only an
+in-memory ring buffer of the last 120 events, so its history is lost on reload.
+Filter tabs: All / Warn / Error. Each entry links to the run workbench. It is
+**not** a durable cross-namespace audit log.
+
+---
+
+## Command Palette
+
+Press **`Ctrl+K`** (or `Cmd+K` on macOS) to open the command palette. The
+search icon in the top-right corner of the navigation bar opens the same modal.
+
+The palette (`components/command-palette.js:6-14`) indexes:
+
+- The seven nav pages — Dashboard, Jobs, Sweeps, Launch, Leaderboard, Compare,
+  History — each with the sub-label "Page".
+- Every AIPerfJob from the current `jobs` signal — sub-label `ns: <namespace>`,
+  selecting navigates to that job's workbench (`/jobs/<ns>/<name>`, pinned to
+  its epoch when known).
+
+There are no namespace entries. Type to fuzzy-match either the label or the
+sub-label; matching is in-order-character, not substring. Navigation:
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move highlight |
+| `Home` / `End` | Jump to first / last |
+| `Enter` | Select the highlighted item |
+| `Escape` or backdrop click | Close |
+| Mouse hover | Move highlight |
+
+---
+
+## Theme and Layout
+
+The dashboard has a **three-way theme toggle** — auto / light / dark — in the
+top-right of the navigation bar (`lib/theme-switch.js`, rendered by
+`top-nav.js`). Clicking it cycles auto → light → dark and persists the choice
+to `localStorage['aiperfTheme']`; `auto` follows the OS `prefers-color-scheme`
+and updates live. The resolved theme is applied via
+`document.documentElement.dataset.theme`, and the color tokens live in
+`src/aiperf/operator/ui/lib/theme.js` / `style.css`. Model colors in charts are
+assigned deterministically from a hash of the model name, so the same model
+keeps the same color across pages and reloads.
+
+The layout is a single column with a fixed top navigation bar, a breadcrumb
+row, an ALPHA banner, an optional global error banner, the current page, and a
+persistent log strip at the bottom. The SPA is responsive down to tablet
+widths; very narrow viewports are not a supported target.
+
+---
+
+## Troubleshooting
+
+### Blank page with console 404s for `/app.js`
+
+The UI assets were not baked into the operator image, or `ui_dir.is_dir()`
+returned false at startup. Verify the image tag includes
+`src/aiperf/operator/ui/` and check the Results server logs for
+"UI static files mounted" output.
+
+### "Error: API 503 …" banners
+
+The Results API returned 503 — typically because `ResultsDB` hasn't finished
+initializing, or the kubernetes_asyncio client failed to load config. Check
+the operator pod logs:
+
+```bash
+kubectl logs -n aiperf-system deploy/aiperf-operator -c results-server --tail=200
+```
+
+If the line `kubernetes_asyncio client initialized for UI endpoints` is
+missing, the live job and cluster endpoints will stay unavailable even after
+the analytics engine comes up. The Dashboard page surfaces this as a
+"Cluster endpoint unavailable — data may be stale" banner.
+
+### Dashboard KPI tiles show "—" for throughput
+
+The Dashboard's KPI tiles (Peak Throughput, Best TTFT, Token Throughput) and
+the throughput-vs-latency scatter only populate from **completed** jobs whose
+summary carries the relevant fields (e.g. `request_throughput.avg`). If your
+runs never finished, the tiles fall back to "—". Open the run workbench from
+the recent-jobs table to inspect individual runs instead.
+
+### Port-forward drops during operator rollout
+
+`aiperf kube dashboard` **auto-reconnects with backoff** and pins the local
+port across reconnects, so an open browser tab keeps working after a rollout
+that terminates the operator pod — no need to re-run the command. Press
+`Ctrl+C` to stop the forward.
+
+### Mutating action is unavailable from the dashboard
+
+Launch and cancel are intentionally not exposed as unauthenticated browser
+actions. Use an authenticated terminal instead:
+
+```bash
+# Cancel a running AIPerfJob.
+kubectl patch aiperfjob <name> -n <namespace> --type=merge -p '{"spec":{"cancel":true}}'
+
+```
+
+If an API or CLI client receives 401/403 from `POST /api/v1/jobs` or
+`POST /api/v1/jobs/{ns}/{name}/cancel`, verify
+that the operator has `AIPERF_OPERATOR_MUTATING_ROUTES_ENABLED=true` and a
+non-empty `AIPERF_OPERATOR_MUTATING_ROUTES_TOKEN`, then send
+`Authorization: Bearer <token>`. Read-only dashboard/API calls continue to work
+without this token. `POST /admin/index/rebuild` is mounted disabled and returns
+503 regardless of credentials; restart the operator pod to rebuild the index.
+
+---
+
+## Isolated Plotly Dashboard Sidecar (opt-in)
+
+The Plotly Dash plot-building runs in its own container in the operator
+Pod, behind the `dashboard.enabled` Helm value (default `false`). When
+enabled:
+
+- The operator Pod runs three containers: `operator`,
+  `results-server`, and `dashboard`.
+- `results-server` reverse-proxies `/dashboard/*` to
+  `localhost:<dashboard.port>` so external callers still hit one URL
+  (the existing `results-server.port`, default 8081).
+- The SPA's "Plots ↗" top-nav link appears, opening `/dashboard/` in
+  a new tab. The link is gated by `/api/v1/config/features`'s
+  `dashboard_enabled` field so a misconfigured chart fails closed.
+- After every benchmark completion, the operator fires a
+  fire-and-forget `POST /admin/refresh` against the dashboard sidecar
+  so the next `/dashboard/` view sees the new run.
+
+### Memory budgeting
+
+By default the dashboard container has `requests: 1Gi` and **no
+memory limit** — it can burst to whatever the node has free. This
+matches the original in-process behaviour but isolates blast radius
+to a single container. To enforce a ceiling on shared clusters:
+
+```yaml
+dashboard:
+  enabled: true
+  resources:
+    limits:
+      memory: 4Gi
+```
+
+When the limit is exceeded, only the dashboard container is
+OOMKilled — `results-server` (API, jobs router, WS) and the operator
+keep running.
+
+### Disabling
+
+```bash
+helm upgrade ... --set dashboard.enabled=false
+```
+
+When off, the `/dashboard/*` route returns 503 with a friendly body
+and the SPA hides the "Plots ↗" link.
+
+### Smoke test
+
+1. `helm upgrade ... --set dashboard.enabled=true` — three containers
+   in the operator Pod; "Plots ↗" link visible in the SPA top-nav.
+2. Run a benchmark to completion. The operator POSTs `/admin/refresh`
+   to the dashboard sidecar after a successful completion claim and the
+   dashboard log shows the rebuild. (A `dashboard refresh skipped`
+   DEBUG line in the operator log means the POST *failed* and was
+   swallowed — refresh is best-effort.) Click "Plots ↗" — the new run
+   is in the Dash app's run picker.
+3. `--set dashboard.enabled=false` — link gone; `/dashboard/` returns
+   503; dashboard container absent from the Pod.
+4. `--set dashboard.resources.limits.memory=512Mi` — cap enforced;
+   OOMKill of dashboard alone does not restart results-server or operator.

--- a/docs/kubernetes/debug-command.md
+++ b/docs/kubernetes/debug-command.md
@@ -1,0 +1,277 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Debug Command
+---
+
+# Debug Command
+
+`aiperf kube debug` produces a one-shot diagnostic snapshot of a benchmark namespace: which pods are in trouble, what Kubernetes events fired recently, what the cluster nodes look like, and — in verbose mode — the tail of every problem pod's logs. It is designed for triage *after* a benchmark has misbehaved, not for live observation.
+
+If you need continuous updates while a benchmark is running, use [`aiperf kube attach`](./attach.md) instead.
+
+---
+
+## When to Use Which Command
+
+AIPerf ships three cluster-inspection commands that overlap in theme but serve different moments in the lifecycle:
+
+| Command | Timing | Duration | What it answers |
+|---|---|---|---|
+| `aiperf kube preflight` | Before deploy | One-shot | "Will my cluster even accept this job?" (CRDs installed, operator healthy, permissions OK, nodes have capacity) |
+| `aiperf kube attach` | During a run | Streaming | "What is the job doing right now?" (live progress from the controller) |
+| `aiperf kube debug` | After something went wrong | One-shot | "Why did this job fail or stall?" (container-status problem map, recent events, node pressure, failed-pod logs) |
+
+Use `debug` when:
+
+- A benchmark is stuck in Pending and you want a single report to attach to an issue.
+- Pods are CrashLoopBackOff-ing and you want all their log tails in one place.
+- The operator's `status.phase` is `Failed` and you want a post-mortem summary without scripting `kubectl` calls.
+- An AI agent is triaging a failure and needs a structured, grep-friendly snapshot.
+
+Use `aiperf kube list --watch` instead when the job is still running and you
+want to catch the state transition as it happens. Use `aiperf kube attach` for
+the live progress and log stream of one job.
+
+```mermaid
+flowchart LR
+    A[Plan a run] --> B[preflight]
+    B -->|pass| C[profile / apply]
+    C --> D[list --watch / attach]
+    D -->|job failed or stalled| E[debug]
+    D -->|job succeeded| F[results]
+    E --> G[Fix config / cluster]
+    G --> B
+```
+
+---
+
+## CLI Reference
+
+```
+aiperf kube debug [OPTIONS]
+```
+
+All flags are optional. With no flags, `debug` falls back to the namespace of the last benchmark deployed from this machine (the same record `aiperf kube results` uses) and inspects every AIPerf pod it finds there.
+
+| Flag | Short | Default | Description |
+|---|---|---|---|
+| `--namespace` | `-n` | last-deployed benchmark's namespace | Kubernetes namespace to inspect. |
+| `--job-id` | `-j` | (auto-resolve) | AIPerf job ID **or AIPerfSweep name** to diagnose. A sweep name selects `status.currentChildRef.name`, or its latest completed `status.runs[].childName` when no child is running, and restricts the report to that child's pods. |
+| `--all-namespaces` | `-A` | `false` | Inspect every namespace that contains at least one AIPerf JobSet. |
+| `--verbose` | `-v` | `false` | Fetch logs from problem pods and show all recent events (not just `Warning`s). |
+| `--variation` | | (unset) | When `--job-id` is an AIPerfSweep name, target child variation index (0..199); resolves to `<sweep>-v<idx:02d>[-t<trial>]`. `-v` is reserved for `--verbose`, so use the long form. |
+| `--trial` | `-t` | (unset) | Trial index (0..9) within a sweep variation. Requires `--variation`. |
+| `--kubeconfig` | | `$KUBECONFIG` | Path to kubeconfig file. |
+| `--kube-context` | | current context | Kubernetes context to use. |
+
+### Namespace resolution order
+
+`debug` picks its target(s) using the first rule that matches:
+
+1. `-A` / `--all-namespaces` — list every namespace with an AIPerf JobSet.
+2. `-j <job-id>` — resolve the AIPerfJob / AIPerfSweep / JobSet with that name and use its namespace. For an AIPerfSweep, select the current child or latest completed child; use `--variation` and optionally `--trial` to choose a different child explicitly. Prints a warning and returns without a report when the sweep has not exposed any child yet.
+3. `-n <namespace>` — use the given namespace verbatim.
+4. Fall back to the namespace recorded for the last benchmark deployed from this machine, or `default` if none is recorded.
+
+---
+
+## What It Collects
+
+For each target namespace, `debug` gathers five independent slices of cluster state and renders them as sections in the report. The collection is best-effort: a failing API call in one section does not prevent the others from being displayed.
+
+### 1. Pod problem map
+
+Every AIPerf pod in the namespace (selected by the `app.kubernetes.io/part-of=aiperf` label — `AIPerfLabels.SELECTOR` in `src/aiperf/kubernetes/constants.py` — or a narrower per-job selector when `-j` is set) is walked for container-status problems. See [`_extract_pod_info`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/cli_commands/kube/_debug_extract.py) — each container status is classified into one of:
+
+| State | Severity | Suggested action |
+|---|---|---|
+| `CrashLoopBackOff` | CRITICAL | Check logs for the root cause. |
+| `ImagePullBackOff` | CRITICAL | Verify the image name and registry access. |
+| `ErrImagePull` | CRITICAL | Check image name, tag, and pull secrets. |
+| `OOMKilled` (current or previous) | CRITICAL | Increase memory limits. |
+| `CreateContainerConfigError` | ERROR | Check ConfigMaps, Secrets, and volume mounts. |
+| `RunContainerError` | ERROR | Check security context and resource limits. |
+| Pending with a waiting `reason` (e.g. `ContainerCreating`, `PodInitializing`) | WARNING | Container is waiting for the given reason. |
+| `Unschedulable` (pod-level condition) | CRITICAL | Check node resources, taints/tolerations, and node selectors. |
+
+The report also shows each pod's `phase`, total restart count across init and app containers, and the node it landed on.
+
+### 2. Benchmark diagnostics
+
+When `-j` / `--job-id` targets a specific AIPerfJob, directly or by resolving
+an AIPerfSweep child, the operator-published
+`status.liveMetrics` is run through the detectors in
+[`benchmark_diagnosis.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/kubernetes/benchmark_diagnosis.py).
+These complement the pod problem map above: that section reports *container*
+faults, this one reports what the *benchmark* is doing.
+
+| Finding | Trips when | Threshold env var |
+|---|---|---|
+| `high_error_rate` | `error_count / request_count` exceeds the threshold | `AIPERF_K8S_DIAGNOSIS_HIGH_ERROR_RATE_THRESHOLD` (default `0.05`) |
+| `high_latency` | request-latency p99 exceeds N x the average | `AIPERF_K8S_DIAGNOSIS_HIGH_LATENCY_P99_MULTIPLIER` (default `10.0`) |
+| `stalled_pending` | phase is `Pending` for longer than the threshold | `AIPERF_K8S_DIAGNOSIS_STALLED_PENDING_THRESHOLD_SECONDS` (default `60`) |
+| `stalled_running` | phase is `Running` past the threshold with **zero** throughput **and** zero completed requests | `AIPERF_K8S_DIAGNOSIS_STALLED_RUNNING_THRESHOLD_SECONDS` (default `30`) |
+
+`stalled_running` deliberately requires both signals to be absent: throughput
+legitimately reads `0.0` between liveMetrics windows on a healthy run, so
+throughput alone would produce false alarms.
+
+The section is omitted entirely when nothing trips, and when no specific job is
+targeted (`-A` or a bare namespace), since the detectors need one CR's status.
+
+#### Worker-state source
+
+The operator copies worker counts from the controller pod's `/api/progress`
+response into `AIPerfJob.status.workers`. The API sidecar queries the
+SystemController's authoritative worker tracker for each response, so a sidecar
+that starts late or misses a pub/sub update still reports current data. The
+internal `/api/debug/pod-states` and `/api/debug/worker-startup-states`
+endpoints use the same snapshot and identify it with `source: controller`.
+During controller startup, shutdown, or an RPC timeout, both API paths fall
+back to their local bus-fed cache; the debug response then reports
+`source: cache`. The query timeout is controlled by
+`AIPERF_API_SERVER_GET_POD_STATES_TIMEOUT` (default `2.0` seconds).
+
+### 3. Namespace events
+
+Recent `Event` objects are fetched from the target namespace (CoreV1 `list_namespaced_event`) and sorted newest-first. By default `debug` shows up to 15 `Warning` events; with `-v` it widens to the 30 most-recent events of any type. See `_get_namespace_events` in `src/aiperf/cli_commands/kube/debug.py`.
+
+### 4. Node resources
+
+Cluster-wide node information is collected once per invocation (shared across all namespaces when `-A` is set). For each node the report shows:
+
+- Ready condition
+- CPU capacity and allocatable
+- Memory capacity and allocatable
+- `nvidia.com/gpu` capacity and allocatable (omitted when zero)
+- Any active pressure conditions: `MemoryPressure`, `DiskPressure`, `PIDPressure`
+
+See `_get_node_resources` in `src/aiperf/cli_commands/kube/debug.py`.
+
+### 5. Problem pod logs (verbose only)
+
+When `-v` is passed, `debug` calls `read_namespaced_pod_log` on every container of every pod flagged with at least one problem, tailing the last 20 lines. If the API call fails (pod deleted, container not yet started, RBAC denied), the report substitutes `<logs unavailable>` or `<error fetching logs>` and continues. See `_get_problem_pod_logs` in `src/aiperf/cli_commands/kube/debug.py`.
+
+---
+
+## Output Format
+
+`debug` renders a human-oriented Rich report to the terminal. Each namespace produces the same section sequence:
+
+1. `Diagnostic Report: <namespace>` header
+2. Pod overview table (pod, status, restarts, node, issues count)
+3. `Problems Found` list (or `No problems detected` on a clean namespace)
+4. `Warning Events` table (or `Recent Events` table under `-v`)
+5. `Node Resources` table
+6. `Problem Pod Logs` sections (only under `-v`, only for pods with problems)
+7. `Summary` footer (pod counts, warning-event count, nodes under pressure)
+
+The report is rendered by `_print_report` in `src/aiperf/cli_commands/kube/_debug_report.py`.
+
+`debug` does not currently emit machine-readable JSON. If you need structured output for automation, script against `kubectl get events`, `kubectl get pods -o json`, and `kubectl get aiperfjob -o json` directly.
+
+---
+
+## Triage Recipes
+
+The scenarios below are grouped by the symptom you'd see in `aiperf kube list`. Each one shows the exact command to run and what to look for in the output.
+
+### Pod OOMKilled mid-run
+
+Symptom: a worker pod restarts repeatedly; `list --watch` shows request-rate gaps.
+
+```bash
+aiperf kube debug -j aiperf-bench-7f2a -v
+```
+
+In the report:
+
+- **Problems Found** section — look for `OOMKilled` or `OOMKilled (previous)` rows. The pod name is in brackets.
+- **Summary** — `Nodes under pressure:` will list any node reporting `MemoryPressure`; if the OOM pod is pinned there, the node is the root cause rather than your memory request.
+- **Problem Pod Logs** — the last 20 lines usually show the allocation site (e.g. a large dataset load).
+
+Fix by raising the container's memory limit.
+
+### ImagePullBackOff on a fresh deployment
+
+Symptom: `aiperf kube list` shows the job in `Pending` for minutes; no worker pods have transitioned to `Running`.
+
+```bash
+aiperf kube debug -j aiperf-bench-7f2a
+```
+
+In the report:
+
+- **Problems Found** — `ImagePullBackOff` or `ErrImagePull` with container name.
+- **Warning Events** — the `Failed` event's `MESSAGE` column contains the actual registry error (unauthorized, manifest not found, network unreachable).
+
+Fix by correcting the image tag in the spec, adding an `imagePullSecrets` reference, or verifying that cluster nodes can reach the registry.
+
+### PVC binding failure
+
+Symptom: pods stuck in `Pending`, but there is no image error.
+
+```bash
+aiperf kube debug -n my-benchmark -v
+```
+
+In the report:
+
+- **Problems Found** — an `Unschedulable` entry on a pod, severity `CRITICAL`, with a message like `persistentvolumeclaim "aiperf-results" not found` or `0/4 nodes are available: pod has unbound immediate PersistentVolumeClaims`.
+- **Recent Events** (verbose) — the `FailedScheduling` events from the scheduler, repeated every few seconds.
+
+Fix by ensuring the StorageClass exists and a provisioner is running; see [configuration.md](./configuration.md#storage).
+
+### CrashLoopBackOff in the controller
+
+Symptom: `aiperf kube list` shows the job `Failed` within seconds of deploy.
+
+```bash
+aiperf kube debug -j aiperf-bench-7f2a -v
+```
+
+In the report:
+
+- **Problems Found** — the controller pod's container is in `CrashLoopBackOff`.
+- **Problem Pod Logs** — the tail almost always contains the Python traceback. Common causes: bad dataset URL, missing tokenizer HF token, invalid endpoint URL.
+
+Fix the config and redeploy. If the traceback mentions an AIPerf subsystem, cross-reference it against [ai-debugging-guide.md](./ai-debugging-guide.md).
+
+### Zero pods scheduled
+
+Symptom: `aiperf kube list` shows the job, but `kubectl get pods` in the namespace is empty.
+
+```bash
+aiperf kube debug -n my-benchmark -v
+```
+
+In the report:
+
+- **Pods table** — `No pods found` warning at the top.
+- **Recent Events** (verbose) — look for `JobSet` or `AIPerfJob` `Warning` events. Common causes: the operator failed to admit the CR (check the operator pod itself with `kubectl logs -n aiperf-system deploy/aiperf-operator`), or the JobSet hit a quota.
+- **Node Resources** — if every node reports `Ready: No` or pressure, the scheduler is refusing to place anything.
+
+Fix by correcting the CR, clearing quota, or resolving the node-level issue before redeploying.
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Report printed successfully. Note: `debug` exits `0` even when problems are found — the report is the payload. |
+| `0` | `-j <job-id>` was given, no job exists with that ID. A user-facing `No AIPerf job found with ID` error is printed and `debug` returns cleanly. |
+| `0` | `-A` was given and no namespace contained an AIPerf JobSet. A warning is printed. |
+| non-zero | Unrecoverable failure (kubeconfig missing, cluster unreachable, unexpected exception). The error is surfaced via the shared `cli_utils.exit_on_error("Error Running Diagnostics")` wrapper, which prints a red panel and propagates the cyclopts exit code. |
+
+If you are wrapping `debug` from a script and need to distinguish "ran clean, found problems" from "ran clean, no problems", parse the **Summary** section — specifically the `Pods: N total, M running, K with issues` line.
+
+---
+
+## See Also
+
+- [`aiperf kube attach`](./attach.md) — live progress stream for a running job.
+- [`aiperf kube preflight`](./getting-started.md) — pre-deploy checks that often prevent the failures `debug` diagnoses.
+- [AI Debugging Guide](./ai-debugging-guide.md) — structured troubleshooting recipes that use `debug` output as input.
+- Source: [`src/aiperf/cli_commands/kube/debug.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/cli_commands/kube/debug.py), [`_debug_extract.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/cli_commands/kube/_debug_extract.py), [`_debug_report.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/cli_commands/kube/_debug_report.py).

--- a/docs/kubernetes/direct-mode.md
+++ b/docs/kubernetes/direct-mode.md
@@ -1,0 +1,221 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Direct Mode (no operator)
+---
+
+# Direct Mode (no operator)
+
+Direct mode runs an AIPerf benchmark on Kubernetes without requiring the AIPerf
+operator (and the `AIPerfJob` CRD it owns) to be installed. The `aiperf kube`
+CLI instead creates the underlying Kubernetes resources — `Namespace`,
+`ConfigMap`, `Role`, `RoleBinding`, and `JobSet` — directly against the API
+server via `kubernetes_asyncio`.
+
+It is triggered explicitly with `--no-operator`:
+
+```bash
+aiperf kube profile --model Qwen/Qwen3-0.6B \
+    --url http://server:8000 --image aiperf:latest --no-operator
+```
+
+or automatically when `aiperf kube profile` detects that the `AIPerfJob` CRD
+is not installed on the cluster. The CLI prints which mode it chose:
+
+```
+AIPerfJob CRD detected, using operator mode
+# or
+AIPerfJob CRD not found, deploying directly (no operator)
+```
+
+## What direct mode is not
+
+Direct mode still uses:
+
+- The same container image (`--image`) and the same JobSet topology (one
+  controller pod plus N worker pods).
+- The same `ConfigMap` containing the run config.
+- The same per-namespace `Role` / `RoleBinding` that lets the controller pod
+  read and update its own run state.
+- The same live attach workflow (`aiperf kube attach`), which streams
+  WebSocket progress through a port-forward to the controller pod.
+
+What it does not use is the cluster-scoped operator Deployment, the
+`AIPerfJob` custom resource, and anything that lives on the operator side —
+dashboard UI, cross-job analytics, and the operator PVC that aggregates
+results across runs.
+
+You can still use an `AIPerfJob` YAML as the input to direct mode. The CLI
+projects its JobSet-compatible deployment fields into the raw manifests, so
+pod templates, scheduling, resource mode, failed-pod retention, image policy,
+and an authored TTL are preserved. Explicit benchmark and Kubernetes CLI flags
+overlay that YAML with the same precedence used in operator mode.
+
+## Trade-off matrix
+
+| Feature                                   | Operator mode                                       | Direct mode                                                                         |
+| ----------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Submission object                         | `AIPerfJob` CR                                      | `Namespace` + `ConfigMap` + `Role` + `RoleBinding` + `JobSet`                       |
+| Status surface                            | `AIPerfJob.status.phase` reconciled by the operator | `JobSet` + pod status only (`kubectl get jobset`, `kubectl get pods`)               |
+| Web dashboard (port 8081)                 | Served by operator Deployment                       | Not available                                                                       |
+| Analytics: leaderboard / compare / history | Served by operator (cross-job view over PVC)       | Not available (no cross-job storage)                                                |
+| Results persistence                       | Controller publishes to operator PVC (durable)      | Results live only on the controller pod's ephemeral volume + the inline sidecar     |
+| Automated TTL / cleanup                   | Operator reconciles terminal CRs and prunes them    | Relies on `JobSet.spec.ttlSecondsAfterFinished` (direct-mode default: 8 hours)      |
+| Preflight checks                          | Operator-side preflight before admitting the CR     | None automatically — run `aiperf kube preflight` yourself first                      |
+| Parameter sweeps and multi-run orchestration | `AIPerfSweep` + sweep-controller pod              | Not supported; `generate --no-operator` rejects these configs                        |
+| RBAC footprint                            | Cluster-scoped ServiceAccount for the operator      | Benchmark namespace only: one `Role` + `RoleBinding` per run                        |
+| Multi-user fairness (Kueue)               | Operator submits with Kueue labels end-to-end       | Supported — Kueue labels still flow through the `JobSet` spec                       |
+| `aiperf kube results` default path        | Pulls from the operator PVC (works post-pod-GC)     | Requires `--from-pods`; pulls from the controller pod while it's still alive        |
+| Concurrent benchmark isolation            | Operator reconciles; CR conflicts rejected          | CLI refuses to overwrite a `Running` or `Pending` same-named resource; you clean up |
+
+## When direct mode is appropriate
+
+Direct mode is the right choice when at least one of these holds:
+
+- You do not have cluster-admin rights and cannot install the AIPerf CRD or
+  the operator Deployment.
+- You are restricted to a single namespace (e.g. a tenant namespace in a
+  shared cluster) and your `RoleBinding` cannot grant cluster-wide access.
+- You are running a one-off ad-hoc benchmark and don't need cross-run
+  history, leaderboard, or compare views.
+- You're running a CI smoke test (`--detach`) against an ephemeral cluster
+  (kind, minikube, GitHub Actions kubernetes-in-docker) where installing the
+  operator per job is more overhead than the benchmark itself.
+
+Use operator mode when you need durable results across benchmark deletions,
+the dashboard or analytics UIs, or centralized multi-user job management.
+
+## End-to-end workflow
+
+The typical direct-mode run is three commands:
+
+```bash
+# 1. Deploy the benchmark. --no-operator forces direct mode; it is also
+#    picked automatically when the CRD is missing.
+aiperf kube profile \
+    --model Qwen/Qwen3-0.6B \
+    --url http://inference.example.com:8000 \
+    --image ghcr.io/nvidia/aiperf:v1.2.3 \
+    --total-workers 10 \
+    --concurrency 100 \
+    --namespace aiperf-bench \
+    --no-operator
+
+# 2. (Optional) If you detached, reattach any time before the JobSet TTL
+#    expires to stream progress.
+aiperf kube attach --namespace aiperf-bench
+
+# 3. Pull results off the controller pod BEFORE the JobSet TTL expires and
+#    the pod is garbage-collected. --from-pods is required in direct mode.
+#    --shutdown tells the controller API service to exit cleanly so the pod
+#    can terminate afterwards.
+aiperf kube results --from-pods --shutdown --namespace aiperf-bench
+```
+
+On a successful deploy the CLI prints a summary of the created resources,
+for example:
+
+```
+Created Namespace/aiperf-bench
+Created Role/aiperf-bench-benchmark-1a2b3c
+Created RoleBinding/aiperf-bench-benchmark-1a2b3c
+Created ConfigMap/aiperf-bench-benchmark-1a2b3c-config
+Created JobSet/aiperf-bench-benchmark-1a2b3c
+```
+
+## Dry-run inspection
+
+Preview the manifests without submitting them:
+
+```bash
+aiperf kube profile --model Qwen/Qwen3-0.6B \
+    --url http://server:8000 --image aiperf:latest \
+    --no-operator --dry-run > bench.yaml
+
+kubectl apply -f bench.yaml   # equivalent to what the CLI would have done
+```
+
+The memory estimate is written to stderr, so `bench.yaml` contains only the
+multi-document Kubernetes YAML and can be passed directly to `kubectl apply`.
+
+This is useful when your cluster requires a GitOps commit or a manual review
+before resources can be created.
+
+## Results retrieval
+
+In operator mode, `aiperf kube results` retrieves results from the operator's
+PVC — this works even after the benchmark pods have been garbage-collected.
+
+In direct mode there is no operator PVC. Results must be pulled via
+`--from-pods`, which:
+
+1. Port-forwards to the controller pod's API service and downloads the
+   exported artifacts (`metrics.json`, `profile_export_aiperf.json`,
+   console exports, parquet files, plus checkpoint data under
+   `--all`).
+2. Falls back to `kubectl cp` from the controller pod's shared `/results`
+   volume if the API service is not reachable.
+
+The controller pod runs a small results sidecar that serves those files from
+the shared `/results` volume (see `src/aiperf/kubernetes/results_sidecar.py`),
+so the files survive even after the main controller container exits.
+
+**The pod must still exist when you run `aiperf kube results --from-pods`.**
+The direct-mode JobSet sets `ttlSecondsAfterFinished` to 8 hours by default
+(`K8sEnvironment.JOBSET.DIRECT_MODE_TTL_SECONDS`, tunable via
+`AIPERF_K8S_JOBSET_DIRECT_MODE_TTL_SECONDS`), giving you a generous window
+before the pod is deleted. Pass `--ttl-seconds` on `profile` to override.
+
+## Cleanup
+
+Operator mode cleans up by deleting the `AIPerfJob` CR; the operator
+reconciles the deletion and removes all child resources.
+
+Direct mode has no CR, so cleanup is manual. Once results are safely pulled:
+
+```bash
+kubectl delete jobset <job-name>      -n <namespace>
+kubectl delete configmap <job-name>-config -n <namespace>
+kubectl delete role <job-name>        -n <namespace>
+kubectl delete rolebinding <job-name> -n <namespace>
+```
+
+Or, if you created a dedicated namespace for the run and don't need it
+anymore:
+
+```bash
+kubectl delete namespace <namespace>
+```
+
+The default `ttlSecondsAfterFinished` on the `JobSet` means completed pods
+will eventually be reaped automatically, but the `ConfigMap`, `Role`, and
+`RoleBinding` will stay until you delete them (they are cheap, but
+accumulate).
+
+## Limitations
+
+- **No cross-job analytics.** Leaderboards, compare views, and the run
+  history UI are all served by the operator over its PVC; none of them work
+  in direct mode.
+- **Results are lost if the pod is deleted before you run `results`.**
+  Set a longer `--ttl-seconds` on `profile` if you plan to pull results
+  well after the run finishes, and prefer running `results --from-pods
+  --shutdown` at the end of the workflow.
+- **No operator-side admission / validation.** The operator normally
+  validates specs, checks quota, and can reject malformed CRs before any
+  pod starts. Direct mode skips all of it — including the endpoint check
+  (`--skip-endpoint-check` is accepted for CLI parity but is a no-op here).
+  Run `aiperf kube preflight` and `aiperf kube validate` yourself before
+  submitting.
+- **No CR lifecycle reconciler.** `timeoutSeconds`, `resultsTtlDays`, `cancel`,
+  and `failurePolicy` require the operator and therefore do not take effect in
+  direct mode. JobSet-native `ttlSecondsAfterFinished` and `keepFailedPods`
+  still apply.
+- **No CR-level status.** `kubectl get aiperfjob` does not work. Use
+  `kubectl get jobset` and `kubectl get pods -l app.kubernetes.io/part-of=aiperf` (plus
+  `aiperf kube logs` and `aiperf kube list`) to observe the run.
+- **Existing resources with the same name.** Direct mode can safely reuse the
+  Namespace, but it refuses to adopt an existing Role, RoleBinding, ConfigMap,
+  or JobSet because there is no owner CR or immutable run UID that can prove
+  the resource belongs to the new invocation. Pass a unique `--name` or delete
+  all resources from the prior direct-mode run first.

--- a/docs/kubernetes/getting-started.md
+++ b/docs/kubernetes/getting-started.md
@@ -1,0 +1,673 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Getting Started on Kubernetes
+---
+
+# Getting Started with AIPerf on Kubernetes
+
+> **AI Agents (Claude, Copilot, Cursor, etc.):** For diagnosing failures, see the [AI Agent Debugging Guide](ai-debugging-guide.md).
+
+This guide walks you through benchmarking an NVIDIA Dynamo inference server on Kubernetes using AIPerf. By the end, you will have a cluster running, both operators installed, a benchmark executed against a Dynamo deployment, and your results downloaded.
+
+The same workflow applies to any OpenAI-compatible endpoint (vLLM, TRT-LLM, SGLang) -- just change the endpoint URL and model name.
+
+---
+
+
+## Preparing a cluster
+
+`aiperf kube setup` installs everything a cluster needs before its first
+benchmark. It is idempotent -- each step checks first, so re-running against a
+prepared cluster reports what is already there instead of failing.
+
+```bash
+# See what is missing without touching the cluster
+aiperf kube setup --dry-run
+
+# Install JobSet, the namespaces, and the AIPerf operator
+aiperf kube setup
+
+# Prerequisites only, with JobSet pinned
+aiperf kube setup --jobset-version v0.5.2 --skip-operator
+```
+
+It installs, in order: the **JobSet CRD** (AIPerf runs every benchmark as a
+JobSet), the **operator and benchmark namespaces**, and the **AIPerf
+operator** Helm chart that owns the AIPerfJob and AIPerfSweep CRDs. Point
+`--chart` at an alternate chart directory only when testing a customized
+operator chart; normal package installs use the chart bundled in the AIPerf
+wheel. A missing chart is fatal, so `setup` cannot report a ready cluster after
+skipping the operator. Follow it with `aiperf kube preflight` to confirm the
+cluster is ready. The CLI creates the resolved benchmark namespace first, then
+installs the chart with `benchmarkNamespace.create=false` and
+`benchmarkNamespace.name` set to that namespace. This lets Helm own the
+namespace-local benchmark RBAC without trying to adopt a namespace it did not
+create; `aiperf kube setup --namespace team-benchmarks` therefore prepares and
+authorizes `team-benchmarks`, not the chart's default namespace.
+
+## Cluster Setup
+
+If you already have a Kubernetes cluster with GPU nodes and `kubectl` configured, skip to [Prerequisites](#prerequisites).
+
+### Option A: Use an Existing Cluster
+
+Any Kubernetes v1.24+ cluster with NVIDIA GPUs works. You need:
+
+- `kubectl` configured to talk to the cluster
+- GPU nodes with the NVIDIA device plugin installed
+- Permissions to install CRDs and create namespaces
+
+Verify your connection:
+
+```bash
+kubectl cluster-info
+kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\\.com/gpu
+```
+
+If GPUs show up, skip to [Prerequisites](#prerequisites).
+
+### Option B: Create a Local Kind Cluster with GPU Passthrough
+
+[Kind](https://kind.sigs.k8s.io/) runs Kubernetes inside Docker containers on your local machine. With the NVIDIA container runtime configured as Docker's default, a Kind node can see the host's GPUs.
+
+**Host requirements:**
+- Docker with the NVIDIA container runtime as the default runtime
+- NVIDIA drivers installed on the host
+- `kind` CLI installed (`go install sigs.k8s.io/kind@latest` or [releases](https://kind.sigs.k8s.io/docs/user/quick-start/#installation))
+
+#### One-time Docker setup
+
+If you haven't already configured Docker for GPU passthrough:
+
+```bash
+# Enable volume-mount-based GPU injection
+sudo nvidia-ctk config --in-place \
+  --set accept-nvidia-visible-devices-as-volume-mounts=true
+
+# Set nvidia as the default Docker runtime
+sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+
+# Restart Docker to pick up changes
+sudo systemctl restart docker
+```
+
+Verify:
+
+```bash
+docker info 2>/dev/null | grep "Default Runtime"
+# Should show: Default Runtime: nvidia
+```
+
+#### Cluster setup
+
+Create the cluster:
+
+```bash
+kind create cluster --name aiperf
+```
+
+Install the NVIDIA device plugin so GPUs become an allocatable resource, and JobSet, which the AIPerf operator uses to run benchmark pods:
+
+```bash
+kubectl --context kind-aiperf apply -f \
+  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/deployments/static/nvidia-device-plugin.yml
+
+kubectl --context kind-aiperf apply --server-side -f \
+  https://github.com/kubernetes-sigs/jobset/releases/latest/download/manifests.yaml
+```
+
+Build the AIPerf image locally and load it into the Kind node so pods can pull it without a registry:
+
+```bash
+docker build -t aiperf:local .
+kind load docker-image aiperf:local --name aiperf
+```
+
+Verify GPUs are allocatable:
+
+```bash
+kubectl --context kind-aiperf get nodes \
+  -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}'
+# Should show: 1 (or more)
+```
+
+#### Teardown
+
+To delete the cluster when you are done:
+
+```bash
+kind delete cluster --name aiperf
+```
+
+---
+
+## Prerequisites
+
+At this point you should have:
+
+- A Kubernetes cluster with `kubectl` configured
+- GPU nodes with the NVIDIA device plugin
+- [JobSet](https://github.com/kubernetes-sigs/jobset) installed
+- [Helm](https://helm.sh/) v3 installed locally
+- AIPerf installed locally (`uv tool install aiperf`, or `uv sync` from a source checkout)
+- Access to NGC container registry (`nvcr.io/nvidia/ai-dynamo`)
+
+Run the preflight checker to verify:
+
+```bash
+aiperf kube preflight
+```
+
+---
+
+## Step 1: Install the Operators
+
+You need two operators: the **Dynamo operator** (manages inference servers) and the **AIPerf operator** (manages benchmarks).
+
+### Install the Dynamo Operator
+
+```bash
+# Install Dynamo platform (CRDs are bundled into the platform chart in v1.x)
+helm install dynamo-platform \
+  oci://nvcr.io/nvidia/ai-dynamo/dynamo-platform \
+  --version 1.1.0 \
+  --namespace dynamo-system \
+  --create-namespace \
+  --set dynamo-operator.webhook.enabled=false \
+  --set grove.enabled=false \
+  --set kai-scheduler.enabled=false
+```
+
+Verify the Dynamo operator is running:
+
+```bash
+kubectl get pods -n dynamo-system
+```
+
+### Install the AIPerf Operator
+
+```bash
+helm install aiperf-operator deploy/helm/aiperf-operator \
+  --namespace aiperf-system \
+  --create-namespace
+```
+
+For Kind clusters using a locally built image, override the image:
+
+```bash
+helm install aiperf-operator deploy/helm/aiperf-operator \
+  --namespace aiperf-system \
+  --create-namespace \
+  --set image.repository=aiperf \
+  --set image.tag=local \
+  --set image.pullPolicy=Never
+```
+
+Verify it is running:
+
+```bash
+kubectl get pods -n aiperf-system
+```
+
+You should see `2/2` containers ready by default (operator + results-server). With the optional Plotly dashboard enabled (`dashboard.enabled=true`), the count becomes `3/3` (operator + results-server + dashboard).
+
+---
+
+## Step 2: Deploy a Dynamo Inference Server
+
+Create a `DynamoGraphDeployment`. This example deploys Qwen3-0.6B in aggregated mode using the vLLM backend:
+
+```yaml
+# dynamo-server.yaml
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: dynamo-agg
+  namespace: dynamo-server
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: dynamo-agg
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+    VllmWorker:
+      dynamoNamespace: dynamo-agg
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        runtimeClassName: nvidia
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0
+          workingDir: /workspace/examples/backends/vllm
+          command: ["python3", "-m", "dynamo.vllm"]
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: DYN_SYSTEM_PORT
+              value: "9090"
+```
+
+Apply it:
+
+```bash
+kubectl create namespace dynamo-server
+kubectl apply -f dynamo-server.yaml
+```
+
+Wait for the server to be ready (model loading can take a few minutes):
+
+```bash
+# Watch pods until all are Running
+kubectl get pods -n dynamo-server -w
+```
+
+Verify the endpoint is healthy:
+
+```bash
+kubectl run curl-test --rm -it --restart=Never --image=curlimages/curl -- \
+  curl -s http://dynamo-agg-frontend.dynamo-server.svc:8000/v1/models
+```
+
+---
+
+## Step 3: Run Your First Benchmark
+
+Now benchmark the Dynamo server. The Dynamo endpoint URL follows the pattern `http://{deployment-name}-frontend.{namespace}.svc:8000/v1`:
+
+```bash
+aiperf kube profile \
+  --model Qwen/Qwen3-0.6B \
+  --url http://dynamo-agg-frontend.dynamo-server.svc:8000/v1 \
+  --image nvcr.io/nvidia/aiperf:latest \
+  --total-workers 10 \
+  --request-count 500 \
+  --concurrency 50 \
+  --streaming
+```
+
+On a Kind cluster with a locally built image, point `--image` at the loaded tag and disable pulling. Substitute the Service URL of whatever OpenAI-compatible endpoint you are testing against:
+
+```bash
+aiperf kube profile \
+  --model Qwen/Qwen3-0.6B \
+  --url http://my-endpoint.default.svc:8000 \
+  --image aiperf:local \
+  --image-pull-policy Never \
+  --total-workers 10 \
+  --request-count 200 \
+  --concurrency 5 \
+  --streaming
+```
+
+What happens:
+
+1. AIPerf builds an `AIPerfJob` custom resource from your flags
+2. Submits it to the cluster via the AIPerf operator
+3. The operator creates a ConfigMap, RBAC, and a JobSet with a controller pod and worker pods
+4. Workers send requests to the Dynamo frontend
+5. AIPerf attaches to the controller and streams live progress to your terminal
+
+You will see real-time output showing request throughput, latency percentiles, and progress.
+
+Press **Ctrl+C** to detach. The benchmark continues running in the cluster. To cancel it, run `aiperf kube cancel` or patch the CR directly:
+
+```bash
+kubectl patch aiperfjob <name> -n aiperf-benchmarks --type=merge -p '{"spec":{"cancel":true}}'
+```
+
+---
+
+## Step 4: Using a Config File
+
+For repeatable benchmarks, use an AIPerfJob YAML file. Generate a starter template:
+
+```bash
+aiperf kube init --output benchmark.yaml
+```
+
+Edit it for your Dynamo deployment:
+
+```yaml
+apiVersion: aiperf.nvidia.com/v1alpha1
+kind: AIPerfJob
+metadata:
+  name: dynamo-benchmark
+spec:
+  benchmark:
+    models:
+      - "Qwen/Qwen3-0.6B"
+    endpoint:
+      urls:
+        - "http://dynamo-agg-frontend.dynamo-server.svc:8000/v1"
+      streaming: true
+    datasets:
+      - name: main
+        type: synthetic
+        entries: 1000
+        prompts:
+          isl:
+            mean: 512
+            stddev: 0
+          osl:
+            mean: 128
+            stddev: 0
+    phases:
+      - name: warmup
+        kind: warmup
+        type: concurrency
+        concurrency: 10
+        requests: 20
+      - name: profiling
+        kind: profiling
+        type: concurrency
+        concurrency: 50
+        requests: 500
+```
+
+Validate the config before deploying:
+
+```bash
+aiperf kube validate benchmark.yaml
+```
+
+Run it:
+
+```bash
+aiperf kube profile --config benchmark.yaml --image nvcr.io/nvidia/aiperf:latest
+```
+
+Or apply it directly with kubectl (the operator picks it up automatically):
+
+```bash
+kubectl apply -f benchmark.yaml
+```
+
+---
+
+## Step 5: Disaggregated Inference
+
+Dynamo's disaggregated mode separates prefill and decode into different pods for better GPU utilization. To benchmark a disaggregated deployment:
+
+1. Deploy Dynamo in disaggregated mode (separate prefill and decode workers with KV cache transfer):
+
+```yaml
+# dynamo-disagg.yaml
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: dynamo-disagg
+  namespace: dynamo-server
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: dynamo-disagg
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: DYN_ROUTER_MODE
+              value: "kv"
+    VllmPrefillWorker:
+      dynamoNamespace: dynamo-disagg
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        runtimeClassName: nvidia
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0
+          workingDir: /workspace/examples/backends/vllm
+          command: ["python3", "-m", "dynamo.vllm"]
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--is-prefill-worker"
+            - "--connector"
+            - "kvbm"
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: DYN_KVBM_CPU_CACHE_GB
+              value: "1"
+    VllmDecodeWorker:
+      dynamoNamespace: dynamo-disagg
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        runtimeClassName: nvidia
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0
+          workingDir: /workspace/examples/backends/vllm
+          command: ["python3", "-m", "dynamo.vllm"]
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--is-decode-worker"
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: DYN_SYSTEM_PORT
+              value: "9090"
+```
+
+2. Benchmark it -- the endpoint URL changes to match the deployment name:
+
+```bash
+aiperf kube profile \
+  --model Qwen/Qwen3-0.6B \
+  --url http://dynamo-disagg-frontend.dynamo-server.svc:8000/v1 \
+  --image nvcr.io/nvidia/aiperf:latest \
+  --total-workers 20 \
+  --request-count 1000 \
+  --concurrency 100 \
+  --streaming
+```
+
+---
+
+## Step 6: View Results
+
+After the benchmark completes, retrieve your results:
+
+```bash
+aiperf kube results
+```
+
+This downloads the full results package including:
+
+- `profile_export_aiperf.json` -- Summary metrics (throughput, latency percentiles, TTFT, ITL)
+- `inputs.json` -- Dataset that was used
+- `server_metrics_export.json` -- Dynamo server metrics (frontend throughput, KV cache stats, component latencies)
+
+To retrieve results from a specific job:
+
+```bash
+aiperf kube results dynamo-benchmark
+```
+
+Results are stored on the operator's persistent volume by default, so `aiperf kube results` works even after benchmark pods are deleted. To retrieve directly from the benchmark pods instead (tries the controller API first, then falls back to `kubectl cp`):
+
+```bash
+aiperf kube results dynamo-benchmark --from-pods
+```
+
+### Dynamo Server Metrics
+
+When benchmarking Dynamo, AIPerf discovers and collects Prometheus metrics from pods with the `nvidia.com/metrics-enabled=true` label (or a recognizable inference-server image). By default discovery only searches the **benchmark job's own namespace** — the namespace the chart-provisioned benchmark RBAC can list pods in. If Dynamo runs in a different namespace (e.g. `dynamo-server`), set `server_metrics.discovery.namespace: dynamo-server` in the benchmark config **and** grant pod-read access there by adding that namespace to the chart's `serverMetricsDiscoveryNamespaces` value — a plain string entry binds the benchmark namespaces' `default` ServiceAccount, so benchmark pods running under a custom `podTemplate.serviceAccountName` need the `{namespace, serviceAccounts}` entry form (or a manual RoleBinding); see the [server-metrics guide](../server-metrics/server-metrics.md#kubernetes-auto-discovery) for the full RBAC prerequisite table and how to tune or disable discovery. Discovered metrics include:
+
+- **Frontend metrics** -- `dynamo_frontend_requests`, `dynamo_frontend_time_to_first_token_seconds`, `dynamo_frontend_inter_token_latency_seconds`, `dynamo_frontend_output_tokens`
+- **Component metrics** -- Per-worker `dynamo_component_requests`, `dynamo_component_kvstats_gpu_cache_usage_percent`, `dynamo_component_kvstats_gpu_prefix_cache_hit_rate`
+
+These are exported alongside the standard AIPerf metrics in the results package.
+
+---
+
+## Step 7: List and Manage Jobs
+
+See all benchmark jobs across namespaces:
+
+```bash
+aiperf kube list
+```
+
+```
+NAME                 NAMESPACE           PHASE      WORKERS  PROGRESS  THROUGHPUT  LATENCY  AGE
+dynamo-benchmark     aiperf-benchmarks   Completed  10       100%      142.3 rps   187ms    5m
+disagg-test          aiperf-benchmarks   Running    10       42%       98.1 rps    201ms    2m
+```
+
+Use `--wide` to see model and endpoint columns.
+
+Filter by status:
+
+```bash
+aiperf kube list --running
+aiperf kube list --completed
+aiperf kube list --failed
+```
+
+Watch jobs with live refresh:
+
+```bash
+aiperf kube list --watch
+```
+
+---
+
+## Web Dashboard
+
+The AIPerf operator includes a built-in web dashboard for monitoring benchmarks and analyzing results.
+
+Access it by port-forwarding to the operator:
+
+```bash
+kubectl port-forward -n aiperf-system deploy/aiperf-operator 8081:8081
+```
+
+Then open [http://localhost:8081](http://localhost:8081) in your browser.
+
+The dashboard provides:
+
+- **Dashboard** -- Overview with KPI cards, active jobs, and throughput trends
+- **Jobs** -- Sortable table of all benchmark jobs with phase filters
+- **Job Detail** -- Live metrics, charts, phase progress, and pod status for a single job
+- **Leaderboard** -- Rank benchmark runs by any metric
+- **Compare** -- Side-by-side comparison of multiple jobs
+- **History** -- Time-series charts showing metrics across runs
+- **Sweeps** -- AIPerfSweep listings and per-sweep variation drill-down
+
+Use Ctrl+K to quickly search and navigate between jobs and pages.
+
+---
+
+## Dynamo Deployment Modes
+
+| Mode | Description | Endpoint URL Pattern |
+|------|-------------|---------------------|
+| `agg` | Aggregated -- single workers handle prefill + decode | `http://dynamo-agg-frontend.dynamo-server.svc:8000/v1` |
+| `agg-router` | Aggregated with KV-aware routing | `http://dynamo-agg-router-frontend.dynamo-server.svc:8000/v1` |
+| `disagg` | Disaggregated -- separate prefill and decode workers | `http://dynamo-disagg-frontend.dynamo-server.svc:8000/v1` |
+
+### Backends
+
+Dynamo supports three inference backends. Change the worker image and command:
+
+| Backend | Image | Worker Command |
+|---------|-------|---------------|
+| vLLM | `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0` | `python3 -m dynamo.vllm` |
+| TRT-LLM | `nvcr.io/nvidia/ai-dynamo/trtllm-runtime:1.1.0` | `python3 -m dynamo.trtllm` |
+| SGLang | `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0` | `python3 -m dynamo.sglang` |
+
+---
+
+## Without the Operator
+
+If you cannot install the AIPerf operator (e.g., limited cluster permissions), AIPerf can deploy benchmarks directly using raw Kubernetes manifests. Use `--no-operator`:
+
+```bash
+aiperf kube profile \
+  --model Qwen/Qwen3-0.6B \
+  --url http://dynamo-agg-frontend.dynamo-server.svc:8000/v1 \
+  --image nvcr.io/nvidia/aiperf:latest \
+  --no-operator
+```
+
+This creates a Namespace, RBAC, ConfigMap, and JobSet directly. You lose operator features (automated monitoring, results storage, conditions) but the benchmark itself works the same way.
+
+To generate the manifests without applying them (useful for GitOps):
+
+```bash
+aiperf kube generate --no-operator \
+  --model Qwen/Qwen3-0.6B \
+  --url http://dynamo-agg-frontend.dynamo-server.svc:8000/v1 \
+  --image nvcr.io/nvidia/aiperf:latest \
+  > manifests.yaml
+```
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Check cluster readiness | `aiperf kube preflight` |
+| Generate config template | `aiperf kube init` |
+| Validate a config file | `aiperf kube validate benchmark.yaml` |
+| Run a benchmark | `aiperf kube profile --config benchmark.yaml --image <img>` |
+| Run without waiting | `aiperf kube profile ... --detach` |
+| Preview without deploying | `aiperf kube profile ... --dry-run` |
+| Attach to a running job | `aiperf kube attach` |
+| Diagnose a job | `aiperf kube debug` |
+| List all jobs | `aiperf kube list` |
+| Get results | `aiperf kube results` |
+| Get logs | `aiperf kube logs` |
+| Debug a stuck job | `aiperf kube debug` |
+
+---
+
+## Next Steps
+
+- [Deploy from a Source Checkout](source-checkout-deploy.md) -- Build and push AIPerf, install the operator with Helm, and run on a real cluster
+- [Kubernetes Configuration Reference](configuration.md) -- All CRD fields, deployment options, and config patterns
+- [Monitoring and Troubleshooting](monitoring.md) -- Watch, debug, and diagnose benchmark issues
+- [Production Deployments](production.md) -- CI/CD, Kueue scheduling, secrets, and GitOps workflows
+
+## Related Documentation
+
+- [YAML Config Reference](../tutorials/yaml-config.md) -- General AIPerf YAML configuration
+- [Sequence Length Distributions](../tutorials/sequence-distributions.md) -- ISL/OSL distribution configuration
+- [Architecture](../architecture.md) -- AIPerf internal architecture

--- a/docs/kubernetes/gpu-telemetry.md
+++ b/docs/kubernetes/gpu-telemetry.md
@@ -1,0 +1,277 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: GPU Telemetry on Kubernetes
+---
+
+# GPU Telemetry on Kubernetes
+
+This page documents how AIPerf collects GPU telemetry when running on Kubernetes: the dedicated
+`gpu-telemetry-manager` sidecar container, how DCGM endpoints are resolved, and the
+ingest path into the final benchmark report.
+
+For the general (non-Kubernetes) tutorial — Dynamo setup, DCGM Exporter container
+flags, pynvml mode, custom metrics CSVs, and console/dashboard output — see
+[`docs/tutorials/gpu-telemetry.md`](../tutorials/gpu-telemetry.md). This page
+focuses only on what is Kubernetes-specific.
+
+## Opt-out by default
+
+GPU telemetry is **on by default** for every `aiperf kube profile` run. The
+`GpuTelemetryConfig` in [`src/aiperf/config/gpu_telemetry.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/config/gpu_telemetry.py)
+defaults `enabled=True`, and the JobSet spec propagates that through
+`AIPerfJobSetSpec.gpu_telemetry_enabled` in
+[`src/aiperf/kubernetes/jobset.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/kubernetes/jobset.py).
+
+To skip the sidecar entirely — useful for non-GPU inference targets, CPU-only
+clusters, or clusters without a DCGM Exporter reachable at the pod level —
+pass `--no-gpu-telemetry`:
+
+```bash
+aiperf kube profile --model Qwen/Qwen3-0.6B ... --no-gpu-telemetry
+```
+
+When disabled, the controller pod omits the `gpu-telemetry-manager` container
+and the memory estimator drops its allocation (see `_estimate_gpu_telemetry`
+in [`src/aiperf/kubernetes/_memory_estimator/components.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/kubernetes/_memory_estimator/components.py)).
+
+## No auto-discovery — user supplies the DCGM URLs
+
+AIPerf does **not** discover the in-cluster DCGM Exporter service via the
+Kubernetes API. The candidate endpoint list is built entirely from two
+sources:
+
+1. **`Environment.GPU.DEFAULT_DCGM_ENDPOINTS`** — hard-coded defaults:
+   - `http://localhost:9400/metrics`
+   - `http://localhost:9401/metrics`
+
+   Inside the controller pod, `localhost` addresses point at the pod itself,
+   which never runs DCGM — so the defaults are effectively unreachable on
+   Kubernetes and exist only for parity with local Docker runs.
+
+2. **`--gpu-telemetry <urls...>`** — user-supplied URLs, appended to the
+   defaults in order (deduplicated) by `GPUTelemetryManager` in
+   [`src/aiperf/gpu_telemetry/manager.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/gpu_telemetry/manager.py).
+
+For a Kubernetes run you almost always need to pass at least one explicit URL
+pointing at a cluster-reachable DCGM Exporter Service:
+
+```bash
+aiperf kube profile \
+    --model Qwen/Qwen3-0.6B \
+    --url dynamo-frontend.inference.svc.cluster.local:8000 \
+    --gpu-telemetry \
+        http://dcgm-exporter.gpu-operator.svc.cluster.local:9400/metrics
+```
+
+The URL scheme prefix (`http://`) is optional. Bare `host:port` forms are
+normalized to `http://host:port` by `GPUTelemetryManager._normalize_dcgm_url`.
+
+There is **no `gpuTelemetry.*` section in the Helm chart**. Endpoint
+configuration is a per-run CLI flag, not a cluster-wide operator setting.
+
+## Sidecar container
+
+When `gpu_telemetry_enabled=True`, the JobSet builder injects a dedicated
+`gpu-telemetry-manager` container into the controller pod via
+`_create_optional_manager_containers` in
+[`src/aiperf/kubernetes/jobset_builder.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/kubernetes/jobset_builder.py).
+It runs the `GPUTelemetryManager` service from
+[`src/aiperf/gpu_telemetry/manager.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/gpu_telemetry/manager.py).
+
+| Property | Value | Source |
+|---|---|---|
+| Container name | `gpu-telemetry-manager` | `Containers.GPU_TELEMETRY_MANAGER` |
+| Service type | `gpu_telemetry_manager` | plugin registry (`plugins.yaml`) |
+| Health port | `8086` (`GPU_TELEMETRY_MANAGER_HEALTH`) | `_PortSettings` |
+| Default CPU request/limit | `25m` | `_K8sEnvironment.GPU_TELEMETRY_MANAGER` |
+| Default memory request/limit | `192Mi` | `_K8sEnvironment.GPU_TELEMETRY_MANAGER` |
+| Collection interval | `333ms` (~3Hz) | `Environment.GPU.COLLECTION_INTERVAL` |
+
+Override resource limits with environment variables on the operator (or on
+a direct-mode controller pod):
+
+- `AIPERF_K8S_GPU_TELEMETRY_MANAGER_CPU=500m`
+- `AIPERF_K8S_GPU_TELEMETRY_MANAGER_MEMORY=1Gi`
+
+The scrape interval applies to every DCGM endpoint and is overridable via
+`AIPERF_GPU_COLLECTION_INTERVAL`.
+
+## Ingest path into the benchmark report
+
+The sidecar scrapes each configured endpoint and accumulates records locally.
+Publishing happens once, coordinated by the lifecycle commands from
+`SystemController`:
+
+1. **`PROFILE_CONFIGURE`** — `GPUTelemetryManager` resolves endpoints,
+   probes reachability, and publishes a `TelemetryStatusMessage`
+   (including `endpoints_configured` / `endpoints_reachable`) back to the
+   controller.
+2. **`PROFILE_START`** — collectors initialize and begin periodic scrapes
+   at `COLLECTION_INTERVAL`.
+3. **`PhaseBaselineRequestMessage` (profiling phase boundary)** — the timing
+   service's phase publisher broadcasts this message; `GPUTelemetryManager`
+   handles it through `BaselineCollectorMixin.collect_baseline` and forces a
+   boundary scrape so counter/histogram deltas use a clean post-warmup
+   baseline instead of the pre-warmup reference captured at
+   `PROFILE_CONFIGURE`. Capture is best-effort — a failure is logged as a
+   warning, never fatal.
+4. **`PROFILE_COMPLETE`** — forces a final scrape, stops collectors, then
+   publishes exactly one `ProcessTelemetryResultMessage` containing the
+   accumulated `ProcessTelemetryResult`.
+5. **`SystemController._on_process_telemetry_result_message`** — receives the
+   published message (see
+   [`src/aiperf/controller/system_controller.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/controller/system_controller.py)),
+   stamps `endpoints_configured` / `endpoints_successful` onto the summary,
+   and stores the results for the unified export. `_check_and_trigger_shutdown`
+   waits for profile records, telemetry, and server metrics before triggering
+   final export and JobSet shutdown.
+6. **Export** — the accumulator's results are written into the top-level
+   `telemetry_data` block of `profile_export_aiperf.json` (shape shown in the
+   [general tutorial](../tutorials/gpu-telemetry.md#example-json-export))
+   and, separately, streamed per-record to `gpu_telemetry_export.jsonl`
+   via the `gpu_telemetry_jsonl_writer` plugin
+   (`src/aiperf/gpu_telemetry/jsonl_writer.py`).
+
+```mermaid
+sequenceDiagram
+    participant SC as SystemController
+    participant TM as TimingManager
+    participant GM as gpu-telemetry-manager
+    participant DCGM as DCGM Exporter(s)
+
+    SC->>GM: PROFILE_CONFIGURE
+    GM->>DCGM: probe each URL
+    GM-->>SC: TelemetryStatus (configured, reachable)
+    SC->>GM: PROFILE_START
+    loop every 333ms
+        GM->>DCGM: scrape /metrics
+        GM->>GM: accumulator.ingest(record)
+    end
+    TM-->>GM: PhaseBaselineRequestMessage (profiling boundary)
+    GM->>DCGM: boundary scrape
+    SC->>GM: PROFILE_COMPLETE
+    GM->>DCGM: final scrape
+    GM-->>SC: ProcessTelemetryResultMessage
+    SC->>SC: _check_and_trigger_shutdown
+    SC->>SC: unified export (JSON + JSONL)
+```
+
+## Recipes
+
+### Minimal Kubernetes run with one in-cluster DCGM endpoint
+
+```bash
+aiperf kube profile \
+    --model Qwen/Qwen3-0.6B \
+    --endpoint-type chat \
+    --endpoint /v1/chat/completions \
+    --streaming \
+    --url dynamo-frontend.inference.svc.cluster.local:8000 \
+    --concurrency 32 \
+    --request-count 1024 \
+    --gpu-telemetry \
+        http://dcgm-exporter.gpu-operator.svc.cluster.local:9400/metrics
+```
+
+### Multi-node DCGM
+
+Each node's dcgm-exporter DaemonSet typically exposes a per-node endpoint
+through a headless Service (one URL per node) or via a single Service that
+load-balances across nodes (one logical URL, aggregated). AIPerf treats
+each URL as an independent scrape target — supply them all:
+
+```bash
+--gpu-telemetry \
+    http://dcgm-node01.gpu-operator.svc.cluster.local:9400/metrics \
+    http://dcgm-node02.gpu-operator.svc.cluster.local:9400/metrics \
+    http://dcgm-node03.gpu-operator.svc.cluster.local:9400/metrics
+```
+
+GPU indices and hostnames in the exported report disambiguate metrics
+from different endpoints.
+
+### Disable on a CPU-only cluster
+
+```bash
+aiperf kube profile --model ... --no-gpu-telemetry
+```
+
+### Verify the sidecar is present
+
+After submitting the job, inspect the controller pod:
+
+```bash
+kubectl -n aiperf get pod -l aiperf.nvidia.com/job-id=<job-id> \
+    -o jsonpath='{.items[*].spec.containers[*].name}'
+```
+
+Look for `gpu-telemetry-manager` in the listed container names. If it is
+missing, the JobSet was built with `gpu_telemetry_enabled=False` — either
+`--no-gpu-telemetry` was passed or the CR spec was overridden.
+
+### Verify reachability from inside the controller pod
+
+```bash
+kubectl -n aiperf exec -c control-plane <controller-pod> -- \
+    curl -s -o /dev/null -w '%{http_code}\n' \
+    http://dcgm-exporter.gpu-operator.svc.cluster.local:9400/metrics
+```
+
+A `200` confirms the URL is reachable from the pod network. The
+`gpu-telemetry-manager` container will do the same probe during
+`PROFILE_CONFIGURE` and report the result via `TelemetryStatus`.
+
+## Troubleshooting
+
+### No `telemetry_data` in the exported report
+
+Either no endpoints were reachable, no records were produced before
+`PROFILE_COMPLETE`, or the sidecar was disabled. Check in order:
+
+1. Did the run include the `gpu-telemetry-manager` container?
+   (`kubectl get pod ... -o jsonpath='{.spec.containers[*].name}'`)
+2. Are the URLs resolvable from inside the controller pod network?
+   DNS must resolve the DCGM Service, and the pod's NetworkPolicy must
+   permit egress to the `:9400` target.
+3. The defaults `localhost:9400` / `localhost:9401` are always tried;
+   in-cluster they will fail probes silently — that is expected. Look
+   for the URL you passed via `--gpu-telemetry` in the status line.
+
+### Endpoints listed as configured but not as successful
+
+`ProcessTelemetryResult.summary.endpoints_configured` includes every URL
+attempted; `endpoints_successful` includes only those that responded during
+the configuration probe. A URL in the first but not the second means the
+probe failed — typically DNS, NetworkPolicy, or the exporter not listening
+on the expected path. DCGM Exporter serves `/metrics` by default; verify
+the path suffix matches.
+
+### Counter metrics look wrong (energy, XID, violations)
+
+Counter-style DCGM metrics are reported as deltas between the profiling
+boundary and final scrapes. If the phase-boundary baseline scrape fails
+for an endpoint, the delta for that endpoint will fall back to the
+pre-warmup baseline captured at `PROFILE_CONFIGURE`, so warmup activity
+leaks into the reported value. `BaselineCollectorMixin` logs
+`Baseline capture failed for phase '<name>' <kind>: ...` at WARN level
+when that happens — grep the `gpu-telemetry-manager` container logs for
+`Baseline capture failed`.
+
+### Memory estimator shows `disabled (no DCGM URLs)`
+
+The memory estimator reports zero GPU-telemetry memory usage when
+`gpu_telemetry.enabled=False` OR `gpu_telemetry.urls` is empty (defaults
+never count as URLs for estimation purposes — see
+`_derive_gpu_telemetry` in
+[`src/aiperf/kubernetes/_memory_estimator/params.py`](https://github.com/ai-dynamo/aiperf/blob/main/src/aiperf/kubernetes/_memory_estimator/params.py)).
+That is a display heuristic, not a runtime gate: the sidecar still runs
+and still tries the hard-coded defaults. To prevent it from running at
+all, use `--no-gpu-telemetry`.
+
+## See also
+
+- [`docs/tutorials/gpu-telemetry.md`](../tutorials/gpu-telemetry.md) — general (local) GPU telemetry tutorial, console/dashboard output, CSV and JSON schemas, pynvml mode
+- [`docs/kubernetes/configuration.md`](configuration.md) — resource overrides and operator environment variables
+- [`docs/kubernetes/sidecars.md`](sidecars.md) — other sidecar containers in the controller pod
+- [`docs/dev/kubernetes-flow.md`](../dev/kubernetes-flow.md) — lifecycle hooks and CR state flow

--- a/docs/kubernetes/init-and-generate.md
+++ b/docs/kubernetes/init-and-generate.md
@@ -1,0 +1,390 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Config Init and Manifest Generation
+---
+
+# Config Init and Manifest Generation
+
+AIPerf ships two offline commands that let you author benchmarks as files
+before touching a cluster:
+
+- `aiperf kube init` — scaffold a starter YAML config (an `AIPerfJob` CR
+  template) that you can edit by hand.
+- `aiperf kube generate` — render the finished Kubernetes manifests
+  (either an `AIPerfJob` CR or a raw `Namespace + RBAC + ConfigMap +
+  JobSet` bundle) to stdout or a file, with no cluster calls.
+
+Both commands are the foundation of a GitOps workflow: you commit the
+rendered YAML to a repo, open a PR for review, and then `kubectl apply`
+the reviewed file. No cluster access is required to run either command.
+
+## `aiperf kube init`
+
+### Purpose
+
+`init` renders one of the bundled AIPerf config templates
+(`src/aiperf/config/templates/`, the same library `aiperf config init`
+uses), wraps it in an `AIPerfJob` CR shell, and writes the result to
+stdout (or to a file with `--output`). The default template
+(`minimal`) covers only the required fields; commented-out blocks for
+deployment options, pod customization, and Kueue scheduling are
+appended to every template so you can uncomment what you need.
+
+### CLI reference
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `-t`, `--template` | `str` | `minimal` | Template name to render (e.g. `minimal`, `goodput_slo`). Run with `--list` to see all bundled templates. |
+| `-l`, `--list` | flag | `false` | List all available templates grouped by category. |
+| `-s`, `--search` | `str` | `None` | Search templates by keyword (matches name, description, tags, features). |
+| `-c`, `--category` | `str` | `None` | Filter template listings by category (substring match). |
+| `-v`, `--verbose` | flag | `false` | Show tags, features, and difficulty in template listings. |
+| `--model` | `str` | `None` | Override the model name in the generated config. |
+| `--url` | `str` | `None` | Override the endpoint URL in the generated config. |
+| `-o`, `--output` | path | `None` (stdout) | Output file path. When set, writes to disk; prompts before overwriting an existing file. |
+| `--job-name` | `str` | `my-benchmark` | Value for `metadata.name` on the generated `AIPerfJob`. |
+
+With no arguments, `init` renders the `minimal` template (bundled in
+`src/aiperf/config/templates/`) wrapped in an `AIPerfJob` CR shell. Use
+`--list` / `--search` / `--category` to browse the other bundled templates
+and `--template` to pick one.
+
+### Examples
+
+```bash
+# Print template to stdout (pipe it anywhere)
+aiperf kube init
+
+# Write to a file
+aiperf kube init --output benchmark.yaml
+
+# Write and confirm overwrite if benchmark.yaml already exists
+aiperf kube init -o benchmark.yaml
+```
+
+### Template walkthrough
+
+The scaffold is an `AIPerfJob` CR. Below is the template as emitted by
+`init`; usage comments at the top are substituted with the filename
+you wrote to (defaulting to `benchmark.yaml`).
+
+```yaml
+# AIPerf Kubernetes Benchmark - AIPerfJob Custom Resource
+#
+# Usage (CLI):
+#   aiperf kube profile --config benchmark.yaml --image <your-image>
+#
+# Usage (GitOps / operator):
+#   kubectl apply -f benchmark.yaml
+#
+# This file defines an AIPerfJob CR. When using the CLI, --image and other
+# Kubernetes flags are still required; benchmark config comes from this file.
+
+apiVersion: aiperf.nvidia.com/v1alpha1
+kind: AIPerfJob
+metadata:
+  name: my-benchmark
+spec:
+  #
+  # Minimal Configuration
+  # =====================
+  # The fastest way to benchmark a model. Uses shorthand forms that AIPerf
+  # auto-expands:
+  #   model:   -> models.items[0].name  (single string becomes a model list)
+  #   dataset: -> datasets[0]            (singular becomes a one-entry list named "default")
+  #   phases:  -> phases[0]              (single flat config becomes a one-entry list)
+  #
+  # Both snake_case and camelCase keys are accepted in all config files.
+  #
+  # Run: aiperf profile --config minimal.yaml
+
+  benchmark:
+    # "model:" is shorthand for models: { items: [{ name: ... }] }
+    model: meta-llama/Llama-3.1-8B-Instruct
+
+    endpoint:
+      url: http://localhost:8000 # Path auto-detected from endpoint type (chat -> /v1/chat/completions)
+
+    # "dataset:" (singular) is shorthand for datasets: [{name: default, ...}]
+    dataset:
+      type: synthetic
+      entries: 100
+      prompts:
+        isl: 512
+        osl: 128
+
+    # Flat "phases:" with a "type:" key is shorthand for phases: [{name: profiling, ...}]
+    phases:
+      type: concurrency
+      concurrency: 8
+      requests: 100
+
+  # === Deployment Options ===
+  # ttlSecondsAfterFinished: 300
+  # timeoutSeconds: 0
+  # resourceMode: burstable  # burstable (requests only, default), guaranteed (requests==limits), none (omit all)
+
+  # === Pod Customization ===
+  # podTemplate:
+  #   nodeSelector:
+  #     nvidia.com/gpu.product: "A100"
+  #   tolerations:
+  #     - key: nvidia.com/gpu
+  #       operator: Exists
+  #       effect: NoSchedule
+  #   imagePullSecrets:
+  #     - my-registry-secret
+  #   env:
+  #     - name: AIPERF_HTTP_CONNECTION_LIMIT
+  #       value: "200"
+  #   volumes:
+  #     - name: model-cache
+  #       persistentVolumeClaim:
+  #         claimName: model-cache
+  #   volumeMounts:
+  #     - name: model-cache
+  #       mountPath: /root/.cache/huggingface
+
+  # === Kueue Scheduling ===
+  # scheduling:
+  #   queueName: my-queue
+  #   priorityClass: high-priority
+```
+
+The `minimal` template uses AIPerf's shorthand forms — `model:` (scalar),
+`endpoint.url:`, `dataset:` (singular), and a flat `phases:` block — which
+AIPerf auto-expands to their canonical list forms at load time. Point
+`model:` and `endpoint.url:` at your real model and server before running
+anything else. A realistic edit looks like:
+
+```yaml
+benchmark:
+  model: meta-llama/Llama-3.1-8B-Instruct
+  endpoint:
+    url: http://llm-service.default.svc:8000/v1
+```
+
+To scaffold a different starting point (goodput SLOs, multi-phase load,
+etc.), pick another bundled template with `aiperf kube init --list` and
+`--template <name>`.
+
+### Relationship with other commands
+
+The file `init` writes is the same format accepted by every other
+config-consuming command:
+
+| Command | What it does with the file |
+| --- | --- |
+| `aiperf kube validate` | Parses and schema-checks the config without any cluster call. |
+| `aiperf kube generate` | Renders the final manifests from the config. |
+| `aiperf kube profile` | Applies and runs the benchmark on the cluster. |
+
+`aiperf kube preflight` is deliberately absent from that table: it does
+not read a config file at all. It takes only `--image`,
+`--endpoint-url`, and `--workers` (plus the shared namespace/kubeconfig
+flags) and probes the cluster with them.
+
+When invoking `profile` or `generate`, CLI flags for Kubernetes
+settings (`--image`, `--namespace`, `--total-workers`, etc.) still
+overlay the CR — the file owns the benchmark config, the flags own the
+deployment shape.
+
+## `aiperf kube generate`
+
+### Purpose
+
+`generate` renders the YAML that would otherwise be submitted by
+`profile`, and writes it to stdout. It does not connect to a cluster
+and does not require the AIPerf operator to be installed.
+
+It has two mutually exclusive modes:
+
+- `--operator` — emits one `AIPerfJob` CR document for a single run, or one
+  `AIPerfSweep` CR document when the config has `sweep:` or requests multiple
+  trials through `multiRun.numRuns > 1` / `multiRun.convergence`. Requires the
+  AIPerf operator to be installed on the target cluster for `kubectl apply` to
+  do anything useful.
+- `--no-operator` — emits multiple documents separated by `---`:
+  `Namespace`, `Role`, `RoleBinding`, `ConfigMap`, and `JobSet`. Works
+  on any cluster with the JobSet controller (no operator required). This mode
+  executes exactly one benchmark run; configs with `sweep:` or multi-run
+  orchestration must use `--operator` or `aiperf kube sweep`.
+
+One of the two flags must be specified; the command exits with an
+error if neither (or both) is given.
+
+### CLI reference
+
+`generate` accepts the full set of `aiperf` benchmark flags plus the
+`Kubernetes` / `KubeOptions` group. The mode flags are:
+
+| Flag | Description |
+| --- | --- |
+| `--operator` | Emit one `AIPerfJob` or `AIPerfSweep` CR, selected from the resolved config. |
+| `--no-operator` | Emit raw manifests (Namespace + Role + RoleBinding + ConfigMap + JobSet). |
+
+Relevant `KubeOptions` flags that shape the rendered manifests:
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--image` | config value, installed chart default (`--operator`), or `nvcr.io/nvidia/aiperf:latest` (`--no-operator`) | Explicit container-image override. An image authored in workload YAML remains authoritative when omitted. |
+| `--image-pull-policy` | `None` | `Always` / `IfNotPresent` / `Never`. |
+| `--name` | auto-generated | Human-readable DNS label, max 40 chars. |
+| `--namespace` | `aiperf-benchmarks` | Target namespace. |
+| `--total-workers` | `10` | Total workers; divided across pods by `workers_per_pod`. |
+| `--ttl-seconds` | `300`. In `--no-operator` mode, when the flag is not set explicitly, `generate` overrides the default to `AIPERF_K8S_JOBSET_DIRECT_MODE_TTL_SECONDS` (8h / 28800s) so pods stay alive for `aiperf kube results`. | Seconds to keep pods after completion. |
+| `--node-selector`, `--tolerations` | `{}`, `[]` | Pod placement. |
+| `--queue-name`, `--priority-class` | `None` | Kueue scheduling. |
+| `--annotations`, `--labels` | `{}` | Extra pod metadata. |
+| `--image-pull-secrets`, `--env-vars`, `--env-from-secrets`, `--secret-mounts`, `--service-account` | `[]` / `{}` / `None` | Secrets and credentials. |
+
+Output always goes to **stdout**. Redirect it to capture to a file; a
+memory-usage estimate is printed to **stderr** so it does not
+contaminate the YAML stream.
+
+### Examples
+
+```bash
+# Render an AIPerfJob CR (or AIPerfSweep for sweep/multi-run config)
+aiperf kube generate --operator \
+  --model Qwen/Qwen3-0.6B \
+  --url http://server:8000 \
+  --image aiperf:latest
+
+# Render raw manifests
+aiperf kube generate --no-operator \
+  --model Qwen/Qwen3-0.6B \
+  --url http://server:8000 \
+  --image aiperf:latest
+
+# Pipe straight to kubectl
+aiperf kube generate --no-operator \
+  --config benchmark.yaml --image aiperf:latest \
+  | kubectl apply -f -
+
+# Capture to disk for review
+aiperf kube generate --operator \
+  --config benchmark.yaml --image aiperf:latest \
+  > benchmarks/nightly-llama3.yaml
+```
+
+### What's in the rendered manifest
+
+Operator mode (`--operator`) emits one document:
+
+- `aiperf.nvidia.com/v1alpha1` `AIPerfJob` — for a single-run config, with
+  `spec.benchmark` holding the benchmark body and deployment fields (`image`,
+  `podTemplate`, `scheduling`, `workers`, etc.) at the top of `spec`.
+- `aiperf.nvidia.com/v1alpha1` `AIPerfSweep` — when the resolved config has a
+  parameter `sweep:` or needs multiple trials. A multi-run-only config receives
+  a one-cell `base` scenario so the sweep controller executes the canonical
+  trial plan without inventing a parameter dimension.
+
+Direct mode (`--no-operator`) emits, in order:
+
+Direct mode accepts only a single-run config. It fails before writing manifests
+when the resolved config requires parameter-sweep or multi-run orchestration,
+because a raw JobSet has no sweep-controller owner and would otherwise execute
+only the base cell.
+
+1. `v1` `Namespace` — always emitted first for the resolved `--namespace`
+   (default: `aiperf-benchmarks`). Applying this minimal manifest is
+   idempotent, so the complete generated stream also works when the target
+   namespace does not exist yet.
+2. `rbac.authorization.k8s.io/v1` `Role` — grants the controller pod:
+   full CRUD on `configmaps`; get/list/watch/create/delete on
+   `services` and `endpoints`; get/list/watch/create/patch on
+   `events`; read on `pods`, `pods/log`, and `jobs`; full CRUD on
+   `jobsets` with read on `jobsets/status`; and
+   get/list/watch/patch/update on `aiperfjobs` /
+   `aiperfjobs/status`.
+3. `rbac.authorization.k8s.io/v1` `RoleBinding` — binds the Role to
+   the pods' ServiceAccount (default: `default`).
+4. `v1` `ConfigMap` named `aiperf-<job_id>-config`, containing a single
+   key `run_config.json` with the fully materialized `BenchmarkRun`
+   (1 MiB hard cap — `generate` validates this before emitting).
+5. `jobset.x-k8s.io/v1alpha2` `JobSet` named `aiperf-<job_id>` — the
+   controller + worker + (optional) GPU telemetry + server-metrics
+   pods.
+
+Worker count is derived from the max phase concurrency and
+`connections_per_worker`; `generate` runs the same
+`apply_k8s_runtime_config` + `apply_worker_config` passes that
+`profile` uses, so the rendered JobSet has the correct number of
+replicas baked in.
+
+### GitOps recipe
+
+```bash
+# 1. scaffold (once)
+aiperf kube init -o benchmarks/nightly-llama3.yaml
+$EDITOR benchmarks/nightly-llama3.yaml
+
+# 2. render to a reviewable artifact
+aiperf kube generate --operator \
+  --config benchmarks/nightly-llama3.yaml \
+  --image aiperf:latest \
+  --total-workers 20 \
+  --namespace bench-prod \
+  > manifests/nightly-llama3.yaml
+
+# 3. commit + PR
+git add benchmarks/nightly-llama3.yaml manifests/nightly-llama3.yaml
+git commit -s -m "Add nightly Llama3 benchmark"
+# open PR, get reviews
+
+# 4. merge + apply
+kubectl apply -f manifests/nightly-llama3.yaml
+```
+
+The source config and the rendered manifest are both tracked; the
+rendered file is the one the cluster sees, so reviewers can inspect
+the exact JobSet spec, RBAC rules, and ConfigMap payload that will be
+applied.
+
+### Preview vs. `profile --dry-run`
+
+Both `generate` and `profile --dry-run` run entirely offline and
+neither submits anything to the cluster. The difference is output:
+
+| Behaviour | `aiperf kube generate` | `aiperf kube profile --dry-run` |
+| --- | --- | --- |
+| Cluster calls | None | None |
+| AIPerfJob CR output | Yes (`--operator`) | Yes (printed as JSON, operator path) |
+| Raw manifests output | Yes (`--no-operator`, YAML) | Yes (YAML, direct path / `--no-operator`) |
+| Memory estimate | Yes (stderr) | Yes (stderr) |
+| Intended use | Stable GitOps authoring and review | Exact preview of the corresponding `profile` path |
+
+Both commands keep stdout machine-readable and safe to pipe. Use `generate`
+when the YAML itself is the stable artifact you want to commit or diff. Use
+`profile --dry-run` to preview the exact operator or direct deployment path
+without actually running it.
+
+## Validation chain
+
+The typical end-to-end flow is:
+
+```mermaid
+flowchart LR
+    init[aiperf kube init] --> edit[Edit YAML]
+    edit --> validate[aiperf kube validate]
+    validate --> preflight[aiperf kube preflight]
+    preflight --> choice{GitOps?}
+    choice -- "Yes" --> generate[aiperf kube generate]
+    generate --> kubectl[kubectl apply -f ...]
+    choice -- "No" --> profile[aiperf kube profile]
+```
+
+Each step is independent and idempotent:
+
+1. **`init`** writes the starter file.
+2. **Edit** — adjust models, endpoint, phases, pod template.
+3. **`validate`** — schema-check the file; purely offline.
+4. **`preflight`** — verify cluster reachability and endpoint health.
+5a. **GitOps path**: **`generate`** → commit → `kubectl apply`.
+5b. **CLI path**: **`profile`** — deploy and stream progress directly.
+
+For long-lived recurring benchmarks that are reviewed and versioned,
+prefer the GitOps path. For ad-hoc experiments, run `profile`
+directly — it performs the same manifest generation under the hood.

--- a/docs/kubernetes/kueue.md
+++ b/docs/kubernetes/kueue.md
@@ -1,0 +1,305 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Kueue Integration
+---
+
+# Kueue Integration
+
+AIPerf integrates with [Kueue](https://kueue.sigs.k8s.io/) to provide
+gang-scheduling, quota management, and prioritization for benchmark JobSets.
+This page explains what Kueue buys you, how to install and configure it, and
+how AIPerfJobs bind to Kueue resources.
+
+---
+
+## What Kueue Is
+
+Kueue is a Kubernetes-native job queueing system maintained by the upstream
+`kubernetes-sigs` project. It sits between job controllers (JobSet, Job,
+`RayJob`, etc.) and the cluster scheduler, admitting workloads only when the
+cluster has enough free capacity in a named *ClusterQueue* (cluster-scoped
+quota pool) addressed through a *LocalQueue* (namespace-scoped handle). A
+workload either runs in full or stays suspended; Kueue never schedules a
+partial JobSet.
+
+Useful upstream entry points:
+
+- [Overview](https://kueue.sigs.k8s.io/docs/overview/)
+- [Concepts: ClusterQueue, LocalQueue, ResourceFlavor](https://kueue.sigs.k8s.io/docs/concepts/)
+- [JobSet integration](https://kueue.sigs.k8s.io/docs/tasks/run/jobsets/)
+- [Workload Priority Classes](https://kueue.sigs.k8s.io/docs/concepts/workload_priority_class/)
+
+---
+
+## Why Use Kueue With AIPerf
+
+An AIPerf benchmark runs as a JobSet of several coordinated pods: the
+controller, worker replicas, records manager, and optional telemetry
+sidecars. All pods must start together, or the controller sits idle while
+workers slowly trickle in and the benchmark either fails or produces
+misleading numbers.
+
+Kueue solves three problems that matter for benchmark campaigns:
+
+- **Gang scheduling.** Kueue suspends the JobSet until the cluster can admit
+  *every* pod at once. On a mixed cluster, this prevents a half-scheduled
+  run that would skew latency metrics.
+- **Priority and preemption across campaigns.** A
+  `WorkloadPriorityClass` lets a smoke-test job jump the queue ahead of a
+  long soak-test, or lets a tenant's urgent run preempt an idle reservation.
+- **Fair sharing across teams.** A single ClusterQueue with `borrowingLimit`
+  rules lets multiple namespaces share GPU capacity without one team
+  starving another — useful when several groups run benchmarks on the same
+  cluster.
+
+Without Kueue, AIPerfJobs are submitted directly to the JobSet controller
+and compete for nodes using default Kubernetes scheduling.
+
+---
+
+## Install
+
+AIPerf does not vendor or pin a Kueue release; install any version whose
+`kueue.x-k8s.io/v1beta1` API AIPerf targets (`LocalQueue`, `ClusterQueue`,
+`ResourceFlavor`, `WorkloadPriorityClass`). Follow the upstream
+[installation guide](https://kueue.sigs.k8s.io/docs/installation/). A typical
+install applies the released manifest bundle:
+
+```bash
+kubectl apply --server-side -f \
+  https://github.com/kubernetes-sigs/kueue/releases/latest/download/manifests.yaml
+```
+
+The `aiperf kube preflight` command verifies that the Kueue CRDs are
+present and that any referenced LocalQueue actually exists (see
+`src/aiperf/operator/preflight/_infra.py`). If Kueue is not installed and no
+queue was requested, the check is marked `SKIP` and AIPerfJobs run without
+gang-scheduling. If an explicit queue was requested, preflight fails because
+the resulting suspended JobSet would otherwise never be admitted.
+
+---
+
+## Configuring a ClusterQueue and LocalQueue
+
+A minimal setup for a benchmark cluster looks like this. Adjust the
+`nominalQuota` values to match your real GPU inventory.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: aiperf-cluster-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+    - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]
+      flavors:
+        - name: default-flavor
+          resources:
+            - name: "cpu"
+              nominalQuota: 256
+            - name: "memory"
+              nominalQuota: 1024Gi
+            - name: "nvidia.com/gpu"
+              nominalQuota: 16
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: aiperf-queue
+  namespace: aiperf-benchmarks
+spec:
+  clusterQueue: aiperf-cluster-queue
+```
+
+Optional: add a `WorkloadPriorityClass` for high-priority runs.
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: aiperf-high
+value: 1000
+description: "High-priority AIPerf benchmark runs"
+```
+
+---
+
+## Binding an AIPerfJob to a Queue
+
+There are three ways to route a job to a LocalQueue. All three ultimately
+set the `kueue.x-k8s.io/queue-name` label on the JobSet.
+
+### 1. CLI flags
+
+The `aiperf kube profile` command (and every other submit subcommand)
+accepts `--queue-name` and `--priority-class`:
+
+```bash
+aiperf kube profile \
+  --url http://my-server:8000/v1 \
+  --model Qwen/Qwen3-0.6B \
+  --queue-name aiperf-queue \
+  --priority-class aiperf-high
+```
+
+These flags live in the `Kubernetes Scheduling` group and are defined on
+`KubeOptions` in `src/aiperf/config/kube.py`.
+
+### 2. CR YAML
+
+Set the same fields directly in the AIPerfJob spec under `scheduling`:
+
+```yaml
+apiVersion: aiperf.nvidia.com/v1alpha1
+kind: AIPerfJob
+metadata:
+  name: latency-sweep-7f2a
+  namespace: aiperf-benchmarks
+spec:
+  scheduling:
+    queueName: aiperf-queue
+    priorityClass: aiperf-high
+  benchmark:
+    models: ["Qwen/Qwen3-0.6B"]
+    endpoint:
+      urls: ["http://dynamo-agg-frontend.dynamo-server.svc:8000/v1"]
+      streaming: true
+    datasets:
+      - name: main
+        type: synthetic
+        entries: 1000
+    phases:
+      - name: profiling
+        type: concurrency
+        concurrency: 50
+        requests: 500
+```
+
+### 3. Namespace default via Helm
+
+The `aiperf-operator` Helm chart exposes a `kueue.defaultQueueName` value
+(see `deploy/helm/aiperf-operator/values.yaml`). When set, the chart
+annotates the benchmark namespace with
+`kueue.x-k8s.io/default-queue-name`, and every AIPerfJob in that namespace
+is admitted through Kueue automatically — no per-job flag required.
+
+```yaml
+# values.yaml
+kueue:
+  defaultQueueName: aiperf-queue
+```
+
+The annotation is applied by
+`deploy/helm/aiperf-operator/templates/benchmark-namespace.yaml` when the
+chart creates the benchmark namespace.
+
+The chart can also provision the queue objects themselves instead of you
+applying the YAML above by hand. Set `kueue.createQueues=true` and the chart
+renders a `ResourceFlavor`, `ClusterQueue`, and `LocalQueue` from
+`deploy/helm/aiperf-operator/templates/kueue-queues.yaml`, using
+`kueue.flavorName`, `kueue.clusterQueueName`, `kueue.localQueueName`, and the
+`kueue.resources` quota map (`cpu`, `memory`, and an optional `gpu` entry that
+is skipped when empty). It is off by default so the chart renders on clusters
+without Kueue CRDs. When `defaultQueueName` is left empty and
+`createQueues=true`, the namespace annotation falls back to
+`kueue.localQueueName`.
+
+---
+
+## What the Operator Does
+
+```mermaid
+flowchart LR
+  CLI["aiperf kube profile<br/>--queue-name aiperf-queue"] --> CR["AIPerfJob CR<br/>spec.scheduling.queueName"]
+  CR --> OP["Operator<br/>handlers/create.py"]
+  OP --> JS["JobSet<br/>metadata.labels:<br/>kueue.x-k8s.io/queue-name<br/>spec.suspend: true"]
+  JS --> K["Kueue admission<br/>controller"]
+  K -->|admitted| RUN["spec.suspend: false<br/>pods scheduled"]
+  K -->|queued| WAIT["Workload pending<br/>quota unavailable"]
+  JS --> MON["Operator monitor<br/>Phase: QUEUED"]
+  RUN --> MON2["Operator monitor<br/>Phase: INITIALIZING"]
+```
+
+Concretely:
+
+1. `src/aiperf/kubernetes/jobset.py` translates
+   `spec.scheduling.queueName` and `priorityClass` into JobSet labels
+   (`kueue.x-k8s.io/queue-name`, `kueue.x-k8s.io/priority-class`) via
+   `KueueLabels` in `src/aiperf/kubernetes/constants.py`.
+2. When a `queueName` is set, the JobSet is created with
+   `spec.suspend: true`. Kueue unsuspends it once the `Workload` it
+   generates has been admitted.
+3. `src/aiperf/operator/handlers/monitor.py::_handle_kueue_suspension`
+   watches the JobSet's `spec.suspend` field. While the JobSet is suspended
+   and carries a Kueue queue label, the operator surfaces the
+   `QUEUED` phase on the AIPerfJob status (see `Phase.QUEUED` in
+   `src/aiperf/operator/status.py`).
+4. Once Kueue admits the workload, the JobSet unsuspends, pods start, and
+   the monitor transitions the phase to `INITIALIZING` -> `RUNNING`.
+
+You can observe admission directly with `kubectl`:
+
+```bash
+kubectl get workloads -n aiperf-benchmarks
+kubectl get aiperfjob latency-sweep-7f2a -n aiperf-benchmarks \
+  -o jsonpath='{.status.phase}'
+```
+
+---
+
+## Troubleshooting
+
+**Job stuck in `QUEUED` phase.** Kueue has accepted the Workload but has
+not admitted it. Check in order:
+
+1. `kubectl describe workload -n aiperf-benchmarks` — look at the
+   `QuotaReserved` and `Admitted` conditions. The message usually names
+   the resource that is over quota.
+2. `kubectl get clusterqueue aiperf-cluster-queue -o yaml` — compare
+   `spec.resourceGroups.*.nominalQuota` to what the JobSet requests.
+   Benchmark worker pods request the CPU and memory listed in the CR's
+   `podTemplate.resources`; see
+   [`configuration.md`](configuration.md) for defaults.
+3. Another admitted Workload may be holding the quota. List active
+   workloads with
+   `kubectl get workloads -A -o wide` and cancel stale ones.
+
+**Preflight fails: `Kueue LocalQueue '<name>' not found`.** The
+`--queue-name` flag references a LocalQueue that does not exist in the
+target namespace. Either create it (see the YAML above) or drop the flag.
+The preflight logic distinguishes "CRD missing" (`SKIP`) from "queue
+missing" (`FAIL`) in `_verify_kueue_local_queue`.
+
+**Preflight warns: `Kueue is installed but no queue configured`.** Kueue
+is present on the cluster but the job bypasses it. Fix by either passing
+`--queue-name`, setting `spec.scheduling.queueName` in the CR, or adding
+the namespace default:
+
+```bash
+kubectl annotate namespace aiperf-benchmarks \
+  kueue.x-k8s.io/default-queue-name=aiperf-queue
+```
+
+**`priorityClass` set but preemption never happens.** The
+`WorkloadPriorityClass` value must be *higher* than currently admitted
+workloads, and the ClusterQueue must enable preemption
+(`spec.preemption.reclaimWithinCohort` / `withinClusterQueue`). See the
+upstream
+[preemption guide](https://kueue.sigs.k8s.io/docs/concepts/preemption/).
+
+---
+
+## See Also
+
+- [`getting-started.md`](getting-started.md) — install the operator and
+  run your first job.
+- [`configuration.md`](configuration.md) — full AIPerfJob spec reference,
+  including the `scheduling` block.
+- [`production.md`](production.md) — multi-tenant and HA considerations.

--- a/docs/kubernetes/logs.md
+++ b/docs/kubernetes/logs.md
@@ -1,0 +1,267 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Logs
+---
+
+# Logs
+
+`aiperf kube logs` fetches or streams container logs from a specific
+AIPerfJob. It targets the controller pod's service containers, the
+per-pod worker / record-processor containers, and the sidecars that
+surround them. Use it for post-mortem triage of a finished run, for live
+streaming during an active benchmark, or for bulk-dumping every pod's
+log to disk.
+
+Unlike `aiperf kube debug`, which is a one-shot diagnostic snapshot
+across an entire namespace, `logs` targets a single AIPerfJob and
+operates at container granularity.
+
+---
+
+## CLI reference
+
+```bash
+aiperf kube logs [JOB_ID] [OPTIONS]
+```
+
+| Flag / argument | Type | Default | Description |
+|---|---|---|---|
+| `JOB_ID` (positional) | `str` | last-deployed job | AIPerfJob ID — or an `AIPerfSweep` name, when combined with `-v` — to pull logs from. If omitted, falls back to the job ID stored on disk by the most recent `aiperf kube profile` / `aiperf kube sweep` invocation. |
+| `--container` | `str` | *(all containers on every pod)* | Restrict to a single container name. See the [container catalog](#container-catalog) below. |
+| `-f`, `--follow` | flag | `false` | Stream logs in real time. Only one target can be followed at a time; see [follow semantics](#follow-semantics). |
+| `--tail` | `int` | *(full log)* | Return only the last N lines. Combine with `-f` to start a stream at the tail. |
+| `-o`, `--output` | `Path` | *(stdout)* | Write logs to a directory instead of printing. See [bulk dump](#bulk-dump-to-disk). |
+| `-v`, `--variation` | `int` | unset | When `JOB_ID` names an `AIPerfSweep`, the child variation index (`0`..`199`). Resolves to `<sweep>-v<idx:02d>`. |
+| `-t`, `--trial` | `int` | unset | Trial index (`0`..`9`) within a sweep variation, resolving to `<sweep>-v<idx:02d>-t<trial>`. Requires `-v`. |
+| `--namespace` | `str` | `aiperf-benchmarks` (or cached) | Namespace that holds the AIPerfJob. Composite flag from `KubeManageOptions`. |
+| `--kubeconfig` | `Path` | `$KUBECONFIG` / `~/.kube/config` | kubeconfig file to use. Composite flag from `KubeManageOptions`. |
+| `--kube-context` | `str` | current context | kubeconfig context to use. Composite flag from `KubeManageOptions`. |
+
+Job resolution works exactly like every other `aiperf kube` subcommand:
+if you omit `JOB_ID`, the CLI reads the last-benchmark cache
+(`~/.aiperf/last_kube_benchmark.json`) written by `aiperf kube profile`
+/ `aiperf kube sweep` and reuses that ID and namespace. `aiperf kube
+generate` does **not** write this cache — it never contacts the
+cluster. Supplying `--namespace` on the command line always overrides
+the cached namespace.
+
+---
+
+## Container catalog
+
+AIPerf pods run one process per container. Most names below are among the
+11 canonical container-name constants declared on
+`aiperf.kubernetes.constants.Containers` (see
+`src/aiperf/kubernetes/constants.py`); the `worker-<N>` and
+`record-processor-<N>` names are formed at runtime by indexing and are **not**
+declared constants. Feed any of them to `--container` verbatim.
+
+### Controller pod
+
+The controller pod runs nine containers:
+
+| Container | Purpose |
+|---|---|
+| `control-plane` | SystemController and orchestration logic. |
+| `event-bus-proxy` | XPUB/XSUB event-bus proxy sidecar. Isolates pub/sub forwarding from the SystemController event loop so large fan-ins of workers and record processors at startup do not starve the control plane. |
+| `dataset-manager` | Dataset generation and memory-map serving. |
+| `timing-manager` | Request scheduling and credit timing. |
+| `records-manager` | Metric record aggregation, export, and storage. |
+| `api` | HTTP + WebSocket API surface for monitoring, progress, and result artifacts. |
+| `results-sidecar` | Lightweight sidecar serving exported artifacts from `/results`; outlives the main controller on export so the operator can still download results. |
+| `gpu-telemetry-manager` | DCGM GPU metrics collection. Present only when GPU telemetry is enabled. |
+| `server-metrics-manager` | Prometheus server-side metrics scraping. Present only when server metrics are enabled. |
+
+### Worker pod
+
+Each worker pod runs three kinds of containers. The `<N>` indices are
+pod-local and start at `0`:
+
+| Container | Purpose |
+|---|---|
+| `worker-group-manager` | Per-pod worker-group lifecycle, dataset download, local inference proxy, raw-record upload coordination. One per pod. |
+| `worker-<N>` | One request-issuing worker. Count controlled by `workers_per_pod`. |
+| `record-processor-<N>` | One record processor. Count defaults to `workers_per_pod / RECORD_PROCESSOR_SCALE_FACTOR`. |
+
+### Deprecated name
+
+`worker-manager` is listed on `Containers` for backwards compatibility
+with older manifests; it is **not** placed on any pod rendered by the
+current `_JobSetManifestBuilder`. Passing `--container worker-manager`
+matches nothing and emits `No matching containers found`.
+
+---
+
+## Default behaviour (no `--container`)
+
+When `--container` is omitted, `aiperf kube logs` enumerates every pod
+that carries the AIPerf job label (`aiperf.nvidia.com/job-id=<JOB_ID>`)
+and prints the logs of **every container on every pod**, in the order
+the API returns them. For a default JobSet with `worker_replicas=N` and
+`workers_per_pod=W`, this fans out to:
+
+- the 7–9 controller-pod containers (depending on which optional
+  managers are enabled and whether the event-bus proxy sidecar is
+  configured), plus
+- `N * (1 + W + record_processors_per_pod)` worker-pod containers.
+
+For large benchmarks that total quickly runs to hundreds of containers,
+so you almost always want `--container` for interactive triage and
+`-o <dir>` for a full capture.
+
+---
+
+## Follow semantics
+
+```bash
+aiperf kube logs -f --container control-plane
+```
+
+The `-f/--follow` flag streams logs over a long-lived
+`read_namespaced_pod_log(follow=True)` connection and prints lines to
+stdout as they arrive. Key properties:
+
+- **Single-target streaming.** The implementation breaks out of the
+  target loop after the first streamed container (`if follow: break`).
+  If you pass `-f` and the resolved target list has more than one
+  entry, the CLI prints a warning of the form:
+
+  ```text
+  Follow mode streams one container at a time.
+  Showing controller-0/control-plane (9 targets total).
+  Use --container to select a specific container.
+  ```
+
+  and only the first target is followed.
+
+- **No auto-reattach.** When the underlying pod is deleted, restarted,
+  or evicted, the stream ends and the command returns. AIPerf does
+  not transparently reconnect; re-run the command.
+
+- **Tail-at-start is supported.** `-f --tail 200` begins the stream at
+  the last 200 buffered lines, then follows live.
+
+- **Ctrl+C** terminates the stream cleanly; the `finally` block
+  releases the underlying HTTP response so the connection does not
+  leak.
+
+---
+
+## Output format
+
+Output is plain UTF-8 text, one line per log record, with a short
+header per target:
+
+```text
+==> controller-0/control-plane <==
+<log line 1>
+<log line 2>
+...
+```
+
+Bytes that cannot be decoded as UTF-8 are replaced (`errors="replace"`)
+so a single corrupt line never aborts the stream. The format is
+intentionally close to `kubectl logs` so the output is easy to pipe
+into `grep`, `rg`, or a pager.
+
+---
+
+## Bulk dump to disk
+
+```bash
+aiperf kube logs <JOB_ID> -o ./triage-2026-04-22
+```
+
+With `-o <DIR>`:
+
+- The CLI creates `<DIR>/logs/` if it does not exist.
+- For every pod matching the job label, it shells out to
+  `kubectl logs -n <NAMESPACE> <POD_NAME> --all-containers=true --prefix`
+  (forwarding `--kubeconfig` / `--context` when set) and writes the
+  stdout to `<DIR>/logs/<POD_NAME>.log`.
+- On success, prints `Logs saved to <DIR>/logs/`.
+
+Notes on the bulk dump path specifically:
+
+- It writes **one file per pod**, not per container. Because
+  `--all-containers --prefix` is always passed, every container on the
+  pod is captured into that single file, with each line prefixed
+  `[pod/<pod>/<container>]` so you can split them apart afterwards.
+- It calls the local `kubectl` binary via `run_command`, so `kubectl`
+  must be on `PATH` and able to reach the cluster with the same
+  credentials the rest of the `aiperf kube` CLI uses.
+- `--follow`, `--container`, and `--tail` are **ignored** in
+  `--output` mode; the dump always captures the full buffered log of
+  each pod.
+
+---
+
+## Troubleshooting
+
+### `No pods found for job ID: <JOB_ID>`
+
+The job label selector (`app.kubernetes.io/part-of=aiperf,aiperf.nvidia.com/job-id=<JOB_ID>`)
+matched nothing in the namespace. Usually one of:
+
+- The job ID is wrong (typo, stale cache). Run `aiperf kube list` to
+  see live jobs.
+- The JobSet has already been garbage-collected by TTL. Check the
+  AIPerfJob CR phase with `aiperf kube list --watch`; once the CR and
+  its JobSet are removed, pod logs are gone from the API server.
+- `--namespace` points at the wrong namespace. The default is
+  `aiperf-benchmarks`.
+
+### `No matching containers found`
+
+Pods exist for the job but none of them have a container named
+`--container <NAME>`. Re-check the spelling against the
+[container catalog](#container-catalog). Common mistakes:
+
+- `worker` (not a real container name — workers are indexed:
+  `worker-0`, `worker-1`, ...).
+- `worker-manager` (deprecated compat name, not present on any pod).
+- `record-processor` without an index.
+
+### `Error getting logs: (400)` or `(404)`
+
+Raised by `kubernetes_asyncio` when the API server rejects the pod-log
+request. Typical causes:
+
+- The container has not started yet (status `ContainerCreating`,
+  `PodInitializing`, or stuck on image pull). Use
+  `aiperf kube debug <JOB_ID>` to see pod phases and events.
+- The pod was deleted between the list and the read call (race
+  between `follow` reconnects and TTL cleanup).
+- The container terminated and its log buffer was rotated out of the
+  kubelet cache — try `--previous`-style recovery via `kubectl logs
+  --previous` against the pod name directly.
+
+### RBAC denials
+
+Log reads require `pods/log` access in the target namespace. If the
+CLI prints `Error getting logs: (403)`, confirm your kubeconfig user
+or ServiceAccount has the verb; see
+[rbac-security.md](./rbac-security.md) for the roles the operator
+itself uses and a minimal user-side role for log access.
+
+### Empty output
+
+A container can legitimately produce zero log lines — for example, a
+short-lived worker that failed its startup probe before any handler
+ran. In follow mode the stream simply stays silent until the container
+writes or exits; in buffered mode the CLI prints a single empty line.
+Cross-check with `aiperf kube debug` and with container status
+(`Waiting` reason / exit code) to rule out a crashed pod versus a
+quiet one.
+
+---
+
+## Related commands
+
+- [`aiperf kube debug`](./debug-command.md) — one-shot namespace-wide
+  snapshot including pod phases, events, and recent log tails.
+- [`aiperf kube attach`](./attach.md) — stream live benchmark progress
+  over the controller's WebSocket instead of container logs.
+- [`aiperf kube list`](./workflow.md) — list live AIPerfJobs to
+  discover the ID you want to pass here.

--- a/docs/kubernetes/memory-estimator.md
+++ b/docs/kubernetes/memory-estimator.md
@@ -1,0 +1,512 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Memory Estimator
+---
+
+# Memory Estimator
+
+AIPerf ships a static memory estimator that predicts the peak and steady-state
+RSS of every pod in a Kubernetes deployment from the benchmark configuration.
+It is an **advisory** report: `aiperf kube generate`, `aiperf kube profile`, and
+the operator preflight all run it and surface its output, but none of them
+rewrite the pod's `resources` block from it. Actual requests/limits come from
+the `AIPERF_K8S_*` resource settings in `src/aiperf/kubernetes/environment.py`.
+
+If your `records-manager` OOMs at 500k concurrency, if workers get killed during
+ramp, or if you need to justify a resource bump — read this page first.
+
+---
+
+## Purpose
+
+The estimator answers three related questions:
+
+1. **Will this workload fit in the current memory limits?** Each `PodEstimate`
+   carries both the projected peak RSS and the configured K8s limit; the
+   `headroom_pct` / `at_risk` properties flag OOM risk before a job is
+   submitted.
+2. **What limits should I set?** `recommended_request_mib` (steady-state × 1.2)
+   and `recommended_limit_mib` (peak × 1.3) come straight off the estimate.
+3. **Where is the memory actually going?** Per-component breakdowns identify
+   whether `RecordsManager` growable arrays, `RecordProcessor` tokenizer caches,
+   or in-flight `Worker` records dominate — so tuning targets the right knob.
+
+The model is purely static: formulas are derived from code inspection and the
+constants were calibrated offline against real RSS measurements (see the
+provenance notes on each constant in
+`src/aiperf/kubernetes/_memory_estimator/constants.py`). No runtime profiling is
+required at estimate time.
+
+**Consumers of estimator output:**
+
+- `aiperf kube generate` — prints the full estimate to **stderr** (so stdout
+  stays a clean `kubectl apply -f -` stream) before emitting the manifests.
+- `aiperf kube profile` — prints the full estimate and warnings before
+  submitting the job.
+- Operator preflight (`src/aiperf/operator/preflight/_resources.py`) — runs the
+  estimator as the `Memory Estimation` check. If `estimate.warnings` is
+  non-empty the check returns `WARN` with `estimate.recommendations` as hints;
+  it does **not** fail or reject the job.
+
+---
+
+## Inputs
+
+All inputs are captured in `MemoryEstimationParams`
+(`src/aiperf/kubernetes/_memory_estimator/params.py`). They fall into four
+groups:
+
+### Topology
+
+| Field | Meaning |
+|---|---|
+| `total_workers` | Total worker processes across all pods. |
+| `workers_per_pod` | Worker processes per worker pod. |
+| `num_worker_pods` | Worker pod replica count (`ceil(total_workers / workers_per_pod)`). |
+| `record_processors_per_pod` | Record processors per worker pod (`workers_per_pod // RECORD_PROCESSOR_SCALE_FACTOR`). |
+
+### Load profile
+
+| Field | Meaning |
+|---|---|
+| `max_concurrency` | Peak in-flight request concurrency across all workers. |
+| `total_requests` | Total requests for the entire benchmark (sum across phases). |
+| `total_benchmark_duration_s` | Total benchmark wall-clock seconds. |
+
+### Dataset shape
+
+| Field | Meaning |
+|---|---|
+| `dataset_count` | Number of conversations pre-synthesized. |
+| `avg_isl_tokens` | Weighted-mean input sequence length in tokens. |
+| `avg_osl_tokens` | Weighted-mean output sequence length in tokens. |
+| `max_turns` | Maximum conversation turns (1 for single-turn). |
+| `streaming` | SSE vs. buffered-text responses (changes per-chunk accounting). |
+| `list_metric_backend` | `ragged` keeps every inter-chunk-latency value; `tdigest` uses one bounded sketch. Derived from `AIPERF_METRICS_LIST_BACKEND`. |
+
+### Observability
+
+| Field | Meaning |
+|---|---|
+| `num_gpus`, `gpu_sample_interval_s`, `num_gpu_metrics` | DCGM sampling shape. |
+| `num_server_metrics_endpoints`, `server_metrics_scrape_interval_s` | Prometheus scrape shape. |
+| `est_unique_metric_series`, `est_histogram_metrics`, `est_histogram_buckets` | Per-endpoint series cardinality. |
+| `num_models`, `num_standard_metrics`, `export_http_trace` | Per-RP tokenizer count, per-record metrics, trace export flag. |
+
+`MemoryEstimationParams.from_config(config, total_workers, workers_per_pod,
+connections_per_worker)` is the normal entry point: it derives all of the above
+from an `AIPerfConfig` plus three CLI flags.
+
+---
+
+## Per-component model
+
+Every per-process estimate returns a `ComponentEstimate` (see
+`src/aiperf/kubernetes/_memory_estimator/estimates.py`) with four numeric
+fields — `base_mib`, `variable_mib`, `peak_mib`, and a derived
+`steady_state_mib = base_mib + variable_mib`.
+
+Two universal baselines ride along on every process:
+
+- `_PYTHON_SUBPROCESS_BASE_MIB = 150` — interpreter + core libs + GC + every
+  module an AIPerf service loads (numpy, pandas, msgspec, pydantic, orjson,
+  aiohttp, ZMQ, asyncio). Calibrated from a real-cluster ISL/OSL sweep
+  (2026-04-30) to a ~150 MiB common baseline per container.
+- `_PYTHON_CHILD_SUBPROCESS_BASE_MIB = 150` — Worker/RP subprocesses are modeled
+  the same as the parent. Copy-on-write does not materially shrink the measured
+  working set (`container_memory_working_set_bytes` is per-container, and each
+  process's heap diverges quickly once it allocates per-task state).
+
+Each service adds a per-service overhead from `_SERVICE_BASE_MIB` (e.g.
+`records_manager: 40`, `dataset_manager: 30`, `worker: 12`,
+`record_processor: 10`).
+
+### RecordsManager
+
+Accumulates one metric record per request for the lifetime of the benchmark.
+The backing `ColumnStore` includes scalar metric columns, timestamp and
+metadata columns, categorical intern tables, and (for streaming runs) the
+list-valued `inter_chunk_latency` (ICL) metric. ICL is usually the dominant
+term when the default `ragged` backend retains every chunk gap.
+
+Source: `_estimate_records_manager`, `components.py`.
+
+For $N$ requests, $M$ standard metrics, dataset cardinality $D$, and average
+output length $O$:
+
+$$C = \max(1024, \text{ceil\_pow2}(N))$$
+$$\text{columns} = C \times \left((M - 1 + 3 + 4) \times 8\text{B} + 6 \times 4\text{B} + 2\text{B}\right) \times 1.05$$
+$$\text{intern} = (N + \min(N, D)) \times 136\text{B}$$
+
+The column counts match the current `MetricsAccumulator.process_record`
+layout: $M-1$ scalar metrics (the 25th standard metric is list-valued ICL),
+three request timestamps, four numeric metadata columns, six categorical
+`int32` code columns, and two boolean `uint8` columns. The intern term models a
+conservative request-unique `x_correlation_id` plus `conversation_id` values
+bounded by dataset cardinality.
+
+When streaming is enabled and `AIPERF_METRICS_LIST_BACKEND=ragged`:
+
+$$S = N \times \max(O - 1, 0)$$
+$$\text{ragged} = \max(1024, \text{ceil\_pow2}(S)) \times (8 + 4)\text{B} \times 1.05 + \max(256, \text{ceil\_pow2}(N)) \times 8\text{B}$$
+
+For $S > 0$, the first ragged term holds every ICL value as `float64` and its
+request index as `int32`; the second is the per-request `int64` offsets array.
+When $S = 0$, no ICL backend is created and the term is zero. Buffered
+responses also contribute no ICL storage. With
+`AIPERF_METRICS_LIST_BACKEND=tdigest`, the entire ICL term is a bounded 4 KiB
+sketch regardless of request count or OSL.
+
+The final variable estimate is `columns + intern + ICL + 1 MiB tracker`.
+
+Key constants:
+
+- `_FLOAT64_BYTES = 8` — numpy element width.
+- `_GROWABLE_ARRAY_OVERHEAD = 1.05` — wrapper-class overhead atop the
+  numpy-backed array (also reused by GPU-telemetry and server-metrics
+  arrays). The doubling-allocator waste is now captured separately
+  by `ceil_pow2(N)` in the capacity term, so this multiplier only covers the
+  ~0–2% wrapper overhead (dict of metric names, bucket tuple, sum tracker).
+- `_DEFAULT_NUM_STANDARD_METRICS = 25` — scalar metrics plus the one
+  list-valued ICL metric.
+- `_CATEGORICAL_INTERN_BYTES_PER_REQUEST = 136` — calibrated
+  high-cardinality string, dictionary slot, and integer-code footprint.
+- `ceil_pow2` rounds capacity up to the next power of two (the doubling
+  allocator's actual footprint, not the logical request count).
+
+**Peak** applies a 10% finalization overhead on top of variable. Tracker
+overhead (`WorkerProcessingStats` per worker) is a flat ~1 MiB.
+
+**Warning:** if `variable_mib > 500` the estimator flags the result. For a
+streaming ragged run, the warning also identifies
+`AIPERF_METRICS_LIST_BACKEND=tdigest` as the bounded-memory alternative and
+notes that its ICL percentiles are approximate.
+
+**Scales with:** `total_requests` (linearly rounded up to a power of two) and
+`num_standard_metrics`; with ragged streaming, it also scales with
+`total_requests × (avg_osl_tokens - 1)`.
+
+### DatasetManager
+
+Two memory regimes. During generation the full dataset is materialized as
+Pydantic `Conversation` objects; at steady state only the mmap index survives.
+
+Source: `_estimate_dataset_manager`, `components.py`.
+
+$$\text{bytes\_per\_turn} = 1500 + (\text{ISL} + \text{OSL}) \times 16$$
+$$\text{peak} = \text{base} + \text{dataset\_count} \times \text{max\_turns} \times \text{bytes\_per\_turn}$$
+$$\text{steady} = \text{base} + \text{dataset\_count} \times 16\text{B}$$
+
+Key constants:
+
+- `16 bytes/token` — effective token cost after Pydantic model wrappers
+  (~1 KiB per `Turn`), Python string headers, and the ~3x multiplier measured
+  against ISL=100K OSL=73K with 100 entries (~297 MiB PSS).
+- `_MMAP_INDEX_ENTRY_BYTES = 16` — per-conversation index entry at steady
+  state.
+
+**Scales with:** `dataset_count`, `max_turns`, `avg_isl + avg_osl`. Generation
+peak dominates; steady state is negligible.
+
+### Worker
+
+One process per worker. Memory = connection pool + in-flight request records
++ session cache (multi-turn only).
+
+Source: `_estimate_worker`, `components.py`. Shares the
+`_per_request_bytes(avg_isl, avg_osl, streaming)` helper with RecordProcessor
+so the two stay consistent.
+
+Per in-flight request:
+
+$$\text{per\_request} = \underbrace{504}_{\text{record base}} + \underbrace{(408 + \text{ISL} \times 4)}_{\text{turn}} + \text{response}$$
+
+Response depends on streaming mode:
+
+$$\text{response}_{\text{SSE}} = 136 + \text{OSL} \times 152 \qquad \text{response}_{\text{text}} = 152 + \text{OSL} \times 4$$
+
+Pod-level:
+
+$$\text{variable} = \text{pool} + \text{concurrency\_per\_worker} \times \text{per\_request} + \text{session\_cache}$$
+
+Key constants (`constants.py`):
+
+- `_REQUEST_RECORD_BASE_BYTES = 504` — `RequestRecord` (Pydantic `AIPerfBaseModel`) shell
+  (pympler-measured deep size of an empty record).
+- `_TURN_BASE_BYTES = 408`, `_TURN_BYTES_PER_TOKEN = 4`.
+- `_SSE_MESSAGE_BASE_BYTES = 136`, `_SSE_BYTES_PER_CHUNK = 152` — SSE per-token
+  cost is ~38x buffered text (152 B/chunk vs 4 B/token) because every chunk is
+  an `SSEField` object plus a short JSON string.
+- `_TEXT_RESPONSE_BASE_BYTES = 152`, `_TEXT_RESPONSE_BYTES_PER_TOKEN = 4`.
+- `_BYTES_PER_CONNECTION = 1024` — aiohttp per-connection kernel + userspace
+  buffers.
+
+Session cache activates when `max_turns > 1`: prior-turn prompts stay resident
+for the session duration.
+
+**Scales with:** `max_concurrency / total_workers`, `avg_osl`, streaming mode,
+`max_turns`, `connections_per_worker`.
+
+### RecordProcessor
+
+One process per RP; `record_processors_per_pod` copies live in each worker
+pod. Memory = tokenizer cache + in-flight records + raw-batch and
+export-batch buffers.
+
+Source: `_estimate_record_processor`, `components.py`.
+
+$$\text{variable} = \underbrace{\text{num\_models} \times 150}_{\text{tokenizer}} + \underbrace{\text{rp\_queue\_depth} \times \text{per\_record}}_{\text{inflight}} + \text{raw\_buf} + \text{export\_buf}$$
+
+Key constants:
+
+- `_TOKENIZER_CACHE_MIB = 150` — per distinct model (GPT-2 ~73 MiB, Llama-3
+  ~50–100 MiB, large SentencePiece models ~150 MiB).
+- `_RAW_BATCH_SIZE = 10`, `_EXPORT_BATCH_SIZE = 100`,
+  `_EXPORT_BYTES_PER_RECORD = 1100` (module-local in `components.py`).
+
+**Queue-depth amplification at high token counts** — the
+`_rp_queue_depth(conc_per_rp, isl, osl)` helper in `estimator.py` models the
+fact that tokenization becomes the bottleneck for ISL+OSL > 10K. Records pile
+up in the RP's unbounded ZMQ pull queue as fully deserialized Python objects:
+
+$$\text{rp\_queue\_depth} = \begin{cases} \text{conc\_per\_rp} \times \min\!\left(\tfrac{\text{ISL}+\text{OSL}}{10000}, 10\right) & \text{if ISL}+\text{OSL} > 10{,}000 \\ \text{conc\_per\_rp} & \text{otherwise} \end{cases}$$
+
+Calibrated against PSS: at ISL+OSL=173K the queue reaches ~150 records per RP
+(10x base). This is the mechanism by which large-token benchmarks OOM worker
+pods even at moderate concurrency.
+
+**Warnings:** triggers on `inflight_mib > 50` (high token pressure) or
+`tokenizer_mib > 450` (too many models loaded per RP).
+
+**Scales with:** `num_models`, `concurrency_per_rp` (amplified by token
+count), streaming mode, `avg_isl + avg_osl`.
+
+### ServerMetrics
+
+Prometheus scrape history, one time series per metric per endpoint, held in
+growable arrays identical in shape to RecordsManager.
+
+Source: `_estimate_server_metrics`, `components.py`.
+
+$$\text{scalar\_bytes} = \text{scalar\_count} \times \text{ceil\_pow2}(\text{n\_scrapes}) \times 16\text{B}$$
+$$\text{hist\_bytes} = \text{hist\_count} \times \text{ceil\_pow2}(\text{n\_scrapes}) \times (24 + \text{buckets} \times 8)\text{B}$$
+$$\text{variable} = \text{num\_endpoints} \times (\text{scalar} + \text{hist} + \text{fetch}) \times 1.05$$
+
+Key constants (`constants.py`):
+
+- `_DEFAULT_SCRAPE_INTERVAL_S = 5.0`
+- `_DEFAULT_UNIQUE_METRIC_SERIES = 200`,
+  `_DEFAULT_HISTOGRAM_METRICS = 20`,
+  `_DEFAULT_HISTOGRAM_BUCKETS = 10`.
+
+Returns zero if `num_endpoints == 0` (server metrics disabled).
+
+**Scales with:** `num_endpoints`, `duration_s / scrape_interval_s`,
+`unique_series`, `histogram_buckets`.
+
+### GPUTelemetry
+
+DCGM samples held as columnar numpy arrays, one per metric per GPU.
+
+Source: `_estimate_gpu_telemetry`, `components.py`.
+
+$$\text{per\_gpu\_bytes} = \text{ceil\_pow2}(\text{n\_samples}) \times 8 + \text{num\_metrics} \times \text{ceil\_pow2}(\text{n\_samples}) \times 8$$
+$$\text{variable} = \text{num\_gpus} \times \text{per\_gpu\_bytes} \times 1.05$$
+
+Key constants:
+
+- `_DEFAULT_GPU_METRICS = 12` (DCGM default set).
+- `gpu_sample_interval_s = 1.0` (default in `params.py`).
+- `_GROWABLE_ARRAY_OVERHEAD = 1.05` — applied as a single multiplier to the
+  total GPU telemetry footprint (same constant as RecordsManager). Note the
+  `formula` string this component reports still says `x 1.5`; the arithmetic
+  uses the constant, and the display string is stale.
+
+Returns zero if no DCGM URLs are configured.
+
+**Scales with:** `num_gpus`, `duration_s / sample_interval_s`,
+`num_gpu_metrics`.
+
+### Fixed-overhead services
+
+`SystemController`, `TimingManager`, `APIService`, `ResultsSidecar` (on the
+controller pod) and `WorkerGroupManager` (on each worker pod) all use
+`_estimate_fixed_service`: a flat `_SERVICE_BASE_MIB[name] +
+_PYTHON_SUBPROCESS_BASE_MIB` with `variable_mib = 0`. These do not scale with
+workload.
+
+Plus 3 ZMQ proxies at 5 MiB each (`_ZMQ_PROXY_MIB = 5`,
+`_NUM_ZMQ_PROXIES = 3`) on the controller pod.
+
+---
+
+## Output schema
+
+`estimate_memory(config, ...)` returns a `ClusterMemoryEstimate`:
+
+```
+ClusterMemoryEstimate
+├── params: MemoryEstimationParams        # echoed inputs
+├── controller: PodEstimate
+│   ├── components: list[ComponentEstimate]   # per-service breakdown
+│   ├── current_limit_mib: float              # configured K8s limit
+│   ├── replicas: int
+│   ├── total_steady_state_mib (property)
+│   ├── total_peak_mib (property)
+│   ├── recommended_request_mib (property)    # steady x 1.2
+│   ├── recommended_limit_mib (property)      # peak x 1.3
+│   ├── headroom_pct (property)
+│   └── at_risk (property)                    # headroom < 15%
+├── worker_pod: PodEstimate                   # single-pod, multiplied by replicas
+├── operator: PodEstimate                     # fixed 256 MiB
+├── warnings: list[str]                       # ordered by severity
+└── recommendations: list[str]                # actionable tuning suggestions
+```
+
+The `replicas` field on `worker_pod` is the number of worker pods; use
+`worker_pod.total_steady_state_mib * worker_pod.replicas` for the cluster-wide
+worker footprint.
+
+Every `ComponentEstimate` carries a `formula` string and a `dominant_factor`
+string for display purposes — `format_estimate()` in
+`formatting.py` renders the full human-readable report, which is what
+`aiperf kube profile` prints.
+
+---
+
+## OOM risk warnings
+
+The estimator attaches warnings at two layers.
+
+### Per-component (attached to `ComponentEstimate.warning`)
+
+| Component | Trigger | Message pattern |
+|---|---|---|
+| RecordsManager | `variable_mib > 500` | `"variable memory is X MiB ... consider reducing request count"` |
+| RecordProcessor | `inflight_mib > 50` | `"in-flight records use X MiB ... driven by <mode> ISL=... OSL=... at concurrency N"` |
+| RecordProcessor | `tokenizer_mib > 450` | `"tokenizer cache is X MiB ... consider reducing model count"` |
+
+`ComponentEstimate.warning` holds at most one string, so the two RecordProcessor
+triggers are mutually exclusive: when both conditions hold, the in-flight
+message wins and the tokenizer message is suppressed.
+
+### Per-cluster (appended to `ClusterMemoryEstimate.warnings`)
+
+| Warning | Trigger (constant) | Meaning |
+|---|---|---|
+| Controller pod at risk | `headroom_pct < 15%` (`_HEADROOM_WARNING_PCT`) | Peak is within 15% of limit; OOM likely. |
+| RecordsManager dominates controller | RM > 50% of controller limit (`_RECORDS_MANAGER_WARN_PCT`) | Request count is the single largest driver. |
+| Worker pod at risk | `headroom_pct < 15%` | Per-pod peak too close to limit. |
+| High request volume | `total_requests > 500_000` | Expect significant metric array storage. |
+| Many models per RP | `num_models * 150 > 450 MiB` | Tokenizer cache will dominate each RP. |
+| HTTP trace at scale | `export_http_trace and total_requests > 10_000` | Per-chunk trace data accumulates unboundedly. |
+| Multi-turn with heavy concurrency | `max_turns > 1 and sessions_per_worker > 100` | Session cache may grow significantly. |
+
+`recommendations` are built by `_build_recommendations(est)` — it prints the
+specific `recommended_limit_mib` values to bump to, or confirms that current
+limits have adequate headroom.
+
+---
+
+## How to run it
+
+### Programmatic
+
+```python
+import yaml
+
+from aiperf.config.config import AIPerfConfig
+from aiperf.kubernetes.memory_estimator import estimate_memory, format_estimate
+
+with open("bench.yaml") as fh:
+    config = AIPerfConfig.model_validate(yaml.safe_load(fh))
+
+est = estimate_memory(
+    config,
+    total_workers=10,
+    workers_per_pod=None,      # None = use config.runtime.workers_per_pod
+    connections_per_worker=200,
+)
+print(format_estimate(est))
+
+if est.controller.at_risk:
+    raise SystemExit(
+        f"Controller would OOM: need {est.controller.recommended_limit_mib} MiB, "
+        f"have {est.controller.current_limit_mib:.0f} MiB"
+    )
+```
+
+### Via CLI
+
+`aiperf kube profile` derives `MemoryEstimationParams.from_config(...)` from
+the rendered config and prints the full report — including per-pod tables,
+warnings, and recommendations — before any cluster resources are created.
+
+`aiperf kube generate` runs the same estimate and prints it to **stderr**
+before writing the manifests to stdout. The rendered manifests take their
+`resources.requests` / `resources.limits` from the `AIPERF_K8S_*` resource
+settings, not from `recommended_request_mib` / `recommended_limit_mib` — read
+the report, then set the env vars yourself if it says you need to.
+
+The operator preflight step (`src/aiperf/operator/preflight/_resources.py`)
+runs the estimator once more as the `Memory Estimation` check. Any estimator
+warning downgrades that check to `WARN` and attaches `recommendations` as
+hints; it never blocks admission.
+
+---
+
+## Tuning recipes
+
+### "My records-manager OOMs at 500k concurrency"
+
+1. Run `aiperf kube profile` and look at the `RecordsManager` row in the
+   Controller Pod table.
+2. If `RecordsManager uses N% of controller limit` appears in warnings, the
+   report's formula separates fixed `ColumnStore` columns, categorical intern
+   entries, and ICL storage. For streaming runs, ragged ICL scales as
+   `requests × (OSL - 1)` and can dominate by gigabytes.
+3. If exact ICL percentiles and ICL-aware sweep curves are not required, set
+   `AIPERF_METRICS_LIST_BACKEND=tdigest`. This bounds ICL aggregation to about
+   4 KiB while retaining exact count/sum/min/max/average/std and approximate
+   percentiles. Otherwise, provision for the ragged estimate.
+4. Bump `AIPERF_K8S_RECORDS_MANAGER_MEMORY` (and its CPU sibling) on the
+   operator to at least `recommended_limit_mib`. Controller resource keys are
+   listed in `CONTROLLER_RESOURCE_KEYS` in `aiperf.kubernetes.environment`.
+
+### "Workers OOM mid-ramp on a large-token workload"
+
+Check the RecordProcessor warning first. If `in-flight records use X MiB` fires
+with `ISL+OSL > 10_000`, you have hit the tokenization-queue-depth
+amplification — at ISL+OSL=173K the queue reaches 10x `conc_per_rp`. Options:
+
+- Increase `workers_per_pod` to drop concurrency-per-RP.
+- Increase `record_processors_per_pod` so each RP processes fewer records.
+- Bump the worker pod's memory limit via the estimator's
+  `recommended_limit_mib`.
+
+### "Tokenizer cache dominates each RP"
+
+Triggered by `num_models * 150 MiB > 450 MiB`. Either split models across
+separate AIPerfJob CRs (one model per benchmark) or accept the higher
+worker-pod memory limit — there is no per-process cache deduplication.
+
+### "The estimator disagrees with measured RSS"
+
+Constants are calibrated but static, and the calibration harness that produced
+them is not checked into this branch. Update the constants in
+`src/aiperf/kubernetes/_memory_estimator/constants.py` against your own
+measured RSS and record the provenance in the constant's comment the way the
+existing ones do; do not edit the formulas ad-hoc.
+
+---
+
+## References
+
+- Public API: `src/aiperf/kubernetes/memory_estimator.py`
+- Orchestrator: `src/aiperf/kubernetes/_memory_estimator/estimator.py`
+- Per-component formulas: `src/aiperf/kubernetes/_memory_estimator/components.py`
+- Calibration constants: `src/aiperf/kubernetes/_memory_estimator/constants.py`
+- Result dataclasses: `src/aiperf/kubernetes/_memory_estimator/estimates.py`
+- Param extraction: `src/aiperf/kubernetes/_memory_estimator/params.py`
+- Formatter: `src/aiperf/kubernetes/_memory_estimator/formatting.py`

--- a/docs/kubernetes/monitoring.md
+++ b/docs/kubernetes/monitoring.md
@@ -1,0 +1,442 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Monitoring and Troubleshooting
+---
+
+# Monitoring and Troubleshooting
+
+AIPerf provides several tools for monitoring running benchmarks, diagnosing problems, and retrieving logs. This guide covers how to use each one.
+
+---
+
+## Attaching to a Benchmark
+
+The `attach` command connects to a running benchmark via port-forward and streams live progress updates via WebSocket:
+
+```bash
+aiperf kube attach
+```
+
+This is what `aiperf kube profile` does automatically after deploying. Use `attach` to reconnect after detaching or from a different terminal.
+
+Attach to a specific job:
+
+```bash
+aiperf kube attach my-benchmark
+```
+
+Press **Ctrl+C** to cancel the benchmark. AIPerf sends a cancellation signal (`spec.cancel=true`) to the cluster, and the operator cleans up the resources.
+
+---
+
+## Listing Jobs
+
+See all benchmark jobs and their status:
+
+```bash
+aiperf kube list
+```
+
+```
+NAME                 NAMESPACE           PHASE      PROGRESS  AGE
+qwen3-benchmark      aiperf-benchmarks   Running    67%       3m
+llama-throughput      aiperf-benchmarks   Completed  100%      15m
+mistral-test         aiperf-benchmarks   Failed     0%        20m
+```
+
+### Filter by Status
+
+```bash
+aiperf kube list --running
+aiperf kube list --completed
+aiperf kube list --failed
+```
+
+### Wide Output
+
+Show additional columns like model name, endpoint, and error messages:
+
+```bash
+aiperf kube list --wide
+```
+
+### Live Refresh
+
+Watch the list with automatic updates:
+
+```bash
+aiperf kube list --watch
+aiperf kube list --watch --interval 10
+```
+
+---
+
+## Reading Logs
+
+Get logs from all pods associated with a benchmark:
+
+```bash
+aiperf kube logs
+```
+
+### Specific Job
+
+```bash
+aiperf kube logs my-benchmark
+```
+
+### Specific Container
+
+The controller pod runs `control-plane` (the SystemController) alongside per-service containers (`dataset-manager`, `timing-manager`, `records-manager`, `api`, `event-bus-proxy`, `results-sidecar`, and optionally `gpu-telemetry-manager` / `server-metrics-manager`). Worker pods run `worker-group-manager`. To see logs from a specific container:
+
+```bash
+aiperf kube logs --container control-plane
+```
+
+### Follow Logs in Real-Time
+
+```bash
+aiperf kube logs -f
+```
+
+### Last N Lines
+
+```bash
+aiperf kube logs --tail 100
+```
+
+### Save Logs to Files
+
+Save all pod logs to a directory (one file per pod):
+
+```bash
+aiperf kube logs --output ./my-logs
+```
+
+---
+
+## Debugging Failed Benchmarks
+
+The `debug` command runs a one-shot diagnostic analysis of your deployment:
+
+```bash
+aiperf kube debug -n aiperf-benchmarks
+```
+
+It inspects:
+
+- **Pod states** -- Identifies CrashLoopBackOff, OOMKilled, ImagePullBackOff, Unschedulable, and other problem states
+- **Kubernetes events** -- Shows recent warning events with suggestions
+- **Node resources** -- Reports CPU, memory, and GPU allocatable vs. capacity for each node
+- **Container logs** -- With `--verbose`, fetches recent logs from problem pods
+
+### Debug a Specific Job
+
+```bash
+aiperf kube debug --job-id my-benchmark
+```
+
+### Verbose Mode
+
+Includes container logs from pods with problems:
+
+```bash
+aiperf kube debug --job-id my-benchmark --verbose
+```
+
+### All Namespaces
+
+Scan every namespace that has AIPerf deployments:
+
+```bash
+aiperf kube debug --all-namespaces
+```
+
+### Sample Output
+
+```
+Diagnostic Report: aiperf-benchmarks
+
+POD                              STATUS    RESTARTS  NODE       ISSUES
+aiperf-bench-controller-0-0      Running   0         node-1     0
+aiperf-bench-worker-0-0          Running   3         node-2     1
+
+Problems Found
+[aiperf-bench-worker-0-0] OOMKilled (container: worker)
+  Suggestion: Container was killed due to out-of-memory. Increase memory limits.
+
+Node Resources
+NODE      READY  CPU      MEMORY      GPU  PRESSURE
+node-1    Yes    8/16     32Gi/64Gi   2/4  -
+node-2    Yes    4/8      8Gi/16Gi    1/2  MemoryPressure
+
+Summary
+Pods: 2 total, 2 running, 1 with issues
+Warning events: 3
+Nodes under pressure: node-2
+```
+
+---
+
+## Pre-Flight Checks
+
+Before deploying, validate that the cluster is ready:
+
+```bash
+aiperf kube preflight
+```
+
+This checks:
+
+- Cluster connectivity and API version
+- JobSet CRD installed
+- RBAC permissions in the target namespace
+- Resource quotas and node capacity
+- Image accessibility
+- Endpoint reachability (if specified)
+
+### With Specific Parameters
+
+```bash
+aiperf kube preflight \
+  --image nvcr.io/nvidia/aiperf:latest \
+  --endpoint-url http://my-server:8000 \
+  --workers 20 \
+  --namespace my-benchmarks
+```
+
+### JSON Output
+
+For CI/CD pipelines:
+
+```bash
+aiperf kube preflight -o json
+```
+
+Returns a structured JSON object with pass/fail/warn status for each check, suitable for automated gating.
+
+---
+
+## Retrieving Results
+
+After a benchmark completes, get the results:
+
+```bash
+aiperf kube results
+```
+
+By default this downloads the full results package from the operator's PVC storage (use `--from-pods` to pull from the benchmark pods instead). The results include:
+
+- `profile_export_aiperf.json` -- Summary metrics
+- `profile_export.jsonl` -- Per-request timing data
+- Server metrics and other exported files
+
+### From the Operator Storage
+
+Even after pods are deleted, results are stored on the operator's PVC. This is the default:
+
+```bash
+aiperf kube results my-benchmark
+```
+
+### Summary Only
+
+Download only the summary results (faster):
+
+```bash
+aiperf kube results --summary-only
+```
+
+### Direct From Pods
+
+If you want to fetch results directly from the running benchmark pods (tries the controller API first, falls back to `kubectl cp`):
+
+```bash
+aiperf kube results --from-pods
+```
+
+### Shut Down After Download
+
+Free up cluster resources by shutting down the API service after downloading (only takes effect with `--from-pods`):
+
+```bash
+aiperf kube results --from-pods --shutdown
+```
+
+### Save to Custom Directory
+
+```bash
+aiperf kube results --output ./my-results
+```
+
+---
+
+## Common Issues and Solutions
+
+### Expired Local Kubernetes Login
+
+When an interactive `aiperf kube` command receives HTTP 401 or a recognized
+`kubectl` logged-out response, it pauses and reloads the selected kubeconfig
+until your normal credential provider works again. Complete the usual login
+(for example, your OIDC, cloud, or access-proxy login) in another terminal.
+AIPerf does not launch the provider or request credentials itself. Press
+**Ctrl+C** to stop waiting.
+
+This behavior is limited to terminals with interactive input and output.
+Operator pods, in-cluster service accounts, redirected output, and CI fail
+immediately so unattended work cannot hang. HTTP 403 is also returned
+immediately because it means the authenticated identity lacks RBAC permission,
+not that the login expired. Missing credential-provider executables, malformed
+plugins, TLS failures, and unreachable API servers remain ordinary errors.
+
+### Pods Stuck in Pending
+
+**Symptom:** `aiperf kube list` shows `Pending` and pods never start.
+
+**Diagnosis:**
+```bash
+aiperf kube debug --job-id my-benchmark
+```
+
+**Common causes:**
+- Insufficient resources (CPU, memory, GPU) -- check node capacity in the debug output
+- Missing node selectors or tolerations -- pods may be targeting nodes that don't exist
+- Kueue quota exhausted -- check your ClusterQueue capacity
+
+In operator mode, inspect the durable startup diagnosis directly:
+
+```bash
+kubectl get aiperfjob my-benchmark \
+  -o jsonpath='{.status.startupIssue}{"\n"}{.status.conditions[?(@.type=="WorkersReady")]}{"\n"}'
+```
+
+Temporary capacity shortages, pending PVC binding, Kueue admission, and unknown
+scheduler reasons remain retryable even when `timeoutSeconds: 0`. Stable image,
+container-configuration, crash-loop, node-selector, untolerated-taint, and
+volume-affinity blockers fail only after the critical startup grace period.
+Tune warning and critical thresholds with
+`AIPERF_K8S_WATCHDOG_PENDING_THRESHOLD_SECONDS` and
+`AIPERF_K8S_WATCHDOG_PENDING_CRITICAL_THRESHOLD_SECONDS` on the operator
+container.
+
+### ImagePullBackOff
+
+**Symptom:** Pods fail with `ImagePullBackOff`.
+
+**Fix:** Verify the image exists and pull secrets are configured:
+```bash
+# Check preflight
+aiperf kube preflight --image your-image:tag
+
+# Add pull secrets
+aiperf kube profile ... --image-pull-secrets my-registry-secret
+```
+
+### OOMKilled
+
+**Symptom:** Worker pods restart with `OOMKilled` status.
+
+**Fix:** Reduce concurrency per worker pod so each pod uses less memory:
+```yaml
+spec:
+  connectionsPerWorker: 50    # reduce from default 100
+```
+
+Increasing per-pod memory requests/limits is done on the operator deployment via the `AIPERF_K8S_*` environment variables (see `values.yaml`).
+
+### Benchmark Timeout
+
+**Symptom:** Job transitions to `Failed` with timeout error.
+
+**Fix:** Increase or disable the timeout:
+```yaml
+spec:
+  timeoutSeconds: 3600    # 1 hour
+  # or
+  timeoutSeconds: 0       # no timeout
+```
+
+### Endpoint Unreachable
+
+**Symptom:** Operator reports endpoint health check failure.
+
+**Diagnosis:** Verify the Dynamo frontend is reachable from inside the cluster:
+```bash
+kubectl run curl-test --rm -it --image=curlimages/curl -- \
+  curl -s http://dynamo-agg-frontend.dynamo-server.svc:8000/v1/models
+```
+
+**Fix:** Ensure the Dynamo deployment is healthy (`kubectl get pods -n dynamo-server`), and the URL in your config uses the correct frontend service DNS name: `http://{deploy-name}-frontend.{namespace}.svc:8000/v1`.
+
+### Stale Namespaces
+
+If old benchmark namespaces are accumulating, the watchdog will warn you. Clean up with:
+
+```bash
+kubectl delete namespace aiperf-benchmarks-old
+```
+
+---
+
+## Web Dashboard
+
+The AIPerf operator includes a built-in web dashboard for comprehensive monitoring and analysis of your benchmarks.
+
+Access it by port-forwarding to the operator:
+
+```bash
+kubectl port-forward -n aiperf-system deploy/aiperf-operator 8081:8081
+```
+
+Then open [http://localhost:8081](http://localhost:8081) in your browser.
+
+### Dashboard Features
+
+- **Dashboard Tab** -- Overview with KPI cards, active jobs count, and throughput trends across all jobs
+- **Jobs Tab** -- Sortable table of all benchmark jobs with phase filters (Running, Completed, Failed)
+- **Job Detail Page** -- Live metrics, charts, phase progress bar, and pod status for a single job
+- **Sweeps Tab** -- Table of AIPerfSweeps with per-sweep drill-down (variation curves, Pareto, children)
+- **Launch Tab** -- Read-only YAML helper for scaffolding a manifest (copy-only; browser submission is disabled)
+- **Leaderboard Tab** -- Rank benchmark runs by any metric (throughput, latency percentiles, etc.)
+- **Compare Tab** -- Side-by-side comparison of multiple jobs to identify performance differences
+- **History Tab** -- Time-series charts showing how metrics evolve across all your benchmark runs
+
+See [Web Dashboard](dashboard-ui.md) for the full page-by-page reference.
+
+### Quick Navigation
+
+Use **Ctrl+K** to open the command palette and quickly jump to any job or page. Search by job name or view recent benchmarks.
+
+---
+
+## Operator Prometheus Metrics
+
+The kopf operator container exposes a Prometheus `/metrics` endpoint from an
+in-process daemon thread (`src/aiperf/operator/metrics.py`). The port is
+`AIPERF_METRICS_PORT` (`OperatorEnvironment.METRICS_PORT`, default **9090**; set
+to `0` to disable). This is separate from the results-server on 8081.
+
+```bash
+kubectl port-forward -n aiperf-system deploy/aiperf-operator 9090:9090
+curl http://localhost:9090/metrics
+```
+
+Exposed series:
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `aiperf_operator_handler_duration_seconds` | Histogram | `handler` | Wall-clock duration of each instrumented kopf reconcile handler. |
+| `aiperf_operator_handler_total` | Counter | `handler`, `outcome` | Reconcile-handler invocations by outcome (success / error / etc.). |
+| `aiperf_operator_completion_claim_races_total` | Counter | — | Lost `try_claim_completion` races (concurrent ticks contending for the completion claim). |
+
+Only kopf reconcile handlers are instrumented (via the `@track_handler("name")`
+decorator); helper functions are not.
+
+---
+
+## Related Documentation
+
+- [Getting Started](getting-started.md) -- First benchmark walkthrough
+- [Kubernetes Configuration](configuration.md) -- All CRD fields and deployment options
+- [Production Deployments](production.md) -- CI/CD, Kueue, and GitOps workflows

--- a/docs/kubernetes/preflight.md
+++ b/docs/kubernetes/preflight.md
@@ -1,0 +1,550 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Preflight Checks
+---
+
+# Preflight Checks
+
+Preflight checks validate that a Kubernetes cluster is ready to run an AIPerf benchmark
+before any resources are created. They surface common failure modes (missing CRDs,
+insufficient RBAC, exhausted quotas, malformed manifests) as explicit, actionable
+failures instead of cryptic pod errors an hour into a run.
+
+There are two entry points:
+
+- **`aiperf kube preflight`** — ad-hoc CLI check against the target cluster. Does not
+  require an AIPerfJob CR.
+- **Operator preflight** — runs on every `AIPerfJob` creation, before the operator
+  creates the ConfigMap, JobSet, Role, or RoleBinding. On any `FAIL`, the operator
+  sets the CR to `Failed` with a `PreflightPassed=False` condition and does not create
+  resources.
+
+Both share the same `CheckResult` / `CheckStatus` / `PreflightResults` shapes
+(`src/aiperf/kubernetes/preflight.py`). The check sets differ because each has
+different inputs: the CLI knows only what the user passed on the command line; the
+operator has the full resolved deployment spec.
+
+## Tiered execution
+
+The operator runs checks in tiers. Later tiers only run if earlier tiers pass —
+no point probing node capacity if the cluster is the wrong Kubernetes version.
+See `src/aiperf/operator/preflight/_checker.py:88` (`OperatorPreflightChecker.run_all`).
+
+```mermaid
+flowchart TD
+    T1[Tier 1: Cluster compatibility<br/>K8s version, JobSet CRD]
+    T2[Tier 2: RBAC permissions]
+    T3[Tier 3+: Concurrent checks<br/>infra, resources, workload]
+    Admit[Admit: create ConfigMap and JobSet]
+    Reject[Reject: CR set to Failed<br/>PreflightPassed=False]
+
+    T1 -->|all pass| T2
+    T2 -->|pass| T3
+    T3 -->|no FAIL| Admit
+    T1 -->|any FAIL| Reject
+    T2 -->|FAIL| Reject
+    T3 -->|any FAIL| Reject
+```
+
+Tier 1 and Tier 2 are sequential and short-circuit: the first failing check aborts the
+whole run. Tier 3+ checks are fanned out with `asyncio.gather` and all results are
+collected regardless of individual failures — users see every problem in one pass
+rather than fix-and-retry whack-a-mole.
+
+The whole sequence is bounded by `AIPERF_PREFLIGHT_TIMEOUT` (default 30 s,
+`src/aiperf/operator/environment.py:306`). A timeout is reported as a synthetic
+`Preflight Timeout` check with status `WARN` — a slow apiserver must not
+permanently fail a job when the aggregate deadline fires before individual checks
+can complete (see `_checker.py:154-168`).
+
+## Operator vs. CLI invocation
+
+| Aspect | Operator (`OperatorPreflightChecker`) | CLI (`CLIPreflightChecker`) |
+|---|---|---|
+| Trigger | `kopf.on.create` for `AIPerfJob` | `aiperf kube preflight` |
+| Inputs | Fully resolved `DeploymentConfig`, `KubernetesDeployment`, `AIPerfConfig` | CLI flags only |
+| Check count | 19 | 13 |
+| On FAIL | CR → `Failed`, `kopf.PermanentError` raised | CLI exits 1, JSON output on stdout if `-o json` |
+| Source | `src/aiperf/operator/preflight/_checker.py` | `src/aiperf/kubernetes/preflight.py:CLIPreflightChecker` |
+
+## Status values
+
+Every check produces one of five statuses (`CheckStatus`,
+`src/aiperf/kubernetes/preflight.py`):
+
+| Status | When |
+|---|---|
+| `pass` | Check confirmed the cluster meets the requirement. |
+| `fail` | Check confirmed a blocking problem. Operator rejects the CR; CLI exits 1. |
+| `warn` | Potential problem or non-blocking concern (e.g. quota close to limit, tainted-node mismatch). Does not block. |
+| `skip` | Check not applicable (e.g. no nodeSelector set, no secrets referenced, Kueue not installed). |
+| `info` | Informational only — value reported, no pass/fail judgment (e.g. external endpoint URL was parsed but cannot be dialled from the CLI). |
+
+## CLI command
+
+```
+aiperf kube preflight [OPTIONS]
+```
+
+| Flag | Type | Default | Purpose |
+|---|---|---|---|
+| `-i`, `--image` | string | unset | Container image to inspect. Enables image-registry and pull-secret checks. |
+| `--image-pull-secret`, `--image-pull-secrets` | string (repeatable) | unset | Image pull secret name to verify and associate with the image check. Repeat for multiple names. |
+| `--secret`, `--secrets` | string (repeatable) | unset | Referenced Kubernetes secret name to verify. Repeat for multiple names. |
+| `-e`, `--endpoint-url` | string | unset | LLM endpoint URL to probe. Enables the endpoint-connectivity check (cluster-service lookup for `*.svc` URLs; informational for external URLs). |
+| `-w`, `--workers` | int | 1 | Planned worker pod count. Used to project CPU and memory requirements against node capacity and namespace quotas. |
+| `-o`, `--output` | `text`\|`json` | `text` | Output format. `text` prints rich-formatted progress; `json` prints only the machine-parseable `PreflightResults` dict on stdout (all logging is suppressed to `WARNING`). |
+
+Composite flags inherited from `KubeManageOptions` — `--namespace`, `--kubeconfig`,
+`--kube-context` — resolve connection and namespace identically to every other
+`aiperf kube` subcommand.
+
+Source: `src/aiperf/cli_commands/kube/preflight.py`.
+
+### Example: JSON output
+
+```bash
+aiperf kube preflight \
+    --namespace aiperf-benchmarks \
+    --image nvcr.io/nvidia/aiperf:25.04 \
+    --image-pull-secret nvcr-creds \
+    --secret endpoint-api-key \
+    --endpoint-url http://vllm.models.svc.cluster.local:8000 \
+    --workers 8 \
+    -o json
+```
+
+```json
+{
+  "passed": true,
+  "has_warnings": true,
+  "checks": [
+    {
+      "name": "Cluster Connectivity",
+      "status": "pass",
+      "message": "Connected to Kubernetes cluster",
+      "details": [],
+      "hints": [],
+      "duration_ms": 42.1
+    },
+    {
+      "name": "Kubernetes Version",
+      "status": "pass",
+      "message": "Kubernetes v1.29.3 (1.24+ required)",
+      "details": [],
+      "hints": [],
+      "duration_ms": 18.0
+    },
+    {
+      "name": "RBAC Permissions",
+      "status": "pass",
+      "message": "All 8 required permissions granted",
+      "details": ["  ✓ create configmaps", "  ✓ get pods"],
+      "hints": [],
+      "duration_ms": 210.6
+    },
+    {
+      "name": "Resource Quotas",
+      "status": "warn",
+      "message": "Benchmark may exceed resource quota(s)",
+      "details": ["ResourceQuota 'team-quota':", "    cpu: 40 / 64"],
+      "hints": ["Request a quota increase or reduce worker count"],
+      "duration_ms": 33.2
+    }
+  ]
+}
+```
+
+## Check catalog — Tier 1 (blocking, cluster compatibility)
+
+### Cluster Connectivity (CLI only)
+
+- **Validates**: `client.VersionApi.get_code()` succeeds against the cluster.
+- **Source**: `src/aiperf/kubernetes/preflight_checks.py:check_cluster_connectivity`
+- **Fails if**: kubeconfig missing, cluster unreachable, TLS error, or auth rejected
+  in a noninteractive session. In an interactive terminal, a recognized expired
+  login pauses while AIPerf reloads kubeconfig until the normal external login is
+  completed; press **Ctrl+C** to stop waiting. HTTP 403 still fails immediately.
+- **Fix**: set `KUBECONFIG`, check `~/.kube/config`, complete the usual credential-
+  provider login, and verify VPN/tunnel and RBAC.
+
+This check is implicit for the operator (the operator is already in-cluster by the
+time handlers run). On CLI failure, the remaining checks are skipped.
+
+### Kubernetes Version
+
+- **Validates**: `major.minor >= 1.24` per `MIN_K8S_MAJOR`/`MIN_K8S_MINOR`
+  (`src/aiperf/operator/preflight/_common.py`).
+- **Source**: `src/aiperf/operator/preflight/_tier1.py:_check_kubernetes_version`,
+  `src/aiperf/kubernetes/preflight_checks.py:check_kubernetes_version`
+- **Fails if**: cluster runs Kubernetes < 1.24.
+- **Fix**: upgrade the control plane. Older versions lack JobSet support and
+  sub-resource patch semantics the operator depends on.
+
+### JobSet CRD
+
+- **Validates**: `jobset.x-k8s.io/v1alpha2` CRD is registered and responds to
+  `list_cluster_custom_object` (operator) or `read_custom_resource_definition` (CLI).
+- **Source**: `src/aiperf/operator/preflight/_tier1.py:_check_jobset_crd`,
+  `src/aiperf/kubernetes/preflight_checks.py:check_jobset_crd`
+- **Fails if**: the CRD is not installed (HTTP 404).
+- **Fix**: install JobSet per the install-hint emitted in the failure message.
+  Example: `kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/download/v0.5.2/manifests.yaml`.
+
+## Check catalog — Tier 2 (blocking, RBAC)
+
+### RBAC Permissions
+
+- **Validates**: every `(verb, resource, group)` in `OPERATOR_RBAC_PERMISSIONS`
+  (operator) or `REQUIRED_RBAC_PERMISSIONS` (CLI) resolves `allowed=true` via
+  `SelfSubjectAccessReview`.
+- **Source**: `src/aiperf/operator/preflight/_tier1.py:_check_rbac_permissions`,
+  `src/aiperf/kubernetes/preflight_checks.py:check_rbac_permissions`,
+  `src/aiperf/operator/preflight/_common.py:OPERATOR_RBAC_PERMISSIONS`
+- **Fails if**: any permission probe returns `allowed=false` or raises. Error message
+  lists every missing permission as `<verb> <group>/<resource>`.
+- **Fix**: bind a Role or ClusterRole granting the listed verbs on the namespace.
+  The operator Helm chart installs these by default
+  (`deploy/helm/aiperf-operator/templates/clusterrole.yaml` and
+  `benchmark-rbac.yaml`); the benchmark-pod Role is also built in code by
+  `RBACSpec._RULES` in `src/aiperf/kubernetes/resources.py`.
+
+Operator permission set (15 verbs over 8 resources): configmaps, roles,
+rolebindings, pods, pods/log, events (all core / rbac), jobsets, jobsets/status
+(jobset group). CLI requires a subset of 8.
+
+## Check catalog — Tier 3 (concurrent, infra)
+
+### Namespace (CLI only)
+
+- **Validates**: target namespace exists, or the user can create it.
+- **Source**: `src/aiperf/kubernetes/preflight_checks.py:check_namespace`
+- **Status**:
+  - `pass` — namespace exists, or 404 + create permission granted.
+  - `fail` — namespace missing and no create permission.
+  - `warn` — namespace missing and create-permission probe itself failed.
+- **Fix**: create the namespace, or have an admin do so.
+
+### JobSet Controller
+
+- **Validates**: a deployment containing `"jobset"` in its name exists in
+  `jobset-system` and has `ready_replicas > 0`.
+- **Source**: `src/aiperf/operator/preflight/_infra.py:_check_jobset_controller`,
+  `src/aiperf/kubernetes/preflight_checks.py:check_jobset_controller`
+- **Status**:
+  - `pass` — deployment found and ready.
+  - `warn` — deployment found but not ready.
+  - `warn` — deployment not found (CLI: `fail`).
+  - `skip` — cannot list `jobset-system` (403).
+- **Fix**: `kubectl get pods -n jobset-system` to diagnose; reinstall the JobSet
+  controller if missing.
+
+### Service Account (operator only)
+
+- **Validates**: if `spec.podTemplate.serviceAccountName` is set, the named service
+  account exists in the target namespace.
+- **Source**: `src/aiperf/operator/preflight/_infra.py:_check_service_account`
+- **Status**:
+  - `skip` — no custom service account configured (operator uses default).
+  - `pass` — service account exists.
+  - `fail` — 404 on `read_namespaced_service_account`.
+- **Fix**: `kubectl create serviceaccount <name> -n <namespace>`.
+
+### DNS Resolution
+
+- **Validates**: a deployment containing `"coredns"` in its name exists in
+  `kube-system` and is ready. Workers resolve the controller's DNS name for ZMQ
+  connections, so a broken DNS plane is a silent killer.
+- **Source**: `src/aiperf/operator/preflight/_infra.py:_check_dns`,
+  `src/aiperf/kubernetes/preflight_checks.py:check_dns`
+- **Status**: `pass` if ready, `warn` if found-but-not-ready or not found,
+  `skip` if `kube-system` is inaccessible.
+- **Fix**: `kubectl get pods -n kube-system -l k8s-app=kube-dns`.
+
+### Network Policies
+
+- **Validates**: enumerates `NetworkPolicy` objects in the target namespace.
+- **Source**: `src/aiperf/operator/preflight/_infra.py:_check_network_policies`,
+  `src/aiperf/kubernetes/preflight_checks.py:check_network_policies`
+- **Status**:
+  - `pass` — no policies (pod-to-pod traffic unrestricted).
+  - `warn` — at least one policy exists; lists all by name. AIPerf pods need
+    multi-port TCP intra-namespace traffic, so restrictive policies can silently
+    break the ZMQ mesh.
+  - `skip` — 403.
+- **Fix**: ensure policies allow ingress/egress within the namespace on ZMQ ports.
+
+### Kueue Queue (operator only)
+
+- **Validates**:
+  - If `spec.scheduling.queueName` is set: the named `LocalQueue` exists in the
+    namespace.
+  - If not set and Kueue is installed: the namespace has the
+    `kueue.x-k8s.io/default-queue-name` annotation.
+- **Source**: `src/aiperf/operator/preflight/_infra.py:_check_kueue_queue`
+- **Status**:
+  - `pass` — queue exists, or namespace has default-queue annotation.
+  - `fail` — explicit `queueName` set but Kueue is not installed or the
+    `LocalQueue` is not found.
+  - `skip` — Kueue CRD not installed and no queue was requested.
+  - `warn` — Kueue installed, no queue configured; job will bypass gang-scheduling.
+- **Fix**: create the `LocalQueue`, set `scheduling.queueName`, or annotate the
+  namespace with `kueue.x-k8s.io/default-queue-name`.
+
+### Pod Security Admission (operator only)
+
+- **Validates**: reads the `pod-security.kubernetes.io/enforce` label on the
+  namespace. AIPerf pods run as non-root (UID 1000) with
+  `seccomp=RuntimeDefault` and drop all capabilities, so they are compatible with
+  `privileged` and `baseline`. The `restricted` level adds further constraints
+  (runAsNonRoot, allowPrivilegeEscalation=false, locked seccomp/capabilities, no
+  host paths) that the AIPerf pod template has not been fully audited against.
+- **Source**: `src/aiperf/operator/preflight/_infra.py:_check_pod_security_admission`
+- **Status**:
+  - `pass` — no PSA label, or label is `privileged` or `baseline`.
+  - `warn` — label is `restricted` (not yet verified compatible) or unknown PSA
+    level, or namespace lookup failed.
+- **Fix**: usually informational; relabel the namespace if the enforced level
+  blocks pod creation.
+
+## Check catalog — Tier 3 (concurrent, resources)
+
+All resource checks are short-circuited to `skip` when `spec.resourceMode=none`
+(controller and worker CPU/mem requests and limits are intentionally omitted).
+See `OperatorPreflightChecker._resource_mode_skip`.
+
+### Node Resources
+
+- **Validates**: sum of allocatable CPU and memory across Ready nodes is at least
+  the deployment's estimated requirement (controller pods + `workers * worker-pod`).
+- **Source**: `src/aiperf/operator/preflight/_resources.py:_check_node_resources`,
+  `src/aiperf/kubernetes/preflight_capacity_checks.py:check_node_resources`
+- **Status**:
+  - `pass` — cluster has sufficient aggregate capacity and at least one node
+    can fit the single largest pod (CLI combined check).
+  - `warn` — aggregate shortfall. Message includes required vs. available CPU/mem.
+  - `fail` (CLI only) — no single node can fit any one pod.
+- **Fix**: reduce worker count, add nodes, or right-size the pods via
+  `AIPERF_K8S_WORKER_POD_*` and the per-container control-plane resource vars
+  (`AIPERF_K8S_SYSTEM_CONTROLLER_*`, `AIPERF_K8S_RECORDS_MANAGER_*`, etc.).
+  There is no `AIPERF_K8S_CONTROLLER_POD_*` variable — `AIPERF_CONTROLLER_POD`
+  is only a boolean marker that tells a pod it is running the controller role.
+
+### Node Selector Match (operator only)
+
+- **Validates**: at least one Ready node has labels matching every
+  key/value pair in `spec.podTemplate.nodeSelector`.
+- **Source**: `src/aiperf/operator/preflight/_resources.py:_check_node_selector_match`
+- **Status**:
+  - `skip` — no `nodeSelector` specified.
+  - `pass` — one or more nodes match.
+  - `fail` — no Ready nodes match the selector.
+- **Fix**: label an existing node (`kubectl label node <name> key=value`) or drop
+  the selector from the CR.
+
+### Per-Node Schedulability (operator only)
+
+- **Validates**: at least one Ready node (matching any `nodeSelector`) has
+  allocatable capacity to fit the single largest pod in the deployment (max of
+  controller-pod and worker-pod CPU/mem).
+- **Source**: `src/aiperf/operator/preflight/_resources.py:_check_per_node_schedulability`
+- **Status**:
+  - `pass` — at least one node can fit the largest pod.
+  - `fail` — no node can; reports the largest pod size in the message.
+- **Fix**: add larger nodes or reduce per-pod requests/limits.
+
+### Resource Quotas
+
+- **Validates**: for each `ResourceQuota` in the namespace, projected CPU and memory
+  usage after the benchmark deploys stays under the hard limit.
+- **Source**: `src/aiperf/operator/preflight/_resources.py:_check_resource_quotas`,
+  `src/aiperf/kubernetes/preflight_capacity_checks.py:check_resource_quotas`
+- **Status**:
+  - `pass` — no quotas, or all quotas have headroom.
+  - `info` (CLI) — quotas exist, headroom available; details list each quota.
+  - `fail` — at least one quota would be exceeded. Message calls out which
+    resource and the overage.
+- **Fix**: request a quota increase, reduce worker count, or deploy to a
+  different namespace.
+
+### Memory Estimation (operator only)
+
+- **Validates**: runs `aiperf.kubernetes.memory_estimator.estimate_memory` with the
+  resolved config, total workers, and connections-per-worker. Flags configurations
+  that are predicted to OOM.
+- **Source**: `src/aiperf/operator/preflight/_resources.py:_check_memory_estimation`
+- **Status**:
+  - `pass` — estimator returned no warnings.
+  - `warn` — estimator produced warnings; hints are the estimator's own
+    recommendations.
+- **Fix**: follow the estimator hints — usually reduce concurrency, reduce
+  dataset size, or raise the pod memory ceiling via `AIPERF_K8S_*_MEMORY`.
+
+### Tolerations (operator only)
+
+- **Validates**: if `spec.podTemplate.tolerations` is set, at least one node has
+  a taint whose `key` matches a configured toleration key.
+- **Source**: `src/aiperf/operator/preflight/_resources.py:_check_tolerations`
+- **Status**:
+  - `skip` — no tolerations configured.
+  - `pass` — at least one tainted node matches.
+  - `warn` — no matching tainted nodes (tolerations may be unnecessary).
+- **Fix**: either taint the intended nodes or remove the tolerations from the CR.
+
+## Check catalog — Tier 3 (concurrent, workload)
+
+### Secrets
+
+- **Validates**: every secret referenced by the pod template — `imagePullSecrets`,
+  `volumes[].secret.secretName`, and `env[].valueFrom.secretKeyRef.name` — exists;
+  required `secretKeyRef.key` entries must also be present. References marked
+  `optional: true` retain Kubernetes' optional-secret semantics.
+  in the namespace.
+- **Source**: `src/aiperf/operator/preflight/_workload.py:_check_secrets`,
+  `src/aiperf/kubernetes/preflight_capacity_checks.py:check_secrets`
+- **Status**:
+  - `skip` — no secrets referenced.
+  - `pass` — all secrets readable.
+  - `fail` — a required secret returned 404 or a required key is absent.
+  - `warn` — at least one secret returned 403 (cannot verify).
+- **Fix**: `kubectl create secret -n <namespace>` for missing names, or grant
+  `get secrets` to the caller.
+
+### Image Reference (operator) / Image Pull (CLI)
+
+- **Validates**: the configured image has a well-formed reference and a pull path
+  that is plausibly authenticated.
+- **Source**: `src/aiperf/operator/preflight/_workload.py:_check_image_reference`,
+  `src/aiperf/kubernetes/preflight_capacity_checks.py:check_image`
+- **Warns on**:
+  - Implicit `:latest` tag — inconsistent deployments across reconciles.
+  - Non-public registry (`PUBLIC_REGISTRIES`: `docker.io`, `registry-1.docker.io`,
+    `ghcr.io`, `quay.io`, `nvcr.io`, `registry.k8s.io`) with no
+    `imagePullSecrets` configured.
+- **Fails on** (operator): empty image.
+- **Fix**: pin an explicit tag; add `imagePullSecrets` for private registries.
+
+### ConfigMap Size (operator only)
+
+- **Validates**: the generated benchmark ConfigMap's data payload fits within
+  Kubernetes' 1 MiB per-ConfigMap limit (`CONFIGMAP_MAX_SIZE_BYTES`).
+- **Source**: `src/aiperf/operator/preflight/_workload.py:_check_configmap_size`
+- **Status**:
+  - `pass` — size below 1 MiB; exact byte count reported.
+  - `fail` — over 1 MiB (API server would reject the Create).
+- **Fix**: reduce input-dataset size, move large fixtures to a `PersistentVolume`,
+  or drop optional config fields.
+
+### Dry Run (operator only)
+
+- **Validates**: posts the generated JobSet manifest with `dryRun=All`. Catches
+  admission-time rejections (OPA/Gatekeeper, validating webhooks, schema errors)
+  before the CR is admitted.
+- **Source**: `src/aiperf/operator/preflight/_workload.py:_check_dry_run`
+- **Status**:
+  - `pass` — API server accepts the manifest.
+  - `fail` — API server rejects; error body is parsed and surfaced.
+  - `warn` — transient network/timeout error.
+- **Fix**: read the API server's error message; usually points to a missing
+  label, a forbidden field, or an admission-controller rule.
+
+### Endpoint Connectivity (CLI only)
+
+- **Validates**: the `--endpoint-url` is reachable. For `*.svc` / `*.svc.cluster.local`
+  hosts, looks up the corresponding `Service` in the cluster. For external URLs,
+  only parses the URL and reports `info` — actual egress cannot be tested from the CLI.
+- **Source**: `src/aiperf/kubernetes/preflight_checks.py:check_endpoint_connectivity`
+- **Status**:
+  - `skip` — no `--endpoint-url` passed.
+  - `pass` — cluster service exists.
+  - `fail` — cluster service not found.
+  - `info` — external URL; connectivity verified later at runtime.
+- **Fix**: `kubectl get svc -A | grep <service>`.
+
+## Skipping preflight
+
+### Skipping the endpoint reachability probe
+
+Endpoint reachability has a single operator-side probe. After an AIPerfJob is
+admitted, the operator runs `_check_endpoint_reachable` and records an
+`EndpointReachable` condition. Passing `--skip-endpoint-check` on
+`aiperf kube profile` serializes `spec.skipEndpointCheck: true` for an
+operator-managed AIPerfJob, so the operator skips this probe and proceeds
+without setting the condition.
+
+Direct `--no-operator` mode accepts `--skip-endpoint-check` for CLI parity but
+does not perform a client-side endpoint reachability probe, so the flag has no
+effect in that mode.
+
+```bash
+aiperf kube profile --model Qwen/Qwen3-0.6B \
+    --url http://vllm.models.svc.cluster.local:8000 \
+    --image nvcr.io/nvidia/aiperf:25.04 \
+    --skip-endpoint-check
+```
+
+Source: `src/aiperf/cli_commands/kube/profile.py` (CLI option),
+`src/aiperf/cli_commands/kube/profile_deploy.py` (CR spec propagation),
+`src/aiperf/cli_commands/kube/profile_deploy_direct.py` (direct-mode no-op),
+`src/aiperf/kubernetes/crd_models.py` (`skip_endpoint_check` field on
+`AIPerfWorkloadSpec`), and `src/aiperf/operator/handlers/create.py`
+(`_check_endpoint_reachable`).
+
+### `spec.resourceMode=none`
+
+Setting `resourceMode: none` on the `AIPerfJob` spec causes the operator's
+resource-capacity checks (`Node Resources`, `Per-Node Schedulability`,
+`Resource Quotas`, `Memory Estimation`) to return `skip`. Use this when pod
+resource requests and limits are intentionally omitted so the scheduler can
+fit pods anywhere. See `OperatorPreflightChecker._resource_mode_skip`.
+
+### Per-check skip conditions
+
+Several checks `skip` automatically when they have nothing to validate:
+
+| Check | Skips when |
+|---|---|
+| Service Account | `serviceAccountName` not set |
+| Node Selector Match | `nodeSelector` not set |
+| Tolerations | `tolerations` not set |
+| Secrets | no secrets referenced |
+| Kueue Queue | Kueue CRD not installed |
+| Endpoint Connectivity (CLI) | `--endpoint-url` not passed |
+| Image Pull (CLI) | `--image` not passed |
+
+### `AIPERF_PREFLIGHT_TIMEOUT`
+
+Increase the whole-preflight timeout if your cluster is slow to respond:
+
+```bash
+export AIPERF_PREFLIGHT_TIMEOUT=90
+```
+
+Default: 30 s. Range: 0 (exclusive) to 120 s. Set on the operator pod's
+environment — not on the CLI. See `src/aiperf/operator/environment.py:306`.
+
+## Exit codes
+
+`aiperf kube preflight` exits based on the aggregated `PreflightResults`:
+
+| Condition | Exit code |
+|---|---|
+| All checks `pass` / `skip` / `info` | `0` |
+| At least one `warn`, no `fail` | `0` (`has_warnings=true` in JSON) |
+| At least one `fail` | `1` |
+
+Source: `src/aiperf/cli_commands/kube/preflight.py` — `if not results.passed:
+raise SystemExit(1)`. `results.passed` is false iff any check status is `fail`.
+Warnings never block.
+
+## Further reading
+
+- [ai-debugging-guide.md](ai-debugging-guide.md) — interpreting `PreflightResults`
+  JSON, surfacing failures in CI pipelines, and the full CR status-condition set
+  (`PreflightPassed`, `JobSetReady`, `BenchmarkComplete`).
+- [configuration.md](configuration.md) — CRD fields consumed by preflight
+  (`resourceMode`, `scheduling.queueName`, `podTemplate.nodeSelector`,
+  `podTemplate.tolerations`, `podTemplate.serviceAccountName`).
+- [production.md](production.md) — recommended RBAC, Kueue setup, and PSA
+  configurations for production clusters.

--- a/docs/kubernetes/production.md
+++ b/docs/kubernetes/production.md
@@ -1,0 +1,500 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Production Deployments
+---
+
+# Production Deployments
+
+This guide covers patterns for running AIPerf benchmarks in production environments -- CI/CD pipelines, Kueue-managed clusters, private registries, GitOps workflows, and multi-tenant setups.
+
+---
+
+## CI/CD Integration
+
+### Detach Mode
+
+In non-interactive environments (CI pipelines, cron jobs), AIPerf automatically detaches after deploying. You can also force this explicitly:
+
+```bash
+aiperf kube profile \
+  --config benchmark.yaml \
+  --image nvcr.io/nvidia/aiperf:latest \
+  --detach
+```
+
+After deploying, poll for completion:
+
+```bash
+# Wait for the job to complete
+while true; do
+  PHASE=$(aiperf kube list my-benchmark 2>/dev/null | awk 'NR==2{print $3}')
+  [ "$PHASE" = "Completed" ] || [ "$PHASE" = "Failed" ] && break
+  sleep 30
+done
+
+# Download results
+aiperf kube results my-benchmark --output ./artifacts
+```
+
+`aiperf kube results` exits nonzero when the job cannot be resolved or the
+requested download is incomplete, so CI artifact steps fail instead of
+silently publishing an empty or partial directory.
+
+### JSON-Based Monitoring
+
+For automated pipelines, use JSON output:
+
+```bash
+# Preflight check with exit code
+aiperf kube preflight -o json
+echo "Exit code: $?"    # 0 = all checks passed, 1 = failures
+
+# Validation with structured output
+aiperf kube validate -o json benchmark.yaml
+
+```
+
+### Example GitHub Actions Workflow
+
+```yaml
+jobs:
+  benchmark:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight check
+        run: |
+          aiperf kube preflight \
+            --endpoint-url http://dynamo-agg-frontend.dynamo-server.svc:8000/v1 \
+            -o json
+
+      - name: Run benchmark
+        run: |
+          aiperf kube profile \
+            --config benchmark.yaml \
+            --image nvcr.io/nvidia/aiperf:${{ github.sha }} \
+            --name "ci-${{ github.run_number }}" \
+            --detach
+
+      - name: Wait for completion
+        run: |
+          kubectl wait --for=condition=Complete \
+            aiperfjob/ci-${{ github.run_number }} --timeout=60m
+
+      - name: Collect results
+        if: always()
+        run: aiperf kube results ci-${{ github.run_number }} --output ./artifacts
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: benchmark-results
+          path: ./artifacts/
+```
+
+---
+
+## GitOps Workflows
+
+### Generate Manifests for Version Control
+
+Instead of deploying from the CLI, generate Kubernetes manifests and commit them to your GitOps repository:
+
+```bash
+# Generate an AIPerfJob CR (operator mode)
+aiperf kube generate --operator \
+  --config benchmark.yaml \
+  --image nvcr.io/nvidia/aiperf:latest \
+  > deploy/aiperfjob.yaml
+
+# Or generate raw manifests (no operator needed)
+aiperf kube generate --no-operator \
+  --config benchmark.yaml \
+  --image nvcr.io/nvidia/aiperf:latest \
+  > deploy/manifests.yaml
+```
+
+Commit the generated YAML and let ArgoCD, Flux, or your GitOps tool apply it.
+
+### Operator Mode vs. Raw Manifests
+
+| Feature | Operator Mode | Raw Manifests |
+|---------|--------------|---------------|
+| Output | Single AIPerfJob CR | Namespace + RBAC + ConfigMap + JobSet |
+| Requires | Operator installed | Only JobSet CRD |
+| Monitoring | Operator tracks phase/progress | Manual pod watching |
+| Results | Stored on operator PVC | Must retrieve before TTL |
+| Cancellation | `spec.cancel: true` | Delete the JobSet |
+| Conditions | Status conditions populated (`ConfigValid`, `EndpointReachable`, `PreflightPassed`, `ResourcesCreated`, `WorkersReady`, `BenchmarkRunning`, `ResultsAvailable`, `IndexUpdated`, `PreflightHasWarnings`, `Complete`, `Failed`) | None |
+
+Operator mode also persists the active pod startup blocker in
+`status.startupIssue`. This keeps the first-observed timestamp across operator
+restarts and lets CI distinguish a retryable capacity delay from a stable
+image, configuration, or placement failure before the terminal `Failed`
+condition is set.
+
+For production use, the operator mode is recommended.
+
+---
+
+## Kueue Gang-Scheduling
+
+If your cluster uses [Kueue](https://kueue.sigs.k8s.io/) for resource management, AIPerf integrates with it for quota-managed gang-scheduling.
+
+### Submit to a Kueue Queue
+
+```bash
+aiperf kube profile \
+  --config benchmark.yaml \
+  --image nvcr.io/nvidia/aiperf:latest \
+  --queue-name gpu-benchmarks \
+  --priority-class high-priority
+```
+
+Or in YAML:
+
+```yaml
+spec:
+  scheduling:
+    queueName: gpu-benchmarks
+    priorityClass: high-priority
+```
+
+When a queue is specified:
+
+1. The JobSet is created in a suspended state
+2. Kueue evaluates quota availability
+3. Once resources are available, Kueue unsuspends the JobSet
+4. The operator detects the transition and monitors normally
+
+`aiperf kube list` shows Kueue suspension status:
+
+```bash
+aiperf kube list
+# Shows phase "Queued" while the JobSet awaits Kueue admission
+```
+
+---
+
+## Private Registries
+
+### Image Pull Secrets
+
+If your AIPerf image is in a private registry:
+
+```bash
+# Create the pull secret
+kubectl create secret docker-registry my-registry \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password='YOUR_TOKEN' \
+  -n aiperf-benchmarks
+
+# Reference it when deploying
+aiperf kube profile ... --image-pull-secrets my-registry
+```
+
+Or in YAML:
+
+```yaml
+spec:
+  podTemplate:
+    imagePullSecrets:
+      - {name: my-registry}
+```
+
+### API Keys and Secrets
+
+Pass API keys to the benchmark pods without embedding them in the config:
+
+```bash
+# Create a secret with your API key
+kubectl create secret generic llm-api-key \
+  --from-literal=api-key='sk-...' \
+  -n aiperf-benchmarks
+
+# Reference it as an environment variable
+aiperf kube profile ... \
+  --env-from-secrets 'OPENAI_API_KEY=llm-api-key/api-key'
+```
+
+Endpoint credentials are transported out of band from the benchmark
+ConfigMap. AIPerf writes only redacted placeholders to `run_config.json`, then
+each service restores the real values from Secret-backed environment
+variables at startup. A credentialed endpoint without the matching
+`valueFrom.secretKeyRef` mapping is rejected before the JobSet is created.
+
+| Endpoint credential | Secret-backed pod environment variable |
+|---|---|
+| `endpoint.apiKey` | `AIPERF_INJECTED_API_KEY` or `OPENAI_API_KEY` |
+| Sensitive headers such as `Authorization` or `X-API-Key` | `AIPERF_INJECTED_HEADERS` containing a JSON object of header strings |
+| URL userinfo such as `https://user:password@host` | `AIPERF_INJECTED_ENDPOINT_URLS` containing a JSON list of full URL strings |
+
+Do not use `--env-vars` for these values: literal pod environment values are
+not Secret-backed and fail the credential transport check.
+
+Or in YAML:
+
+```yaml
+spec:
+  podTemplate:
+    env:
+      - name: OPENAI_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: llm-api-key
+            key: api-key
+```
+
+### Mounting Secret Files
+
+For secrets that need to be files (e.g., certificates, tokens):
+
+```bash
+aiperf kube profile ... \
+  --secret-mounts '[{"name": "tls-cert", "mount_path": "/certs/ca.pem", "sub_path": "ca.pem"}]'
+```
+
+---
+
+## Node Placement
+
+### Target Specific GPUs
+
+```bash
+aiperf kube profile ... \
+  --node-selector '{"nvidia.com/gpu.product": "NVIDIA-A100-SXM4-80GB"}'
+```
+
+### Tolerate GPU Taints
+
+Many clusters taint GPU nodes. Add tolerations so benchmark pods can schedule there:
+
+```bash
+aiperf kube profile ... \
+  --tolerations '[{"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}]'
+```
+
+Or in YAML:
+
+```yaml
+spec:
+  podTemplate:
+    nodeSelector:
+      nvidia.com/gpu.product: "NVIDIA-A100-SXM4-80GB"
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+```
+
+---
+
+## Scaling Workers
+
+AIPerf distributes workers across pods automatically. The `--total-workers` flag sets the total number of workers. The system places 10 workers per pod by default:
+
+| `--total-workers` | Pods Created | Workers Per Pod |
+|-----------------|-------------|-----------------|
+| 10 | 1 | 10 |
+| 50 | 5 | 10 |
+| 100 | 10 | 10 |
+| 200 | 20 | 10 |
+
+Each worker maintains up to `connectionsPerWorker` concurrent requests (default: 100). The CLI auto-computes this from your concurrency and worker count: `connectionsPerWorker = ceil(concurrency / workers)`.
+
+For high-concurrency benchmarks, scale workers rather than increasing connections per worker. This distributes the load across pods and nodes.
+
+---
+
+## Results Server
+
+The operator includes a results server sidecar that provides HTTP access to stored results. This powers `aiperf kube results` (which retrieves from the operator's PVC by default) and provides analytics endpoints backed by the SQLite runs index (`.aiperf_index.sqlite` on the results volume).
+
+### Available Endpoints
+
+After the operator is running:
+
+```bash
+# Port-forward to the results server
+kubectl port-forward -n aiperf-system svc/aiperf-operator 8081:8081
+
+# List stored results
+curl localhost:8081/api/v1/results
+
+# Get summary for a specific job
+curl localhost:8081/api/v1/analytics/summary/aiperf-benchmarks/my-benchmark
+
+# Leaderboard across all benchmarks
+curl localhost:8081/api/v1/analytics/leaderboard
+
+# Compare two runs (repeat the jobs parameter, one per job)
+curl "localhost:8081/api/v1/analytics/compare?jobs=run-a&jobs=run-b"
+
+# Job history
+curl "localhost:8081/api/v1/analytics/history?model=Qwen/Qwen3-0.6B"
+```
+
+### Storage Configuration
+
+Results are stored on the operator's PVC. Configure retention in the Helm values:
+
+```yaml
+operator:
+  env:
+    resultsTtlDays: "30"           # auto-cleanup after 30 days
+    resultsCompressOnDisk: "true"  # zstd compression
+
+storage:
+  enabled: true                    # default; backs results in a PVC so they survive pod restarts
+  size: 1Ti                        # only used when enabled: true
+  storageClassName: ""             # cluster default; only used when enabled: true
+```
+
+`spec.resultsTtlDays` overrides this default per AIPerfJob or AIPerfSweep. A
+sweep persists the selected value in each epoch's aggregate, so cleanup remains
+effective after Kubernetes deletes the parent CR. Cleanup also removes the
+corresponding sweep index rows and repairs the sweep's `latest.txt` pointer.
+
+### Exposing Results Outside the Cluster (Ingress)
+
+By default the results server is reachable only via `ClusterIP + kubectl port-forward`. To expose it through an Ingress (e.g. for a shared dashboard link), enable `ingress.*` in the Helm values:
+
+```yaml
+ingress:
+  enabled: true
+  className: "nginx"          # empty uses the cluster default IngressClass
+  annotations: {}
+  hosts:
+    - host: aiperf.example.com
+      paths:
+        - path: /
+          pathType: Prefix    # backend port defaults to resultsServer.port (8081)
+  tls: []                     # optional: list of {hosts: [...], secretName: ...}
+```
+
+The template lives at `deploy/helm/aiperf-operator/templates/ingress.yaml` and routes to the operator Service on `resultsServer.port`. Each path may override the backend port via `portNumber`.
+
+---
+
+## Environment Variables
+
+Fine-tune benchmark behavior with environment variables in the pod template:
+
+```yaml
+spec:
+  podTemplate:
+    env:
+      - name: AIPERF_HTTP_CONNECTION_LIMIT
+        value: "200"
+      - name: AIPERF_HTTP_KEEPALIVE_TIMEOUT
+        value: "120"
+      - name: AIPERF_K8S_HEALTH_STARTUP_PERIOD_SECONDS
+        value: "30"
+      - name: AIPERF_K8S_HEALTH_STARTUP_FAILURE_THRESHOLD
+        value: "60"
+```
+
+There is no `AIPERF_HTTP_TIMEOUT` variable; set the per-request timeout with
+the `--request-timeout-seconds` CLI flag (or `request_timeout_seconds` in the
+benchmark config) instead. See the
+[Environment Variables Reference](../environment-variables.md) for the full list.
+
+---
+
+## Multi-Tenant Clusters
+
+### Namespace Isolation
+
+By default, benchmarks run in `aiperf-benchmarks`. For multi-tenant setups, use separate namespaces:
+
+```bash
+aiperf kube profile ... --namespace team-a-benchmarks --operator
+aiperf kube profile ... --namespace team-b-benchmarks --operator
+```
+
+The operator watches all namespaces for AIPerfJob CRs. Each job gets its own
+RBAC scoped to its namespace. Here `--operator` bypasses cluster-scoped CRD
+discovery, and the explicit namespaces are treated as pre-provisioned: the CLI
+does not issue Namespace-create requests. A tenant therefore needs permission
+to create `AIPerfJob` resources in its namespace, not permission to read CRDs or
+create namespaces.
+
+### Resource Quotas
+
+The preflight checker validates resource quotas before deploying:
+
+```bash
+aiperf kube preflight --namespace team-a-benchmarks --workers 20
+```
+
+If the namespace has a ResourceQuota, preflight projects the total CPU and memory requirements and warns if deployment would exceed the quota.
+
+---
+
+## Operator Management
+
+### Upgrading
+
+```bash
+helm upgrade aiperf-operator deploy/helm/aiperf-operator \
+  --namespace aiperf-system
+```
+
+### Uninstalling
+
+```bash
+helm uninstall aiperf-operator --namespace aiperf-system
+```
+
+Both CRDs carry `helm.sh/resource-policy: keep`, so the `AIPerfJob` and `AIPerfSweep` CRDs -- and any existing custom resources -- survive the uninstall. To remove everything:
+
+```bash
+kubectl delete crd aiperfjobs.aiperf.nvidia.com
+kubectl delete crd aiperfsweeps.aiperf.nvidia.com
+kubectl delete namespace aiperf-system
+```
+
+### Monitoring the Operator
+
+Check operator logs:
+
+```bash
+kubectl logs -n aiperf-system -l app.kubernetes.io/name=aiperf-operator -f
+```
+
+The operator emits structured logs with job events, phase transitions, and error details.
+
+### Debugging Failed Jobs
+
+By default the operator cleans up JobSet pods once a job terminates, which makes postmortems hard. Set `keepFailedPods: true` on the AIPerfJob spec to preserve failed pod attempts for inspection:
+
+```yaml
+spec:
+  keepFailedPods: true   # default: false; retains failed JobSet pods for kubectl logs/exec
+```
+
+This changes JobSet lifecycle (completed pods still get reaped via `ttlSecondsAfterFinished`); enable it only while diagnosing, then remove for steady-state runs.
+
+### Deploying Before the Endpoint Is Reachable
+
+The operator runs a TCP/HTTP reachability probe against `spec.benchmark.endpoint` before spinning up workers. If the inference server isn't live yet at deploy time (e.g. GitOps applies the CR before the model pod is Ready), set `skipEndpointCheck: true` to bypass the probe:
+
+```yaml
+spec:
+  skipEndpointCheck: true   # default: false; skips the operator-side endpoint reachability probe
+```
+
+Workers will still fail fast if the endpoint never comes up -- this only suppresses the upfront check.
+
+---
+
+## Related Documentation
+
+- [Getting Started](getting-started.md) -- First benchmark walkthrough
+- [Deploy from a Source Checkout](source-checkout-deploy.md) -- Build and push AIPerf, Helm install the operator, and run on a real cluster
+- [Kubernetes Configuration](configuration.md) -- All CRD fields and deployment options
+- [Monitoring and Troubleshooting](monitoring.md) -- Watch, debug, and diagnose issues
+- [Environment Variables](../environment-variables.md) -- All AIPERF_* environment variables

--- a/docs/kubernetes/rbac-security.md
+++ b/docs/kubernetes/rbac-security.md
@@ -1,0 +1,497 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: RBAC and Security
+---
+
+# RBAC and Security
+
+AIPerf separates cluster-wide operator authority from per-namespace benchmark
+authority. The operator Deployment runs under a ServiceAccount bound to a
+`ClusterRole` so a single operator replica can watch `AIPerfJob` custom
+resources across the cluster and create JobSets in benchmark namespaces.
+The chart grants no `coordination.k8s.io/leases` rule, so the operator is
+expected to run as a single replica rather than a leader-elected set.
+Benchmark pods (controllers, workers, record
+processors) run under the `default` ServiceAccount of their namespace, bound
+to a namespace-scoped `Role` that grants only the verbs those pods need to
+discover peers, patch their JobSet status, and read the parent `AIPerfJob`.
+
+The split lets cluster admins pre-provision the operator's cluster-wide
+RBAC once (under a security review), then hand developers a `Role` template
+that cannot escalate beyond the benchmark namespace. Developers never touch
+cluster-scoped resources; operators never grant benchmark pods permissions
+they don't need.
+
+```mermaid
+flowchart TB
+    subgraph ClusterScope[Cluster scope]
+        CR[ClusterRole<br/>aiperf-operator]
+        CRB[ClusterRoleBinding]
+        CR -.bound by.-> CRB
+    end
+
+    subgraph OperatorNS[Operator namespace]
+        OperSA[ServiceAccount<br/>aiperf-operator]
+        OperPod[Operator Deployment pod]
+        OperPod -->|runs as| OperSA
+    end
+
+    subgraph BenchNS[Benchmark namespace]
+        BRole[Role<br/>aiperf-operator-benchmark]
+        BRB[RoleBinding]
+        DefSA[ServiceAccount<br/>default]
+        CtlPod[Controller pod]
+        WkPod[Worker pod]
+        BRole -.bound by.-> BRB
+        BRB -.subject.-> DefSA
+        CtlPod -->|runs as| DefSA
+        WkPod -->|runs as| DefSA
+    end
+
+    CRB -.subject.-> OperSA
+    OperPod -->|creates JobSet in| BenchNS
+    OperPod -->|watches AIPerfJob across| ClusterScope
+```
+
+The operator owns JobSet/ConfigMap/Role creation in the benchmark namespace.
+Benchmark pods only read what the operator placed there and patch their own
+status.
+
+## Operator ClusterRole catalog
+
+The operator's `ClusterRole` is rendered from
+`deploy/helm/aiperf-operator/templates/clusterrole.yaml`. Every rule exists
+to support a concrete operator responsibility; nothing is granted
+speculatively.
+
+| API group | Resources | Verbs | Purpose | Source |
+|---|---|---|---|---|
+| `apiextensions.k8s.io` | `customresourcedefinitions` | `get, list, watch` | kopf CRD discovery at startup | `clusterrole.yaml:12-14` |
+| `aiperf.nvidia.com` | `aiperfjobs`, `aiperfjobs/status`, `aiperfjobs/finalizers` | `get, list, watch, create, update, patch, delete` | Reconcile AIPerfJob CRs, patch status/phase, manage finalizers | `clusterrole.yaml:17-19` |
+| `aiperf.nvidia.com` | `aiperfsweeps`, `aiperfsweeps/status`, `aiperfsweeps/finalizers` | `get, list, watch, create, update, patch, delete` | Reconcile AIPerfSweep CRs, patch status, manage finalizers | `clusterrole.yaml:22-24` |
+| `jobset.x-k8s.io` | `jobsets` | `create, delete, get, list, patch, update, watch` | Create/own the controller + worker JobSet for each AIPerfJob | `clusterrole.yaml:27-29` |
+| `jobset.x-k8s.io` | `jobsets/status` | `get, list, watch` | Observe JobSet readiness and roll it up to AIPerfJob status | `clusterrole.yaml:30-32` |
+| `kueue.x-k8s.io` | `localqueues` | `get, list` | Preflight verifies `scheduling.queueName` resolves to an existing LocalQueue and probes whether Kueue is installed at all | `clusterrole.yaml:38-40` |
+| `batch` | `jobs` | `get, list, watch` | Monitor the Jobs that JobSet creates under the hood | `clusterrole.yaml:43-45` |
+| `apps` | `deployments` | `get, list, watch` | Preflight checks for the JobSet controller and other operators | `clusterrole.yaml:48-50` |
+| `""` (core) | `serviceaccounts` | `get, list, watch, create` | Preflight verifies custom SA; sweep handler creates a per-sweep SA | `clusterrole.yaml:58-60` |
+| `""` (core) | `resourcequotas`, `secrets` | `get, list, watch` | Preflight inspects ResourceQuota headroom and referenced imagePullSecrets / env secrets | `clusterrole.yaml:61-63` |
+| `networking.k8s.io` | `networkpolicies` | `get, list, watch` | Preflight checks whether the benchmark namespace has a restrictive NetworkPolicy | `clusterrole.yaml:66-68` |
+| `""` (core) | `configmaps` | `create, delete, get, list, patch, update, watch` | Store benchmark configuration ConfigMap consumed by every benchmark pod | `clusterrole.yaml:71-73` |
+| `""` (core) | `services`, `endpoints` | `create, delete, get, list, watch` | Headless Service for pod DNS; endpoint monitoring | `clusterrole.yaml:76-78` |
+| `rbac.authorization.k8s.io` | `roles`, `rolebindings` | `create, delete, get, list, watch` | Create the per-namespace benchmark `Role`/`RoleBinding` on first deploy | `clusterrole.yaml:81-83` |
+| `""` (core) | `namespaces` | `get, list, watch` | Resolve the benchmark namespace referenced by AIPerfJob | `clusterrole.yaml:86-88` |
+| `""` (core) | `pods`, `pods/log` | `get, list, watch` | Surface pod status, restart counts, and logs in `aiperf kube logs` | `clusterrole.yaml:91-93` |
+| `""` (core) | `nodes` | `get, list` | Count GPUs for the cluster endpoint served by the API sidecar | `clusterrole.yaml:96-98` |
+| `""` (core) | `events` | `get, list, watch, create, patch` | Emit Kubernetes events and let benchmark pods read them for UI display | `clusterrole.yaml:101-103` |
+
+The binding
+(`deploy/helm/aiperf-operator/templates/clusterrolebinding.yaml:10-17`) connects
+this `ClusterRole` to the operator `ServiceAccount` in the release namespace.
+
+## Benchmark-namespace Role catalog
+
+`deploy/helm/aiperf-operator/templates/benchmark-rbac.yaml` renders a `Role`
+and a matching `RoleBinding` in every namespace where benchmark pods may
+run: the configured `benchmarkNamespace.name` (default `aiperf-benchmarks`,
+whether the chart creates that namespace or it already exists) plus every
+entry in the `benchmarkRbacNamespaces` list. The `RoleBinding` subject is that
+namespace's `default` ServiceAccount — benchmark pods never need a custom SA.
+
+| API group | Resources | Verbs | Purpose | Source |
+|---|---|---|---|---|
+| `""` (core) | `pods` | `get, list, watch` | Workers discover controller and peer record processors via pod labels | `benchmark-rbac.yaml:19-21` |
+| `jobset.x-k8s.io` | `jobsets` | `get, list, watch, patch, update` | Controller patches JobSet status to signal graceful completion | `benchmark-rbac.yaml:24-26` |
+| `aiperf.nvidia.com` | `aiperfjobs`, `aiperfjobs/status` | `get, list, watch, patch, update` | Controller reads AIPerfJob spec and patches per-phase progress fields | `benchmark-rbac.yaml:29-31` |
+
+Notice that benchmark pods have no create/delete permission on any
+resource, no access to Secrets, and no access to Events. They can only read
+what the operator placed there and patch the status subresources they own.
+
+The one deliberate exception to namespace confinement is cross-namespace
+server-metrics discovery. Each entry in `serverMetricsDiscoveryNamespaces`
+renders a second, narrower `Role` (`<fullname>-metrics-discovery`, `pods:
+get/list/watch` only) in that inference namespace, bound back to the
+benchmark namespaces' ServiceAccounts. A plain string entry binds the
+`default` ServiceAccount; use the `{namespace, serviceAccounts}` object form
+when benchmark pods run under a custom `podTemplate.serviceAccountName`. The
+chart does not create those namespaces.
+
+## Credential redaction at metadata boundaries
+
+When endpoint configuration derived from an AIPerfJob CR crosses a persistence
+or display boundary, AIPerf redacts both the public YAML `apiKey` spelling and
+the internal `api_key` spelling, credential-bearing headers, URL userinfo, and
+sensitive URL query parameters. This applies to `job_spec.json`, the runs
+index (including its flattened endpoint), operator results/config/analytics
+API responses, Kubernetes events and status messages, JobSet endpoint
+annotations, preflight details, and CLI submission summaries. Redaction keeps
+non-secret URL host, path, and query context available for diagnosis.
+Legacy `job_spec.json` files are also sanitized when downloaded directly or as
+part of a result bundle; this compatibility protection does not rewrite the
+copy already stored on the results PVC.
+
+This boundary protection does not rewrite the source CR stored by the
+Kubernetes API server. Prefer Secret-backed endpoint credentials and restrict
+CR read permissions; do not rely on result/API redaction as storage encryption.
+Credentials cannot be Kubernetes sweep parameters: grid, zip, scenario,
+adaptive, Sobol, and Latin Hypercube axes that target credential fields or
+contain credential-bearing values are rejected before child creation. Keep
+endpoint credentials fixed and use the Secret-backed pod environment transport
+for every variation.
+
+## `rbac.create=false` workflow
+
+In security-sensitive clusters, RBAC is usually reviewed and committed
+separately from workload charts. Set `rbac.create=false` and
+`serviceAccount.create=false` to make the operator chart use a
+pre-provisioned `ServiceAccount` and skip both the `ClusterRole` + `ClusterRoleBinding`
+and the per-namespace `Role` + `RoleBinding`.
+
+```bash
+helm install aiperf-operator ./deploy/helm/aiperf-operator \
+  --namespace aiperf-system \
+  --set rbac.create=false \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=aiperf-operator-sa
+```
+
+The cluster admin applies the RBAC tree out-of-band. A minimal example
+mirroring the chart defaults:
+
+```yaml
+---
+# ServiceAccount in the operator namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aiperf-operator-sa
+  namespace: aiperf-system
+---
+# ClusterRole — copy the rules from clusterrole.yaml verbatim
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aiperf-operator
+rules:
+- apiGroups: ["aiperf.nvidia.com"]
+  resources: ["aiperfjobs", "aiperfjobs/status", "aiperfjobs/finalizers"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# ... (remaining rules from clusterrole.yaml) ...
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aiperf-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aiperf-operator
+subjects:
+- kind: ServiceAccount
+  name: aiperf-operator-sa
+  namespace: aiperf-system
+---
+# Per-benchmark-namespace Role + RoleBinding (apply once per namespace)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aiperf-operator-benchmark
+  namespace: aiperf-benchmarks
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["jobset.x-k8s.io"]
+  resources: ["jobsets"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: ["aiperf.nvidia.com"]
+  resources: ["aiperfjobs", "aiperfjobs/status"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aiperf-operator-benchmark
+  namespace: aiperf-benchmarks
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aiperf-operator-benchmark
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: aiperf-benchmarks
+```
+
+Under `rbac.create=false`, the operator still tries to call
+`create roles` and `create rolebindings` on the first reconcile of a new
+namespace (see the `rbac.authorization.k8s.io` rule in the `ClusterRole`
+catalog). If the admin pre-provisions the per-namespace `Role` and
+`RoleBinding` in every intended benchmark namespace, the operator's
+idempotent create returns `AlreadyExists` and reconciliation proceeds.
+If you intend to run in a single fixed namespace only, you can trim those
+verbs from the admin-owned `ClusterRole` without functional regression.
+
+The helper
+`deploy/helm/aiperf-operator/templates/_helpers.tpl`'s
+`aiperf-operator.serviceAccountName` template resolves to `.Values.serviceAccount.name`
+when `serviceAccount.create` is false, so the operator Deployment will
+reference the pre-provisioned SA as expected.
+
+## Pod `securityContext`
+
+Every container in both the controller and worker pods receives a
+hardened `securityContext` assembled by
+`build_security_context()` in `src/aiperf/kubernetes/jobset_helpers.py:19-47`.
+The base context applied to every container is:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+This context is applied to:
+
+- The five control-plane containers in the controller pod
+  (`jobset_builder.py:185`)
+- The event-bus proxy sidecar (`jobset_builder.py:236`)
+- The results-serving sidecar (`jobset_builder.py:263`)
+- Each worker and record-processor container
+
+### Overriding via `podTemplate.containerSecurityContext`
+
+The CRD schema at
+`deploy/helm/aiperf-operator/templates/crd-aiperfjob.yaml:856` exposes
+`spec.podTemplate.containerSecurityContext` as a free-form object. Keys
+supplied there merge on top of the base context. `capabilities` is merged
+shallowly (user keys update the drop/add lists); all other keys are replaced.
+
+```yaml
+apiVersion: aiperf.nvidia.com/v1alpha1
+kind: AIPerfJob
+metadata:
+  name: hardened-run
+spec:
+  podTemplate:
+    containerSecurityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      capabilities:
+        drop: ["ALL"]
+        add: []
+  benchmark:
+    models: [meta-llama/Meta-Llama-3-8B-Instruct]
+    endpoint: {type: chat, url: https://llm.example.com/v1}
+    datasets:
+      - name: main
+        type: synthetic
+    phases:
+      - name: profiling
+        type: concurrency
+        concurrency: 10
+        requests: 100
+```
+
+### What `readOnlyRootFilesystem: true` requires
+
+The root filesystem is read-only. AIPerf writes to five locations, which
+must be provided as writable volumes (the JobSet builder already mounts
+these as `emptyDir` volumes on every container via
+`build_shared_volumes()` in `src/aiperf/kubernetes/jobset_helpers.py`):
+
+- `/aiperf/ipc` — ZMQ IPC socket files (controller mode)
+- `/aiperf/datasets` — shared dataset mmap files (dataset-manager writes, API serves to workers)
+- `/aiperf/hf_home` — HuggingFace cache (`tokenizer-cache` volume; `HF_HOME` points here)
+- `/results` — exported metrics, profile artifacts
+- `/tmp` — general scratch (tempfile, matplotlib config)
+
+If you supply an alternate `podTemplate.volumeMounts`, ensure each of these
+paths is covered by a writable volume. Otherwise the controller will fail
+to bind IPC sockets on startup and pods will CrashLoopBackOff.
+
+## NetworkPolicy expectations
+
+The chart ships an opt-in `NetworkPolicy` template for the operator pod
+itself (`deploy/helm/aiperf-operator/templates/networkpolicy.yaml`, enabled
+via `networkPolicy.enabled=true`) — it restricts ingress to the health
+port 8080 and the results-server port (`resultsServer.port`, default
+8081) and permits egress to DNS (kube-system UDP/TCP 53), the Kubernetes
+API server (443/6443), and the configured benchmark namespace. See
+[Operator NetworkPolicy](#operator-networkpolicy) below. For benchmark-pod
+traffic — the flows listed in the table below — the chart does not ship a
+policy; policy is site-specific. When you enforce a default-deny policy
+in the benchmark namespace, allow:
+
+| Source | Destination | Ports | Reason |
+|---|---|---|---|
+| Worker pods | Controller pod | 5557, 5564, 5661/5662, 5663/5664, 5665/5666, 5667, 5668, 5669 (TCP) | ZMQ records push/pull (5557), credit router (5564), dataset-manager proxy DEALER/ROUTER (5661/5662), event-bus XPUB/XSUB (5663/5664), raw-inference PUSH/PULL (5665/5666), control ROUTER/DEALER (5667), credit-return router (5668), credit-return PUSH/PULL fan-in (5669). See `src/aiperf/config/comm/tcp.py:109-178`. |
+| All benchmark pods | Controller pod | 8080-8088 (TCP) | Health and readiness probes (`src/aiperf/kubernetes/environment.py:180-215`) |
+| Client / ingress | API service | 9090 (TCP) | UI dispatch, progress streaming (`environment.py:195-196`) |
+| Client / ingress | Results sidecar | 9091 (TCP) | Post-run result downloads (`environment.py:198-203`) |
+| Controller + worker pods | LLM inference endpoint | 443 (TCP) | Outbound HTTPS to the endpoint under benchmark |
+| All benchmark pods | `kube-dns` (UDP 53) | 53 | Pod DNS lookups for headless Service peer discovery |
+| Operator pod | Kube API server | 443/6443 (TCP) | Watch CRDs, create JobSets, patch status |
+
+Sample allow-list in the benchmark namespace:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: aiperf-benchmark-allow
+  namespace: aiperf-benchmarks
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: aiperf
+  policyTypes: [Ingress, Egress]
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: aiperf
+    ports:
+    - {protocol: TCP, port: 5557}
+    - {protocol: TCP, port: 5564}
+    - {protocol: TCP, port: 5661}
+    - {protocol: TCP, port: 5662}
+    - {protocol: TCP, port: 5663}
+    - {protocol: TCP, port: 5664}
+    - {protocol: TCP, port: 5665}
+    - {protocol: TCP, port: 5666}
+    - {protocol: TCP, port: 5667}
+    - {protocol: TCP, port: 5668}
+    - {protocol: TCP, port: 5669}
+  - from: []
+    ports:
+    - {protocol: TCP, port: 9090}
+    - {protocol: TCP, port: 9091}
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: aiperf
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - {protocol: UDP, port: 53}
+  - to: []
+    ports:
+    - {protocol: TCP, port: 443}
+```
+
+The final egress rule to `0.0.0.0/0:443` is the LLM endpoint reach; lock
+it down to the endpoint's `Service`/`Endpoints` selector or an
+`ipBlock.cidr` matching your inference gateway when the target is on-cluster.
+
+### Operator NetworkPolicy
+
+`deploy/helm/aiperf-operator/templates/networkpolicy.yaml` ships an opt-in
+policy that locks down the **operator pod** (not the benchmark pods).
+Enable with `networkPolicy.enabled=true`. The rendered policy:
+
+- **Ingress** — allows TCP 8080 (operator health) and TCP
+  `resultsServer.port` (default 8081) from the benchmark namespace plus any
+  namespaces listed in `networkPolicy.allowedNamespaces`. CIDR blocks in
+  `networkPolicy.allowedIngressCIDRs` are added as a second ingress rule
+  for external scrapers (e.g. Prometheus, ingress controllers) on the same
+  two ports.
+- **Egress** — allows DNS (UDP/TCP 53 to `kube-system`), the Kubernetes
+  API server (TCP 443 and 6443, no selector), and full egress to the
+  benchmark namespace plus any `allowedNamespaces` entries.
+
+Pair this with a default-deny in the operator namespace so only these
+flows are permitted. The policy's `podSelector` targets the operator
+Deployment labels (`aiperf-operator.selectorLabels`), so other workloads
+in the namespace are unaffected.
+
+### Ingress
+
+`deploy/helm/aiperf-operator/templates/ingress.yaml` ships an opt-in
+`Ingress` that exposes the operator's **results-server** (the `API_SERVICE`
+on `resultsServer.port`, default 8081) outside the cluster. Disabled by
+default — results are reachable via ClusterIP + `kubectl port-forward` or
+the `aiperf kube` CLI. Enable with `ingress.enabled=true`.
+
+Security implications:
+
+- **TLS** — set `ingress.tls` to a list of `{hosts, secretName}` entries;
+  the chart threads them straight into the Ingress `spec.tls`. Without
+  this, traffic to the results server transits the ingress controller as
+  plain HTTP.
+- **Annotations** — `ingress.annotations` is passed through verbatim. Use
+  it to wire ingress-controller-specific auth (e.g. `nginx.ingress.kubernetes.io/auth-*`,
+  OIDC annotations), rate limits, and WAF rules. The results server itself
+  has no built-in authentication; if the Ingress is reachable from
+  untrusted networks, front it with auth at the controller layer.
+- **IngressClass** — set `ingress.className` to pin the controller (e.g.
+  `nginx`, `traefik`); empty uses the cluster default. Mis-pinning to a
+  public-facing class when you meant internal-only is the most common
+  misconfiguration.
+- **Backend** — each path's default backend port is
+  `resultsServer.port`; override per-path with `portNumber` if you fan
+  multiple services behind a single host. The Ingress does not expose the
+  kopf operator's leader-election or health endpoints.
+
+Pair with `networkPolicy.enabled=true` (see above) so only the Ingress
+controller's namespace can reach the operator pod on the results port.
+
+## Least-privilege recipe
+
+A hardened rollout checklist:
+
+1. **Pre-provision operator RBAC** — apply the `ServiceAccount`,
+   `ClusterRole`, and `ClusterRoleBinding` under admin review. Install the
+   chart with `rbac.create=false` and `serviceAccount.create=false`.
+2. **Dedicated benchmark namespace per team** — never share the benchmark
+   namespace between teams. Benchmark pods have read access to every pod
+   in the namespace (`benchmark-rbac.yaml:22-24`), so coexisting unrelated
+   workloads leak metadata.
+3. **Distinct ServiceAccounts per namespace** — the benchmark `RoleBinding`
+   targets `default`. If multiple apps must coexist, rename the benchmark
+   SA (e.g. `aiperf-benchmark-sa`) and set `spec.podTemplate.serviceAccountName`
+   on the AIPerfJob instead of binding to `default`.
+4. **`runAsNonRoot: true` everywhere** — the base context already enforces
+   this. Do not override with `runAsUser: 0`.
+5. **`readOnlyRootFilesystem: true`** — keep the default; cover the five
+   writable paths above with `emptyDir` volumes.
+6. **Drop all Linux capabilities** — the base context drops `ALL`. If a
+   sidecar demands `NET_BIND_SERVICE` for a low port, add via
+   `containerSecurityContext.capabilities.add` rather than reverting the
+   drop.
+7. **`seccompProfile: RuntimeDefault`** — default-applied. Do not downgrade
+   to `Unconfined`.
+8. **NetworkPolicy default-deny + allow-list** — apply the sample above
+   and lock the LLM endpoint egress to a CIDR or selector.
+9. **ResourceQuota on the benchmark namespace** — AIPerf preflight reads
+   quotas (`clusterrole.yaml:61-63`) and will fail fast if headroom is
+   insufficient.
+10. **Audit logging** — enable Kubernetes audit logging on the
+    `aiperf.nvidia.com` and `jobset.x-k8s.io` API groups. Operator
+    reconciliation events, including status patches and JobSet creation,
+    appear under the operator SA and are easy to attribute.
+11. **Image pull secrets** — reference secrets via `imagePullSecrets` in
+    `values.yaml` rather than mounting credentials into pods.
+12. **PodSecurity admission** — enforce the `restricted` profile on the
+    benchmark namespace. AIPerf's default container `securityContext`
+    already satisfies it.
+
+With this profile, a compromised benchmark pod cannot escape the
+namespace, cannot read cluster-wide resources, cannot write outside its
+emptyDir volumes, cannot add capabilities, and can only reach the LLM
+endpoint and its own peers.

--- a/docs/kubernetes/results-api.md
+++ b/docs/kubernetes/results-api.md
@@ -1,0 +1,569 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Results Server API Reference
+---
+
+# Results Server API
+
+The AIPerf operator ships a standalone HTTP server (the **results server**) as a sidecar inside the operator pod. It exposes a catalog of `/api/v1/...` endpoints for listing jobs, downloading raw result files, querying the SQLite-backed runs index for analytics, and introspecting live AIPerfJob state.
+
+This reference documents the primary endpoints served by that process; it is not exhaustive. The results server also mounts a **sweeps** router (`/api/v1/sweeps/...` — list, detail, cells, children, epochs, events, logs, artifacts), a **config** router (`/api/v1/config/retention`, `/api/v1/config/features`), additional per-job routes (`/api/v1/jobs/{ns}/{name}/epochs|events|logs`, zip and per-epoch result downloads), and an admin `run/{ns}/{job_id}` index-row route. The source of truth is `src/aiperf/operator/results_server.py` and the routers under `src/aiperf/operator/routers/`.
+
+---
+
+## How to reach the API
+
+The results server listens on `resultsServer.port` (default **`8081`**) inside the operator pod. It is fronted by the operator's Service, not exposed externally by default. Two common access patterns:
+
+### Port-forward via the CLI
+
+```bash
+aiperf kube dashboard
+```
+
+This opens the browser UI and port-forwards the results server to an ephemeral local port. Pass `--no-browser` to just print the URL, or `--port 8081` to pin a specific local port. The port-forward stays open until Ctrl+C.
+
+### Direct `kubectl port-forward`
+
+```bash
+kubectl -n aiperf-system port-forward svc/aiperf-operator 8081:8081
+```
+
+The base URL is then `http://localhost:8081`, and all endpoints below are reachable at `http://localhost:8081/api/v1/...`.
+
+### Request topology
+
+```mermaid
+flowchart LR
+    client[CI / browser / script] -->|HTTP :8081| svc[Service<br/>aiperf-operator]
+    svc --> sidecar[results-server<br/>container]
+    sidecar --> pvc[(Results PVC)]
+    sidecar --> idx[(runs index<br/>SQLite)]
+    sidecar -->|kubernetes_asyncio| kubeapi[Kubernetes API]
+    idx --> pvc
+```
+
+The sidecar reads result files from the shared PVC and queries the Kubernetes API (via in-cluster RBAC) for live job/cluster state. Read-only routes have no per-request authentication layer; mutating routes are disabled by default and require explicit bearer-token configuration when enabled. See [Auth / security](#auth--security).
+
+---
+
+## Endpoint reference
+
+| Method | Path | Router | Purpose |
+|--------|------|--------|---------|
+| GET | `/healthz` | root | Liveness probe |
+| GET | `/api/v1/jobs` | jobs | List jobs (live CRs + archived PVC runs) |
+| POST | `/api/v1/jobs` | jobs | Create an AIPerfJob CR (mutating route; bearer token required when enabled) |
+| GET | `/api/v1/jobs/{namespace}/{name}` | jobs | Single CR + pods + raw status |
+| POST | `/api/v1/jobs/{namespace}/{name}/cancel` | jobs | Set `spec.cancel=true` (mutating route; bearer token required when enabled) |
+| WS  | `/api/v1/jobs/{namespace}/{name}/ws` | jobs-ws | Live realtime feed (proxied to controller pod) |
+| GET | `/api/v1/cluster` | jobs | Node count, GPU total, K8s version |
+| GET | `/api/v1/results` | results-files | List every stored job |
+| GET | `/api/v1/results/{namespace}/{job_id}` | results-files | List files for one job |
+| GET | `/api/v1/results/{namespace}/{job_id}/{filename}` | results-files | Download a result file |
+| GET | `/api/v1/jobs/{namespace}/{name}/epochs` | jobs | List historical run epochs for a job |
+| GET | `/api/v1/jobs/{namespace}/{name}/events` | jobs | Recent Kubernetes events for the job |
+| GET | `/api/v1/jobs/{namespace}/{name}/logs` | jobs | Pod logs (`?pod=`, `?container=`, `?tail_lines=`, `?follow=`) |
+| GET | `/api/v1/analytics/leaderboard` | results-analytics | Rank runs by metric |
+| GET | `/api/v1/analytics/history` | results-analytics | Metric values over time |
+| GET | `/api/v1/analytics/compare` | results-analytics | Side-by-side job compare |
+| GET | `/api/v1/analytics/summary/{namespace}/{job_id}` | results-analytics | Full aggregated summary |
+| GET | `/api/v1/index` | results-analytics | Fast job index |
+| GET | `/admin/index/stats` | admin | Runs-index row counts, DB size, and schema version |
+| POST | `/admin/index/rebuild` | admin | Rebuild the runs index from disk — **disabled on the results-server** (mounted `allow_rebuild=False`), returns `503`; the index rebuilds automatically at operator startup |
+| GET | `/api/v1/config/{namespace}/{job_id}` | results-analytics | Original CR spec/config |
+| GET | `/dashboard/` | dashboard-proxy | httpx reverse-proxy to the optional Plotly Dash sidecar (returns `503` when the sidecar is disabled or unreachable) |
+
+The per-run file-list response includes `per_record_filename` and
+`server_metrics_filename` when those artifacts are present. Clients should use
+these fields rather than assuming the default filenames: `artifacts.prefix`
+changes both names for that particular run.
+
+---
+
+## Meta
+
+### `GET /healthz`
+
+Liveness probe. Always returns `200 OK`.
+
+```bash
+curl http://localhost:8081/healthz
+```
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## Jobs
+
+Live state read directly from the Kubernetes API. Every endpoint in this section returns `503 Service Unavailable` if the results server could not initialize its Kubernetes client at startup (e.g. no kubeconfig and not running in-cluster).
+
+### `GET /api/v1/jobs`
+
+List every known AIPerfJob across all namespaces.
+
+**The response is a union**, not just live CRs: `job_union.list_all_jobs` merges live AIPerfJob CRs (`source: "live"`), PVC-only historical runs whose CRs were garbage-collected (`source: "archived"`), and runs present in both (`source: "both"`). Entries are keyed by `(namespace, name)`; overlaps prefer CR values on live fields and backfill historical fields from the PVC.
+
+```bash
+curl http://localhost:8081/api/v1/jobs
+```
+
+```json
+{
+  "jobs": [
+    {
+      "name": "aiperf-bench-7f2a",
+      "namespace": "aiperf-benchmarks",
+      "phase": "Running",
+      "jobId": "aiperf-bench-7f2a",
+      "created": "2026-04-22T14:08:11Z"
+    }
+  ]
+}
+```
+
+**Status codes**
+
+- `200` — success (possibly empty list)
+- `401` / `403` — surfaced verbatim if the sidecar's ServiceAccount lacks RBAC to list `aiperfjobs.aiperf.nvidia.com`
+- `503` — Kubernetes client unavailable
+
+### `GET /api/v1/jobs/{namespace}/{name}`
+
+Fetch a single AIPerfJob CR plus its pod roster. Accepts an optional `?epoch=` query parameter to pin the archived half to a specific historical run directory instead of following `latest.txt`.
+
+Archived (PVC-only) jobs have no cluster CR, so the response carries the archived summary with an empty `status` object and an empty `pods` list.
+
+**Path parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `namespace` | string | Kubernetes namespace of the AIPerfJob CR |
+| `name` | string | AIPerfJob CR name |
+
+```bash
+curl http://localhost:8081/api/v1/jobs/aiperf-benchmarks/aiperf-bench-7f2a
+```
+
+```json
+{
+  "job": {
+    "name": "aiperf-bench-7f2a",
+    "namespace": "aiperf-benchmarks",
+    "phase": "Running"
+  },
+  "status": {
+    "phase": "Running",
+    "conditions": [],
+    "liveMetrics": {"requestThroughput": 1842.3}
+  },
+  "pods": [
+    {"name": "aiperf-bench-7f2a-controller-0", "phase": "Running", "ready": true, "restarts": 0},
+    {"name": "aiperf-bench-7f2a-worker-0",     "phase": "Running", "ready": true, "restarts": 0}
+  ]
+}
+```
+
+Pods are filtered by the label selector `aiperf.nvidia.com/job-id=<name>`.
+
+**Status codes**
+
+- `200` — success
+- `400` — `namespace` or `name` is not a valid RFC 1123 name (rejected before any path join)
+- `404` — no AIPerfJob with that name in that namespace and no archived run on the PVC
+- `401` / `403` — RBAC denial
+- `503` — Kubernetes client unavailable
+
+### `POST /api/v1/jobs/{namespace}/{name}/cancel`
+
+Request cancellation of a running benchmark by patching the CR's `spec.cancel` to `true`.
+
+**This endpoint is asynchronous.** It returns immediately after the patch; the kopf operator observes the change and drives workers to a stopped state over the next several seconds. Poll `GET /api/v1/jobs/{namespace}/{name}` and wait for `status.phase` to become `Cancelled`, `Failed`, or `Succeeded` if you need to confirm termination.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer ${AIPERF_OPERATOR_MUTATING_ROUTES_TOKEN}" \
+  http://localhost:8081/api/v1/jobs/aiperf-benchmarks/aiperf-bench-7f2a/cancel
+```
+
+```json
+{"cancelled": true}
+```
+
+**Status codes**
+
+- `200` — patch submitted
+- `404` — CR does not exist
+- `401` / `403` — RBAC denial
+- `409` — concurrent-modification conflict (retry)
+- `503` — Kubernetes client unavailable
+
+### `GET /api/v1/cluster`
+
+Best-effort cluster-wide totals for the dashboard header.
+
+```bash
+curl http://localhost:8081/api/v1/cluster
+```
+
+```json
+{
+  "nodes": 12,
+  "gpus": 96,
+  "gpus_used": 40,
+  "gpus_free": 56,
+  "utilization_percent": 41.7,
+  "gpu_nodes": 8,
+  "nodes_free": 4,
+  "nodes_partial": 3,
+  "nodes_full": 1,
+  "kubernetes_version": "v1.29.4",
+  "cluster_name": "dgx-prod"
+}
+```
+
+`ClusterResponse` (`operator/routers/jobs_models.py`) carries the full GPU
+accounting (`gpus_used`/`gpus_free`/`utilization_percent`), GPU-node breakdown
+(`gpu_nodes`, `nodes_free`/`nodes_partial`/`nodes_full`), and an optional
+`cluster_name` in addition to the basic `nodes`/`gpus`/`kubernetes_version`.
+Both the node list and version query are best-effort: if RBAC is insufficient or the call fails, `kubernetes_version` is reported as `"unknown"` and counts fall back to `0`. The endpoint does not surface errors for these sub-queries.
+
+### `WS /api/v1/jobs/{namespace}/{name}/ws`
+
+Per-job WebSocket proxy. The browser dashboard's per-job detail page uses this to subscribe to the same realtime message stream the controller pod publishes (e.g. `realtime_metrics`, `credit_phase_progress`, `worker_group_stats`), so KPI tiles update at the controller's emit cadence (~1Hz) instead of the page's REST poll interval.
+
+The proxy is transparent: it does not subscribe on the client's behalf. After the WS opens, the browser sends the controller's standard subscribe frame:
+
+```json
+{"type": "subscribe", "message_types": ["realtime_metrics"]}
+```
+
+…and from then on receives upstream frames verbatim. Implementation: `src/aiperf/operator/routers/jobs_ws.py`.
+
+**Topology**
+
+```mermaid
+flowchart LR
+    browser[browser<br/>job-detail page] -->|WS /api/v1/jobs/{ns}/{name}/ws| op[operator<br/>results-server]
+    op -->|reads CR status.jobSetName| api[Kubernetes API]
+    op -->|WS controller-svc:API_SERVICE/ws| ctl[controller pod]
+```
+
+The operator looks up the AIPerfJob CR's `status.jobSetName`, derives the controller pod's headless-service DNS via `controller_dns_name(jobset_name, namespace)`, and opens an `aiohttp` WebSocket to `ws://<controller-dns>:<API_SERVICE>/ws`. Two `asyncio` pumps then bridge frames in both directions until either side closes.
+
+**Refusal close codes**
+
+The proxy refuses connections with private-use (`4xxx`) WebSocket close codes so the browser can distinguish causes:
+
+| Code | Meaning |
+|---:|---|
+| `4503` | Operator's Kubernetes API client is not yet initialized (lifespan startup race). Retrying after a moment is correct. |
+| `4404` | The CR has no `status.jobSetName` yet — either the job is still being created or it doesn't exist. The dashboard only opens this WS when `phase === 'running'`, so this should be rare. |
+| `4502` | Upstream WS to the controller pod failed (DNS, connection refused, timeout). Typically means the controller pod isn't running. |
+| `1000` | Normal close (either side hung up). |
+
+
+---
+
+## Results (file serving)
+
+All file-serving endpoints read from the shared results PVC mounted at `AIPERF_RESULTS_DIR` (default `/data`). Files are laid out as `<namespace>/<job_id>/<filename>`.
+
+### `GET /api/v1/results`
+
+List every namespace/job directory with at least one stored file.
+
+```bash
+curl http://localhost:8081/api/v1/results
+```
+
+```json
+{
+  "jobs": [
+    {
+      "namespace": "aiperf-benchmarks",
+      "job_id": "aiperf-bench-7f2a",
+      "file_count": 8,
+      "total_size_bytes": 24837211
+    }
+  ]
+}
+```
+
+Returns an empty `jobs` list (not a 404) if the PVC base directory doesn't exist yet.
+
+### `GET /api/v1/results/{namespace}/{job_id}`
+
+List all result files for one job.
+
+```bash
+curl http://localhost:8081/api/v1/results/aiperf-benchmarks/aiperf-bench-7f2a
+```
+
+```json
+{
+  "namespace": "aiperf-benchmarks",
+  "job_id": "aiperf-bench-7f2a",
+  "files": [
+    {
+      "name": "profile_export_aiperf.csv",
+      "stored_name": "profile_export_aiperf.csv.zst",
+      "size_bytes": 381220,
+      "compressed": true,
+      "mtime_epoch": 1777472025
+    },
+    {
+      "name": "inputs.json",
+      "stored_name": "inputs.json",
+      "size_bytes": 4812,
+      "compressed": false,
+      "mtime_epoch": 1777472025
+    }
+  ],
+  "ready": true
+}
+```
+
+The `name` field is the **display name** (zstd suffix stripped); use it as the `{filename}` path parameter on the download endpoint. `stored_name` is the actual file on disk.
+
+**Status codes**
+
+- `200` — success
+- `400` — `namespace` / `job_id` failed RFC 1123 path-parameter validation (this is how encoded traversal attempts are rejected)
+- `404` — no directory `<namespace>/<job_id>/` exists
+
+### `GET /api/v1/results/{namespace}/{job_id}/{filename}`
+
+Download a single result file. The server handles content negotiation automatically based on `Accept-Encoding`.
+
+The lookup tries `<filename>.zst` first, then `<filename>` as-is. `namespace` and `job_id` are validated as RFC 1123 names before any path join (`400` on failure), and the resolved file path must stay under the job directory.
+
+**Content negotiation for stored `.zst` files**
+
+| Client `Accept-Encoding` | Response `Content-Encoding` | Server action |
+|--------------------------|-----------------------------|---------------|
+| `zstd` (substring match) | `zstd` | Stream raw bytes unmodified |
+| `gzip` (no zstd)         | `gzip` | Decompress zstd, recompress as gzip on the fly |
+| anything else / absent   | absent | Decompress zstd to identity |
+
+**Content negotiation for stored raw files**
+
+The `common.compression.select_encoding` helper picks the best encoding the client accepts (default `IDENTITY`). `Content-Encoding` is set only if the server is recompressing; otherwise it's omitted.
+
+**Response headers (both paths)**
+
+- `Content-Disposition: attachment; filename="<display-name>"`
+- `X-Filename: <display-name>`
+
+```bash
+# Native zstd — smallest over the wire
+curl -H "Accept-Encoding: zstd" \
+  http://localhost:8081/api/v1/results/aiperf-benchmarks/aiperf-bench-7f2a/profile_export_aiperf.csv \
+  --output profile.csv.zst
+
+# Let curl transparently decompress gzip
+curl --compressed \
+  http://localhost:8081/api/v1/results/aiperf-benchmarks/aiperf-bench-7f2a/profile_export_aiperf.csv \
+  -o profile.csv
+```
+
+**Status codes**
+
+- `200` — stream begins (note: errors mid-stream surface as truncated bodies, not HTTP errors)
+- `400` — invalid `namespace` / `job_id` path parameter
+- `404` — job directory missing or neither `<filename>` nor `<filename>.zst` found
+
+---
+
+## Analytics (runs-index backed)
+
+All analytics endpoints return `503` with message `"Analytics engine not initialized"` if the results-server lifespan hook has not yet populated the DB handle.
+
+`/analytics/leaderboard`, `/history`, `/compare`, and `/summary` are backed by the `runs_index` SQLite store (`operator/runs_index.py`, exposed through the thin `ResultsDB` facade in `operator/results_db.py`) — flat-column SELECTs against indexed rows, with a zstd-compressed `metrics_json` blob for full-summary access. The earlier DuckDB JSON-glob read path has been removed. The cold-start cost (one PVC walk) moves to the operator's startup bootstrap; subsequent queries are O(1) regardless of run count, with disk fallback + lazy backfill when the index is stale.
+
+### `GET /api/v1/analytics/leaderboard`
+
+Rank every run by a metric.
+
+**Query parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `metric` | string | `request_throughput` | Metric to rank by (e.g. `request_throughput`, `request_latency`) |
+| `stat` | string | `avg` | Statistic (`avg`, `p50`, `p99`, `min`, `max`) |
+| `order` | string | `desc` | Sort order (`asc` or `desc`) |
+| `limit` | int | `20` | Max results, `[1, 1000]` |
+| `epoch` | string? | `None` | Restrict to one run epoch; `None` = latest per `(namespace, job)` |
+
+```bash
+curl "http://localhost:8081/api/v1/analytics/leaderboard?metric=request_throughput&stat=avg&limit=5"
+```
+
+```json
+{
+  "metric": "request_throughput",
+  "stat": "avg",
+  "order": "desc",
+  "entries": [
+    {
+      "namespace": "aiperf-benchmarks",
+      "job_id": "aiperf-bench-7f2a",
+      "value": 1842.3,
+      "unit": "requests/sec",
+      "start_time": "2026-04-22T14:08:11Z",
+      "end_time":   "2026-04-22T14:13:45Z",
+      "model": "meta-llama/Llama-3.1-70B",
+      "endpoint": "http://llama:8000/v1/chat/completions"
+    }
+  ]
+}
+```
+
+### `GET /api/v1/analytics/history`
+
+Return metric values over time, optionally filtered by model or endpoint.
+
+**Query parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `metric` | string | `request_throughput` | Metric to track |
+| `stat` | string | `avg` | Statistic |
+| `model` | string? | `None` | Filter by model name (substring match) |
+| `endpoint` | string? | `None` | Filter by endpoint URL (substring match) |
+| `limit` | int | `100` | Max results, `[1, 10000]` |
+| `epoch` | string? | `None` | Restrict to one run epoch; `None` = latest per `(namespace, job)` |
+
+```bash
+curl "http://localhost:8081/api/v1/analytics/history?metric=request_latency&stat=p99&model=Llama&limit=50"
+```
+
+```json
+{
+  "metric": "request_latency",
+  "stat": "p99",
+  "entries": [
+    {
+      "namespace": "aiperf-benchmarks",
+      "job_id": "aiperf-bench-7f2a",
+      "value": 412.7,
+      "unit": "ms",
+      "start_time": "2026-04-22T14:08:11Z",
+      "model": "meta-llama/Llama-3.1-70B",
+      "endpoint": "http://llama:8000/v1/chat/completions"
+    }
+  ]
+}
+```
+
+### `GET /api/v1/analytics/compare`
+
+Pull a side-by-side comparison of named jobs across a set of metrics. The response pivots the runs-index rows into `(metric, stat, unit, values={namespace/job_id: value})` entries for the UI.
+
+**Query parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `jobs` | list[string] | required | Repeat the parameter once per job ID |
+| `metrics` | list[string]? | `DEFAULT_COMPARE_METRICS` | Repeat the parameter; defaults to key performance metrics |
+| `epoch` | string? | `None` | Restrict every job to one run epoch; `None` = latest per job |
+
+```bash
+curl "http://localhost:8081/api/v1/analytics/compare?jobs=aiperf-bench-7f2a&jobs=aiperf-bench-9d4c&metrics=request_throughput&metrics=request_latency"
+```
+
+```json
+{
+  "job_ids": ["aiperf-bench-7f2a", "aiperf-bench-9d4c"],
+  "metrics": ["request_throughput", "request_latency"],
+  "entries": [
+    {
+      "metric": "request_throughput",
+      "stat": "avg",
+      "unit": "requests/sec",
+      "values": {
+        "aiperf-benchmarks/aiperf-bench-7f2a": 1842.3,
+        "aiperf-benchmarks/aiperf-bench-9d4c": 1790.8
+      }
+    }
+  ]
+}
+```
+
+For each metric, the server emits one entry per stat (`avg`, `p50`, `p99`), plus a `meta` block alongside `entries`. Entries where no job has a value are omitted. Value keys are `namespace/job_id` when a namespace is known, otherwise just the job ID.
+
+Passing a bare job name that matches runs in more than one namespace returns `409` with the ambiguous candidates listed; re-request using `namespace/job` syntax.
+
+### `GET /api/v1/analytics/summary/{namespace}/{job_id}`
+
+Return the full aggregated summary for one job (as a raw JSON object — no Pydantic schema because the shape is driven by the metrics plugin registry).
+
+```bash
+curl http://localhost:8081/api/v1/analytics/summary/aiperf-benchmarks/aiperf-bench-7f2a
+```
+
+**Status codes**
+
+- `200` — summary found
+- `404` — no summary data for that `namespace/job_id`
+
+### `GET /api/v1/index`
+
+Return the full job index used for fast lookups, keyed by `<namespace>/<job_id>`. It is backed by the runs-index SQLite store via `get_db().index_entries()` (`operator/results_db.py` / `operator/runs_index.py`) — there is no `aiperf.operator.job_index` module. The shape is a dict of index rows consumed by the dashboard.
+
+```bash
+curl http://localhost:8081/api/v1/index
+```
+
+### `GET /api/v1/config/{namespace}/{job_id}`
+
+Return the original CR spec/config used to run a job. The server tries four sources in order (first hit wins) and records which one it used:
+
+1. **Index** (`source: "index"`) — fast path, served from the runs-index SQLite cache.
+2. **Standalone spec file** (`source: "file"`) — `<base>/<namespace>/<job_id>/job_spec.json` on the PVC.
+3. **Summary extraction** (`source: "summary"`) — pulls `input_config` out of the aggregated summary if the spec wasn't persisted separately.
+4. **Live CR** (`source: "cr"`) — fetches `spec` from the apiserver, covering running jobs whose artifacts haven't been persisted yet.
+
+Specs from the first three sources are passed through `_redact_exposed_spec` before being returned.
+
+Accepts an optional `?epoch=` query param (default: follow latest).
+
+```bash
+curl http://localhost:8081/api/v1/config/aiperf-benchmarks/aiperf-bench-7f2a
+```
+
+```json
+{
+  "source": "file",
+  "spec": {
+    "benchmark": {
+      "model": ["meta-llama/Llama-3.1-70B"],
+      "endpoint": {"url": "http://llama:8000/v1/chat/completions"}
+    }
+  }
+}
+```
+
+**Status codes**
+
+- `200` — config found via one of the four sources
+- `404` — none of the sources had data for that `namespace/job_id`
+
+---
+
+## Auth / security
+
+Read-only results-server routes do not authenticate individual HTTP requests. Mutating routes are disabled by default and require an explicit bearer token when enabled.
+
+- **Mutating-route gate.** `POST /api/v1/jobs` and `POST /api/v1/jobs/{namespace}/{name}/cancel` return `403` unless `AIPERF_OPERATOR_MUTATING_ROUTES_ENABLED=true` is set on the results-server. When enabled, `AIPERF_OPERATOR_MUTATING_ROUTES_TOKEN` must also be set and callers must send `Authorization: Bearer <token>`; missing or invalid credentials return `401`. Note that `POST /admin/index/rebuild` is separately **disabled** on the results-server (`allow_rebuild=False`) and returns `503` regardless of the token — the index is rebuilt automatically at operator startup.
+- **Helm configuration.** The bundled chart does **not** template these variables — there is no `resultsServer.mutatingRoutes` value and no token-secret projection. Set `AIPERF_OPERATOR_MUTATING_ROUTES_ENABLED` and `AIPERF_OPERATOR_MUTATING_ROUTES_TOKEN` directly on the `results-server` container (e.g. via a deployment patch or a customized chart template).
+- **First-party callers.** Clients must send the configured token as `Authorization: Bearer <token>` on protected POST requests. Note the rebuild route is mounted with `allow_rebuild=False` on the results-server and always returns `503`; only a fresh bootstrap in the operator's writer process rebuilds the index, so restart the operator pod instead. The browser dashboard does not receive this secret and keeps create/cancel controls read-only/disabled; use `aiperf kube` or `kubectl` for those operations.
+- **In-cluster RBAC.** The sidecar uses its ServiceAccount token to call the Kubernetes API. Every `/api/v1/jobs/*` and `/api/v1/cluster` call runs with those permissions, so `list aiperfjobs`, `get pods`, `patch aiperfjobs/spec`, and `list nodes` must be granted in the operator's ClusterRole. RBAC failures surface as `401` / `403` propagated from `kubernetes_asyncio`.
+- **Network isolation.** The Service is typically `ClusterIP` only. External access is expected to come via `kubectl port-forward` (trusted user), `aiperf kube dashboard` (trusted user), or an ingress controller. Add a `NetworkPolicy` if your cluster requires stricter pod-to-pod controls.
+- **Path traversal.** File-serving endpoints resolve every `{namespace}/{job_id}/{filename}` under the results directory and reject resolved paths that escape the base (`404`). Callers cannot read files outside the PVC.
+
+Do **not** expose the results server directly to the public internet without a proxy that enforces authentication in front of the read-only routes too.

--- a/docs/kubernetes/sidecars.md
+++ b/docs/kubernetes/sidecars.md
@@ -1,0 +1,231 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Controller Pod Sidecars
+---
+
+# Controller Pod Sidecars
+
+> **Scope:** **controller-pod** sidecars only — the event-bus proxy and the
+> results sidecar that ride alongside the SystemController. The operator
+> Pod's `results-server` container (port 8081) is also colloquially called
+> a sidecar; that one hosts the operator's HTTP API and is documented in
+> [`docs/kubernetes/results-api.md`](results-api.md) and
+> [`docs/dev/kubernetes-flow.md`](../dev/kubernetes-flow.md). Don't confuse
+> the two — the URL stamped onto `AIPerfSweep.status.apiUrl` and the
+> sweep-controller's empty-summary fallback both target the **operator**'s
+> results-server, never the controller's `results-sidecar`.
+
+Every AIPerf benchmark controller pod runs a short stack of sidecar containers alongside the control-plane process. Two of them — the **event-bus proxy** and the **results sidecar** — exist to offload load or provide a fallback surface that the SystemController itself cannot reliably host. They are invisible in normal usage, but anyone debugging fan-in hangs, startup races, or partial result retrieval needs to know what they do and how to tune them.
+
+The source of truth is `src/aiperf/kubernetes/jobset_builder.py` (composition), `src/aiperf/kubernetes/results_sidecar.py` (FastAPI app), and `src/aiperf/kubernetes/environment.py` (resource defaults and ports).
+
+---
+
+## Overview
+
+**Event-bus proxy** runs the XPUB/XSUB ZMQ proxy for the benchmark's pub/sub event bus in a dedicated container. It exposes `tcp://*:5663` (XSUB frontend — publishers connect here) and `tcp://*:5664` (XPUB backend — subscribers connect here) on the controller pod so that workers and record processors can connect and publish/subscribe without talking to the SystemController directly. It is an independent sidecar because, at high concurrency, hundreds of simultaneous RP and worker pub/sub connections arriving at pod startup previously starved the SystemController's event loop while it tried to forward socket I/O itself. Health endpoint is `:8088/healthz` and `:8088/readyz`.
+
+**Results sidecar** runs a minimal FastAPI app on `:9091` that serves the controller pod's `/results` volume read-only. It exists as a fallback so the operator (and `aiperf kube results --from-pods`) can still retrieve exported artifacts after the main control-plane container exits — for example, when the controller completes exports and terminates but the JobSet TTL hasn't cleaned the pod up yet. Files are hidden until the controller writes the `.aiperf_results_ready.json` marker on clean exit, so clients never download half-written artifacts.
+
+Both sidecars are always injected into controller pods by default. Disabling them is almost never correct.
+
+---
+
+## Event-bus proxy
+
+### Architecture
+
+```mermaid
+flowchart LR
+    subgraph workerpods[Worker pods N x]
+        w1[workers]
+        rp1[record processors]
+    end
+    subgraph controller[Controller pod]
+        ebp[event-bus-proxy<br/>XSUB:5663 / XPUB:5664]
+        sc[control-plane<br/>SystemController]
+        mgrs[dataset-manager<br/>timing-manager<br/>records-manager<br/>...]
+    end
+    w1 -- PUB tcp:5663 --> ebp
+    rp1 -- PUB tcp:5663 --> ebp
+    ebp -- XPUB tcp:5664 --> sc
+    ebp -- XPUB tcp:5664 --> mgrs
+    sc -- PUB tcp:5663 --> ebp
+```
+
+All pub/sub traffic for the benchmark flows through the proxy, not the SystemController. The SystemController is just another subscriber.
+
+### Ports
+
+| Port | Protocol | Name          | Purpose                                    |
+|------|----------|---------------|--------------------------------------------|
+| 5663 | TCP      | pub-frontend  | XSUB socket that publishers connect to     |
+| 5664 | TCP      | sub-backend   | XPUB socket that subscribers connect to    |
+| 8088 | HTTP     | health        | `/healthz` liveness, `/readyz` readiness   |
+
+### Resource budget
+
+Defaults are set in `_K8sEnvironment.EVENT_BUS_PROXY`:
+
+| Setting        | Default | Env var                                |
+|----------------|---------|----------------------------------------|
+| CPU request    | 50m     | `AIPERF_K8S_EVENT_BUS_PROXY_CPU`       |
+| Memory request | 64Mi    | `AIPERF_K8S_EVENT_BUS_PROXY_MEMORY`    |
+
+The default request is small because the proxy is pure socket I/O forwarding. Isolating it in its own container (rather than in the SystemController event loop) is what fixed several "SystemController heartbeat timeout during initialization" incidents at 500k+ concurrency: even a brief single-core saturation during the initial subscription storm no longer starves the control plane. If you observe the proxy pegging its core at very large fan-ins, raise `AIPERF_K8S_EVENT_BUS_PROXY_CPU`.
+
+### Startup ordering
+
+The proxy container is prepended to the controller pod's container list, so the kubelet begins pulling and starting it before the control-plane container. The proxy's bind sockets come up in tens of milliseconds — well inside the 90-second client connection-probe timeout used by the rest of the services.
+
+### Disabling (legacy fallback)
+
+Set on the operator deployment:
+
+```
+AIPERF_K8S_EVENT_BUS_SIDECAR_ENABLED=false
+```
+
+This reverts to pre-sidecar behavior: the SystemController itself hosts the XPUB/XSUB proxy inside its own event loop. This is a legacy code path kept only for bisecting regressions — do not run production benchmarks with it disabled. At anything above ~50k concurrency it will reintroduce the startup fan-in stall that motivated the sidecar in the first place.
+
+---
+
+## Results sidecar
+
+The results sidecar is a small FastAPI app launched via `python -m aiperf.kubernetes.results_sidecar`. It mounts the controller pod's `/results` PVC volume read-only and exposes three endpoints on port **9091**.
+
+### Endpoint catalog
+
+| Method | Path                              | Purpose                                        |
+|--------|-----------------------------------|------------------------------------------------|
+| GET    | `/healthz`                        | Liveness probe. Always `200 OK`.               |
+| GET    | `/api/results/list`               | List available result files (JSON)             |
+| GET    | `/api/results/files/{filename}`   | Download a result file (with content negotiation) |
+
+The response models (`ResultFileInfo`, `ResultsListResponse`) are shared with the in-process controller API router at `src/aiperf/api/models/results.py`, so the two HTTP surfaces are contractually identical.
+
+### `GET /healthz`
+
+```bash
+curl http://localhost:9091/healthz
+# {"status":"ok"}
+```
+
+### `GET /api/results/list`
+
+Returns the JSON body defined by `ResultsListResponse`. Names are paths
+relative to `/results` (the walk is recursive, so nested sweep-harvest
+layouts surface too), and the response also carries the two readiness flags:
+
+```json
+{
+  "files": [
+    {"name": "checkpoints/phase_0.parquet", "size": 1048576},
+    {"name": "metrics.json",                "size": 41820},
+    {"name": "profile_export_aiperf.json",  "size": 18331144},
+    {"name": "profile_export_console.txt",  "size": 3402}
+  ],
+  "ready": true,
+  "processing": false
+}
+```
+
+Readiness semantics:
+
+- If `.aiperf_results_ready.json` exists, every file under `/results` is listed recursively (except the marker itself).
+- If the marker is absent, only files under `/results/checkpoints/` are listed. Everything else is hidden until the controller finishes cleanly.
+- `processing` reflects a separate in-progress marker written while the controller is still exporting.
+
+### `GET /api/results/files/{filename}`
+
+Streams a single file. Honors `Accept-Encoding` — if the client advertises `zstd` or `gzip`, the sidecar streams the compressed body and sets `Content-Encoding` accordingly (via `aiperf.common.compression.stream_file_compressed`). Otherwise the file is returned as-is.
+
+- Sets `Content-Disposition: attachment; filename="..."` and `X-Filename` headers.
+- `Content-Type` is inferred from the extension: `.json`, `.jsonl`, `.csv`, `.parquet`, `.txt`; everything else is `application/octet-stream`.
+
+Error semantics:
+
+| Status | When                                                                          |
+|--------|-------------------------------------------------------------------------------|
+| 400    | Path traversal (`..`, symlink escaping `/results`) or reserved marker name    |
+| 404    | Controller not ready (marker absent) and file is not under `checkpoints/`     |
+| 404    | File path resolves correctly but does not exist                               |
+
+### Path safety
+
+`_safe_resolve` resolves the requested filename under the base directory and rejects anything that, after resolution, does not sit inside `base_dir.resolve()`. This catches `..`, absolute paths, and symlinks that would escape `/results`. The readiness marker `.aiperf_results_ready.json` is explicitly unfetchable.
+
+### Readiness marker
+
+The controller writes `/results/.aiperf_results_ready.json` via `write_ready_marker()` at the end of `SystemController` shutdown, once all exporters have flushed. The payload records whether the run was cancelled:
+
+```json
+{"ready": true, "was_cancelled": false}
+```
+
+Until the marker exists, the sidecar returns 404 on any top-level file. Checkpoint artifacts under `/results/checkpoints/` are served unconditionally so that in-flight progress can be inspected mid-run.
+
+---
+
+## When the results sidecar is used
+
+The results sidecar is reached by the operator, not directly by `aiperf kube results --from-pods`:
+
+1. **`aiperf kube results --from-pods`** tries two tiers: the **Controller API** (`http://controller-pod:9090/api/results/files/...`) via port-forward, then **`kubectl cp`** against the `control-plane` container's `/results` directory. Both require the control-plane container to still be running.
+2. **Operator completion fetch** reaches the results sidecar directly via `_download_final_and_sidecar` in `src/aiperf/operator/handlers/_completion_fetch.py`. When the primary client returns without the key result files, the operator re-issues the download against the sidecar port (`:9091`). Because the sidecar outlives the control-plane container, it covers the window between export completion and pod deletion.
+
+If neither path returns the files, results can only be recovered from operator-side storage (see `aiperf kube results` without `--from-pods`).
+
+---
+
+## Tuning
+
+### Event-bus proxy
+
+| Env var                                | Default | Notes                                                                     |
+|----------------------------------------|---------|---------------------------------------------------------------------------|
+| `AIPERF_K8S_EVENT_BUS_PROXY_CPU`       | `50m`   | Raise if the proxy pegs one core at >1M concurrency                       |
+| `AIPERF_K8S_EVENT_BUS_PROXY_MEMORY`    | `64Mi`  | Rarely the bottleneck                                                     |
+| `AIPERF_K8S_EVENT_BUS_SIDECAR_ENABLED` | `true`  | `false` only for bisecting regressions against the pre-sidecar code path  |
+
+### Results sidecar
+
+| Env var                              | Default | Notes                                                               |
+|--------------------------------------|---------|---------------------------------------------------------------------|
+| `AIPERF_K8S_RESULTS_SIDECAR_CPU`     | `25m`   | Adequate; streaming is compression-bound not CPU-bound              |
+| `AIPERF_K8S_RESULTS_SIDECAR_MEMORY`  | `192Mi` | Adequate                                                            |
+| `AIPERF_RESULTS_DIR`                 | `/results` | Volume mount path; do not change unless remounting the PVC        |
+| `AIPERF_RESULTS_SIDECAR_PORT`        | `9091`  | Container port; set by the JobSet builder to match `PORTS.RESULTS_SIDECAR` |
+| `AIPERF_RESULTS_SIDECAR_LOG_LEVEL`   | `info`  | uvicorn log level                                                   |
+
+---
+
+## When to disable
+
+- **Event-bus proxy**: basically never. The pre-sidecar code path exists only as a bisection escape hatch and will reintroduce the SystemController startup starvation it was built to fix.
+- **Results sidecar**: always-on. There is no supported toggle to turn it off, because the operator's completion-fetch path depends on it when the control-plane container has already exited. If you want to skip artifact retrieval entirely, set `ttlSecondsAfterFinished: 0` on the AIPerfJob and let the JobSet delete the pod immediately.
+
+---
+
+## Troubleshooting
+
+### The `results-sidecar` container shows `Running` but `/api/results/list` returns only checkpoints (or 404 on key files)
+
+The controller has not finished exporting. The sidecar filters out top-level files until `.aiperf_results_ready.json` is written. This is expected while the run is still in progress — checkpoint artifacts will appear as they are written, but `metrics.json` and the profile exports only show up after a clean controller exit.
+
+If the controller has exited but the marker is still missing, the run was killed (OOM, SIGKILL, node eviction) before exporters flushed. Recover partial results by:
+
+1. Downloading `checkpoints/` via the sidecar — these are written incrementally.
+2. Falling back to `aiperf kube results` without `--from-pods` (operator-side storage, if the operator successfully fetched anything before termination).
+
+### `event-bus-proxy` is `CrashLoopBackOff`
+
+Check `aiperf kube logs <job> --container event-bus-proxy`. The two real failure modes:
+
+- `AddressAlreadyInUse` on 5663/5664 — something else is bound to those ports inside the pod; almost always a sign that the main control-plane container was started with the legacy in-process proxy (`AIPERF_K8S_EVENT_BUS_SIDECAR_ENABLED=false` on one side and `true` on the other). Align both.
+- Missing `run_config.json` — the ConfigMap didn't mount before the container started. `aiperf kube debug <job>` will show the volume error.
+
+### `/healthz` returns `200` but connections to `5663`/`5664` hang
+
+The proxy is up but has no subscribers yet. This is normal during pod startup before the control-plane container has registered as a subscriber on `tcp://127.0.0.1:5664`. If it persists more than ~30 seconds after the control-plane container reports `RUNNING`, inspect its logs for `EventBusProxy` connection errors — the control-plane may be trying to run its own in-process proxy instead of connecting to the sidecar.

--- a/docs/kubernetes/source-checkout-deploy.md
+++ b/docs/kubernetes/source-checkout-deploy.md
@@ -1,0 +1,400 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Source Checkout Deployment
+---
+
+# Deploy from a Source Checkout to a Real Kubernetes Cluster
+
+This guide starts from an AIPerf source checkout and deploys that code to a real Kubernetes cluster. It builds a container image, pushes it to a registry, installs or upgrades the AIPerf operator with Helm, then runs a benchmark against a real inference endpoint.
+
+This guide does **not** use the mock server path. Use it when you have a real OpenAI-compatible endpoint already running, or when you want to deploy a real Dynamo/vLLM endpoint first.
+
+## Prerequisites
+
+You need:
+
+- An AIPerf source checkout.
+- `kubectl` configured for the target cluster.
+- Helm v3.
+- Docker or another container builder that can build and push OCI images.
+- Registry credentials for the image repository you will use.
+- Permission to install CRDs, create the operator namespace, create benchmark namespaces, and create JobSet workloads.
+- JobSet installed on the cluster. If it is not installed, install it before the AIPerf operator.
+- A real OpenAI-compatible inference endpoint reachable from benchmark pods, or permission to deploy one.
+
+Check the cluster first:
+
+```bash
+kubectl cluster-info
+kubectl get nodes
+kubectl api-resources | grep -i jobset
+```
+
+For GPU benchmarks, verify GPU resources are allocatable:
+
+```bash
+kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu
+```
+
+## 1. Set up the checkout
+
+Install the local development environment from the checkout:
+
+```bash
+make first-time-setup
+```
+
+Use the local CLI through `uv run` until the package is installed somewhere else:
+
+```bash
+uv run aiperf --help
+uv run aiperf kube --help
+```
+
+Pick a tag that identifies the exact checkout you are deploying:
+
+```bash
+export AIPERF_TAG="$(git rev-parse --short HEAD)"
+```
+
+## 2. Build and push the AIPerf image
+
+The same image is used by the operator containers and benchmark JobSet pods unless you explicitly override `defaults.image` in the Helm chart.
+
+### NGC-style registry
+
+Use this shape for an NGC organization or private NVIDIA registry namespace:
+
+```bash
+export AIPERF_IMAGE="nvcr.io/<org>/aiperf:${AIPERF_TAG}"
+
+docker build -t "${AIPERF_IMAGE}" .
+docker push "${AIPERF_IMAGE}"
+```
+
+### GitHub Container Registry
+
+Use this shape for GHCR:
+
+```bash
+export AIPERF_IMAGE="ghcr.io/<org>/aiperf:${AIPERF_TAG}"
+
+docker build -t "${AIPERF_IMAGE}" .
+docker push "${AIPERF_IMAGE}"
+```
+
+If your cluster nodes use a different architecture than the build host, build for the cluster platform:
+
+```bash
+docker buildx build \
+  --platform linux/amd64 \
+  -t "${AIPERF_IMAGE}" \
+  --push \
+  .
+```
+
+## 3. Create an image pull secret if the registry is private
+
+Skip this section if every node can pull the image without a secret.
+
+Create the operator namespace first:
+
+```bash
+kubectl create namespace aiperf-system --dry-run=client -o yaml | kubectl apply -f -
+```
+
+For NGC-style registries:
+
+```bash
+kubectl create secret docker-registry aiperf-registry \
+  --namespace aiperf-system \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password="${NGC_API_KEY}"
+```
+
+For GHCR:
+
+```bash
+kubectl create secret docker-registry aiperf-registry \
+  --namespace aiperf-system \
+  --docker-server=ghcr.io \
+  --docker-username="${GITHUB_USER}" \
+  --docker-password="${GITHUB_TOKEN}"
+```
+
+The Helm install below references this secret for the operator. Benchmark jobs also need pull access in their namespace. The chart creates the default benchmark namespace `aiperf-benchmarks`, but Kubernetes secrets are namespace-scoped, so create the same pull secret there too if you use the default namespace:
+
+```bash
+kubectl create namespace aiperf-benchmarks --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret docker-registry aiperf-registry \
+  --namespace aiperf-benchmarks \
+  --docker-server=<registry-host> \
+  --docker-username=<username> \
+  --docker-password=<token>
+```
+
+## 4. Install or upgrade the AIPerf operator
+
+Split the image into repository and tag for Helm:
+
+```bash
+export AIPERF_IMAGE_REPOSITORY="${AIPERF_IMAGE%:*}"
+export AIPERF_IMAGE_TAG="${AIPERF_IMAGE##*:}"
+```
+
+Install the operator:
+
+```bash
+helm upgrade --install aiperf-operator deploy/helm/aiperf-operator \
+  --namespace aiperf-system \
+  --create-namespace \
+  --set image.repository="${AIPERF_IMAGE_REPOSITORY}" \
+  --set image.tag="${AIPERF_IMAGE_TAG}" \
+  --set image.pullPolicy=IfNotPresent
+```
+
+If you created `aiperf-registry`, include it in the Helm release:
+
+```bash
+helm upgrade --install aiperf-operator deploy/helm/aiperf-operator \
+  --namespace aiperf-system \
+  --create-namespace \
+  --set image.repository="${AIPERF_IMAGE_REPOSITORY}" \
+  --set image.tag="${AIPERF_IMAGE_TAG}" \
+  --set image.pullPolicy=IfNotPresent \
+  --set 'imagePullSecrets[0].name=aiperf-registry'
+```
+
+The chart default for `defaults.image` is empty, which means AIPerfJob pods use `<image.repository>:<image.tag>`. Set `defaults.image` only when benchmark pods should run a different image from the operator.
+
+Wait for the operator and results server:
+
+```bash
+kubectl rollout status deploy/aiperf-operator -n aiperf-system --timeout=180s
+kubectl get pods -n aiperf-system
+```
+
+Run Helm tests if the cluster can pull the chart's test image:
+
+```bash
+helm test aiperf-operator -n aiperf-system
+```
+
+## 5. Run against an existing real endpoint
+
+Use this path when your inference server is already deployed in the cluster or reachable from the cluster network.
+
+Set the endpoint and model:
+
+```bash
+export MODEL="Qwen/Qwen3-0.6B"
+export ENDPOINT_URL="http://vllm.default.svc.cluster.local:8000/v1"
+```
+
+Run cluster-side preflight checks:
+
+```bash
+uv run aiperf kube preflight \
+  --image "${AIPERF_IMAGE}" \
+  --endpoint-url "${ENDPOINT_URL}" \
+  --workers 8
+```
+
+Submit a benchmark:
+
+```bash
+uv run aiperf kube profile \
+  --model "${MODEL}" \
+  --url "${ENDPOINT_URL}" \
+  --image "${AIPERF_IMAGE}" \
+  --total-workers 8 \
+  --request-count 1000 \
+  --concurrency 50 \
+  --streaming
+```
+
+For private benchmark images, pass the pull secret name when submitting jobs:
+
+```bash
+uv run aiperf kube profile \
+  --model "${MODEL}" \
+  --url "${ENDPOINT_URL}" \
+  --image "${AIPERF_IMAGE}" \
+  --image-pull-secrets aiperf-registry \
+  --total-workers 8 \
+  --request-count 1000 \
+  --concurrency 50 \
+  --streaming
+```
+
+For repeatable runs, put the benchmark configuration in YAML and pass `--config benchmark.yaml`; see [End-to-End Workflow](workflow.md) for the `init` -> `validate` -> `preflight` -> `profile` sequence.
+
+## 6. Optional: deploy a real Dynamo/vLLM endpoint first
+
+Skip this section if you already have a real endpoint.
+
+Install the Dynamo platform chart if your cluster does not already have it:
+
+```bash
+helm upgrade --install dynamo-platform \
+  oci://nvcr.io/nvidia/ai-dynamo/dynamo-platform \
+  --version 1.1.0 \
+  --namespace dynamo-system \
+  --create-namespace \
+  --set dynamo-operator.webhook.enabled=false \
+  --set grove.enabled=false \
+  --set kai-scheduler.enabled=false
+```
+
+Deploy an aggregated Dynamo vLLM server by applying a `DynamoGraphDeployment` manifest such as the aggregated vLLM example in [Getting Started on Kubernetes](getting-started.md#step-2-deploy-a-dynamo-inference-server):
+
+```bash
+kubectl create namespace dynamo-server --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f dynamo-server.yaml
+```
+
+Wait for the frontend and worker pods to become ready:
+
+```bash
+kubectl get pods -n dynamo-server -w
+```
+
+Use the Dynamo service URL as the benchmark endpoint:
+
+```bash
+export ENDPOINT_URL="http://dynamo-agg-frontend.dynamo-server.svc:8000/v1"
+
+uv run aiperf kube preflight \
+  --image "${AIPERF_IMAGE}" \
+  --endpoint-url "${ENDPOINT_URL}" \
+  --workers 8
+
+uv run aiperf kube profile \
+  --model "${MODEL}" \
+  --url "${ENDPOINT_URL}" \
+  --image "${AIPERF_IMAGE}" \
+  --total-workers 8 \
+  --request-count 1000 \
+  --concurrency 50 \
+  --streaming
+```
+
+## 7. Monitor and retrieve results
+
+Watch progress:
+
+```bash
+uv run aiperf kube list
+```
+
+Reattach to a detached run:
+
+```bash
+uv run aiperf kube attach
+```
+
+Download results:
+
+```bash
+uv run aiperf kube results --output ./aiperf-results
+```
+
+Port-forward the results server and dashboard:
+
+```bash
+kubectl port-forward -n aiperf-system svc/aiperf-operator 8081:8081
+```
+
+Then open `http://localhost:8081`.
+
+## 8. Upgrade after source changes
+
+After changing source code, repeat the build and push with a new immutable tag:
+
+```bash
+export AIPERF_TAG="$(git rev-parse --short HEAD)-$(date +%Y%m%d%H%M%S)"
+export AIPERF_IMAGE="nvcr.io/<org>/aiperf:${AIPERF_TAG}"
+
+docker build -t "${AIPERF_IMAGE}" .
+docker push "${AIPERF_IMAGE}"
+
+export AIPERF_IMAGE_REPOSITORY="${AIPERF_IMAGE%:*}"
+export AIPERF_IMAGE_TAG="${AIPERF_IMAGE##*:}"
+
+helm upgrade aiperf-operator deploy/helm/aiperf-operator \
+  --namespace aiperf-system \
+  --reuse-values \
+  --set image.repository="${AIPERF_IMAGE_REPOSITORY}" \
+  --set image.tag="${AIPERF_IMAGE_TAG}"
+```
+
+Wait for the new operator pod before submitting new jobs:
+
+```bash
+kubectl rollout status deploy/aiperf-operator -n aiperf-system --timeout=180s
+```
+
+## Troubleshooting
+
+### ImagePullBackOff
+
+Check the failing pod and events:
+
+```bash
+kubectl describe pod -n aiperf-system -l app.kubernetes.io/name=aiperf-operator
+uv run aiperf kube debug
+```
+
+Common fixes:
+
+- Confirm the image was pushed with the exact tag used by Helm or `aiperf kube profile`.
+- Create the pull secret in both `aiperf-system` and the benchmark namespace.
+- Pass `--image-pull-secrets aiperf-registry` to `aiperf kube profile` for private benchmark images.
+- Use `--set image.pullPolicy=Always` while testing mutable tags; prefer immutable tags for normal use.
+
+### Operator is running but jobs use an old image
+
+The operator image and default benchmark image come from the Helm release. Check the rendered CRD default:
+
+```bash
+kubectl get crd aiperfjobs.aiperf.nvidia.com \
+  -o jsonpath='{.spec.versions[?(@.name=="v1alpha1")].schema.openAPIV3Schema.properties.spec.properties.image.default}{"\n"}'
+```
+
+If you set `defaults.image`, it overrides the benchmark image independently of `image.repository` and `image.tag`.
+
+### Endpoint check fails
+
+Verify the endpoint from inside the cluster:
+
+```bash
+kubectl run curl-check \
+  --rm -it \
+  --restart=Never \
+  --image=curlimages/curl:latest \
+  -- curl -sf "${ENDPOINT_URL}/models"
+```
+
+If the server is still starting and you intentionally want the benchmark to wait until worker runtime, set `skipEndpointCheck: true` in the AIPerfJob YAML. Do not use this to hide a wrong service name or namespace.
+
+### RBAC or namespace errors
+
+The Helm chart creates benchmark RBAC for `benchmarkNamespace.name` and any namespaces listed in `benchmarkRbacNamespaces`. If you run jobs in a different namespace, either install the chart with that namespace configured or add the namespace to `benchmarkRbacNamespaces`:
+
+```bash
+helm upgrade aiperf-operator deploy/helm/aiperf-operator \
+  --namespace aiperf-system \
+  --reuse-values \
+  --set 'benchmarkRbacNamespaces[0]=team-a-benchmarks'
+```
+
+## Related Documentation
+
+- [Getting Started on Kubernetes](getting-started.md) -- First benchmark walkthrough and Dynamo manifest examples.
+- [End-to-End Workflow](workflow.md) -- Full `init` -> `validate` -> `preflight` -> `profile` -> `results` lifecycle.
+- [Production Deployments](production.md) -- CI/CD, Kueue, private registries, multi-tenancy, and operations patterns.
+- [Kubernetes Configuration Reference](configuration.md) -- CRD fields, Helm values, and AIPerfJob configuration.
+- [Monitoring and Troubleshooting](monitoring.md) -- Watch, debug, logs, and common failure modes.

--- a/docs/kubernetes/user-files.md
+++ b/docs/kubernetes/user-files.md
@@ -1,0 +1,133 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# User-Defined Output Files (`artifacts.user_files`)
+
+`artifacts.user_files` lets you declare arbitrary templated output files that are
+materialized into the run directory before the benchmark begins. Files are rendered
+with jinja2 against the user `variables:` block plus a small set of system-injected
+names. The same mechanism works for `aiperf profile` (local) and `AIPerfJob`
+(Kubernetes) — both load the same config block.
+
+## Quickstart
+
+```yaml
+variables:
+  isl: 1024
+  osl: 512
+
+benchmark:
+  artifacts:
+    user_files:
+      - path: input_config.json
+        format: json                 # optional; inferred from content type
+        content:
+          isl: "{{ isl }}"
+          osl: "{{ osl }}"
+          endpoint: "{{ endpoint_url }}"
+          model: "{{ model }}"
+
+      - path: meta/notes.md          # subdirectories allowed
+        content: |
+          Run {{ job_name }} started at {{ epoch }}.
+          Targeting {{ model }} @ {{ endpoint_url }}.
+
+  models:
+    - my-org/my-model
+  endpoint:
+    type: chat
+    urls: ["http://my-frontend:8000"]
+  datasets:
+    - name: main
+      type: synthetic
+  phases:
+    - name: profiling
+      type: concurrency
+      concurrency: 10
+      requests: 100
+```
+
+Result in the run directory:
+
+```
+{artifact_dir}/{epoch}_{job_name}/    # operator-managed (AIPerfJob)
+├── input_config.json
+├── meta/
+│   └── notes.md
+└── ... (standard AIPerf artifacts)
+```
+
+For local `aiperf profile` runs the layout is whatever `artifacts.dir` points at —
+typically a single per-run directory with no `{epoch}_{job_name}` wrapper. The
+`{{ epoch }}` system-injected name still resolves: locally it's wall-clock seconds
+captured at run start, and `{{ job_name }}` is the `--artifact-dir` basename.
+
+## Schema
+
+Each entry is:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `path` | string | yes | Output path **relative** to the run directory. Subdirectories OK. Absolute paths and any segment equal to `..` are rejected. |
+| `format` | `json` \| `yaml` \| `text` | no | Serialization format. If omitted: `text` when `content` is a string, `json` otherwise. |
+| `content` | structured or string | yes | Templated value. Dict/list/scalar for `json`/`yaml`; string for `text`. Jinja2 expressions in any string leaf are rendered. |
+
+Format/content compatibility:
+- `format: json` or `format: yaml` requires structured `content` (dict/list/scalar).
+- `format: text` requires string `content`.
+
+**Dict keys are not rendered.** Jinja2 expressions only resolve in string *values*,
+not in dict keys. `content: {"{{ model }}": "x"}` writes a file with the literal key
+`"{{ model }}"`, not the resolved model name. Put templated values where they belong
+— in values — or pre-flatten the dict before passing it to AIPerf.
+
+## Templating context
+
+Inside `content`, you can reference:
+
+**1. User-declared variables** — anything you put in the top-level `variables:` block of your config. Variables may reference each other (in any YAML order); cross-references are resolved in dependency order at config-load time, so a derived variable like `total_concurrency: "{{ concurrency_per_gpu * deployment_gpu_count }}"` already holds its computed value (`120`) by the time `user_files` rendering runs. Cycles raise `ConfigurationError`.
+
+**2. System-injected names** (stable API):
+
+| Name | Type | Meaning |
+|---|---|---|
+| `epoch` | str | Run epoch identifier (e.g. `"1714000000"`). |
+| `job_name` | str | AIPerfJob name in Kubernetes; `--artifact-dir` basename locally. |
+| `namespace` | str | Kubernetes namespace; empty string locally. |
+| `model` | str | First entry of `benchmark.models`. |
+| `endpoint_url` | str | First entry of `benchmark.endpoint.urls`. |
+| `artifact_dir` | str | Absolute path to the run directory. |
+
+**Collision rule:** if a user `variables:` key shadows an injected name, the injected name wins and a `WARNING` is logged at startup. Rename your variable.
+
+## Errors
+
+These are all fatal — the benchmark does not start.
+
+| Failure | Cause | Where you see it |
+|---|---|---|
+| Path validation | Absolute path, `..` segment, empty path, control chars | Config load (pydantic `ValidationError`) |
+| Format/content mismatch | e.g. `format: json` with `content: "string"` | Config load (pydantic `ValidationError`) |
+| Undefined variable | Template references a name not in context | Run start (`UserFileError`); message names the file path and the variable |
+| Path escape | Resolved path is not inside the run directory | Run start (`UserFileError`) |
+| Write failure | Disk full, permission denied, etc. | Run start (`UserFileError`); message includes resolved path and OS error |
+
+In Kubernetes, controller-pod failures surface on `status.phase: Failed` with the
+error in `status.conditions`.
+
+## Use cases
+
+- **Sidecar metadata** — produce an `input_config.json` for downstream tooling that expects
+  the dynamo-style deployment-shape file.
+- **Run notes** — write a `notes.md` summarizing what this run is for, who triggered it.
+- **Manifests** — emit a manifest a downstream pipeline will read.
+
+## Limitations (v1)
+
+- **Pre-run only.** Files render before the benchmark starts. Post-run files that include
+  results are tracked as a future extension.
+- **Files always overwrite.** No `overwrite: false` safety net.
+- **No `required: false`.** Every declared file must materialize successfully or the run aborts.
+- **Strict undefined.** A typo in `{{ varaibles_name }}` is a hard error, not a silent empty string.

--- a/docs/kubernetes/validate.md
+++ b/docs/kubernetes/validate.md
@@ -1,0 +1,253 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: Config Validation
+---
+
+# Config Validation
+
+`aiperf kube validate` performs **client-side** validation of one or more
+`AIPerfJob` **or** `AIPerfSweep` YAML files against the full CRD schema, the
+Pydantic spec models, and Kubernetes resource-naming rules. It dispatches per
+document on the `kind:` field (`validate.py` `SUPPORTED_KINDS = {AIPerfJob,
+AIPerfSweep}`), routing to `AIPerfJobSpec` or `AIPerfSweepSpec`. It does not
+contact the cluster — making it safe to run in CI, pre-commit hooks, and local
+editors.
+
+> **Two layers, same rules.** `aiperf kube validate` runs the same structural
+> checks the apiserver enforces at `kubectl apply`. For the catalog of CEL
+> `x-kubernetes-validations` rules (shorthand-vs-canonical, mutual exclusion,
+> `apiHost ⇒ apiPort`, etc.) see [CRD Validation Rules](crd-validation.md).
+> Item-internal Pydantic validators (phase-name uniqueness, phase→dataset
+> reference integrity, "seamless not on first phase") run only at apply
+> time on the operator side because CEL can't see into opaque
+> preserve-unknown array items — the client-side `validate` command runs
+> them via Pydantic, so it catches both layers in one pass.
+
+## When to use
+
+| Situation | Tool |
+|---|---|
+| Validate YAML before `kubectl apply` or `aiperf kube profile` | `aiperf kube validate` (this doc) |
+| Check that a *live cluster* can actually schedule the job (quotas, GPU availability, operator health) | `aiperf kube preflight` |
+| Confirm the operator is installed and responsive | `aiperf kube list` |
+
+Think of `validate` as the offline static check and `preflight` as the online
+dynamic check. Both are cheap; run `validate` on every commit and `preflight`
+before the first apply of a new job.
+
+Typical integration points:
+
+- **CI gate** — run `find recipes -name perf.yaml -print0 | xargs -0 aiperf
+  kube validate --strict` in a GitHub Action or GitLab job before merging
+  changes to benchmark specs.
+- **Pre-commit** — catch typos in `spec.benchmark` fields before they reach the
+  cluster (see [Integration recipes](#integration-recipes)).
+- **IDE / Makefile target** — add `make validate-jobs` so contributors get fast
+  feedback without spinning up a cluster.
+
+## CLI reference
+
+```text
+aiperf kube validate <files...> [--strict] [--output text|json]
+```
+
+| Flag | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `files` | — | `Path...` (positional, one or more) | — | Paths to `AIPerfJob` or `AIPerfSweep` YAML files. Globs are expanded by the shell. |
+| `--strict` | `-s` | bool | `false` | Treat warnings (unknown spec fields) as errors. |
+| `--output` | `-o` | `text` \| `json` | `text` | Output format. `text` prints a coloured per-file summary; `json` prints a machine-parseable array. |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | All files passed. Warnings may still be present in non-strict mode. |
+| `1` | At least one file failed validation, or an internal error occurred. |
+
+### Examples
+
+```bash
+# Validate a single job file
+aiperf kube validate aiperfjob.yaml
+
+# Validate selected checked-in recipes
+aiperf kube validate recipes/llama-3-70b/vllm/agg/perf.yaml \
+  recipes/qwen3-32b/vllm/agg-round-robin/perf.yaml
+
+# Treat unknown spec fields as hard errors (recommended in CI)
+aiperf kube validate --strict aiperfjob.yaml
+
+# Machine-parseable output for scripting
+aiperf kube validate -o json aiperfjob.yaml | jq '.[] | select(.passed==false)'
+```
+
+## What gets validated
+
+`validate` runs the following checks on each file, in order. Structural errors
+that make later checks impossible short-circuit the file (remaining checks are
+skipped for that file only).
+
+1. **File reachability** — the path exists and is a regular file.
+2. **YAML parse** — the document is valid YAML and decodes to a mapping.
+3. **Required top-level fields**:
+   - `apiVersion` must equal the current operator API version
+     (`aiperf.nvidia.com/v1alpha1`).
+   - `kind` must be one of `AIPerfJob` or `AIPerfSweep`. The kind selects
+     which spec model the document is validated against; an `AIPerfJob` must
+     omit `spec.sweep` while an `AIPerfSweep` requires it.
+   - `metadata` must be a mapping with a `name` field.
+   - `spec` must be a mapping.
+   - `spec.benchmark` must be a mapping containing at least one of `models` or
+     `endpoint`.
+4. **Kubernetes naming** — `metadata.name` must:
+   - be at most **253 characters** (`K8S_NAME_MAX_LENGTH`), and
+   - match the RFC 1123 subdomain pattern `[a-z0-9]([a-z0-9-]*[a-z0-9])?`
+     (lowercase alphanumerics and hyphens; must start and end with an
+     alphanumeric).
+5. **Unknown field detection** (warning by default, error with `--strict`):
+   - **Top-level `spec`** is compared against `KNOWN_SPEC_FIELDS`
+     (`validate.py`) — the deployment fields `image`, `imagePullPolicy`,
+     `keepFailedPods`, `resourceMode`, `connectionsPerWorker`,
+     `timeoutSeconds`, `ttlSecondsAfterFinished`, `resultsTtlDays`, `cancel`,
+     `podTemplate`, `scheduling`, `skipEndpointCheck`, `failurePolicy`; the
+     envelope fields `schemaVersion`, `sweep`, `multiRun`, `plot`, `variables`,
+     `randomSeed`, `noSweepTable`, `childMetadata`; plus the nested `benchmark` block. Stray top-level keys
+     often mean a benchmark-config field was placed at `spec.<x>` instead of
+     `spec.benchmark.<x>` — the warning message says so explicitly.
+   - **`spec.benchmark`** is compared against `CONFIG_FIELDS`
+     (`kubernetes/spec_converter.py`): every `BenchmarkConfig` model field, its
+     serialization aliases, plus the shorthand keys `model`, `dataset`,
+     `warmup`, `profiling`.
+6. **`AIPerfConfig` construction** — `spec.benchmark` is fed through
+   `AIPerfJobSpecConverter.to_aiperf_config()`, which performs the same env-var
+   and Jinja2 expansion as a local CLI file load, then validates the result
+   against the Pydantic model. Type, range, and cross-field errors surface
+   here.
+7. **Endpoint sanity** — at least one model name must be present, and every
+   entry in `endpoint.urls` must start with `http://` or `https://`.
+8. **Deployment-config extraction** — top-level spec fields are materialised
+   into a `DeploymentConfig` via `to_deployment_config()`. Catches malformed
+   `podTemplate`, invalid `resourceMode`, bad `scheduling` blocks, etc.
+9. **Endpoint credential transport** — credential-bearing endpoint fields
+   must have the matching Secret-backed pod environment (`AIPERF_INJECTED_API_KEY`,
+   `AIPERF_INJECTED_HEADERS`, or `AIPERF_INJECTED_ENDPOINT_URLS`). Literal
+   secrets and plain-value environment variables fail before deployment.
+10. **Worker-count calculation** — `calculate_workers()` must return a value
+   `>= 1` given the current `concurrency`, `connectionsPerWorker`, and mode.
+11. **Kind-specific spec validation** — the Config-v2 envelope is rendered
+    before the complete `AIPerfJobSpec` or `AIPerfSweepSpec` check. Raw Jinja
+    values therefore validate as their resolved numeric or structured types,
+    while unknown variables and invalid rendered values still fail closed.
+
+> Note: `validate` is intentionally conservative about what it considers
+> "unknown". Any key in `CONFIG_FIELDS` (every `BenchmarkConfig` field, its
+> aliases, and the shorthand keys) is accepted under `spec.benchmark`, so
+> newly added config fields do not require a docs update to this page.
+
+## JSON output schema
+
+With `-o json`, a single JSON array is printed to stdout. Each element
+corresponds to one input file, in the order given on the command line.
+
+```jsonc
+[
+  {
+    "path": "string",         // filesystem path as provided
+    "passed": true,           // bool; true iff errors is empty
+    "errors":   ["string..."], // fatal issues (empty when passed=true)
+    "warnings": ["string..."]  // non-fatal issues; upgraded to errors under --strict
+  }
+]
+```
+
+### Example — all files pass
+
+```json
+[
+  {
+    "path": "recipes/llama-3-70b/vllm/agg/perf.yaml",
+    "passed": true,
+    "errors": [],
+    "warnings": []
+  }
+]
+```
+
+### Example — multiple errors
+
+```json
+[
+  {
+    "path": "recipes/broken.yaml",
+    "passed": false,
+    "errors": [
+      "kind: expected one of ['AIPerfJob', 'AIPerfSweep'], got 'AIPerfConfig'",
+      "metadata.name: 'My_Benchmark' is not a valid Kubernetes resource name (must match [a-z0-9][a-z0-9-]*[a-z0-9])",
+      "Unknown spec fields (did you mean to put these under spec.benchmark?): models, endpoint",
+      "endpoint.urls: 'localhost:8000' must start with http:// or https://"
+    ],
+    "warnings": []
+  }
+]
+```
+
+Scripting tip — fail a CI job on any warning, not just errors:
+
+```bash
+find recipes -name perf.yaml -print0 \
+  | xargs -0 aiperf kube validate -o json \
+  | jq -e 'all(.passed and (.warnings | length == 0))'
+```
+
+## Integration recipes
+
+### Pre-commit hook
+
+Add to `.pre-commit-config.yaml`:
+
+```yaml
+- repo: local
+  hooks:
+    - id: aiperf-kube-validate
+      name: aiperf kube validate
+      entry: aiperf kube validate --strict
+      language: system
+      files: ^recipes/.*\.ya?ml$
+      pass_filenames: true
+```
+
+### GitHub Actions step
+
+```yaml
+- name: Validate AIPerfJob specs
+  run: |
+    uv tool install aiperf
+    find recipes -name perf.yaml -print0 | xargs -0 aiperf kube validate --strict
+```
+
+In a matrix/monorepo setup, use JSON output to surface a compact report:
+
+```yaml
+- name: Validate AIPerfJob specs
+  run: |
+    find recipes -name perf.yaml -print0 \
+      | xargs -0 aiperf kube validate -o json > validation.json
+    jq -r '.[] | select(.passed==false) | "::error file=\(.path)::\(.errors[0])"' validation.json
+```
+
+### Makefile target
+
+```makefile
+.PHONY: validate-jobs
+validate-jobs:
+	find recipes -name perf.yaml -print0 | xargs -0 aiperf kube validate --strict
+```
+
+## See also
+
+- [`production.md`](production.md) — production deployment guide, including
+  the recommended CI pipeline.
+- [`configuration.md`](configuration.md) — reference for `spec` and
+  `spec.benchmark` fields.
+- `aiperf kube preflight` — live-cluster counterpart to `validate`.

--- a/docs/kubernetes/workflow.md
+++ b/docs/kubernetes/workflow.md
@@ -1,0 +1,513 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+sidebar-title: End-to-End Workflow
+---
+
+# End-to-End Workflow
+
+This guide walks through the full lifecycle of a single AIPerf benchmark on
+Kubernetes: from generating a config template all the way through retrieving
+results and cleaning up. Each individual subcommand has its own reference
+page; this page is the linear narrative that ties them together and shows how
+state flows from one step to the next.
+
+If you have never deployed AIPerf on Kubernetes before, start with
+[Getting Started](./getting-started.md) for cluster prerequisites and
+installing the operator, then return here.
+
+## Lifecycle overview
+
+Most runs follow the same path. Commands marked "local" run entirely on your
+laptop; commands marked "cluster" talk to the Kubernetes API server.
+
+```mermaid
+flowchart TD
+    init["aiperf kube init<br/>(local)"] --> validate["aiperf kube validate<br/>(local)"]
+    validate --> preflight["aiperf kube preflight<br/>(cluster)"]
+    preflight --> profile["aiperf kube profile<br/>(cluster)"]
+    profile -->|foreground| attach_inline["streams logs<br/>until completion"]
+    profile -->|--detach| detached["returns immediately;<br/>CR running in cluster"]
+    attach_inline --> results["aiperf kube results<br/>(cluster)"]
+    detached --> attach["aiperf kube attach<br/>(re-stream logs)"]
+    attach --> results
+    results --> cleanup["kubectl delete<br/>aiperfjob / jobset"]
+```
+
+The commands on the left-hand column (init, validate, preflight) are
+pre-flight work: they write or inspect files and poke at the cluster but
+never create workload resources. `profile` is the one command that actually
+deploys. `attach`, `results`, `logs`, and `debug` all operate on an
+already-deployed benchmark; `list --watch` continuously refreshes cluster
+status.
+
+## Stage 1: `init` — scaffold a config
+
+`aiperf kube init` renders one of the bundled AIPerf config templates
+(`src/aiperf/config/templates/`), wraps it in an `AIPerfJob` CR shell, and
+prints it to stdout — or writes it to a file with `-o` / `--output`.
+
+```bash
+# Print the default 'minimal' template to stdout
+aiperf kube init
+
+# Browse the bundled templates
+aiperf kube init --list
+aiperf kube init --search goodput
+
+# Pick a template and pre-fill model / endpoint, write to benchmark.yaml
+aiperf kube init -t goodput_slo \
+    --model Qwen/Qwen3-0.6B \
+    --url http://server:8000 \
+    --output benchmark.yaml
+```
+
+The output is an `apiVersion: aiperf.nvidia.com/v1alpha1`, `kind: AIPerfJob`
+document: the template body lands under `spec`, and commented-out blocks for
+deployment options, pod customization, and Kueue scheduling are appended. It is
+the same CR format the operator accepts, so you can either hand it to
+`aiperf kube profile --config benchmark.yaml` or `kubectl apply -f
+benchmark.yaml` it directly. `--job-name` (default `my-benchmark`) sets
+`metadata.name`. See [init-and-generate.md](./init-and-generate.md) for the
+full flag list and a walkthrough of the emitted template.
+
+`init` writes nothing else — no cluster state, no `last_kube_benchmark.json`,
+no container image references. Image, workers, and namespace are still
+supplied at `profile` time via CLI flags.
+
+## Stage 2: `validate` — offline config check
+
+`aiperf kube validate` reads one or more YAML files and validates them
+against the CRD schema and the `AIPerfConfig` model, without touching the
+cluster. Use it in CI or in a pre-commit hook to catch typos before you
+deploy.
+
+```bash
+aiperf kube validate benchmark.yaml
+find recipes -name perf.yaml -print0 | xargs -0 aiperf kube validate --strict
+aiperf kube validate -o json benchmark.yaml
+```
+
+See [validate.md](./validate.md) for the full list of checks (RFC 1123 name
+validation, endpoint presence, worker math, unknown-field detection, etc.)
+and CI recipes.
+
+## Stage 3: `preflight` — cluster-side check
+
+`aiperf kube preflight` confirms that the cluster you are about to deploy
+into is actually capable of running the benchmark. It is the first command
+that contacts the cluster.
+
+```bash
+# Basic
+aiperf kube preflight
+
+# With image and endpoint probes and a worker-count projection
+aiperf kube preflight \
+    --image aiperf:latest \
+    --endpoint-url http://server:8000 \
+    --workers 8
+
+# JSON output for CI
+aiperf kube preflight -o json
+```
+
+It verifies connectivity, API versions, RBAC, node capacity vs. worker
+projection, image pull-ability, and endpoint reachability. See
+[preflight.md](./preflight.md) for the full check list and the JSON schema.
+Running `validate` and `preflight` together gives you full coverage of "is
+the config sane?" plus "is the cluster ready?".
+
+## Stage 4: `profile` — deploy the benchmark
+
+This is the load-bearing command. It parses a config (from CLI flags or from
+the YAML file you validated), picks a deployment mode, submits resources to
+the cluster, and optionally streams logs until the benchmark finishes.
+
+### Operator mode vs. direct mode
+
+By default, `profile` looks for the `aiperfjobs.aiperf.nvidia.com` CRD on the
+cluster (see `operator_available` in
+`src/aiperf/cli_commands/kube/profile_deploy.py`). Use `--operator` to select
+operator mode without that cluster-scoped discovery request, or
+`--no-operator` to select direct mode.
+
+- **Operator mode (default when CRD is present).** `profile` creates a
+  single `AIPerfJob` custom resource. The in-cluster operator reconciles the
+  CR and owns the lifecycle of the downstream `JobSet`, `ConfigMap`, `Role`,
+  and `RoleBinding`. Results are fetched into a shared operator PVC as the
+  benchmark runs. When `--namespace` is explicit, `profile` treats that
+  namespace as pre-provisioned and does not issue a Namespace-create request.
+  This lets namespace-scoped tenants submit AIPerfJobs without cluster-wide
+  CRD-read or Namespace-create permission by combining `--operator` with
+  `--namespace`.
+
+- **Direct mode (CRD absent, or forced with `--no-operator`).** `profile`
+  skips the operator and creates the `Namespace`, `ConfigMap`, `Role`,
+  `RoleBinding`, and `JobSet` itself. There is no CR and no operator-managed
+  PVC; results stay on the pod filesystem until you pull them with `aiperf
+  kube results --from-pods`. See [direct-mode.md](./direct-mode.md). The
+  JobSet TTL defaults to 8 hours in direct mode (vs. 5 minutes in operator
+  mode) specifically so pods stay alive long enough for manual results
+  retrieval.
+
+Both modes accept the same flags. To preview the manifests without
+submitting them, use `aiperf kube generate --operator` or `aiperf kube
+generate --no-operator` instead — or pass `--dry-run` to `profile`, which
+prints the would-be CR as JSON in operator mode, or the raw manifests as
+multi-document YAML in direct mode.
+
+### Foreground vs. `--detach`
+
+Once the resource is created, `profile` decides whether to block:
+
+- **Foreground (the default, when stdout is a TTY).** In operator mode the CLI
+  polls the AIPerfJob CR every 2 seconds via `watch_job` until the benchmark
+  finishes or a hard 600-second timeout is reached. It does not port-forward to
+  the controller pod; use `aiperf kube attach` after submission for real-time log
+  streaming. Ctrl+C returns to the shell but leaves the cluster-side run intact.
+  For benchmarks that run longer than 600 seconds, pass `--detach` and monitor
+  separately with `aiperf kube attach`.
+- **`--detach` (or any non-interactive stdout, e.g. a pipe or CI).** The CLI
+  submits the resource, prints "Detached" with a hint about how to re-attach,
+  and exits immediately. The benchmark continues running in the cluster.
+  Non-interactive environments auto-upgrade to detach mode with a warning —
+  see `wait_or_detach` in `src/aiperf/cli_commands/kube/profile_deploy.py`.
+
+### The "last benchmark" handoff
+
+As part of a successful submit, `profile` writes
+`~/.aiperf/last_kube_benchmark.json` — this is how the rest of the workflow
+commands default their `job_id` and `--namespace` to "whatever you just
+deployed". The file is written by both operator-mode (`deploy_via_operator`)
+and direct-mode paths. See [Last benchmark persistence](#last-benchmark-persistence)
+below for details.
+
+Operator jobs and sweeps also record their custom-resource kind. Destructive
+commands use that kind when no `job_id` is supplied, so a same-named
+`AIPerfJob` and `AIPerfSweep` cannot redirect the last-benchmark shorthand to
+the wrong resource. Legacy and direct-mode records remain readable without a
+kind.
+
+### Common `profile` invocations
+
+```bash
+# From a CR-format YAML file (validated above), with operator auto-detect
+aiperf kube profile \
+    --config benchmark.yaml \
+    --image aiperf:latest \
+    --total-workers 10
+
+# From pure CLI flags, foreground, follows logs until done
+aiperf kube profile \
+    --model Qwen/Qwen3-0.6B \
+    --url http://server:8000 \
+    --image aiperf:latest \
+    --total-workers 8
+
+# CI / scripted: deploy and return control immediately
+aiperf kube profile \
+    --config benchmark.yaml \
+    --image aiperf:latest \
+    --detach
+
+# Force direct mode even if the operator is installed
+aiperf kube profile \
+    --model Qwen/Qwen3-0.6B \
+    --url http://server:8000 \
+    --image aiperf:latest \
+    --no-operator
+
+# Pre-provisioned tenant namespace; skip cluster-scoped CRD discovery
+aiperf kube profile \
+    --config benchmark.yaml \
+    --namespace team-a-benchmarks \
+    --operator
+```
+
+## Stage 5: `attach` — re-connect to a detached run
+
+If you detached (or Ctrl-C'd out of a foreground run), `aiperf kube attach`
+re-opens the log stream. It port-forwards to the controller pod's API
+container and streams real-time progress over WebSocket.
+
+```bash
+# Re-attach to the last deployed benchmark
+aiperf kube attach
+
+# Re-attach to a specific job
+aiperf kube attach my-benchmark --namespace aiperf-bench
+```
+
+Called without arguments, `attach` reads
+`~/.aiperf/last_kube_benchmark.json` for the job-id and namespace, so the
+zero-argument form works as long as you haven't deployed a second benchmark
+in between. Ctrl+C disconnects from the stream without killing the
+benchmark.
+
+### Cancelling a run
+
+`aiperf kube cancel` patches `spec.cancel: true` on the CR. The operator
+tears down the JobSet, stamps `status.phase=Cancelled`, and emits a
+`Cancelled` event; already-terminal benchmarks are left alone. A job created
+with `spec.cancel: true` is terminalized the same way before any endpoint
+probe, preflight check, or Kubernetes benchmark resource is created.
+
+```bash
+# Cancel the last deployed benchmark
+aiperf kube cancel
+
+# Cancel a specific job, a whole sweep, or one variation of it
+aiperf kube cancel my-benchmark --namespace aiperf-bench
+aiperf kube cancel my-sweep
+aiperf kube cancel shared-name --kind sweep
+aiperf kube cancel my-sweep -v 7
+```
+
+When an `AIPerfJob` and `AIPerfSweep` share a name, pass `--kind job` or
+`--kind sweep`. The CLI refuses an ambiguous destructive command instead of
+selecting one kind by lookup order.
+
+Cancelling is not the same as deleting: the CR (and any results already
+harvested) stays, so `aiperf kube results` still works afterwards.
+
+### Retiring and removing runs
+
+```bash
+# Let a finished benchmark's controller pod exit and free its reservation.
+# Refuses while the run is still going -- cancel it first.
+aiperf kube shutdown my-benchmark
+
+# Delete one benchmark; the JobSet and pods go with it via ownerReferences.
+aiperf kube delete my-benchmark --force
+aiperf kube delete shared-name --kind sweep --force
+
+# Bulk-remove finished benchmarks from a namespace (running ones are left alone)
+aiperf kube cleanup --dry-run
+aiperf kube cleanup
+
+# Include running benchmarks; each is cancelled before it is removed
+aiperf kube cleanup --all --force
+```
+
+`delete` and `cleanup` prompt before removing anything and refuse outright
+when stdin is not a terminal, so a CI job cannot delete by accident -- pass
+`--force` when you mean it. Results already harvested onto the operator's PVC
+survive all three commands.
+
+`delete --delete-namespace` additionally requires the namespace name to be
+`aiperf-<job_id>` and the live Namespace to carry AIPerf's canonical
+`aiperf.nvidia.com/auto-generated: "true"` label plus a matching
+`aiperf.nvidia.com/job-id: <job_id>` ownership label. Shared and older
+namespaces without provable job ownership are left in place. The delete uses
+the UID and resource version read with those labels, so a removed, recreated,
+or modified namespace is also left in place.
+
+## Stage 6: `results` — pull the artifacts
+
+When the run is complete (phase `Completed` in `aiperf kube list`), fetch
+the artifacts:
+
+```bash
+# Default: operator mode — reads from the operator's PVC via HTTP.
+aiperf kube results
+
+# Custom output directory (default is ./artifacts/{name})
+aiperf kube results --output ./out
+
+# Direct mode, or fallback if the operator hasn't imported results yet
+aiperf kube results --from-pods
+
+# Direct mode + let the controller pod exit cleanly
+aiperf kube results --from-pods --shutdown
+
+# Summary only (no per-request parquet)
+aiperf kube results --summary-only
+```
+
+`results` has two retrieval paths:
+
+1. **Operator PVC (default).** Calls the operator's results API at
+   `/api/v1/results/...` over a port-forward to the operator pod. Works
+   even after the benchmark pods have been TTL-deleted, because the operator
+   copied everything into its persistent volume. See
+   [results-api.md](./results-api.md) for the HTTP surface and PVC layout.
+
+2. **`--from-pods`.** Goes directly to the benchmark controller pod. Tries
+   the controller HTTP API first, then falls back to `kubectl cp`. Required
+   for direct-mode deployments; useful in operator mode if the operator
+   hasn't synced yet or if you want the raw on-pod artifact tree. Combined
+   with `--shutdown`, the controller pod exits cleanly after the copy so the
+   JobSet can complete.
+
+The command exits with status 1 when the target cannot be resolved or any
+requested result download fails. This makes a successful exit safe to use as
+the artifact-collection gate in CI; partial sweep downloads also fail the
+command even though successfully downloaded child artifacts remain on disk.
+
+Output directory defaults to `./artifacts/{benchmark-name}`.
+
+## Intermediate commands
+
+These don't fit the linear sequence but are part of everyday operation:
+
+- **`aiperf kube list`** — enumerates AIPerfJob CRs (falls back to JobSet
+  lookup in direct mode), with `--running`, `--completed`, `--failed`,
+  `--watch`, and `-A`. This is how you discover names you've forgotten.
+- **`aiperf kube logs`** — raw pod logs, with `--follow`, `--tail`,
+  `--container`, and `--output` (save per-pod files to a directory).
+- **`aiperf kube debug`** — one-shot diagnostic: pod states, recent events,
+  node resources, and a slice of logs from any pod with problems. See
+  [debug-command.md](./debug-command.md).
+- **`aiperf kube dashboard`** — port-forwards the operator's results server
+  UI and opens it in your browser. Useful for browsing multiple past
+  benchmarks stored on the operator PVC.
+- **`aiperf kube sweep`** — deploys an `AIPerfSweep` (parameter sweep or
+  multi-run) instead of a single `AIPerfJob`. See [Running Sweeps on Kubernetes](../tutorials/sweeps.md#running-sweeps-on-kubernetes).
+- **`aiperf kube show`** — renders an `AIPerfJob` CR with Jinja2 and env-var
+  substitutions resolved, so you can see what the operator will actually read.
+
+## Stage 7: cleanup
+
+Benchmark resources carry a TTL, but you often want to reclaim space (and the
+CR name) sooner.
+
+- **Operator mode:**
+  ```bash
+  kubectl delete aiperfjob my-benchmark -n aiperf-benchmarks
+  ```
+  The operator cleans up the downstream JobSet, ConfigMap, and RBAC as part
+  of CR finalization. The `last_kube_benchmark.json` entry is not cleared
+  automatically — subsequent `attach`/`results` calls will report
+  "not found". Pass the job ID (positional) and `-n` / `--namespace`
+  explicitly, or deploy a new benchmark to repopulate.
+
+- **Direct mode:**
+  ```bash
+  kubectl delete jobset my-benchmark -n aiperf-benchmarks
+  ```
+  Delete the ConfigMap, Role, and RoleBinding before re-deploying the same
+  name. Direct mode reuses an existing Namespace but refuses to adopt any
+  existing workload or RBAC resource because it cannot prove that resource
+  belongs to the new invocation. The JobSet `ttl_seconds` defaults to 28800
+  (8 hours) so the pods stay alive long enough for `aiperf kube results
+  --from-pods`; after TTL, Kubernetes garbage-collects the JobSet for you.
+
+## Last benchmark persistence
+
+The file `~/.aiperf/last_kube_benchmark.json` is the glue that lets
+`attach`, `results`, `logs`, and `debug` default to the most
+recently deployed benchmark.
+
+The format is:
+
+```json
+{
+  "job_id": "qwen3-0-6b-openai-throughput",
+  "namespace": "aiperf-benchmarks",
+  "name": "my-benchmark"
+}
+```
+
+`job_id` and `namespace` are always present; `name` is the
+user-supplied-or-generated friendly name and is optional. See
+`LastBenchmarkInfo`, `save_last_benchmark`, and `get_last_benchmark` in
+`src/aiperf/kubernetes/console.py`.
+
+Default-resolution logic lives in `resolve_job_id_and_namespace` in
+`src/aiperf/kubernetes/cli_helpers.py`: if `job_id` is explicitly passed,
+the flag wins. Otherwise the file is consulted, and if the file is missing
+the command prints an error and exits.
+
+**Multi-cluster pitfall.** The file is per-user, not per-kubeconfig or
+per-context. If you alternate between clusters in one shell session, always
+pass the job ID positionally plus `-n` / `--namespace` (and `--kube-context`)
+explicitly. Otherwise "I deployed to
+staging and `results` is reading from prod" is an easy way to chase a ghost.
+
+### Command interaction matrix
+
+| Command | Reads `last_kube_benchmark.json` | Writes it | Notes |
+| --- | --- | --- | --- |
+| `kube init` | no | no | Pure local file generator. |
+| `kube validate` | no | no | Offline YAML validation. |
+| `kube preflight` | no | no | Uses `--namespace`; no job concept. |
+| `kube profile` | no | **yes** (on successful submit) | Both operator and direct paths write the file. |
+| `kube generate` | no | no | Prints manifests; never hits cluster state. |
+| `kube attach` | yes (if `job_id` omitted) | no | |
+| `kube results` | yes (if `job_id` omitted) | no | |
+| `kube logs` | yes (if `job_id` omitted) | no | |
+| `kube debug` | yes (if `-j` and `-n` both omitted and `-A` not set) | no | |
+| `kube list` | no | no | Enumerates the cluster directly. |
+| `kube dashboard` | no | no | Operator-scoped, not job-scoped. |
+
+## Common end-to-end recipes
+
+### Quick smoke test, foreground
+
+Typical developer loop: validate, deploy, watch logs inline, pull results.
+
+```bash
+aiperf kube init --output smoke.yaml
+# edit smoke.yaml: set models, endpoint, datasets
+aiperf kube validate smoke.yaml
+aiperf kube preflight --image aiperf:latest --endpoint-url http://server:8000
+aiperf kube profile --config smoke.yaml --image aiperf:latest
+aiperf kube results
+```
+
+Because `profile` stays in the foreground, the last three commands are a
+tight cycle: change config, re-run `profile`, inspect artifacts.
+
+### Long-running benchmark, detached
+
+For multi-hour runs from a laptop, CI, or SSH session, detach up front and
+poll with `list --watch`.
+
+```bash
+aiperf kube profile --config long.yaml --image aiperf:latest --detach
+# ... walk away; come back later ...
+aiperf kube list --watch --running # continuously refresh running jobs
+aiperf kube debug                  # diagnose a job that looks stuck
+aiperf kube results                # once list reports Completed
+```
+
+CI systems automatically hit this path because stdout is not a TTY — no need
+to pass `--detach` explicitly. Use `kubectl wait --for=condition=Complete aiperfjob/<name>` if you need
+scripted completion detection; the CRD exposes `Complete` / `Failed`
+conditions with the same semantics as a `batchv1.Job`. Every terminal
+transition, including a permanent validation or preflight failure during
+creation, stamps `status.completionTime` for TTL and history consumers.
+
+### Multi-user shared cluster
+
+On a cluster shared by multiple users, deploy each benchmark into its own
+namespace and use [Kueue](./kueue.md) to gate admission.
+
+```bash
+aiperf kube profile \
+    --config long.yaml \
+    --image aiperf:latest \
+    --namespace bench-alice \
+    --queue-name aiperf-local-queue \
+    --detach
+aiperf kube list --namespace bench-alice
+aiperf kube results --namespace bench-alice
+```
+
+Because `last_kube_benchmark.json` is per-user (not per-namespace), Alice's
+shell and Bob's shell each remember their own most-recent deploy
+independently. Within a single shell, always pass `--namespace` explicitly
+when you work across more than one.
+
+## Related references
+
+- [Getting Started](./getting-started.md) — cluster prerequisites, operator
+  install.
+- [Configuration](./configuration.md) — CLI and CR configuration surfaces.
+- [Validate](./validate.md) — YAML validation details.
+- [Preflight](./preflight.md) — cluster-readiness checks.
+- [Direct mode](./direct-mode.md) — running without the operator.
+- [Results API](./results-api.md) — operator PVC retrieval and HTTP surface.
+- [Kueue](./kueue.md) — multi-tenant admission control.
+- [Production](./production.md) — hardening, quotas, and monitoring.

--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -111,6 +111,8 @@ This document provides a comprehensive reference of all metrics available in AIP
     - [Request Throughput](#request-throughput)
     - [Request Count](#request-count)
     - [Error Request Count](#error-request-count)
+    - [Cancelled Request Count](#cancelled-request-count)
+    - [Request Error Rate](#request-error-rate)
     - [Minimum Request Timestamp](#minimum-request-timestamp)
     - [Maximum Response Timestamp](#maximum-response-timestamp)
     - [Benchmark Duration](#benchmark-duration)
@@ -1594,7 +1596,7 @@ good_request_count = sum(1 for r in records if r.all_slos_met)
 
 **Tag:** `good_request_fraction`
 
-The fraction of all attempted requests that satisfied every per-request SLO. Returns a ratio in `[0.0, 1.0]`. Errored requests count toward the denominator so a backend that drops traffic under load cannot look "good" simply because the surviving requests stayed under the latency budget.
+The fraction of all attempted requests that satisfied every per-request SLO. Returns a ratio in `[0.0, 1.0]`. Errored requests count toward the denominator so a backend that drops traffic under load cannot look "good" simply because the surviving requests stayed under the latency budget. Deliberate client cancellations are tracked separately and excluded.
 
 **Formula:**
 ```python
@@ -1606,7 +1608,7 @@ good_request_fraction = good_request_count / attempted if attempted > 0 else 0.0
 
 **Unit:** `RATIO` (0.0–1.0)
 
-**Required upstream metrics:** `good_request_count`, `request_count`. `error_request_count` is included in the denominator when present (it is `ERROR_ONLY` and absent on clean runs).
+**Required upstream metrics:** None. Each counter may legitimately be absent: valid-request counters on an all-error run, and `error_request_count` on a clean run.
 
 **Notes:**
 - Requires SLO thresholds to be configured (e.g., `--goodput`); without SLOs, `good_request_count` is always 0 and this metric is 0.
@@ -1732,11 +1734,45 @@ The total number of failed/error requests encountered during the benchmark. This
 
 **Formula:**
 ```python
-error_request_count = sum(1 for r in records if not r.valid)
+error_request_count = sum(1 for r in records if not r.valid and not r.was_cancelled)
 ```
 
 **Notes:**
-- Error rate can be computed as `error_request_count / (request_count + error_request_count)`.
+- Client-cancelled requests are counted separately and do not inflate server errors.
+
+---
+
+### Cancelled Request Count
+
+**Type:** [Aggregate Metric](#aggregate-metrics)
+
+The number of requests deliberately cancelled client-side via `--request-cancellation-rate`.
+
+**Formula:**
+```python
+cancelled_request_count = sum(1 for r in records if r.was_cancelled)
+```
+
+**Notes:**
+- Hidden from the console table; available in structured result exports.
+- Excluded from the Request Error Rate and Good Request Fraction denominators.
+
+---
+
+### Request Error Rate
+
+**Type:** [Derived Metric](#derived-metrics)
+
+The percentage of non-cancelled completed requests that ended in error.
+
+**Formula:**
+```python
+request_error_rate = 100.0 * error_request_count / (request_count + error_request_count)
+```
+
+**Notes:**
+- Omitted only when both successful and error counts are zero.
+- Deliberate client cancellations do not affect the rate.
 
 ---
 

--- a/docs/reference/yaml-config-roadmap.md
+++ b/docs/reference/yaml-config-roadmap.md
@@ -57,14 +57,12 @@ benchmark:
       type: concurrency
       concurrency: 4
       requests: 50
-      exclude_from_results: true
 
     - name: warm_cache_warmup
       kind: warmup
       type: concurrency
       concurrency: 16
       requests: 100
-      exclude_from_results: true
 
     - name: steady_state_profile
       kind: profiling
@@ -82,7 +80,7 @@ benchmark:
 Key changes:
 
 - `name` becomes free-form (validated against a permissive identifier regex), rather than a `Literal`.
-- A new `kind` field carries the warmup-vs-profiling distinction the credit pipeline currently derives from the name. `exclude_from_results` is then driven by `kind`, not by string equality on `name`.
+- A new `kind` field carries the warmup-vs-profiling distinction. Warmup data remains phase-scoped, while only profiling-kind phases contribute to profiling aggregates.
 - Reports, artifact subdirectories, and sweep parameter paths address phases by user-given name (`phases.steady_state_profile.rate`).
 - Existing two-phase configs continue to load: `name: warmup` defaults `kind: warmup`, `name: profiling` defaults `kind: profiling`.
 

--- a/docs/server-metrics/server-metrics.md
+++ b/docs/server-metrics/server-metrics.md
@@ -197,6 +197,71 @@ aiperf profile --model MODEL ... --server-metrics \
     http://node2:8081
 ```
 
+### Kubernetes auto-discovery
+
+When AIPerf runs in Kubernetes, `server_metrics.discovery` can add inference-pod
+Prometheus endpoints to the endpoints derived from `endpoint.urls` and the explicit
+`server_metrics.urls` list:
+
+```yaml
+server_metrics:
+  discovery:
+    mode: kubernetes
+    namespace: dynamo-server
+    label_selector: app.kubernetes.io/name=dynamo
+    timeout_seconds: 10
+```
+
+`mode: auto` (the default) uses Kubernetes discovery only when AIPerf is running
+in-cluster. `mode: kubernetes` requires the Kubernetes path and warns when used
+outside a cluster. `mode: disabled` uses only URL-derived and explicit endpoints.
+Discovery is best-effort: a timeout or API error does not prevent the benchmark
+from using its other endpoints.
+
+If `namespace` is omitted, discovery searches only the benchmark pod's own
+namespace, resolved from `AIPERF_NAMESPACE` or its mounted ServiceAccount namespace.
+It never silently expands to cluster scope. `namespace: "*"` is the explicit
+all-namespace mode and requires a cluster-scoped `pods: list` grant. To discover a
+server in another named namespace, add that namespace to the operator chart's
+`serverMetricsDiscoveryNamespaces` value; if the benchmark pod uses a custom
+ServiceAccount, use the chart's `{namespace, serviceAccounts}` entry form. See
+[Kubernetes RBAC and security](../kubernetes/rbac-security.md#benchmark-pod-permissions).
+
+The built-in eligibility rules select Dynamo's
+`nvidia.com/metrics-enabled=true` pods, pods with
+`aiperf.nvidia.com/metrics-paths`, and recognized inference-server images. A supplied
+`label_selector` explicitly selects matching pods. A generic
+`prometheus.io/scrape=true` annotation alone is not enough, which avoids collecting
+unrelated Loki, Grafana, and cluster-monitoring endpoints. Eligible pods can use the
+standard `prometheus.io/{port,path,scheme}` annotations; the AIPerf paths annotation
+accepts a comma-separated path list. Discovered paths are used as declared after
+adding a leading slash when needed; AIPerf does not append `/metrics` to a custom
+annotation path.
+
+#### RBAC prerequisites
+
+Discovery lists pods using the benchmark pod's ServiceAccount:
+
+| `discovery.namespace` | Searches | RBAC required |
+|---|---|---|
+| omitted | The benchmark pod's own namespace | None beyond the operator chart's normal benchmark Role (`pods: get/list/watch`) |
+| A named inference namespace | That namespace | Add it to `serverMetricsDiscoveryNamespaces`, using `{namespace, serviceAccounts}` when benchmarks use a custom ServiceAccount |
+| `"*"` | All namespaces | A manually provisioned ClusterRole with `pods: list`, bound to the benchmark ServiceAccount; the chart intentionally does not create this grant |
+
+For example, to allow benchmarks in the chart-configured benchmark namespace to
+discover Dynamo in `dynamo-server`:
+
+```bash
+helm upgrade aiperf-operator deploy/helm/aiperf-operator \
+  --namespace aiperf-system \
+  --reuse-values \
+  --set 'serverMetricsDiscoveryNamespaces={dynamo-server}'
+```
+
+Then set `server_metrics.discovery.namespace: dynamo-server` in the AIPerf YAML.
+A denied pod list emits a warning naming the namespace and required grant; it does
+not fail the benchmark.
+
 ### Disabling Server Metrics
 
 ```bash
@@ -249,6 +314,7 @@ WARNING  Disabling server metrics collection for http://127.0.0.1:60000/metrics:
 |---------------------|---------|-------------|
 | `AIPERF_SERVER_METRICS_COLLECTION_INTERVAL` | 0.333s | Collection frequency (333ms, ~3Hz) |
 | `AIPERF_SERVER_METRICS_COLLECTION_FLUSH_PERIOD` | 2.0s | Wait time for final metrics after benchmark |
+| `AIPERF_SERVER_METRICS_PROFILE_COMPLETE_RELAY_TIMEOUT` | 60s | Maximum wait for the manager-owned final scrape and artifact flush command |
 | `AIPERF_SERVER_METRICS_REACHABILITY_TIMEOUT` | 10s | Timeout for endpoint reachability tests |
 | `AIPERF_SERVER_METRICS_EXPORT_BATCH_SIZE` | 100 | Batch size for JSONL writer |
 | `AIPERF_SERVER_METRICS_SHUTDOWN_DELAY` | 5.0s | Shutdown delay for command response transmission |
@@ -659,4 +725,3 @@ with open('server_metrics_export.json') as f:
 latency = data['metrics']['vllm:e2e_request_latency_seconds']['series'][0]['stats']
 assert latency['p99_estimate'] < 5.0, f"P99 latency too high: {latency['p99_estimate']}"
 ```
-

--- a/docs/tutorials/benchmark-control-hooks.md
+++ b/docs/tutorials/benchmark-control-hooks.md
@@ -147,7 +147,7 @@ sequenceDiagram
   server before profiling load starts. Warmup is opt-in: omit
   `--warmup-request-count` / `--warmup-num-sessions` /
   `--warmup-duration` on the CLI, or omit the `warmup:` block (and any
-  `exclude_from_results` warmup phase) in YAML. Note that
+  phase with `kind: warmup`) in YAML. Note that
   `--warmup-request-count 0` is **not** the way to do this — the flag is
   constrained to `> 0` and a `0` fails validation with `Input should be
   greater than 0`.

--- a/docs/tutorials/multi-phase-workflows.md
+++ b/docs/tutorials/multi-phase-workflows.md
@@ -148,6 +148,8 @@ Use the root `profile_export_aiperf.json` and CSV when you need the traditional 
 
 Use `phase_manifest.json` and `phases/<phase_name>/profile_export_aiperf.json` when you need exact per-phase request metrics. This is the right view for comparing `baseline_traffic`, `cancellation_stress`, and `recovery_traffic` independently.
 
+On Kubernetes, the operator also uses the manifest's per-phase success and error counts to finalize `status.phases` by phase name. This closes the controller-shutdown sampling window for workflows with multiple profiling phases; older single-profiling runs without a readable manifest continue to use the aggregate root export as a compatibility fallback.
+
 For server metrics, the root `server_metrics_export.json` preserves the legacy aggregate view. In workflows with repeated phase kinds, its phase ranges may span gaps between phases of the same kind. Use `phases/<phase_name>/server_metrics.json` for exact phase-scoped server telemetry.
 
 Adaptive profiling phases also write their own controller artifacts. See [Adaptive Scale](adaptive-scale.md#multiple-adaptive-phases) for multiple adaptive phases and `adaptive_scale_manifest.json`.

--- a/docs/tutorials/sweeps.md
+++ b/docs/tutorials/sweeps.md
@@ -629,12 +629,13 @@ benchmark:
 
   phases:
     - name: warmup
+      kind: warmup
       type: concurrency
-      exclude_from_results: true
       requests: 100
       concurrency: 8
 
     - name: profiling
+      kind: profiling
       type: poisson
       duration: 120
       rate: 30
@@ -841,7 +842,10 @@ aiperf profile --config sweep_ci.yaml
 
 **Check CV before drawing conclusions.** A variation with CV > 0.20 has too much noise to trust on its own — increase `num_runs`, add cooldown, or investigate the system at that load.
 
-**Use warmup exclusion and `disable_warmup_after_first`.** Define a warmup phase with `exclude_from_results: true` and enable `multi_run.disable_warmup_after_first` (default). The server is then warm without re-warming on every trial.
+**Use a warmup-kind phase and `disable_warmup_after_first`.** Define a phase
+with `kind: warmup` and enable `multi_run.disable_warmup_after_first` (default).
+The server is then warm without re-warming on every trial; warmup data remains
+phase-scoped and does not enter profiling aggregates.
 
 **Set `random_seed` for reproducibility.** A fixed seed ensures identical prompt selection and request ordering. When `multi_run.set_consistent_seed` is enabled (default), seed 42 is auto-set if you don't supply one.
 
@@ -888,6 +892,328 @@ pareto = {tuple(sorted(p.items())) for p in sweep["pareto_optimal"]}
 ```
 
 The full schema (every field, every metric stat, the `failed_runs` shape) is documented at [Sweep Aggregates API Reference](../api/sweep-aggregates.md).
+
+## Running Sweeps on Kubernetes
+
+`aiperf kube sweep` submits an `AIPerfSweep` CR that orchestrates parameter sweeps,
+multi-run confidence trials, and adaptive convergence on a Kubernetes cluster.
+The orchestration loop runs in a dedicated sweep-controller pod, not in the kopf
+operator.
+
+The local and Kubernetes paths share the same Config-v2 loader,
+`build_benchmark_plan`, `MultiRunOrchestrator`, and search-planner factory. The
+Kubernetes adapter preserves Jinja template leaves in the submitted CR, renders
+them per variation from the retained raw envelope, attaches the operator's
+`failurePolicy`, and executes each resulting `BenchmarkRun` through
+`K8sChildJobExecutor`. Operator-owned child tracking, status rollup, aggregate
+harvest, and result indexing remain outside the canonical planner.
+
+### Quick start: grid sweep over concurrency × rate
+
+`sweep.yaml`:
+
+```yaml
+benchmark:
+  models: [Qwen/Qwen3-0.6B]
+  endpoint:
+    urls: [http://server:8000/v1/chat/completions]
+    type: chat
+    streaming: true
+  datasets:
+    - name: main
+      type: synthetic
+  phases:
+    - name: profiling
+      type: poisson
+      duration: 120
+      concurrency: 8
+      rate: 10
+sweep:
+  type: grid
+  parameters:
+    phases.profiling.concurrency: [4, 8, 16, 32]
+```
+
+Submit:
+
+```bash
+aiperf kube sweep --config sweep.yaml --image aiperf:latest --total-workers 64
+```
+
+Preview the submitted resource with `--dry-run`. The JSON includes the resolved
+`metadata.namespace` (from `--namespace`, or `aiperf-benchmarks` by default), so
+redirecting it to a file and applying it targets the same namespace as a live
+submission.
+
+Benchmark CLI flags override the matching Config-v2 YAML fields before the
+`AIPerfSweep` is submitted. When the input is an `AIPerfJob` manifest, kube
+deployment flags merge over its deployment settings; unrelated nested
+`podTemplate` fields are preserved.
+
+> Parameter keys are dotted paths rooted **inside** the `benchmark:` block,
+> so `phases.profiling.concurrency` is correct and the redundant
+> `benchmark.` prefix is rejected by the validator. A handful of bare names
+> (`concurrency`, `rate`, `requests`, `duration`, ...) are sugar for
+> `phases.profiling.<name>`. The one envelope-level escape is
+> `variables.<name>`, which rewrites the top-level Jinja `variables:` block
+> per variation.
+
+#### Credentials must remain fixed
+
+Kubernetes sweeps reject credential-bearing parameter axes before the
+sweep-controller or any child AIPerfJob is created. This includes API keys,
+tokens, passwords, credential-bearing URLs, every `endpoint.headers.*` axis,
+and credential-like `variables.*` names. The rule applies to grid, zip,
+scenario, adaptive-search, Sobol, and Latin Hypercube sweeps.
+
+Keep credentials fixed across every variation and inject them through the
+Secret-backed endpoint credential environment variables described in
+[RBAC and Security](../kubernetes/rbac-security.md). Safe endpoint URL axes remain
+supported when their values contain no userinfo or sensitive query parameters.
+Display redaction is a defense-in-depth boundary for legacy data, not a way to
+make secret sweep parameters safe.
+
+### What gets created
+
+1. One `AIPerfSweep` CR (the parent — `kubectl get aiperfsweeps`).
+2. One `JobSet` for the sweep-controller pod (which orchestrates the loop).
+3. One `AIPerfJob` CR per `(variation, trial)` pair, deterministically named
+   `<sweep>-v<idx:02d>[-t<trial:01d>]`. List them with
+   `kubectl get aiperfjobs -l aiperf.nvidia.com/sweep=<sweep-name>`.
+4. Per-child results under `<base>/<ns>/<sweep>-v07-t2/<child-epoch>/`.
+5. Sweep aggregate under `<base>/<ns>/sweeps/<sweep>/<sweep-epoch>/`
+   (`aggregate.json`, `children.json`, and a `sweep_aggregate/` directory).
+
+The sweep-controller initially writes child `sweep.json` backlinks on its
+ephemeral results volume. During aggregate commit, the operator recreates those
+backlinks on its PVC from the canonical `children.json` manifest before it
+publishes the aggregate or deletes the sweep-controller JobSet. Archived child
+lookups therefore continue to resolve their parent, variation, trial, and both
+run epochs after the child and parent CRs have been removed.
+
+The sweep controller owns the `(variation, trial)` expansion. It omits the
+parent `multiRun` block from each child AIPerfJob, so every child executes
+exactly one benchmark run instead of recursively repeating all trials.
+
+### Auto-plotting the parent aggregate
+
+The Config-v2 `plot:` field has the same meaning for `AIPerfSweep` as it does
+for an in-process sweep. Plotting runs once in the sweep-controller after
+cross-variation aggregation, not once in every child AIPerfJob. Generated
+plots and the materialized `.aiperf-plot-config.yaml` receipt are stored under
+`<base>/<ns>/sweeps/<sweep>/<sweep-epoch>/` and are harvested to the operator
+PVC with the other parent artifacts.
+
+The sweep aggregate ready marker is written only after plotting returns. An
+optional plot failure (`benchmark.artifacts.plotRequired: false`) is logged and
+the aggregate still becomes ready. A required plot failure
+(`plotRequired: true`) moves aggregation to failed and withholds the ready
+marker, preventing the operator from harvesting a partial completion. An
+explicit `benchmark.artifacts.autoPlot: false` suppresses plotting even when a
+`plot:` envelope is present.
+
+### Mode: independent vs repeated
+
+`spec.sweep.iterationOrder` (or `--parameter-sweep-mode` for in-process runs)
+selects the iteration order of variations and trials. Both produce the
+same total runs and the same `sweep_aggregate/` output — only the artifact
+path layout and submit order differ.
+
+| Mode (default `repeated`) | Iteration order | Artifact tree |
+|---|---|---|
+| `repeated`    | trials outer, variations inner | `<base>/profile_runs/trial_NNNN/<variation>/` |
+| `independent` | variations outer, trials inner | `<base>/<variation>/profile_runs/trial_NNNN/` |
+
+`repeated` (the default) is the right choice when absolute wall-clock timing across variations matters and you
+want to interleave variations within each trial — e.g. "run the whole
+sweep, then run it again". `independent` groups all trials of a single
+configuration in close temporal proximity, which gives tight confidence
+intervals per variation.
+
+Adaptive convergence (`spec.multiRun.convergence` / `--convergence-metric`) is
+incompatible with `repeated` and rejected at submit time — convergence
+needs to evaluate per-cell stability, which has no place to land in
+trial-outer iteration. Use `independent` for adaptive sweeps.
+
+### Multi-run confidence
+
+```yaml
+multiRun:
+  numRuns: 5
+  cooldownSeconds: 30
+```
+
+A parameter axis is optional. When `multiRun.numRuns > 1` is present without
+`sweep:`, `aiperf kube sweep` and `aiperf kube generate --operator` create an
+`AIPerfSweep` with one no-op `base` scenario. The canonical plan therefore has
+one unchanged configuration and five trials; it never collapses the request to
+one `AIPerfJob`. A config with no `sweep:` and the single-run default
+`multiRun.numRuns: 1` still generates an `AIPerfJob`.
+Hand-authored `AIPerfJob` resources must follow the same boundary: setting
+`multiRun.numRuns > 1` or `multiRun.convergence` is rejected at admission so
+the requested trials cannot be silently collapsed to one run.
+
+### Adaptive convergence (composes with sweep)
+
+```yaml
+multiRun:
+  numRuns: 10
+  cooldownSeconds: 30
+  convergence:
+    metric: time_to_first_token
+    stat: p99
+    minRuns: 3
+    threshold: 0.05
+    mode: ci_width
+```
+
+When `multiRun.convergence` is set, trials early-stop once the criterion fires
+(or `multiRun.numRuns` is hit, whichever comes first); the `numRuns` field
+remains the hard ceiling. `sweep` and `multiRun.convergence` compose freely:
+each cell of a grid sweep runs adaptive trials.
+
+For convergence without a parameter axis, the generated one-cell scenario uses
+independent iteration order so the controller can evaluate the completed cell
+after each trial and stop before the hard ceiling.
+
+### Adaptive search (Bayesian Optimization)
+
+When the search space is too large to grid-enumerate (e.g. concurrency
+1–1000) and a single scalar objective captures what you care about, use
+`sweep.type: adaptive_search` instead of `sweep.type: grid`. The sweep-controller
+pod instantiates the same `BayesianSearchPlanner` used in-process by
+`aiperf profile --search-*` and drives the loop one `AIPerfJob` per
+iteration; the kopf operator stays unaware of BO and just sees ordinary
+child create/delete events. The completed `search_history.json` is archived
+inside the parent sweep's run-epoch directory so histories from separate
+sweeps cannot overwrite one another. `status.totalVariations` and
+`status.maxTotalRuns` become upper bounds (early plateau convergence
+may terminate sooner), and the BO trajectory is logged incrementally to
+`search_history.json` so partial runs survive a crash or cancellation.
+Sobol and Latin Hypercube sweeps similarly archive `sampling_design.json`
+under the parent epoch's `sweep_aggregate/` directory; separate sweep runs
+therefore retain separate design audits on the shared operator PVC. Before
+the results-sidecar marks the bundle ready, the sweep controller removes the
+canonical orchestrator's temporary top-level run and aggregate directories.
+The operator harvests only `<namespace>/sweeps/<name>/<epoch>/`, so unrelated
+sweeps cannot overwrite shared-PVC root paths.
+
+See [Adaptive search on Kubernetes](../kubernetes/adaptive-search.md) for the full
+walkthrough — CR examples, status semantics, mutual-exclusion rules,
+operator-managed gate exception, cancellation behaviour, and on-disk
+layout. For the algorithm reference, see
+[Bayesian-Optimization Outer Loop](../sweeping/bayesian-optimization.md).
+
+### Cancel
+
+```bash
+kubectl patch aiperfsweep <name> --type merge -p '{"spec":{"cancel":true}}'
+```
+
+The sweep-controller pod observes `spec.cancel`, propagates it to the current
+child via `spec.cancel: true`, and after that child reaches a terminal phase,
+skips remaining variations and runs aggregation over completed children only.
+Child labels are discovery hints only: cancellation is authorized by the exact
+parent owner reference, sweep UID and run epoch, then applied with an immutable
+child-UID precondition so a same-named replacement cannot be cancelled.
+If the controller restarts after cancellation was already recorded, it performs
+a read-only recovery of terminal children before aggregation. Recovery requires
+the exact parent name, UID, and sweep-run epoch, does not create new children,
+and does not wait for non-terminal children. This preserves completed, failed,
+and cancelled child outcomes even though the restarted controller has a fresh
+`emptyDir`.
+
+### Resume after sweep-controller crash
+
+The sweep-controller pod is JobSet-managed: a crash restarts it, and idempotency
+uses deterministic child names, `ownerReferences`, and a reserved hash of each
+generated child execution contract. Terminal reads and result rollups recheck
+the immutable child UID, parent owner identity, and sweep run epoch before a
+child is credited. Grid sweeps therefore resume from the first non-existent
+child without re-running terminal ones. For Sobol and Latin
+hypercube sweeps, Kubernetes derives a stable sampling seed from the parent CR
+UID when `sweep.seed` is omitted; an explicit seed is preserved. Adaptive
+searches similarly derive a stable planner seed when `sweep.randomSeed` is
+omitted, then replay terminal child metrics through `ask()` / `tell()` in order.
+The first new proposal is made only after that planner history is reconstructed;
+an owned child whose contract hash is missing or different is rejected rather
+than silently reused. Once the epoch bundle has its ready marker, a controller
+restart validates the raw parent aggregate and republishes terminal status
+directly; it does not replay the planner or recreate temporary run artifacts.
+If the operator has already published its PVC-backed result reference, a late
+controller restart preserves that reference instead of replacing it with the
+ephemeral sidecar address.
+The controller's live status patch keeps `resultsAvailable: false`; the
+operator flips it to true only after every advertised file is durable on the
+results PVC. Parent TTL cleanup waits for that durable reference, including
+when `ttlSecondsAfterFinished` is zero.
+Sweep result retention does not depend on that parent CR remaining present.
+The durable `aggregate.json` stores the sweep's `resultsTtlDays`, and an
+operator background reconciliation removes expired epoch directories and
+their index rows, then repoints or removes `latest.txt`. Archives without an
+explicit value use the operator-level `AIPERF_RESULTS_TTL_DAYS` default.
+Local execution keeps its ordinary unseeded behavior.
+
+If the sweep-controller exhausts the JobSet retry budget before it can publish
+its own terminal status, the operator marks the owning `AIPerfSweep` Failed
+from the JobSet event. The fallback writes the same failure timestamps,
+`aggregation.phase`, and `resultsAvailable: false` shape as the controller's
+normal failure writer. Both the JobSet owner reference and the parent UID must
+match, and the status update is resource-version fenced, so a delayed event
+cannot fail a recreated same-named sweep or overwrite an already-terminal one.
+
+### Failure policy
+
+```yaml
+failurePolicy:
+  onChildFailure: continue       # default
+  maxFailures: 3                 # 0 = unbounded (default)
+```
+
+A failed child becomes a `failedRuns` count entry on the parent and the sweep
+advances to the next variation. Set `onChildFailure: abort` for stricter behavior.
+
+`status.failedRuns` counts only `Failed` and `PartiallyFailed` children;
+cancelled children are tallied separately under `status.runStates.cancelled`.
+The full per-phase breakdown lives at `status.runStates`
+(`pending` / `running` / `completed` / `failed` / `cancelled`). If you previously
+relied on `failedRuns` as a "did anything not succeed" signal, read
+`status.runStates` instead — `failedRuns` no longer includes cancelled
+children.
+
+### Schema invariants
+
+The apiserver rejects these before any pod is scheduled (CEL rules on the
+`AIPerfSweep` CRD):
+
+- `spec.sweep` is required on `AIPerfSweep` (use `AIPerfJob` for a
+  single benchmark).
+- `spec.sweep` and `spec.multiRun` are immutable after creation
+  (mutating them would corrupt the run-epoch ledger).
+
+These are enforced by Pydantic instead — client-side by
+`aiperf kube validate`, server-side by the operator on reconcile
+(`status.phase=Failed`). They cannot move to CEL because `spec.benchmark`
+is a preserve-unknown node:
+
+- `multiRun.convergence.minRuns <= multiRun.numRuns` — the convergence
+  criterion's minimum trials cannot exceed the multi-run hard ceiling.
+- `spec.benchmark.sweep` / `spec.benchmark.multiRun` are rejected as
+  unknown fields — the orchestration axes belong at the CR top level, not
+  on the per-child benchmark stamp.
+
+Full rule catalog: [CRD Validation Rules](../kubernetes/crd-validation.md).
+
+### Listing historical sweep runs
+
+The sweep aggregate is served by the operator's results server under
+`/api/v1/sweeps/<ns>/<sweep>/epochs/<epoch>/artifacts` (per-child results
+stay on the `AIPerfJob` route, `/api/v1/results/<ns>/<sweep>-v00-t1/`):
+
+```bash
+aiperf kube results <sweep-name>
+aiperf kube results <sweep-name> --run <epoch>
+```
 
 ## Related Documentation
 

--- a/docs/tutorials/user-centric-timing.md
+++ b/docs/tutorials/user-centric-timing.md
@@ -341,11 +341,15 @@ Gap = 15 / 0.5 = **30 seconds** between each user's requests.
 
 | Metric | What It Tells You |
 |--------|-------------------|
-| **TTFT (Time to First Token)** | Lower TTFT on subsequent turns indicates cache hits |
-| **TTFT by Turn Index** | Compare Turn 0 vs Turn 1+ to measure cache benefit |
+| **TTFT (Time to First Token)** | Aggregate prefill latency across benchmark requests |
 | **Throughput** | Higher throughput with caching enabled indicates cache effectiveness |
 
-### Expected Patterns
+AIPerf does not emit a built-in per-turn TTFT trend metric. Raw exports retain
+turn metadata for offline analysis when a turn-by-turn cache study is required.
+
+### Expected Raw-Record Patterns
+
+When grouping a raw export by turn index offline, expect these patterns:
 
 **With effective caching:**
 - Turn 0 (first turn): Higher TTFT (cache miss, full prefill)

--- a/docs/tutorials/yaml-config.md
+++ b/docs/tutorials/yaml-config.md
@@ -180,6 +180,8 @@ For canonical names, `kind` is optional. A phase named `warmup` defaults to `kin
 
 Named phases are useful for long soaks with multiple profiling windows. See [Multi-Phase Workflows](multi-phase-workflows.md) for a full example, multiple warmup phases, artifacts, sweeps, and seamless transitions.
 
+`kind` is the sole source of truth for result inclusion: `kind: warmup` is excluded from final results and `kind: profiling` is included. The older per-phase `exclude_from_results` (alias `excludeFromResults`) switch is deprecated — it is still accepted so older configs keep loading, but it is ignored and logs a warning. Remove it and set `kind` instead.
+
 ```yaml
 benchmark:
   phases:
@@ -316,11 +318,12 @@ benchmark:
         stddev: "{{ isl_target // 10 }}"        # 51 (integer division)
   phases:
     - name: warmup
+      kind: warmup
       type: concurrency
       concurrency: "{{ base_concurrency // 2 }}"  # 8
       requests: "{{ base_concurrency * 5 }}"      # 80
-      exclude_from_results: true
     - name: profiling
+      kind: profiling
       type: gamma
       rate: 30
       duration: "{{ test_duration }}"
@@ -343,12 +346,13 @@ A typical benchmark is a quick warmup followed by the real measurement. CLI warm
 benchmark:
   phases:
     - name: warmup
+      kind: warmup
       type: concurrency
       concurrency: 8
       requests: 50
-      exclude_from_results: true   # don't pollute the report
 
     - name: profiling
+      kind: profiling
       type: poisson
       rate: 30.0
       duration: 120
@@ -356,7 +360,11 @@ benchmark:
       grace_period: 60             # finish in-flight requests after duration
 ```
 
-Each phase is a complete arrival pattern in its own right, with its own concurrency, duration, and arrival shape (`concurrency`, `constant`, `poisson`, `gamma`, `fixed_schedule`, `user_centric`, ...).
+Each phase is a complete arrival pattern in its own right, with its own
+concurrency, duration, and arrival shape (`concurrency`, `constant`, `poisson`,
+`gamma`, `fixed_schedule`, `user_centric`, ...). Phase `kind` owns result
+semantics: warmup data remains available under that phase, while profiling
+phases contribute to profiling aggregates.
 
 ## Adaptive scale in YAML
 
@@ -476,6 +484,40 @@ The precedence order, lowest to highest:
 1. Defaults baked into AIPerf
 2. Values in the YAML file
 3. Explicit CLI flags
+
+For Jinja-backed sweeps, this precedence is applied before every variation is
+materialized. An explicit CLI flag that targets a templated field replaces the
+template for every variation, while unrelated templates remain live and render
+against each variation's `sweep.parameters` values. This keeps `aiperf profile
+--config`, `aiperf kube profile --config`, and `aiperf config expand` on the
+same raw-envelope semantics.
+
+The overlay covers endpoint/model selection, the sole dataset and its content
+modifiers, the unique profiling phase (including rate shape, ramps, and request
+cancellation), artifacts, SLOs, telemetry/export integrations, multi-run and
+sweep controls, runtime/logging, tokenizer, accuracy, and scenario locks.
+Explicit false, zero, and empty values still count as overrides; CLI defaults
+that were not passed do not replace YAML values. The one exception is the
+bare-boolean control hooks `--reset-kv-cache` and `--server-profiler`: passing
+them with no sub-flags means "enable this hook", so a YAML-supplied `path`,
+`startPath`, `stopPath`, or `timeoutSeconds` is preserved rather than reset to
+defaults. Pass the matching sub-flag (for example `--reset-kv-cache-path`) to
+change one of those values from the CLI.
+
+`--request-rate` and `--arrival-pattern` do not convert a YAML `user_centric`
+profiling phase into an open-loop one. A `user_centric` phase already carries a
+`rate`, so `--request-rate` sets it in place and the phase keeps its `users`
+count. `--arrival-pattern` is logged as ignored for that phase because
+user-centric load has no arrival distribution, and `--arrival-smoothness` is
+rejected outright. Change the phase `type` in YAML to `poisson`, `gamma`, or
+`constant` if you want open-loop arrivals.
+
+Warmup flags do not rewrite an existing phase list because inserting or
+choosing a warmup phase is ambiguous in an advanced multi-phase workflow. Set
+warmup phases in YAML. Likewise, if more than one phase has `kind: profiling`,
+put phase-local values in YAML so the target is explicit. Command-operation
+flags such as `--config` itself and Kubernetes deployment/manage options are
+consumed by their commands rather than merged into `benchmark:`.
 
 ## Where to go next
 

--- a/docs/tutorials/yaml-distributions.md
+++ b/docs/tutorials/yaml-distributions.md
@@ -256,11 +256,12 @@ benchmark:
 
   phases:
     - name: warmup
+      kind: warmup
       type: concurrency
       concurrency: 4
       requests: 50
-      exclude_from_results: true
     - name: profiling
+      kind: profiling
       type: poisson
       rate: 30.0
       duration: 120


### PR DESCRIPTION
## Summary

- Adds 4 GitHub Actions workflow files for Kubernetes CI
- `helm-chart.yml` — Helm chart packaging and validation
- `run-kubernetes-tests.yml` — Core Kubernetes operator tests
- `run-kubernetes-audit-tests.yml` — Kubernetes audit tests
- `run-kubernetes-chaos-tests.yml` — Kubernetes chaos tests

Stacked on: #1295

## Test plan
- [ ] Workflow files are syntactically valid YAML
- [ ] All 4 workflows trigger on the expected events
- [ ] No secrets or credentials embedded in workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)