### PR TITLE
fix(enums): make != the negation of == on case-insensitive str enums

### DIFF
--- a/src/aiperf/common/enums/base_enums.py
+++ b/src/aiperf/common/enums/base_enums.py
@@ -31,11 +31,12 @@ class CaseInsensitiveStrEnum(str, Enum):
     def _norm_value(self: Self) -> str:
         # Lazy fallback for members created outside Enum construction
         # (e.g. dynamically registered custom members), which skip __init__.
-        norm = self.__dict__.get("_norm_value_cache")
-        if norm is None:
+        try:
+            return self._norm_value_cache
+        except AttributeError:
             norm = _normalize_name(self.value)
             self._norm_value_cache = norm
-        return norm
+            return norm
 
     def __str__(self) -> str:
         return self.value
@@ -70,11 +71,12 @@ class CaseInsensitiveStrEnum(str, Enum):
         return not result
 
     def __hash__(self: Self) -> int:
-        norm_hash = self.__dict__.get("_norm_hash_cache")
-        if norm_hash is None:
+        try:
+            return self._norm_hash_cache
+        except AttributeError:
             norm_hash = hash(self._norm_value())
             self._norm_hash_cache = norm_hash
-        return norm_hash
+            return norm_hash
 
     @classmethod
     def _missing_(cls, value):

--- a/src/aiperf/common/enums/base_enums.py
+++ b/src/aiperf/common/enums/base_enums.py
@@ -60,6 +60,15 @@ class CaseInsensitiveStrEnum(str, Enum):
             )
         return super().__eq__(other)
 
+    def __ne__(self: Self, other: object) -> bool:
+        # str.__ne__ sits between this class and object in the MRO, so an
+        # inherited __ne__ would compare raw values and disagree with the
+        # normalizing __eq__ above.
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
     def __hash__(self: Self) -> int:
         norm_hash = self.__dict__.get("_norm_hash_cache")
         if norm_hash is None:

--- a/src/aiperf/common/enums/base_enums.py
+++ b/src/aiperf/common/enums/base_enums.py
@@ -62,9 +62,13 @@ class CaseInsensitiveStrEnum(str, Enum):
         return super().__eq__(other)
 
     def __ne__(self: Self, other: object) -> bool:
-        # str.__ne__ sits between this class and object in the MRO, so an
-        # inherited __ne__ would compare raw values and disagree with the
-        # normalizing __eq__ above.
+        """Negate __eq__, forwarding NotImplemented to the other operand.
+
+        Required explicitly: Python only derives __ne__ from __eq__ via
+        object.__ne__, and str.__ne__ sits between this class and object in the
+        MRO. Without this, != compares raw values and disagrees with the
+        normalizing __eq__ above, making `a == b` and `a != b` both true.
+        """
         result = self.__eq__(other)
         if result is NotImplemented:
             return result

--- a/src/aiperf/plugin/extensible_enums.py
+++ b/src/aiperf/plugin/extensible_enums.py
@@ -129,9 +129,13 @@ class ExtensibleStrEnum(str, Enum, metaclass=ExtensibleStrEnumMeta):
         return super().__eq__(other)
 
     def __ne__(self: Self, other: object) -> bool:
-        # str.__ne__ sits between this class and object in the MRO, so an
-        # inherited __ne__ would compare raw values and disagree with the
-        # normalizing __eq__ above.
+        """Negate __eq__, forwarding NotImplemented to the other operand.
+
+        Required explicitly: Python only derives __ne__ from __eq__ via
+        object.__ne__, and str.__ne__ sits between this class and object in the
+        MRO. Without this, != compares raw values and disagrees with the
+        normalizing __eq__ above, making `a == b` and `a != b` both true.
+        """
         result = self.__eq__(other)
         if result is NotImplemented:
             return result

--- a/src/aiperf/plugin/extensible_enums.py
+++ b/src/aiperf/plugin/extensible_enums.py
@@ -127,6 +127,15 @@ class ExtensibleStrEnum(str, Enum, metaclass=ExtensibleStrEnumMeta):
             return self._norm_value() == _normalize_name(other.value)
         return super().__eq__(other)
 
+    def __ne__(self: Self, other: object) -> bool:
+        # str.__ne__ sits between this class and object in the MRO, so an
+        # inherited __ne__ would compare raw values and disagree with the
+        # normalizing __eq__ above.
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
     def __hash__(self: Self) -> int:
         norm_hash = self.__dict__.get("_norm_hash_cache")
         if norm_hash is None:

--- a/src/aiperf/plugin/extensible_enums.py
+++ b/src/aiperf/plugin/extensible_enums.py
@@ -110,11 +110,12 @@ class ExtensibleStrEnum(str, Enum, metaclass=ExtensibleStrEnumMeta):
     def _norm_value(self: Self) -> str:
         # Lazily cached: members can be created dynamically via register(),
         # so there is no single construction point to precompute this.
-        norm = self.__dict__.get("_norm_value_cache")
-        if norm is None:
+        try:
+            return self._norm_value_cache
+        except AttributeError:
             norm = _normalize_name(self.value)
             self._norm_value_cache = norm
-        return norm
+            return norm
 
     def __eq__(self: Self, other: object) -> bool:
         if self is other:
@@ -137,11 +138,12 @@ class ExtensibleStrEnum(str, Enum, metaclass=ExtensibleStrEnumMeta):
         return not result
 
     def __hash__(self: Self) -> int:
-        norm_hash = self.__dict__.get("_norm_hash_cache")
-        if norm_hash is None:
+        try:
+            return self._norm_hash_cache
+        except AttributeError:
             norm_hash = hash(self._norm_value())
             self._norm_hash_cache = norm_hash
-        return norm_hash
+            return norm_hash
 
     @property
     def name(self) -> str:

--- a/tests/unit/common/enums/test_base_enums.py
+++ b/tests/unit/common/enums/test_base_enums.py
@@ -354,3 +354,90 @@ class TestNormalizationCaching:
             X = 1
 
         assert SampleEnum.ALPHA != IntEnum.X
+
+
+# =============================================================================
+# __ne__ / __eq__ Symmetry Tests
+# =============================================================================
+
+
+class TestNotEqualMirrorsEqual:
+    """`!=` must be the exact negation of `==` for every operand shape.
+
+    Regression guard: `str.__ne__` sits between these classes and `object` in
+    the MRO, so an inherited `__ne__` silently bypasses the normalizing
+    `__eq__` and makes `a == b` and `a != b` both True.
+    """
+
+    @pytest.mark.parametrize(
+        "other",
+        [
+            "alpha",
+            "ALPHA",
+            "Alpha",
+            "aLpHa",
+            "beta",
+            "nonexistent",
+            123,
+            None,
+            [],
+            SampleEnum.ALPHA,
+            SampleEnum.BETA,
+        ],
+    )  # fmt: skip
+    def test_ne_is_negation_of_eq(self, other):
+        """`member != other` equals `not (member == other)` for any operand."""
+        assert (SampleEnum.ALPHA != other) is not (SampleEnum.ALPHA == other)
+
+    @pytest.mark.parametrize(
+        "other",
+        ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar", "baz"],
+    )  # fmt: skip
+    def test_ne_is_negation_of_eq_across_dash_forms(self, other):
+        """Dash/underscore/case variants negate consistently."""
+        assert (SampleEnum.FOO_BAR != other) is not (SampleEnum.FOO_BAR == other)
+
+    @pytest.mark.parametrize(
+        "other",
+        ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar"],
+    )  # fmt: skip
+    def test_ne_false_for_normalized_match(self, other):
+        """A normalized match is never `!=`."""
+        assert (SampleEnum.FOO_BAR != other) is False
+
+    @pytest.mark.parametrize(
+        "other",
+        ["my_value", "my-value", "MY_VALUE", "MY-VALUE"],
+    )  # fmt: skip
+    def test_ne_false_for_dash_valued_enum(self, other):
+        """Dash-valued members are not `!=` their underscore spellings."""
+        assert (DashValueEnum.MY_VALUE != other) is False
+
+    @pytest.mark.parametrize(
+        "other",
+        ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar"],
+    )  # fmt: skip
+    def test_ne_false_with_string_on_the_left(self, other):
+        """Reflected `!=` also routes through the normalizing comparison."""
+        assert (other != SampleEnum.FOO_BAR) is False
+
+    def test_ne_true_for_different_member(self):
+        """Genuinely different members stay `!=`."""
+        assert (SampleEnum.ALPHA != SampleEnum.BETA) is True
+
+    def test_ne_false_across_enums_with_same_normalized_value(self):
+        """Cross-enum members sharing a normalized value are not `!=`."""
+
+        class EnumA(CaseInsensitiveStrEnum):
+            ITEM = "foo_bar"
+
+        class EnumB(CaseInsensitiveStrEnum):
+            ITEM = "foo-bar"
+
+        assert (EnumA.ITEM != EnumB.ITEM) is False
+
+    def test_ne_true_for_non_string_types(self):
+        """Non-string, non-enum operands remain `!=`."""
+        assert (SampleEnum.ALPHA != 123) is True
+        assert (SampleEnum.ALPHA != None) is True  # noqa: E711 - testing __ne__ with None
+        assert (SampleEnum.ALPHA != []) is True

--- a/tests/unit/common/enums/test_base_enums.py
+++ b/tests/unit/common/enums/test_base_enums.py
@@ -6,6 +6,7 @@ from typing import Self
 
 import pytest
 from pydantic import BaseModel, ValidationError
+from pytest import param
 
 from aiperf.common.enums.base_enums import CaseInsensitiveStrEnum, _normalize_name
 
@@ -442,7 +443,15 @@ class TestNotEqualMirrorsEqual:
         assert (SampleEnum.ALPHA != None) is True  # noqa: E711 - testing __ne__ with None
         assert (SampleEnum.ALPHA != []) is True
 
-    @pytest.mark.parametrize("other", [123, None, [], 4.5])  # fmt: skip
+    @pytest.mark.parametrize(
+        "other",
+        [
+            param(123, id="int"),
+            param(None, id="none"),
+            param([], id="list"),
+            param(4.5, id="float"),
+        ],
+    )  # fmt: skip
     def test_ne_forwards_notimplemented_for_unsupported_operands(
         self: Self, other: object
     ) -> None:

--- a/tests/unit/common/enums/test_base_enums.py
+++ b/tests/unit/common/enums/test_base_enums.py
@@ -387,7 +387,7 @@ class TestNotEqualMirrorsEqual:
     )  # fmt: skip
     def test_ne_is_negation_of_eq(self, other):
         """`member != other` equals `not (member == other)` for any operand."""
-        assert (SampleEnum.ALPHA != other) is not (SampleEnum.ALPHA == other)
+        assert (SampleEnum.ALPHA != other) is not (SampleEnum.ALPHA == other)  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
     @pytest.mark.parametrize(
         "other",
@@ -395,7 +395,7 @@ class TestNotEqualMirrorsEqual:
     )  # fmt: skip
     def test_ne_is_negation_of_eq_across_dash_forms(self, other):
         """Dash/underscore/case variants negate consistently."""
-        assert (SampleEnum.FOO_BAR != other) is not (SampleEnum.FOO_BAR == other)
+        assert (SampleEnum.FOO_BAR != other) is not (SampleEnum.FOO_BAR == other)  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
     @pytest.mark.parametrize(
         "other",
@@ -403,7 +403,7 @@ class TestNotEqualMirrorsEqual:
     )  # fmt: skip
     def test_ne_false_for_normalized_match(self, other):
         """A normalized match is never `!=`."""
-        assert (SampleEnum.FOO_BAR != other) is False
+        assert (SampleEnum.FOO_BAR != other) is False  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
     @pytest.mark.parametrize(
         "other",
@@ -411,7 +411,7 @@ class TestNotEqualMirrorsEqual:
     )  # fmt: skip
     def test_ne_false_for_dash_valued_enum(self, other):
         """Dash-valued members are not `!=` their underscore spellings."""
-        assert (DashValueEnum.MY_VALUE != other) is False
+        assert (DashValueEnum.MY_VALUE != other) is False  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
     @pytest.mark.parametrize(
         "other",

--- a/tests/unit/common/enums/test_base_enums.py
+++ b/tests/unit/common/enums/test_base_enums.py
@@ -385,7 +385,7 @@ class TestNotEqualMirrorsEqual:
             SampleEnum.BETA,
         ],
     )  # fmt: skip
-    def test_ne_is_negation_of_eq(self, other):
+    def test_ne_is_negation_of_eq(self: Self, other: object) -> None:
         """`member != other` equals `not (member == other)` for any operand."""
         assert (SampleEnum.ALPHA != other) is not (SampleEnum.ALPHA == other)  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
@@ -393,7 +393,7 @@ class TestNotEqualMirrorsEqual:
         "other",
         ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar", "baz"],
     )  # fmt: skip
-    def test_ne_is_negation_of_eq_across_dash_forms(self, other):
+    def test_ne_is_negation_of_eq_across_dash_forms(self: Self, other: object) -> None:
         """Dash/underscore/case variants negate consistently."""
         assert (SampleEnum.FOO_BAR != other) is not (SampleEnum.FOO_BAR == other)  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
@@ -401,7 +401,7 @@ class TestNotEqualMirrorsEqual:
         "other",
         ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar"],
     )  # fmt: skip
-    def test_ne_false_for_normalized_match(self, other):
+    def test_ne_false_for_normalized_match(self: Self, other: str) -> None:
         """A normalized match is never `!=`."""
         assert (SampleEnum.FOO_BAR != other) is False  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
@@ -409,7 +409,7 @@ class TestNotEqualMirrorsEqual:
         "other",
         ["my_value", "my-value", "MY_VALUE", "MY-VALUE"],
     )  # fmt: skip
-    def test_ne_false_for_dash_valued_enum(self, other):
+    def test_ne_false_for_dash_valued_enum(self: Self, other: str) -> None:
         """Dash-valued members are not `!=` their underscore spellings."""
         assert (DashValueEnum.MY_VALUE != other) is False  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
@@ -417,15 +417,15 @@ class TestNotEqualMirrorsEqual:
         "other",
         ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar"],
     )  # fmt: skip
-    def test_ne_false_with_string_on_the_left(self, other):
+    def test_ne_false_with_string_on_the_left(self: Self, other: str) -> None:
         """Reflected `!=` also routes through the normalizing comparison."""
         assert (other != SampleEnum.FOO_BAR) is False
 
-    def test_ne_true_for_different_member(self):
+    def test_ne_true_for_different_member(self: Self) -> None:
         """Genuinely different members stay `!=`."""
         assert (SampleEnum.ALPHA != SampleEnum.BETA) is True
 
-    def test_ne_false_across_enums_with_same_normalized_value(self):
+    def test_ne_false_across_enums_with_same_normalized_value(self: Self) -> None:
         """Cross-enum members sharing a normalized value are not `!=`."""
 
         class EnumA(CaseInsensitiveStrEnum):
@@ -436,8 +436,21 @@ class TestNotEqualMirrorsEqual:
 
         assert (EnumA.ITEM != EnumB.ITEM) is False
 
-    def test_ne_true_for_non_string_types(self):
+    def test_ne_true_for_non_string_types(self: Self) -> None:
         """Non-string, non-enum operands remain `!=`."""
         assert (SampleEnum.ALPHA != 123) is True
         assert (SampleEnum.ALPHA != None) is True  # noqa: E711 - testing __ne__ with None
         assert (SampleEnum.ALPHA != []) is True
+
+    @pytest.mark.parametrize("other", [123, None, [], 4.5])  # fmt: skip
+    def test_ne_forwards_notimplemented_for_unsupported_operands(
+        self: Self, other: object
+    ) -> None:
+        """__ne__ defers to the other operand instead of asserting inequality.
+
+        The operator-level check above cannot see this: `!= 123` is True either
+        way, whether __ne__ forwards NotImplemented or wrongly hardcodes True.
+        Only the direct call distinguishes them, and the difference matters for
+        any third-party type whose reflected __eq__ should decide the result.
+        """
+        assert SampleEnum.ALPHA.__ne__(other) is NotImplemented

--- a/tests/unit/plugin/test_extensible_enums.py
+++ b/tests/unit/plugin/test_extensible_enums.py
@@ -6,6 +6,7 @@ from typing import Self
 
 import pytest
 from pydantic import BaseModel, ValidationError
+from pytest import param
 
 from aiperf.plugin.extensible_enums import (
     ExtensibleStrEnum,
@@ -829,7 +830,15 @@ class TestNotEqualMirrorsEqual:
         assert (SampleEnum.ALPHA != None) is True  # noqa: E711 - testing __ne__ with None
         assert (SampleEnum.ALPHA != []) is True
 
-    @pytest.mark.parametrize("other", [123, None, [], 4.5])  # fmt: skip
+    @pytest.mark.parametrize(
+        "other",
+        [
+            param(123, id="int"),
+            param(None, id="none"),
+            param([], id="list"),
+            param(4.5, id="float"),
+        ],
+    )  # fmt: skip
     def test_ne_forwards_notimplemented_for_unsupported_operands(
         self: Self, other: object
     ) -> None:

--- a/tests/unit/plugin/test_extensible_enums.py
+++ b/tests/unit/plugin/test_extensible_enums.py
@@ -249,6 +249,25 @@ class TestExtensibleStrEnum:
         assert hash(ext) == hash("ext")
         assert ext.__dict__.get("_norm_hash_cache") == hash("ext")
 
+    def test_norm_value_populated_on_never_used_extension(self: Self) -> None:
+        """A registered member that has never been compared still normalizes.
+
+        Distinct from the pop-and-recompute case above: register() creates the
+        member via str.__new__ so the cache attribute is absent, not stale.
+        """
+
+        class TestEnum(ExtensibleStrEnum):
+            BASE = "base"
+
+        TestEnum.register("FOO_BAR", "foo_bar")
+        ext = TestEnum.FOO_BAR
+        assert "_norm_value_cache" not in ext.__dict__
+        assert "_norm_hash_cache" not in ext.__dict__
+
+        assert ext == "FOO-BAR"
+        assert hash(ext) == hash("foo_bar")
+        assert ext.__dict__.get("_norm_value_cache") == "foo_bar"
+
 
 # =============================================================================
 # Registration Tests

--- a/tests/unit/plugin/test_extensible_enums.py
+++ b/tests/unit/plugin/test_extensible_enums.py
@@ -770,7 +770,7 @@ class TestNotEqualMirrorsEqual:
             SampleEnum.BETA,
         ],
     )  # fmt: skip
-    def test_ne_is_negation_of_eq(self, other):
+    def test_ne_is_negation_of_eq(self: Self, other: object) -> None:
         """`member != other` equals `not (member == other)` for any operand."""
         assert (SampleEnum.ALPHA != other) is not (SampleEnum.ALPHA == other)  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
@@ -778,7 +778,9 @@ class TestNotEqualMirrorsEqual:
         "other",
         ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar"],
     )  # fmt: skip
-    def test_ne_false_for_normalized_match(self, enum_with_underscores, other):
+    def test_ne_false_for_normalized_match(
+        self: Self, enum_with_underscores: type[ExtensibleStrEnum], other: str
+    ) -> None:
         """A normalized match is never `!=`."""
         assert (enum_with_underscores.FOO_BAR != other) is False  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
@@ -786,15 +788,19 @@ class TestNotEqualMirrorsEqual:
         "other",
         ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar"],
     )  # fmt: skip
-    def test_ne_false_with_string_on_the_left(self, enum_with_underscores, other):
+    def test_ne_false_with_string_on_the_left(
+        self: Self, enum_with_underscores: type[ExtensibleStrEnum], other: str
+    ) -> None:
         """Reflected `!=` also routes through the normalizing comparison."""
         assert (other != enum_with_underscores.FOO_BAR) is False
 
-    def test_ne_true_for_different_member(self, enum_with_underscores):
+    def test_ne_true_for_different_member(
+        self: Self, enum_with_underscores: type[ExtensibleStrEnum]
+    ) -> None:
         """Genuinely different members stay `!=`."""
         assert (enum_with_underscores.FOO_BAR != enum_with_underscores.BAZ_QUX) is True
 
-    def test_ne_false_for_registered_extension_spellings(self):
+    def test_ne_false_for_registered_extension_spellings(self: Self) -> None:
         """Runtime-registered extensions negate consistently too."""
 
         class TestEnum(ExtensibleStrEnum):
@@ -806,7 +812,7 @@ class TestNotEqualMirrorsEqual:
         assert (TestEnum.FOO_BAR != "FOO-BAR") is False
         assert (TestEnum.FOO_BAR != "base") is True
 
-    def test_ne_false_across_enums_with_same_normalized_value(self):
+    def test_ne_false_across_enums_with_same_normalized_value(self: Self) -> None:
         """Cross-enum members sharing a normalized value are not `!=`."""
 
         class EnumA(ExtensibleStrEnum):
@@ -817,8 +823,21 @@ class TestNotEqualMirrorsEqual:
 
         assert (EnumA.ITEM != EnumB.ITEM) is False
 
-    def test_ne_true_for_non_string_types(self):
+    def test_ne_true_for_non_string_types(self: Self) -> None:
         """Non-string, non-enum operands remain `!=`."""
         assert (SampleEnum.ALPHA != 123) is True
         assert (SampleEnum.ALPHA != None) is True  # noqa: E711 - testing __ne__ with None
         assert (SampleEnum.ALPHA != []) is True
+
+    @pytest.mark.parametrize("other", [123, None, [], 4.5])  # fmt: skip
+    def test_ne_forwards_notimplemented_for_unsupported_operands(
+        self: Self, other: object
+    ) -> None:
+        """__ne__ defers to the other operand instead of asserting inequality.
+
+        The operator-level check above cannot see this: `!= 123` is True either
+        way, whether __ne__ forwards NotImplemented or wrongly hardcodes True.
+        Only the direct call distinguishes them, and the difference matters for
+        any third-party type whose reflected __eq__ should decide the result.
+        """
+        assert SampleEnum.ALPHA.__ne__(other) is NotImplemented

--- a/tests/unit/plugin/test_extensible_enums.py
+++ b/tests/unit/plugin/test_extensible_enums.py
@@ -753,7 +753,7 @@ class TestNotEqualMirrorsEqual:
     )  # fmt: skip
     def test_ne_is_negation_of_eq(self, other):
         """`member != other` equals `not (member == other)` for any operand."""
-        assert (SampleEnum.ALPHA != other) is not (SampleEnum.ALPHA == other)
+        assert (SampleEnum.ALPHA != other) is not (SampleEnum.ALPHA == other)  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
     @pytest.mark.parametrize(
         "other",
@@ -761,7 +761,7 @@ class TestNotEqualMirrorsEqual:
     )  # fmt: skip
     def test_ne_false_for_normalized_match(self, enum_with_underscores, other):
         """A normalized match is never `!=`."""
-        assert (enum_with_underscores.FOO_BAR != other) is False
+        assert (enum_with_underscores.FOO_BAR != other) is False  # noqa: SIM300 - enum must stay on the left; that is the operand order under test
 
     @pytest.mark.parametrize(
         "other",

--- a/tests/unit/plugin/test_extensible_enums.py
+++ b/tests/unit/plugin/test_extensible_enums.py
@@ -712,3 +712,94 @@ class TestDashUnderscoreNormalization:
         assert EnumA.ITEM == "foo_bar"
         assert EnumB.ITEM == "foo-bar"
         assert EnumB.ITEM == "foo_bar"
+
+
+# =============================================================================
+# __ne__ / __eq__ Symmetry Tests
+# =============================================================================
+
+
+class TestNotEqualMirrorsEqual:
+    """`!=` must be the exact negation of `==` for every operand shape.
+
+    Regression guard: `str.__ne__` sits between this class and `object` in the
+    MRO, so an inherited `__ne__` silently bypasses the normalizing `__eq__`
+    and makes `a == b` and `a != b` both True.
+    """
+
+    @pytest.fixture
+    def enum_with_underscores(self) -> type[ExtensibleStrEnum]:
+        class UnderscoreEnum(ExtensibleStrEnum):
+            FOO_BAR = "foo_bar"
+            BAZ_QUX = "baz_qux"
+
+        return UnderscoreEnum
+
+    @pytest.mark.parametrize(
+        "other",
+        [
+            "alpha",
+            "ALPHA",
+            "Alpha",
+            "aLpHa",
+            "beta",
+            "nonexistent",
+            123,
+            None,
+            [],
+            SampleEnum.ALPHA,
+            SampleEnum.BETA,
+        ],
+    )  # fmt: skip
+    def test_ne_is_negation_of_eq(self, other):
+        """`member != other` equals `not (member == other)` for any operand."""
+        assert (SampleEnum.ALPHA != other) is not (SampleEnum.ALPHA == other)
+
+    @pytest.mark.parametrize(
+        "other",
+        ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar"],
+    )  # fmt: skip
+    def test_ne_false_for_normalized_match(self, enum_with_underscores, other):
+        """A normalized match is never `!=`."""
+        assert (enum_with_underscores.FOO_BAR != other) is False
+
+    @pytest.mark.parametrize(
+        "other",
+        ["foo_bar", "foo-bar", "FOO_BAR", "FOO-BAR", "Foo-Bar"],
+    )  # fmt: skip
+    def test_ne_false_with_string_on_the_left(self, enum_with_underscores, other):
+        """Reflected `!=` also routes through the normalizing comparison."""
+        assert (other != enum_with_underscores.FOO_BAR) is False
+
+    def test_ne_true_for_different_member(self, enum_with_underscores):
+        """Genuinely different members stay `!=`."""
+        assert (enum_with_underscores.FOO_BAR != enum_with_underscores.BAZ_QUX) is True
+
+    def test_ne_false_for_registered_extension_spellings(self):
+        """Runtime-registered extensions negate consistently too."""
+
+        class TestEnum(ExtensibleStrEnum):
+            BASE = "base"
+
+        TestEnum.register("FOO_BAR", "foo_bar")
+
+        assert (TestEnum.FOO_BAR != "foo-bar") is False
+        assert (TestEnum.FOO_BAR != "FOO-BAR") is False
+        assert (TestEnum.FOO_BAR != "base") is True
+
+    def test_ne_false_across_enums_with_same_normalized_value(self):
+        """Cross-enum members sharing a normalized value are not `!=`."""
+
+        class EnumA(ExtensibleStrEnum):
+            ITEM = "foo_bar"
+
+        class EnumB(ExtensibleStrEnum):
+            ITEM = "foo-bar"
+
+        assert (EnumA.ITEM != EnumB.ITEM) is False
+
+    def test_ne_true_for_non_string_types(self):
+        """Non-string, non-enum operands remain `!=`."""
+        assert (SampleEnum.ALPHA != 123) is True
+        assert (SampleEnum.ALPHA != None) is True  # noqa: E711 - testing __ne__ with None
+        assert (SampleEnum.ALPHA != []) is True


### PR DESCRIPTION
## Summary

`CaseInsensitiveStrEnum` and `ExtensibleStrEnum` both override `__eq__` so that case and dash/underscore spelling don't matter. Neither overrode `__ne__`, so `!=` never reached that logic:

```python
CustomDatasetType.RANDOM_POOL == "RANDOM_POOL"   # True
CustomDatasetType.RANDOM_POOL != "RANDOM_POOL"   # also True
```

Python only synthesizes `__ne__` from `__eq__` via `object.__ne__`. These classes inherit from `str`, and `str.__ne__` sits between them and `object` in the MRO, so the inherited C-level raw-value comparison won.

Every `if value != SomeEnum.MEMBER:` guard where the left operand is a raw, pre-validation string therefore fired on spellings the enum itself considers equal — the guard rejects input that `==` would have accepted one line earlier.

## Fix

Give both classes an explicit `__ne__` that inverts `__eq__`, forwarding `NotImplemented` so non-string operands keep their normal reflected-comparison fallback.

While in the same two methods, `_norm_value()` and `__hash__()` now read their per-member cache directly rather than through `self.__dict__.get(name)` plus an is-None check, which more than pays for the frame `__ne__` adds on the normalization path. Numbers below.

- `src/aiperf/common/enums/base_enums.py`
- `src/aiperf/plugin/extensible_enums.py`

## Testing

TDD — tests were written and watched fail first.

- **RED:** 32 of the new assertions fail on `main` (commit `35459f2`), with the fix landing in the following commit.
- **GREEN:** 239 pass across both enum test files.
- **Full unit suite:** `18063 passed, 95 skipped, 14 failed`. All 14 failures reproduce identically on pristine `origin/main` (`810fd8bd`) in a clean worktree — they are pre-existing and environmental (timing-sensitive scheduler/ramping tests, tokenizer tests needing network, and `test_imports` needing `jsonschema`). Zero regressions from this change.

The regression tests cover, for both base classes:
- `!=` is the exact negation of `==` for every operand shape (matching, non-matching, non-string, enum)
- dash/underscore/case variants, in both operand orders
- dash-valued members compared against underscore spellings
- runtime-registered `ExtensibleStrEnum` extensions
- cross-enum members sharing a normalized value
- non-string operands (`int`, `None`, `list`, `float`) still compare unequal
- `__ne__` forwards `NotImplemented` on unsupported operands, asserted by direct call — the operator-level `!= 123` check is True either way and cannot tell forwarding apart from a hardcoded `True`

Plus one new test for the cache path the refactor touches: a `register()`-created member whose cache attribute is absent rather than stale, asserted absent before first use and populated after.

## Performance

Two changes pull in opposite directions, so here is the whole picture. All figures are min-of-11 `timeit.repeat` runs, A/B'd **in a single process** against a class carrying the old method bodies, so process-level variance cancels.

`!=` now runs the same normalizing comparison `==` always did, instead of a C-level `str` compare that was fast because it skipped the logic entirely:

| | exact match | needs normalization |
|---|---|---|
| `==` | 101 ns | 189 ns |
| `!=` (this PR) | 128 ns | 204 ns |
| `!=` (before, incorrect) | ~30 ns | ~28 ns |

The member's own normalized value is cached; what cannot be cached is the raw string on the other side, which `_normalize_name` recomputes per call (~34 ns). The `!=`-over-`==` delta is one extra Python frame.

Offsetting that, `_norm_value()` and `__hash__()` previously reached their caches via `self.__dict__.get(name)` plus an is-None check. A direct attribute read with an `AttributeError` fallback is measurably cheaper:

| | before | after | delta |
|---|---|---|---|
| `_norm_value()` | 37.3 ns | 24.8 ns | **-12.5** |
| `==` normalize path | 199.7 ns | 189.1 ns | **-10.7** |
| `!=` normalize path | 218.6 ns | 204.3 ns | **-14.3** |
| `hash()` | 48.4 ns | 38.1 ns | **-10.3** |
| `==` exact match | 99.2 ns | 102.4 ns | +3.1 (noise) |
| `!=` exact match | 127.6 ns | 127.5 ns | -0.1 |

Note the scope: the exact-match fast path is **unaffected**, because `str.__eq__` short-circuits before `_norm_value()` is ever reached. The win lands on the normalization path and on `hash()` — the latter matters for enum members used as dict keys and in set membership.

The lazy fallback is preserved for `ExtensibleStrEnum` members created through `register()`, which use `str.__new__` and skip `__init__`; a new test pins that never-populated path explicitly, alongside the existing pop-and-recompute tests.

## Background

Found while reviewing #1274, where a new `format:` guard using `!=` rejected valid `RANDOM_POOL`, `random-pool`, and `Random_Pool` spellings. That PR's symptom is one instance; this is the root cause, and it is deliberately fixed here on its own branch off `main` rather than inside a feature PR.

## Review notes

**Declined:** annotating `__ne__` as `bool | NotImplementedType`. The adjacent `__eq__` on both classes is annotated `-> bool` and can also return `NotImplemented` (via `str.__eq__`), so narrowing only `__ne__` would make the pair inconsistent. Typeshed annotates `object.__eq__`/`__ne__` as `-> bool` for the same reason, and this repo runs no type checker in CI or pre-commit. If we want the stricter annotation it should land on `__eq__` and `__ne__` together, as its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-insensitive enum comparisons so `!=` consistently returns the opposite result of `==`.
  * Ensured comparisons handle normalized dash/underscore variants, reflected string comparisons, enum values, and unsupported operand types correctly.
  * Improved reliability for lazily initialized enum extensions and cached values.

* **Tests**
  * Added comprehensive coverage for normalized equality, inequality, hashing, and extension handling, including previously unused enum extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->