### PR TITLE
fix(test-harness): implement num_prompt_special_tokens on FakeTokenizer

### DIFF
--- a/tests/harness/fake_tokenizer.py
+++ b/tests/harness/fake_tokenizer.py
@@ -66,3 +66,6 @@ class FakeTokenizer:
     @property
     def block_separation_token_id(self) -> int:
         return 1
+
+    def num_prompt_special_tokens(self) -> int:
+        return 0


### PR DESCRIPTION
## Summary

- `FakeTokenizer` (the test double every `component_integration` test uses via the package-scoped `mock_tokenizer_from_pretrained` fixture) never implemented `num_prompt_special_tokens()`.
- PR #850 added `Tokenizer.num_prompt_special_tokens()` and made `BaseDatasetComposer.__init__` call it unconditionally for every composer, on every run.
- The missing method raises `AttributeError` during composer init. Something upstream swallows the exception instead of failing fast, so the run never progresses and the suite hangs until the watchdog kills it minutes later, instead of failing immediately with a clear error.

## Root cause

Discovered while rebasing an unrelated PR (#1274) onto `main`: every `component_integration` test started hanging for ~10 minutes before being killed, with identical hangs across totally unrelated tests (`test_api_key_redaction`, `test_dag_hard_cap`, `test_record_lockstep_integration`, `test_adaptive_scale`, `test_dag_multi_root_payload_bytes`, etc). Bisected across the `main` commits pulled in by that rebase and isolated it to `94fee7338` (#850).

## Test plan

- [x] Reproduced the hang locally on `94fee7338`; confirmed it does not occur on the parent commit.
- [x] Applied the one-line fix; the previously-hanging tests now pass in seconds instead of hanging.
- [x] Full `tests/component_integration` suite: 319 passed, 4 skipped in 86s (previously: hangs / times out).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test tokenizer to report the number of prompt special tokens consistently.
  * Improved compatibility with components that inspect tokenizer metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->