### PR TITLE
fix: infer benchmark shape from --search-space keywords

### DIFF
--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -99,6 +99,14 @@ has both fields (it shares the rate machinery with the rate shape).
 Searching fields from two mutually-exclusive shapes (e.g. `users` and
 `smoothness` together — no shape has both) is rejected with a clear error.
 
+`rate_ramp`, `rate_series`, and `smoothness` modulate an existing rate
+rather than supplying one, so searching any of them alone still requires a
+base rate from somewhere -- pass `--request-rate` (or `--user-centric-rate`
+for a user shape), or add a `rate` dimension to the same `--search-space`.
+Without one, AIPerf errors at config time with a message explaining what's
+missing, rather than searching `rate_ramp`/`rate_series`/`smoothness` in a
+vacuum.
+
 ### Search space grammar
 
 `PATH:LO,HI[:KIND]`

--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -85,6 +85,20 @@ This runs 30 search iterations × 3 trials each = 90 benchmarks. `--search-plann
 | `--optuna-acquisition ACQ` | no | BoTorch acquisition override. Only consulted with `--search-planner=optuna --optuna-sampler=botorch`. Single-objective: `qnei` (Letham 2019) or `qlognei` (Ament 2023) for noisy-EI; `logei`/`qlogei` are the explicit defaults. Multi-objective: `qehvi`, `qnehvi`, or `qlognehvi` (Daulton 2021). The cross-field validator on `AdaptiveSearchSweep` requires the choice to match `len(objectives)`: single-objective acquisitions reject `len(objectives) > 1`, multi-objective acquisitions reject `len(objectives) == 1`. The `bayesian` preset auto-selects `qlognei` (single-obj) or `qlognehvi` (multi-obj) based on `len(objectives)`. See [Multi-objective Pareto BO](#multi-objective-pareto-bo). |
 | `--optuna-terminator MODE` | no | Posterior-regret stopping: `regret` (Makarova 2022 `RegretBoundEvaluator`) or `emmr` (Ishibashi 2023). Only consulted with `--search-planner=optuna`. Layered on top of three-signal convergence; `convergence_reason` becomes `posterior_regret_bound` or `emmr` when it fires. |
 
+A benchmark has one "shape" before it starts: `concurrency` ("send as many
+requests as possible"), `rate` ("send N requests per second"), `user`
+("simulate N users"), or `gamma` ("send requests with a particular
+bumpy/smooth pattern"). Searching a shape-specific field --
+`rate`/`rate_ramp`/`rate_series` (rate shape), `smoothness` (gamma shape), or
+`users` (user shape) -- automatically switches the base benchmark to a
+compatible shape, the same as passing the matching CLI flag
+(`--request-rate`, `--arrival-pattern gamma`, `--user-centric-rate`) would.
+Fields from the same shape combine freely — e.g. searching `users` and
+`rate` together fully auto-seeds a user shape, since a user-shaped benchmark
+has both fields (it shares the rate machinery with the rate shape).
+Searching fields from two mutually-exclusive shapes (e.g. `users` and
+`smoothness` together — no shape has both) is rejected with a clear error.
+
 ### Search space grammar
 
 `PATH:LO,HI[:KIND]`

--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -89,23 +89,29 @@ A benchmark has one "shape" before it starts: `concurrency` ("send as many
 requests as possible"), `rate` ("send N requests per second"), `user`
 ("simulate N users"), or `gamma` ("send requests with a particular
 bumpy/smooth pattern"). Searching a shape-specific field --
-`rate`/`rate_ramp`/`rate_series` (rate shape), `smoothness` (gamma shape), or
-`users` (user shape) -- automatically switches the base benchmark to a
-compatible shape, the same as passing the matching CLI flag
-(`--request-rate`, `--arrival-pattern gamma`, `--user-centric-rate`) would.
-Fields from the same shape combine freely — e.g. searching `users` and
-`rate` together fully auto-seeds a user shape, since a user-shaped benchmark
-has both fields (it shares the rate machinery with the rate shape).
-Searching fields from two mutually-exclusive shapes (e.g. `users` and
-`smoothness` together — no shape has both) is rejected with a clear error.
+`rate`/`rate_ramp` (rate shape), `smoothness` (gamma shape), or `users`
+(user shape) -- automatically switches the base benchmark to a compatible
+shape, the same as passing the matching CLI flag (`--request-rate`,
+`--arrival-pattern gamma`, `--user-centric-rate`) would. Fields from the
+same shape combine freely — e.g. searching `users` and `rate` together
+fully auto-seeds a user shape, since a user-shaped benchmark has both
+fields (it shares the rate machinery with the rate shape). Searching
+fields from two mutually-exclusive shapes (e.g. `users` and `smoothness`
+together — no shape has both) is rejected with a clear error.
 
-`rate_ramp`, `rate_series`, and `smoothness` modulate an existing rate
-rather than supplying one, so searching any of them alone still requires a
-base rate from somewhere -- pass `--request-rate` (or `--user-centric-rate`
-for a user shape), or add a `rate` dimension to the same `--search-space`.
-Without one, AIPerf errors at config time with a message explaining what's
-missing, rather than searching `rate_ramp`/`rate_series`/`smoothness` in a
-vacuum. `users` is a partial exception: it self-seeds the user count from
+`rate_series` is a piecewise-linear rate schedule, not a single number, so
+it can never be a `--search-space` dimension at all -- `--search-space
+"rate_series:..."` is rejected outright, with or without a companion
+`--request-rate-series`. Pass `--request-rate-series` as a fixed schedule
+instead, or search `rate`/`rate_ramp` for a scalar rate to sweep.
+
+`rate_ramp` and `smoothness` modulate an existing rate rather than
+supplying one, so searching either alone still requires a base rate from
+somewhere -- pass `--request-rate` (or `--user-centric-rate` for a user
+shape), or add a `rate` dimension to the same `--search-space`. Without
+one, AIPerf errors at config time with a message explaining what's
+missing, rather than searching `rate_ramp`/`smoothness` in a vacuum.
+`users` is a partial exception: it self-seeds the user count from
 its own search range, but a user-shaped benchmark still needs the same base
 rate as the rate shapes (users share a global request rate), so searching
 `users` alone also requires `--request-rate`, `--user-centric-rate`, or a

--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -85,6 +85,14 @@ This runs 30 search iterations × 3 trials each = 90 benchmarks. `--search-plann
 | `--optuna-acquisition ACQ` | no | BoTorch acquisition override. Only consulted with `--search-planner=optuna --optuna-sampler=botorch`. Single-objective: `qnei` (Letham 2019) or `qlognei` (Ament 2023) for noisy-EI; `logei`/`qlogei` are the explicit defaults. Multi-objective: `qehvi`, `qnehvi`, or `qlognehvi` (Daulton 2021). The cross-field validator on `AdaptiveSearchSweep` requires the choice to match `len(objectives)`: single-objective acquisitions reject `len(objectives) > 1`, multi-objective acquisitions reject `len(objectives) == 1`. The `bayesian` preset auto-selects `qlognei` (single-obj) or `qlognehvi` (multi-obj) based on `len(objectives)`. See [Multi-objective Pareto BO](#multi-objective-pareto-bo). |
 | `--optuna-terminator MODE` | no | Posterior-regret stopping: `regret` (Makarova 2022 `RegretBoundEvaluator`) or `emmr` (Ishibashi 2023). Only consulted with `--search-planner=optuna`. Layered on top of three-signal convergence; `convergence_reason` becomes `posterior_regret_bound` or `emmr` when it fires. |
 
+The shape-inference, seeding, and rejection rules below are enforced when
+`--search-space` is parsed on the CLI conversion path (`convert_cli_to_aiperf`).
+A `search_space:` entry under a YAML `sweep:` block goes through a
+different code path that doesn't apply the same validation, so a
+config-file sweep can still hit the underlying crashes these rules
+prevent -- prefer `--search-space` on the CLI until config-file sweeps get
+equivalent validation.
+
 A benchmark has one "shape" before it starts: `concurrency` ("send as many
 requests as possible"), `rate` ("send N requests per second"), `user`
 ("simulate N users"), or `gamma` ("send requests with a particular
@@ -100,8 +108,8 @@ fields from two mutually-exclusive shapes (e.g. `users` and `smoothness`
 together — no shape has both) is rejected with a clear error.
 
 `rate_series` is a piecewise-linear rate schedule, not a single number, so
-it can never be a `--search-space` dimension at all -- `--search-space
-"rate_series:..."` is rejected outright, with or without a companion
+it's not a valid dimension to sweep -- `--search-space "rate_series:..."`
+is rejected at config time, with or without a companion
 `--request-rate-series`. Pass `--request-rate-series` as a fixed schedule
 instead, or search `rate`/`rate_ramp` for a scalar rate to sweep.
 

--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -105,7 +105,12 @@ base rate from somewhere -- pass `--request-rate` (or `--user-centric-rate`
 for a user shape), or add a `rate` dimension to the same `--search-space`.
 Without one, AIPerf errors at config time with a message explaining what's
 missing, rather than searching `rate_ramp`/`rate_series`/`smoothness` in a
-vacuum.
+vacuum. `users` is a partial exception: it self-seeds the user count from
+its own search range, but a user-shaped benchmark still needs the same base
+rate as the rate shapes (users share a global request rate), so searching
+`users` alone also requires `--request-rate`, `--user-centric-rate`, or a
+`rate` dimension -- same requirement, same error, just for a different
+field.
 
 ### Search space grammar
 

--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -128,6 +128,14 @@ field. A `users` dimension must also use `:int` kind (e.g.
 `users:1,50:int`) -- the omitted-kind default of `:real` is rejected, since
 the number of simulated users can only ever be a whole number.
 
+`smoothness` auto-selects the gamma shape only when `--arrival-pattern` is
+left unset. An explicit non-gamma `--arrival-pattern` (`poisson` or
+`constant`) wins instead and is rejected at config time if `smoothness` is
+also being searched, the same way `--arrival-smoothness` is rejected
+against an explicit non-gamma pattern -- drop `--arrival-pattern` to let
+`smoothness` auto-select gamma, or pass `--arrival-pattern gamma`
+explicitly.
+
 ### Search space grammar
 
 `PATH:LO,HI[:KIND]`

--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -110,7 +110,9 @@ its own search range, but a user-shaped benchmark still needs the same base
 rate as the rate shapes (users share a global request rate), so searching
 `users` alone also requires `--request-rate`, `--user-centric-rate`, or a
 `rate` dimension -- same requirement, same error, just for a different
-field.
+field. A `users` dimension must also use `:int` kind (e.g.
+`users:1,50:int`) -- the omitted-kind default of `:real` is rejected, since
+the number of simulated users can only ever be a whole number.
 
 ### Search space grammar
 

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -91,49 +91,60 @@ _RATE_SHAPE_SEARCH_FIELDS: frozenset[str] = frozenset(
 )
 
 
-def _search_space_target_fields(cli: CLIConfig) -> set[str]:
-    """Bare field names referenced anywhere in ``--search-space``.
+def _search_space_dimensions(cli: CLIConfig) -> dict[str, float]:
+    """Field name -> lower bound for every dimension in ``--search-space``.
 
     A lightweight companion to ``parse_search_space()`` (which runs later,
     in ``_build_adaptive_search``): only extracts each dimension's final
-    path segment, resolving bare-name aliases the same way the real parser
-    does, so ``_profiling_phase_type`` can pick a compatible phase shape
-    before search-space bounds/kind are even validated. Malformed entries
-    are ignored here -- the real parser reports the actual grammar error.
+    path segment (resolving bare-name aliases the same way the real parser
+    does) and its lower bound, so ``_profiling_phase_type``/``build_profiling``
+    can pick a compatible phase shape -- and seed a self-supplying field's
+    initial value from its own search range -- before search-space
+    bounds/kind are even validated. Malformed entries are skipped here; the
+    real parser reports the actual grammar error.
     """
     if not cli.search_space:
-        return set()
+        return {}
 
     from aiperf.config.loader.dotted_path import _resolve_path_alias
 
-    fields: set[str] = set()
+    dims: dict[str, float] = {}
     for raw in cli.search_space:
-        path = raw.split(":", 1)[0].strip()
+        path_part, _, bounds_part = raw.partition(":")
+        path = path_part.strip()
         if not path:
             continue
         if "." not in path:
             path = _resolve_path_alias(path)
-        fields.add(path.rsplit(".", 1)[-1])
-    return fields
+        field = path.rsplit(".", 1)[-1]
+        lo_str = bounds_part.split(",", 1)[0].strip()
+        try:
+            dims[field] = float(lo_str)
+        except ValueError:
+            continue
+    return dims
 
 
-def _profiling_phase_type(cli: CLIConfig) -> Any:
+def _profiling_phase_type(cli: CLIConfig, search_dims: dict[str, float]) -> Any:
     from aiperf.config.phases import PhaseType
     from aiperf.plugin.enums import ArrivalPattern
 
     if cli.fixed_schedule:
         return PhaseType.FIXED_SCHEDULE
 
-    search_space_fields = _search_space_target_fields(cli)
-    user_centric_needed = "users" in search_space_fields
-    rate_shape_needed = bool(search_space_fields & _RATE_SHAPE_SEARCH_FIELDS)
+    user_centric_needed = "users" in search_dims
+    rate_shape_needed = bool(set(search_dims) & _RATE_SHAPE_SEARCH_FIELDS)
 
-    if user_centric_needed and rate_shape_needed:
+    # UserCentricPhase has no 'smoothness' field and GammaPhase has no
+    # 'users' field -- no phase type can satisfy both, unlike users+rate
+    # (UserCentricPhase legitimately has rate/rate_ramp/rate_series too,
+    # inherited from RatePhaseConfig).
+    if user_centric_needed and "smoothness" in search_dims:
         raise ValueError(
             "--search-space targets both 'users' (a user-centric-shaped "
-            "benchmark) and a rate-shaped field ('rate'/'rate_ramp'/"
-            "'rate_series'/'smoothness'). A benchmark can only have one "
-            "shape at a time -- search these in separate runs."
+            "benchmark) and 'smoothness' (a gamma-shaped benchmark). A "
+            "benchmark can only have one shape at a time -- search these in "
+            "separate runs."
         )
 
     if cli.user_centric_rate is not None or user_centric_needed:
@@ -151,7 +162,7 @@ def _profiling_phase_type(cli: CLIConfig) -> Any:
         # that made --vllm-burstiness unusable on its own. A 'smoothness'
         # search-space dimension is the same knob, so it auto-promotes too.
         if "arrival_pattern" not in cli.model_fields_set and (
-            cli.arrival_smoothness is not None or "smoothness" in search_space_fields
+            cli.arrival_smoothness is not None or "smoothness" in search_dims
         ):
             return PhaseType.GAMMA
         match cli.arrival_pattern:
@@ -162,6 +173,64 @@ def _profiling_phase_type(cli: CLIConfig) -> Any:
             case _:
                 return PhaseType.POISSON
     return PhaseType.CONCURRENCY
+
+
+def _apply_search_space_shape_seeds(
+    prof: dict[str, Any], search_dims: dict[str, float]
+) -> None:
+    """Seed the required scalar(s) a search-space-inferred shape still needs.
+
+    ``_profiling_phase_type`` can auto-switch the phase *type* from
+    ``--search-space`` alone, but rate-controlled/user-centric phases also
+    require a *value* for their defining scalar (``rate``, and for
+    user-centric also ``users``) before Pydantic will accept the base
+    config -- the search planner only supplies that value once trials
+    start. When the searched field is the scalar itself, its own lower
+    bound is a natural seed (the planner immediately overrides it on trial
+    0 anyway). When it isn't -- e.g. searching 'smoothness' or 'rate_ramp'
+    without ever searching or explicitly setting 'rate' -- there's no value
+    to seed from; raise a clear error instead of letting Pydantic's
+    "rate-controlled phases require rate or rate_series" surface as an
+    unexplained crash on the very first config build.
+
+    By construction this is a no-op whenever the phase type came from an
+    explicit CLI flag rather than search-space inference: --request-rate,
+    --request-rate-series, and --user-centric-rate all populate
+    prof["rate"]/prof["rate_series"] via _PROF_FIELD_ROUTES /
+    _apply_profiling_rate_series before this runs.
+    """
+    from aiperf.config.phases import PhaseType
+
+    phase_type = prof["type"]
+
+    if (
+        phase_type == PhaseType.USER_CENTRIC
+        and "users" not in prof
+        and "users" in search_dims
+    ):
+        prof["users"] = int(search_dims["users"])
+
+    if (
+        phase_type
+        in (
+            PhaseType.POISSON,
+            PhaseType.GAMMA,
+            PhaseType.CONSTANT,
+            PhaseType.USER_CENTRIC,
+        )
+        and "rate" not in prof
+        and "rate_series" not in prof
+    ):
+        if "rate" in search_dims:
+            prof["rate"] = search_dims["rate"]
+        else:
+            raise ValueError(
+                f"--search-space selects a rate-shaped benchmark (phase type "
+                f"{phase_type!r}), which also requires a base rate. Pass "
+                "--request-rate <value> (or --user-centric-rate for a "
+                "user-shaped benchmark), or add a 'rate' dimension to "
+                "--search-space."
+            )
 
 
 def _apply_profiling_ramps(prof: dict[str, Any], cli: CLIConfig) -> None:
@@ -562,7 +631,9 @@ def build_profiling(cli: CLIConfig) -> dict[str, Any]:
     _apply_agentic_replay_fields(prof, cli)
     _apply_profiling_rate_series(prof, cli)
 
-    prof["type"] = _profiling_phase_type(cli)
+    search_dims = _search_space_dimensions(cli)
+    prof["type"] = _profiling_phase_type(cli, search_dims)
+    _apply_search_space_shape_seeds(prof, search_dims)
     _reject_orphan_load_generator_flags(prof, cli)
     _apply_phase_specific_routes(prof, cli)
 

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -86,24 +86,72 @@ def _apply_agentic_replay_fields(phase: dict[str, Any], cli: CLIConfig) -> None:
         phase["agentic_warmup_grace_period"] = cli.warmup_grace_period
 
 
+_RATE_SHAPE_SEARCH_FIELDS: frozenset[str] = frozenset(
+    {"rate", "rate_ramp", "rate_series", "smoothness"}
+)
+
+
+def _search_space_target_fields(cli: CLIConfig) -> set[str]:
+    """Bare field names referenced anywhere in ``--search-space``.
+
+    A lightweight companion to ``parse_search_space()`` (which runs later,
+    in ``_build_adaptive_search``): only extracts each dimension's final
+    path segment, resolving bare-name aliases the same way the real parser
+    does, so ``_profiling_phase_type`` can pick a compatible phase shape
+    before search-space bounds/kind are even validated. Malformed entries
+    are ignored here -- the real parser reports the actual grammar error.
+    """
+    if not cli.search_space:
+        return set()
+
+    from aiperf.config.loader.dotted_path import _resolve_path_alias
+
+    fields: set[str] = set()
+    for raw in cli.search_space:
+        path = raw.split(":", 1)[0].strip()
+        if not path:
+            continue
+        if "." not in path:
+            path = _resolve_path_alias(path)
+        fields.add(path.rsplit(".", 1)[-1])
+    return fields
+
+
 def _profiling_phase_type(cli: CLIConfig) -> Any:
     from aiperf.config.phases import PhaseType
     from aiperf.plugin.enums import ArrivalPattern
 
     if cli.fixed_schedule:
         return PhaseType.FIXED_SCHEDULE
-    if cli.user_centric_rate is not None:
+
+    search_space_fields = _search_space_target_fields(cli)
+    user_centric_needed = "users" in search_space_fields
+    rate_shape_needed = bool(search_space_fields & _RATE_SHAPE_SEARCH_FIELDS)
+
+    if user_centric_needed and rate_shape_needed:
+        raise ValueError(
+            "--search-space targets both 'users' (a user-centric-shaped "
+            "benchmark) and a rate-shaped field ('rate'/'rate_ramp'/"
+            "'rate_series'/'smoothness'). A benchmark can only have one "
+            "shape at a time -- search these in separate runs."
+        )
+
+    if cli.user_centric_rate is not None or user_centric_needed:
         return PhaseType.USER_CENTRIC
-    if cli.request_rate is not None or cli.request_rate_series is not None:
+    if (
+        cli.request_rate is not None
+        or cli.request_rate_series is not None
+        or rate_shape_needed
+    ):
         # v1 parity (user_config.py auto-promote): --arrival-smoothness /
         # --vllm-burstiness without an explicit --arrival-pattern resolves to
         # gamma, since smoothness is a gamma-distribution knob. Without this the
         # flag fell through to POISSON and then _apply_phase_specific_routes
         # hard-rejected it ("only supported with gamma") -- a cutover regression
-        # that made --vllm-burstiness unusable on its own.
-        if (
-            "arrival_pattern" not in cli.model_fields_set
-            and cli.arrival_smoothness is not None
+        # that made --vllm-burstiness unusable on its own. A 'smoothness'
+        # search-space dimension is the same knob, so it auto-promotes too.
+        if "arrival_pattern" not in cli.model_fields_set and (
+            cli.arrival_smoothness is not None or "smoothness" in search_space_fields
         ):
             return PhaseType.GAMMA
         match cli.arrival_pattern:

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -101,7 +101,12 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, float]:
     can pick a compatible phase shape -- and seed a self-supplying field's
     initial value from its own search range -- before search-space
     bounds/kind are even validated. Malformed entries are skipped here; the
-    real parser reports the actual grammar error.
+    real parser reports the actual grammar error. Only dimensions that
+    target ``phases.profiling.*`` are considered (bare aliases always
+    resolve there); a fully-qualified path targeting a different phase
+    (e.g. ``phases.warmup.*``) is ignored by this shape-inference helper --
+    the real search-space parser still processes it normally later, just
+    not for the purpose of phase-shape inference.
     """
     if not cli.search_space:
         return {}
@@ -116,6 +121,8 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, float]:
             continue
         if "." not in path:
             path = _resolve_path_alias(path)
+        if not path.startswith("phases.profiling."):
+            continue
         field = path.rsplit(".", 1)[-1]
         lo_str = bounds_part.split(",", 1)[0].strip()
         try:
@@ -208,6 +215,12 @@ def _apply_search_space_shape_seeds(
         and "users" not in prof
         and "users" in search_dims
     ):
+        if search_dims["users"] < 1:
+            raise ValueError(
+                f"--search-space 'users' lower bound must be >= 1 (got "
+                f"{search_dims['users']!r}); the number of simulated users "
+                "can't be less than one."
+            )
         prof["users"] = int(search_dims["users"])
 
     if (
@@ -222,11 +235,16 @@ def _apply_search_space_shape_seeds(
         and "rate_series" not in prof
     ):
         if "rate" in search_dims:
+            if search_dims["rate"] <= 0:
+                raise ValueError(
+                    f"--search-space 'rate' lower bound must be > 0 (got "
+                    f"{search_dims['rate']!r}); rate must be positive."
+                )
             prof["rate"] = search_dims["rate"]
         else:
             raise ValueError(
                 f"--search-space selects a rate-shaped benchmark (phase type "
-                f"{phase_type!r}), which also requires a base rate. Pass "
+                f"{phase_type}), which also requires a base rate. Pass "
                 "--request-rate <value> (or --user-centric-rate for a "
                 "user-shaped benchmark), or add a 'rate' dimension to "
                 "--search-space."

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -124,50 +124,69 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, tuple[float, str]]:
     if not cli.search_space:
         return {}
 
-    from aiperf.config.loader.dotted_path import _resolve_path_alias
-
     dims: dict[str, tuple[float, str]] = {}
     for raw in cli.search_space:
-        path_part, _, rest = raw.partition(":")
-        path = path_part.strip()
-        if not path:
-            continue
-        if "." not in path:
-            path = _resolve_path_alias(path)
-        if not path.startswith("phases.profiling."):
-            continue
-        remainder = path[len("phases.profiling.") :]
-        if "." in remainder:
-            # A nested sub-field (e.g. "phases.profiling.cancellation.rate")
-            # is not the phase's own scalar field -- matching it by leaf
-            # name alone would misclassify e.g. a cancellation-rate sweep
-            # as the phase's request rate. Not a shape-bearing dimension.
-            continue
-        field = remainder
-        if field == "rate_series":
-            raise ValueError(
-                "--search-space 'rate_series' is not a valid adaptive-search "
-                "dimension: it's a piecewise-linear rate schedule (a list of "
-                "time/rate points), not a single number the planner can "
-                "sample between two bounds. Pass --request-rate-series as a "
-                "fixed companion instead of searching over it, or search "
-                "'rate'/'rate_ramp' for a scalar rate to sweep."
-            )
-        bounds_part, _, kind_part = rest.partition(":")
-        if ":" in kind_part:
-            # More than three ':'-separated segments (e.g.
-            # "users:1,50:int:log") -- malformed grammar. Skip rather than
-            # guess a kind from it; the real parser's grammar error is what
-            # the user should see, not a wrong "expected :int" message from
-            # this lightweight helper misreading the extra segment as kind.
-            continue
-        lo_str = bounds_part.split(",", 1)[0].strip()
-        kind = kind_part.strip() or "real"
-        try:
-            dims[field] = (float(lo_str), kind)
-        except ValueError:
-            continue
+        parsed = _parse_shape_dimension(raw)
+        if parsed is not None:
+            field, lo, kind = parsed
+            dims[field] = (lo, kind)
     return dims
+
+
+def _parse_shape_dimension(raw: str) -> tuple[str, float, str] | None:
+    """Parse one ``--search-space`` entry into ``(field, lo, kind)``, or
+    ``None`` if it isn't a shape-bearing ``phases.profiling.<field>`` scalar.
+
+    Raises for ``rate_series`` specifically (see ``_search_space_dimensions``
+    docstring); every other malformed or out-of-scope entry is skipped so
+    the real parser (``parse_search_space``) is what reports the actual
+    grammar error, rather than this lightweight helper guessing wrong.
+    """
+    from aiperf.config.loader.dotted_path import _resolve_path_alias
+
+    path_part, _, rest = raw.partition(":")
+    path = path_part
+    if not path:
+        return None
+    if "." not in path:
+        path = _resolve_path_alias(path)
+    if not path.startswith("phases.profiling."):
+        return None
+    remainder = path[len("phases.profiling.") :]
+    if "." in remainder:
+        # A nested sub-field (e.g. "phases.profiling.cancellation.rate") is
+        # not the phase's own scalar field -- matching it by leaf name alone
+        # would misclassify e.g. a cancellation-rate sweep as the phase's
+        # request rate. Not a shape-bearing dimension.
+        return None
+    field = remainder
+    if field == "rate_series":
+        raise ValueError(
+            "--search-space 'rate_series' is not a valid adaptive-search "
+            "dimension: it's a piecewise-linear rate schedule (a list of "
+            "time/rate points), not a single number the planner can "
+            "sample between two bounds. Pass --request-rate-series as a "
+            "fixed companion instead of searching over it, or search "
+            "'rate'/'rate_ramp' for a scalar rate to sweep."
+        )
+    bounds_part, _, kind_part = rest.partition(":")
+    if ":" in kind_part:
+        # More than three ':'-separated segments (e.g. "users:1,50:int:log")
+        # -- malformed grammar. Skip rather than guess a kind from it.
+        return None
+    kind = kind_part or "real"
+    if kind not in ("int", "real"):
+        # Not one of the real parser's _VALID_KINDS (parsing.py) -- skip so
+        # the real parser's own grammar error is what the user sees. This is
+        # also what makes _seed_users_dimension's "not ':real'" message
+        # always accurate: by the time kind reaches there, it can only ever
+        # be "int" or "real".
+        return None
+    lo_str = bounds_part.split(",", 1)[0]
+    try:
+        return field, float(lo_str), kind
+    except ValueError:
+        return None
 
 
 def _profiling_phase_type(
@@ -272,6 +291,19 @@ def _apply_search_space_shape_seeds(
     _reject_non_positive_bound(search_dims, "rate_ramp", "the ramp duration (seconds)")
 
     phase_type = prof["type"]
+
+    # 'smoothness' only auto-promotes the phase to GAMMA when --arrival-pattern
+    # is unset (see the v1-parity comment in _profiling_phase_type); an
+    # EXPLICIT non-gamma --arrival-pattern silently wins instead, leaving a
+    # searched 'smoothness' dimension with nowhere to land (GammaPhase is the
+    # only phase with that field). Mirrors the equivalent gate for the
+    # --arrival-smoothness *flag* in _apply_phase_specific_routes below.
+    if "smoothness" in search_dims and phase_type != PhaseType.GAMMA:
+        raise ValueError(
+            "--search-space 'smoothness' is only supported with --arrival-pattern "
+            "gamma. Pass --arrival-pattern gamma (or omit --arrival-pattern so "
+            "'smoothness' can auto-select it), or drop the 'smoothness' dimension."
+        )
 
     if phase_type == PhaseType.USER_CENTRIC and "users" in search_dims:
         _seed_users_dimension(prof, search_dims)
@@ -570,16 +602,21 @@ def _maybe_auto_promote_trace(
     # FixedSchedulePhase doesn't accept rate/users/smoothness. If the user
     # explicitly opted into a rate-controlled mode against a timestamped
     # trace, refuse the combo loudly rather than silently dropping their
-    # flag — they almost certainly want one or the other, not both.
+    # flag — they almost certainly want one or the other, not both. `prof`
+    # may hold these because of an explicit CLI flag OR because
+    # _apply_search_space_shape_seeds seeded them from a --search-space
+    # dimension -- "flags" alone would be unactionable in the latter case
+    # (there's no flag to drop), so name both sources.
     conflicts = [k for k in ("rate", "users", "smoothness") if k in prof]
     if conflicts:
         raise ValueError(
             "Trace dataset has per-record timestamps and would be "
-            "auto-promoted to fixed_schedule, but the following flags "
-            f"are incompatible with fixed_schedule mode: {conflicts}. "
-            "Either drop the conflicting flags to enable auto-fixed-"
-            "schedule, or pass --no-fixed-schedule to keep your "
-            "user-selected timing mode and ignore trace timestamps."
+            "auto-promoted to fixed_schedule, but the following flags or "
+            f"--search-space dimensions are incompatible with "
+            f"fixed_schedule mode: {conflicts}. Either drop the "
+            "conflicting flags/dimensions to enable auto-fixed-schedule, "
+            "or pass --no-fixed-schedule to keep your user-selected timing "
+            "mode and ignore trace timestamps."
         )
     prof["type"] = PhaseType.FIXED_SCHEDULE
 

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -206,21 +206,24 @@ def _apply_search_space_shape_seeds(
     "rate-controlled phases require rate or rate_series" surface as an
     unexplained crash on the very first config build.
 
-    By construction this is a no-op whenever the phase type came from an
-    explicit CLI flag rather than search-space inference: --request-rate,
-    --request-rate-series, and --user-centric-rate all populate
-    prof["rate"]/prof["rate_series"] via _PROF_FIELD_ROUTES /
-    _apply_profiling_rate_series before this runs.
+    By construction the rate-seeding block below is a no-op whenever the
+    phase type came from an explicit CLI flag rather than search-space
+    inference: --request-rate, --request-rate-series, and
+    --user-centric-rate all populate prof["rate"]/prof["rate_series"] via
+    _PROF_FIELD_ROUTES / _apply_profiling_rate_series before this runs. The
+    'users' kind/bound validation below intentionally does NOT have that
+    same short-circuit: --num-users populates prof["users"] via the same
+    routes, but a 'users' search-space dimension is validated regardless
+    of whether an explicit --num-users also set prof["users"] first --
+    otherwise `--num-users 10 --search-space "users:1.5,50:real"` would
+    silently skip validation on a real-valued dimension that still reaches
+    the planner and can crash later on a non-integral sampled value.
     """
     from aiperf.config.phases import PhaseType
 
     phase_type = prof["type"]
 
-    if (
-        phase_type == PhaseType.USER_CENTRIC
-        and "users" not in prof
-        and "users" in search_dims
-    ):
+    if phase_type == PhaseType.USER_CENTRIC and "users" in search_dims:
         users_lo, users_kind = search_dims["users"]
         if users_kind != "int":
             raise ValueError(
@@ -234,7 +237,8 @@ def _apply_search_space_shape_seeds(
                 f"{users_lo!r}); the number of simulated users can't be "
                 "less than one."
             )
-        prof["users"] = int(users_lo)
+        if "users" not in prof:
+            prof["users"] = int(users_lo)
 
     if (
         phase_type

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -259,6 +259,18 @@ def _apply_search_space_shape_seeds(
     """
     from aiperf.config.phases import PhaseType
 
+    # 'smoothness' (GammaPhase.smoothness, gt=0) and 'rate_ramp'
+    # (RampConfig.duration, gt=0.0) aren't seeded into prof here -- both are
+    # optional fields the planner only ever writes once trials start -- but
+    # they share the same "validate the bound now, not at sample time" need
+    # as 'rate'/'users': a negative lower bound otherwise builds a valid
+    # base config and only fails once the planner happens to sample a
+    # negative value mid-search.
+    _reject_non_positive_bound(
+        search_dims, "smoothness", "the gamma distribution's shape parameter"
+    )
+    _reject_non_positive_bound(search_dims, "rate_ramp", "the ramp duration (seconds)")
+
     phase_type = prof["type"]
 
     if phase_type == PhaseType.USER_CENTRIC and "users" in search_dims:
@@ -271,6 +283,20 @@ def _apply_search_space_shape_seeds(
         PhaseType.USER_CENTRIC,
     ):
         _seed_rate_dimension(prof, search_dims, phase_type)
+
+
+def _reject_non_positive_bound(
+    search_dims: dict[str, tuple[float, str]], field: str, subject: str
+) -> None:
+    """Raise a clear error if `field`'s search-space lower bound isn't > 0."""
+    if field not in search_dims:
+        return
+    lo, _kind = search_dims[field]
+    if not math.isfinite(lo) or lo <= 0:
+        raise ValueError(
+            f"--search-space '{field}' lower bound must be > 0 (got {lo!r}); "
+            f"{subject} must be positive."
+        )
 
 
 def _seed_users_dimension(

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -143,6 +143,13 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, tuple[float, str]]:
                 "'rate'/'rate_ramp' for a scalar rate to sweep."
             )
         bounds_part, _, kind_part = rest.partition(":")
+        if ":" in kind_part:
+            # More than three ':'-separated segments (e.g.
+            # "users:1,50:int:log") -- malformed grammar. Skip rather than
+            # guess a kind from it; the real parser's grammar error is what
+            # the user should see, not a wrong "expected :int" message from
+            # this lightweight helper misreading the extra segment as kind.
+            continue
         lo_str = bounds_part.split(",", 1)[0].strip()
         kind = kind_part.strip() or "real"
         try:
@@ -222,18 +229,17 @@ def _apply_search_space_shape_seeds(
     "rate-controlled phases require rate or rate_series" surface as an
     unexplained crash on the very first config build.
 
-    By construction the rate-seeding block below is a no-op whenever the
-    phase type came from an explicit CLI flag rather than search-space
-    inference: --request-rate, --request-rate-series, and
-    --user-centric-rate all populate prof["rate"]/prof["rate_series"] via
-    _PROF_FIELD_ROUTES / _apply_profiling_rate_series before this runs. The
-    'users' kind/bound validation below intentionally does NOT have that
-    same short-circuit: --num-users populates prof["users"] via the same
-    routes, but a 'users' search-space dimension is validated regardless
-    of whether an explicit --num-users also set prof["users"] first --
-    otherwise `--num-users 10 --search-space "users:1.5,50:real"` would
-    silently skip validation on a real-valued dimension that still reaches
-    the planner and can crash later on a non-integral sampled value.
+    Both the 'users' and 'rate' validation below run whenever the
+    respective field is in search_dims, regardless of whether an explicit
+    CLI flag (--num-users, --request-rate, --request-rate-series, or
+    --user-centric-rate) already populated prof["users"]/prof["rate"]/
+    prof["rate_series"] via _PROF_FIELD_ROUTES / _apply_profiling_rate_series
+    before this runs -- only the *assignment* is gated on absence.
+    Otherwise `--request-rate 10 --search-space "rate:-5,100"` would
+    silently skip bound validation on a dimension the planner still samples
+    from every trial (crashing mid-search once a negative value is drawn,
+    not at config-build time), the same class of bug as skipping 'users'
+    validation whenever --num-users was also explicit.
     """
     from aiperf.config.phases import PhaseType
 
@@ -256,17 +262,13 @@ def _apply_search_space_shape_seeds(
         if "users" not in prof:
             prof["users"] = int(users_lo)
 
-    if (
-        phase_type
-        in (
-            PhaseType.POISSON,
-            PhaseType.GAMMA,
-            PhaseType.CONSTANT,
-            PhaseType.USER_CENTRIC,
-        )
-        and "rate" not in prof
-        and "rate_series" not in prof
+    if phase_type in (
+        PhaseType.POISSON,
+        PhaseType.GAMMA,
+        PhaseType.CONSTANT,
+        PhaseType.USER_CENTRIC,
     ):
+        has_base_rate = "rate" in prof or "rate_series" in prof
         if "rate" in search_dims:
             rate_lo, _rate_kind = search_dims["rate"]
             if rate_lo <= 0:
@@ -274,8 +276,9 @@ def _apply_search_space_shape_seeds(
                     f"--search-space 'rate' lower bound must be > 0 (got "
                     f"{rate_lo!r}); rate must be positive."
                 )
-            prof["rate"] = rate_lo
-        else:
+            if not has_base_rate:
+                prof["rate"] = rate_lo
+        elif not has_base_rate:
             raise ValueError(
                 f"--search-space selects a rate-shaped benchmark (phase type "
                 f"{phase_type}), which also requires a base rate. Pass "

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -91,17 +91,19 @@ _RATE_SHAPE_SEARCH_FIELDS: frozenset[str] = frozenset(
 )
 
 
-def _search_space_dimensions(cli: CLIConfig) -> dict[str, float]:
-    """Field name -> lower bound for every dimension in ``--search-space``.
+def _search_space_dimensions(cli: CLIConfig) -> dict[str, tuple[float, str]]:
+    """Field name -> (lower bound, kind) for every dimension in ``--search-space``.
 
     A lightweight companion to ``parse_search_space()`` (which runs later,
     in ``_build_adaptive_search``): only extracts each dimension's final
     path segment (resolving bare-name aliases the same way the real parser
-    does) and its lower bound, so ``_profiling_phase_type``/``build_profiling``
-    can pick a compatible phase shape -- and seed a self-supplying field's
-    initial value from its own search range -- before search-space
-    bounds/kind are even validated. Malformed entries are skipped here; the
-    real parser reports the actual grammar error. Only dimensions that
+    does), its lower bound, and its declared ``kind`` (``int``/``real``,
+    default ``real`` when omitted -- matches ``SearchSpaceDimension``'s own
+    default), so ``_profiling_phase_type``/``build_profiling`` can pick a
+    compatible phase shape -- and seed a self-supplying field's initial
+    value from its own search range -- before search-space bounds/kind are
+    even validated by the real parser. Malformed entries are skipped here;
+    the real parser reports the actual grammar error. Only dimensions that
     target ``phases.profiling.*`` are considered (bare aliases always
     resolve there); a fully-qualified path targeting a different phase
     (e.g. ``phases.warmup.*``) is ignored by this shape-inference helper --
@@ -113,9 +115,9 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, float]:
 
     from aiperf.config.loader.dotted_path import _resolve_path_alias
 
-    dims: dict[str, float] = {}
+    dims: dict[str, tuple[float, str]] = {}
     for raw in cli.search_space:
-        path_part, _, bounds_part = raw.partition(":")
+        path_part, _, rest = raw.partition(":")
         path = path_part.strip()
         if not path:
             continue
@@ -124,15 +126,19 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, float]:
         if not path.startswith("phases.profiling."):
             continue
         field = path.rsplit(".", 1)[-1]
+        bounds_part, _, kind_part = rest.partition(":")
         lo_str = bounds_part.split(",", 1)[0].strip()
+        kind = kind_part.strip() or "real"
         try:
-            dims[field] = float(lo_str)
+            dims[field] = (float(lo_str), kind)
         except ValueError:
             continue
     return dims
 
 
-def _profiling_phase_type(cli: CLIConfig, search_dims: dict[str, float]) -> Any:
+def _profiling_phase_type(
+    cli: CLIConfig, search_dims: dict[str, tuple[float, str]]
+) -> Any:
     from aiperf.config.phases import PhaseType
     from aiperf.plugin.enums import ArrivalPattern
 
@@ -183,7 +189,7 @@ def _profiling_phase_type(cli: CLIConfig, search_dims: dict[str, float]) -> Any:
 
 
 def _apply_search_space_shape_seeds(
-    prof: dict[str, Any], search_dims: dict[str, float]
+    prof: dict[str, Any], search_dims: dict[str, tuple[float, str]]
 ) -> None:
     """Seed the required scalar(s) a search-space-inferred shape still needs.
 
@@ -215,13 +221,20 @@ def _apply_search_space_shape_seeds(
         and "users" not in prof
         and "users" in search_dims
     ):
-        if search_dims["users"] < 1:
+        users_lo, users_kind = search_dims["users"]
+        if users_kind != "int":
+            raise ValueError(
+                "--search-space 'users' must use ':int' kind (e.g. "
+                "'users:1,50:int'), not ':real' -- the number of simulated "
+                "users must be a whole number."
+            )
+        if users_lo < 1:
             raise ValueError(
                 f"--search-space 'users' lower bound must be >= 1 (got "
-                f"{search_dims['users']!r}); the number of simulated users "
-                "can't be less than one."
+                f"{users_lo!r}); the number of simulated users can't be "
+                "less than one."
             )
-        prof["users"] = int(search_dims["users"])
+        prof["users"] = int(users_lo)
 
     if (
         phase_type
@@ -235,12 +248,13 @@ def _apply_search_space_shape_seeds(
         and "rate_series" not in prof
     ):
         if "rate" in search_dims:
-            if search_dims["rate"] <= 0:
+            rate_lo, _rate_kind = search_dims["rate"]
+            if rate_lo <= 0:
                 raise ValueError(
                     f"--search-space 'rate' lower bound must be > 0 (got "
-                    f"{search_dims['rate']!r}); rate must be positive."
+                    f"{rate_lo!r}); rate must be positive."
                 )
-            prof["rate"] = search_dims["rate"]
+            prof["rate"] = rate_lo
         else:
             raise ValueError(
                 f"--search-space selects a rate-shaped benchmark (phase type "

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -87,7 +87,7 @@ def _apply_agentic_replay_fields(phase: dict[str, Any], cli: CLIConfig) -> None:
 
 
 _RATE_SHAPE_SEARCH_FIELDS: frozenset[str] = frozenset(
-    {"rate", "rate_ramp", "rate_series", "smoothness"}
+    {"rate", "rate_ramp", "smoothness"}
 )
 
 
@@ -109,6 +109,13 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, tuple[float, str]]:
     (e.g. ``phases.warmup.*``) is ignored by this shape-inference helper --
     the real search-space parser still processes it normally later, just
     not for the purpose of phase-shape inference.
+
+    ``rate_series`` is rejected outright, regardless of any companion CLI
+    flag: it's a piecewise-linear schedule (``RateSeriesConfig``), not a
+    scalar the planner can sample between two bounds. Letting it through
+    would set a phase's ``rate_series`` field to a bare Optuna-sampled
+    float on the first trial and crash there -- reject it immediately and
+    clearly instead.
     """
     if not cli.search_space:
         return {}
@@ -126,6 +133,15 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, tuple[float, str]]:
         if not path.startswith("phases.profiling."):
             continue
         field = path.rsplit(".", 1)[-1]
+        if field == "rate_series":
+            raise ValueError(
+                "--search-space 'rate_series' is not a valid adaptive-search "
+                "dimension: it's a piecewise-linear rate schedule (a list of "
+                "time/rate points), not a single number the planner can "
+                "sample between two bounds. Pass --request-rate-series as a "
+                "fixed companion instead of searching over it, or search "
+                "'rate'/'rate_ramp' for a scalar rate to sweep."
+            )
         bounds_part, _, kind_part = rest.partition(":")
         lo_str = bounds_part.split(",", 1)[0].strip()
         kind = kind_part.strip() or "real"

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import gzip
+import math
 import zlib
 from typing import TYPE_CHECKING, Any
 
@@ -169,21 +170,26 @@ def _profiling_phase_type(
         return PhaseType.FIXED_SCHEDULE
 
     user_centric_needed = "users" in search_dims
+    user_centric_selected = cli.user_centric_rate is not None or user_centric_needed
     rate_shape_needed = bool(set(search_dims) & _RATE_SHAPE_SEARCH_FIELDS)
 
     # UserCentricPhase has no 'smoothness' field and GammaPhase has no
     # 'users' field -- no phase type can satisfy both, unlike users+rate
     # (UserCentricPhase legitimately has rate/rate_ramp/rate_series too,
-    # inherited from RatePhaseConfig).
-    if user_centric_needed and "smoothness" in search_dims:
+    # inherited from RatePhaseConfig). Gated on user_centric_selected (not
+    # just user_centric_needed) so an explicit --user-centric-rate without
+    # a 'users' dimension is caught too: it still resolves to USER_CENTRIC,
+    # which still has no 'smoothness' field for a searched 'smoothness'
+    # dimension to land on.
+    if user_centric_selected and "smoothness" in search_dims:
         raise ValueError(
-            "--search-space targets both 'users' (a user-centric-shaped "
-            "benchmark) and 'smoothness' (a gamma-shaped benchmark). A "
-            "benchmark can only have one shape at a time -- search these in "
-            "separate runs."
+            "--search-space targets 'smoothness' (a gamma-shaped benchmark), "
+            "but --user-centric-rate (or a 'users' dimension) selects a "
+            "user-centric-shaped benchmark. A benchmark can only have one "
+            "shape at a time -- search these in separate runs."
         )
 
-    if cli.user_centric_rate is not None or user_centric_needed:
+    if user_centric_selected:
         return PhaseType.USER_CENTRIC
     if (
         cli.request_rate is not None
@@ -253,7 +259,7 @@ def _apply_search_space_shape_seeds(
                 "'users:1,50:int'), not ':real' -- the number of simulated "
                 "users must be a whole number."
             )
-        if users_lo < 1:
+        if not math.isfinite(users_lo) or users_lo < 1:
             raise ValueError(
                 f"--search-space 'users' lower bound must be >= 1 (got "
                 f"{users_lo!r}); the number of simulated users can't be "
@@ -271,7 +277,7 @@ def _apply_search_space_shape_seeds(
         has_base_rate = "rate" in prof or "rate_series" in prof
         if "rate" in search_dims:
             rate_lo, _rate_kind = search_dims["rate"]
-            if rate_lo <= 0:
+            if not math.isfinite(rate_lo) or rate_lo <= 0:
                 raise ValueError(
                     f"--search-space 'rate' lower bound must be > 0 (got "
                     f"{rate_lo!r}); rate must be positive."

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -105,9 +105,12 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, tuple[float, str]]:
     value from its own search range -- before search-space bounds/kind are
     even validated by the real parser. Malformed entries are skipped here;
     the real parser reports the actual grammar error. Only dimensions that
-    target ``phases.profiling.*`` are considered (bare aliases always
-    resolve there); a fully-qualified path targeting a different phase
-    (e.g. ``phases.warmup.*``) is ignored by this shape-inference helper --
+    target a direct ``phases.profiling.<field>`` scalar are considered
+    (bare aliases always resolve there); a fully-qualified path targeting a
+    different phase (e.g. ``phases.warmup.*``) OR a nested sub-field one
+    level deeper (e.g. ``phases.profiling.cancellation.rate``, the request-
+    cancellation rate -- an unrelated field that merely happens to share
+    the ``rate`` leaf name) is ignored by this shape-inference helper --
     the real search-space parser still processes it normally later, just
     not for the purpose of phase-shape inference.
 
@@ -133,7 +136,14 @@ def _search_space_dimensions(cli: CLIConfig) -> dict[str, tuple[float, str]]:
             path = _resolve_path_alias(path)
         if not path.startswith("phases.profiling."):
             continue
-        field = path.rsplit(".", 1)[-1]
+        remainder = path[len("phases.profiling.") :]
+        if "." in remainder:
+            # A nested sub-field (e.g. "phases.profiling.cancellation.rate")
+            # is not the phase's own scalar field -- matching it by leaf
+            # name alone would misclassify e.g. a cancellation-rate sweep
+            # as the phase's request rate. Not a shape-bearing dimension.
+            continue
+        field = remainder
         if field == "rate_series":
             raise ValueError(
                 "--search-space 'rate_series' is not a valid adaptive-search "

--- a/src/aiperf/config/flags/_converter_profiling.py
+++ b/src/aiperf/config/flags/_converter_profiling.py
@@ -262,21 +262,7 @@ def _apply_search_space_shape_seeds(
     phase_type = prof["type"]
 
     if phase_type == PhaseType.USER_CENTRIC and "users" in search_dims:
-        users_lo, users_kind = search_dims["users"]
-        if users_kind != "int":
-            raise ValueError(
-                "--search-space 'users' must use ':int' kind (e.g. "
-                "'users:1,50:int'), not ':real' -- the number of simulated "
-                "users must be a whole number."
-            )
-        if not math.isfinite(users_lo) or users_lo < 1:
-            raise ValueError(
-                f"--search-space 'users' lower bound must be >= 1 (got "
-                f"{users_lo!r}); the number of simulated users can't be "
-                "less than one."
-            )
-        if "users" not in prof:
-            prof["users"] = int(users_lo)
+        _seed_users_dimension(prof, search_dims)
 
     if phase_type in (
         PhaseType.POISSON,
@@ -284,17 +270,41 @@ def _apply_search_space_shape_seeds(
         PhaseType.CONSTANT,
         PhaseType.USER_CENTRIC,
     ):
-        has_base_rate = "rate" in prof or "rate_series" in prof
-        if "rate" in search_dims:
-            rate_lo, _rate_kind = search_dims["rate"]
-            if not math.isfinite(rate_lo) or rate_lo <= 0:
-                raise ValueError(
-                    f"--search-space 'rate' lower bound must be > 0 (got "
-                    f"{rate_lo!r}); rate must be positive."
-                )
-            if not has_base_rate:
-                prof["rate"] = rate_lo
-        elif not has_base_rate:
+        _seed_rate_dimension(prof, search_dims, phase_type)
+
+
+def _seed_users_dimension(
+    prof: dict[str, Any], search_dims: dict[str, tuple[float, str]]
+) -> None:
+    """Validate and (if absent) seed prof["users"] from a 'users' dimension."""
+    users_lo, users_kind = search_dims["users"]
+    if users_kind != "int":
+        raise ValueError(
+            "--search-space 'users' must use ':int' kind (e.g. "
+            "'users:1,50:int'), not ':real' -- the number of simulated "
+            "users must be a whole number."
+        )
+    if not math.isfinite(users_lo) or users_lo < 1:
+        raise ValueError(
+            f"--search-space 'users' lower bound must be >= 1 (got "
+            f"{users_lo!r}); the number of simulated users can't be "
+            "less than one."
+        )
+    if "users" not in prof:
+        prof["users"] = int(users_lo)
+
+
+def _seed_rate_dimension(
+    prof: dict[str, Any], search_dims: dict[str, tuple[float, str]], phase_type: Any
+) -> None:
+    """Validate and (if absent) seed prof["rate"] from a 'rate' dimension.
+
+    Raises when the phase needs a base rate that neither an explicit CLI
+    flag nor a 'rate' search-space dimension can supply.
+    """
+    has_base_rate = "rate" in prof or "rate_series" in prof
+    if "rate" not in search_dims:
+        if not has_base_rate:
             raise ValueError(
                 f"--search-space selects a rate-shaped benchmark (phase type "
                 f"{phase_type}), which also requires a base rate. Pass "
@@ -302,6 +312,25 @@ def _apply_search_space_shape_seeds(
                 "user-shaped benchmark), or add a 'rate' dimension to "
                 "--search-space."
             )
+        return
+
+    if "rate_series" in prof:
+        raise ValueError(
+            "--search-space targets 'rate', but --request-rate-series "
+            "already supplies a fixed rate schedule for this phase -- "
+            "'rate' and 'rate_series' are mutually exclusive on a "
+            "rate-controlled phase. Drop --request-rate-series to "
+            "search 'rate', or drop the 'rate' dimension to keep the "
+            "fixed schedule."
+        )
+    rate_lo, _rate_kind = search_dims["rate"]
+    if not math.isfinite(rate_lo) or rate_lo <= 0:
+        raise ValueError(
+            f"--search-space 'rate' lower bound must be > 0 (got "
+            f"{rate_lo!r}); rate must be positive."
+        )
+    if not has_base_rate:
+        prof["rate"] = rate_lo
 
 
 def _apply_profiling_ramps(prof: dict[str, Any], cli: CLIConfig) -> None:

--- a/src/aiperf/orchestrator/search_planner/optuna_planner.py
+++ b/src/aiperf/orchestrator/search_planner/optuna_planner.py
@@ -224,6 +224,16 @@ class OptunaSearchPlanner(SearchPlanner):
         try:
             cfg = BenchmarkConfig.model_validate(cfg_dict)
         except ValidationError as e:
+            # Only reframe genuine shape mismatches -- a field that doesn't
+            # exist on this phase type ("extra_forbidden": e.g. injecting
+            # 'rate' onto a concurrency phase) or a required field the base
+            # config never got a chance to seed ("missing"). Ordinary
+            # numeric-bounds violations (e.g. a sampled concurrency=0 against
+            # ge=1) are unrelated to phase shape and should surface as-is --
+            # reframing them as a "shape" problem is actively misleading.
+            shape_error_types = {"extra_forbidden", "missing"}
+            if not any(err.get("type") in shape_error_types for err in e.errors()):
+                raise
             base_phase_type = self._base.phases[0].type
             raise ValueError(
                 f"--search-space path(s) {sorted(values)} do not fit this "

--- a/src/aiperf/orchestrator/search_planner/optuna_planner.py
+++ b/src/aiperf/orchestrator/search_planner/optuna_planner.py
@@ -23,6 +23,8 @@ import logging
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ValidationError
+
 from aiperf.common.finite import is_finite_value
 from aiperf.config.config import BenchmarkConfig
 from aiperf.config.sweep import AdaptiveSearchSweep, SweepVariation, _set_nested_value
@@ -219,7 +221,19 @@ class OptunaSearchPlanner(SearchPlanner):
         )
         for path, val in values.items():
             _set_nested_value(cfg_dict, path, val)
-        cfg = BenchmarkConfig.model_validate(cfg_dict)
+        try:
+            cfg = BenchmarkConfig.model_validate(cfg_dict)
+        except ValidationError as e:
+            base_phase_type = self._base.phases[0].type
+            raise ValueError(
+                f"--search-space path(s) {sorted(values)} do not fit this "
+                f"benchmark's shape ('{base_phase_type}'). A benchmark has one "
+                "shape before it starts (concurrency, rate, user, or gamma); "
+                "searching a field that belongs to a different shape (e.g. "
+                "'rate' needs --request-rate, 'users' needs "
+                "--user-centric-rate, 'smoothness' needs --arrival-pattern "
+                f"gamma) fails like this. Underlying error: {e}"
+            ) from e
 
         variation = SweepVariation(
             index=self._iter,

--- a/src/aiperf/orchestrator/search_planner/optuna_planner.py
+++ b/src/aiperf/orchestrator/search_planner/optuna_planner.py
@@ -225,16 +225,34 @@ class OptunaSearchPlanner(SearchPlanner):
             cfg = BenchmarkConfig.model_validate(cfg_dict)
         except ValidationError as e:
             # Only reframe genuine shape mismatches -- a field that doesn't
-            # exist on this phase type ("extra_forbidden": e.g. injecting
+            # exist on the PROFILING phase ("extra_forbidden": e.g. injecting
             # 'rate' onto a concurrency phase) or a required field the base
             # config never got a chance to seed ("missing"). Ordinary
             # numeric-bounds violations (e.g. a sampled concurrency=0 against
             # ge=1) are unrelated to phase shape and should surface as-is --
             # reframing them as a "shape" problem is actively misleading.
+            # Scoped to errors under "phases" specifically: extra_forbidden
+            # also fires for an unrelated malformed root-level key (e.g. a
+            # search-space path with no "." that never resolves under a
+            # phase at all), which isn't a shape mismatch either.
             shape_error_types = {"extra_forbidden", "missing"}
-            if not any(err.get("type") in shape_error_types for err in e.errors()):
+            if not any(
+                err.get("type") in shape_error_types
+                and err.get("loc", ())[:1] == ("phases",)
+                for err in e.errors()
+            ):
                 raise
-            base_phase_type = self._base.phases[0].type
+            # phases[0] is the warmup phase whenever one exists (warmup is
+            # appended before profiling -- see converter.py's phase-list
+            # assembly and BenchmarkConfig's "order is execution order"
+            # contract), so naming it here would blame the wrong phase's
+            # shape. Match the profiling phase by kind instead, the same
+            # selector BenchmarkConfig.validate_profiling_phase_required
+            # uses (config.py).
+            base_phase_type = next(
+                (p.type for p in self._base.phases if p.kind == "profiling"),
+                self._base.phases[0].type,
+            )
             raise ValueError(
                 f"--search-space path(s) {sorted(values)} do not fit this "
                 f"benchmark's shape ('{base_phase_type}'). A benchmark has one "

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -691,3 +691,141 @@ class TestRateSeries:
 
         with pytest.raises(ValueError, match="user-centric-rate"):
             build_profiling(user)
+
+
+# ---------------------------------------------------------------------------
+# BUG 5 (NVBugs 6656707) — --search-space keywords must auto-infer phase shape
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSpacePhaseShapeInference:
+    def test_bare_rate_keyword_infers_poisson_phase(self) -> None:
+        """--search-space 'rate:...' with no --request-rate must not crash;
+        it should auto-switch to a rate-controlled (poisson default) phase."""
+        loadgen = CLIConfig(
+            search_space=["rate:1,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.POISSON
+        assert "rate" not in prof  # value comes from the search planner, not here
+
+    def test_dotted_rate_path_infers_poisson_phase(self) -> None:
+        """Full dotted path form ('phases.profiling.rate') resolves the same
+        as the bare alias."""
+        loadgen = CLIConfig(
+            search_space=["phases.profiling.rate:1,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.POISSON
+
+    def test_rate_search_space_respects_explicit_arrival_pattern(self) -> None:
+        """--arrival-pattern gamma + --search-space 'rate:...' should still
+        pick GAMMA, not the POISSON default."""
+        loadgen = CLIConfig(
+            search_space=["rate:1,100:real"],
+            arrival_pattern=ArrivalPattern.GAMMA,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.GAMMA
+
+    def test_rate_ramp_keyword_infers_rate_controlled_phase(self) -> None:
+        loadgen = CLIConfig(
+            search_space=["rate_ramp:1,60:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.POISSON
+
+    def test_rate_series_keyword_infers_rate_controlled_phase(self) -> None:
+        loadgen = CLIConfig(
+            search_space=["rate_series:1,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.POISSON
+
+    def test_smoothness_keyword_infers_gamma_phase(self) -> None:
+        """--search-space 'smoothness:...' alone (no --request-rate, no
+        --arrival-pattern) must auto-switch to gamma, not crash."""
+        loadgen = CLIConfig(
+            search_space=["smoothness:0.5,2.0:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.GAMMA
+
+    def test_users_keyword_infers_user_centric_phase(self) -> None:
+        loadgen = CLIConfig(
+            search_space=["users:1,50:int"],
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.USER_CENTRIC
+
+    def test_users_and_rate_together_raises_clear_conflict_error(self) -> None:
+        """A benchmark has exactly one shape; searching 'users' and 'rate' at
+        once is a genuine conflict, not something to silently resolve."""
+        loadgen = CLIConfig(
+            search_space=["users:1,50:int", "rate:1,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="only have one shape"):
+            build_profiling(user)
+
+    def test_users_and_smoothness_together_raises_clear_conflict_error(self) -> None:
+        loadgen = CLIConfig(
+            search_space=["users:1,50:int", "smoothness:0.5,2.0:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="only have one shape"):
+            build_profiling(user)
+
+    def test_explicit_request_rate_still_wins_without_search_space(self) -> None:
+        """Regression guard: explicit --request-rate path (no search-space)
+        is unaffected by the new inference logic."""
+        loadgen = CLIConfig(request_rate=50.0, request_count=10)
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.POISSON
+        assert prof["rate"] == 50.0
+
+    def test_concurrency_search_space_keyword_unaffected(self) -> None:
+        """'concurrency' is already valid on every phase type incl. the
+        default -- must keep resolving to PhaseType.CONCURRENCY."""
+        loadgen = CLIConfig(
+            search_space=["concurrency:1,1000:int"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.CONCURRENCY
+
+    def test_smoothness_search_space_with_gamma_and_explicit_smoothness_flag(
+        self,
+    ) -> None:
+        """--search-space 'smoothness:...' combined with an explicit
+        --arrival-smoothness flag under gamma still succeeds normally (the
+        two features are independent; this just proves no interaction bug)."""
+        loadgen = CLIConfig(
+            search_space=["smoothness:0.5,2.0:real"],
+            arrival_pattern=ArrivalPattern.GAMMA,
+            arrival_smoothness=1.0,
+            request_rate=50.0,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.GAMMA
+        assert prof["smoothness"] == 1.0

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -940,3 +940,40 @@ class TestSearchSpacePhaseShapeInference:
             }
         )
         assert cfg.phases[0].type == PhaseType.USER_CENTRIC
+
+    def test_rate_lower_bound_zero_raises_clear_error(self) -> None:
+        """A zero/negative --search-space 'rate' lower bound must not
+        silently seed an invalid value and crash with a raw Pydantic
+        'greater than' error -- it should fail clearly at seed time."""
+        loadgen = CLIConfig(
+            search_space=["rate:0,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="must be > 0"):
+            build_profiling(user)
+
+    def test_users_lower_bound_zero_raises_clear_error(self) -> None:
+        loadgen = CLIConfig(
+            search_space=["users:0,50:int"],
+            user_centric_rate=10.0,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="must be >= 1"):
+            build_profiling(user)
+
+    def test_warmup_path_search_space_dimension_ignored_for_shape_inference(
+        self,
+    ) -> None:
+        """A dotted path targeting a non-profiling phase (e.g. warmup) must
+        not be mistaken for a profiling-phase field by its trailing segment
+        alone -- it should be ignored by shape inference entirely."""
+        loadgen = CLIConfig(
+            search_space=["phases.warmup.rate:1,10:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.CONCURRENCY
+        assert "rate" not in prof

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -25,6 +25,7 @@ from typing import ClassVar
 
 import pytest
 
+from aiperf.config.config import BenchmarkConfig
 from aiperf.config.flags._converter_profiling import build_profiling
 from aiperf.config.flags.cli_config import CLIConfig
 from aiperf.plugin.enums import ArrivalPattern, PhaseType
@@ -701,7 +702,8 @@ class TestRateSeries:
 class TestSearchSpacePhaseShapeInference:
     def test_bare_rate_keyword_infers_poisson_phase(self) -> None:
         """--search-space 'rate:...' with no --request-rate must not crash;
-        it should auto-switch to a rate-controlled (poisson default) phase."""
+        it should auto-switch to a rate-controlled (poisson default) phase,
+        seeding 'rate' from the search-space dimension's own lower bound."""
         loadgen = CLIConfig(
             search_space=["rate:1,100:real"],
             request_count=10,
@@ -709,7 +711,7 @@ class TestSearchSpacePhaseShapeInference:
         user = _make_user(loadgen=loadgen)
         prof = build_profiling(user)
         assert prof["type"] == PhaseType.POISSON
-        assert "rate" not in prof  # value comes from the search planner, not here
+        assert prof["rate"] == 1.0
 
     def test_dotted_rate_path_infers_poisson_phase(self) -> None:
         """Full dotted path form ('phases.profiling.rate') resolves the same
@@ -721,6 +723,7 @@ class TestSearchSpacePhaseShapeInference:
         user = _make_user(loadgen=loadgen)
         prof = build_profiling(user)
         assert prof["type"] == PhaseType.POISSON
+        assert prof["rate"] == 1.0
 
     def test_rate_search_space_respects_explicit_arrival_pattern(self) -> None:
         """--arrival-pattern gamma + --search-space 'rate:...' should still
@@ -733,57 +736,127 @@ class TestSearchSpacePhaseShapeInference:
         user = _make_user(loadgen=loadgen)
         prof = build_profiling(user)
         assert prof["type"] == PhaseType.GAMMA
+        assert prof["rate"] == 1.0
 
-    def test_rate_ramp_keyword_infers_rate_controlled_phase(self) -> None:
+    def test_rate_ramp_keyword_with_request_rate_stays_poisson(self) -> None:
+        """--request-rate supplies the base rate; 'rate_ramp' alone in
+        search-space just needs a companion rate source, per the bug
+        report's documented workaround."""
+        loadgen = CLIConfig(
+            search_space=["rate_ramp:1,60:real"],
+            request_rate=10.0,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.POISSON
+        assert prof["rate"] == 10.0
+
+    def test_rate_ramp_keyword_alone_raises_clear_error(self) -> None:
+        """'rate_ramp' layers a ramp on top of a base rate -- it cannot
+        supply that base rate itself. Without --request-rate or a 'rate'
+        search-space dimension, this must fail with a clear error, not a
+        raw Pydantic 'rate-controlled phases require rate or rate_series'."""
         loadgen = CLIConfig(
             search_space=["rate_ramp:1,60:real"],
             request_count=10,
         )
         user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="base rate"):
+            build_profiling(user)
+
+    def test_rate_series_keyword_with_request_rate_stays_poisson(self) -> None:
+        loadgen = CLIConfig(
+            search_space=["rate_series:1,100:real"],
+            request_rate=10.0,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
         prof = build_profiling(user)
         assert prof["type"] == PhaseType.POISSON
+        assert prof["rate"] == 10.0
 
-    def test_rate_series_keyword_infers_rate_controlled_phase(self) -> None:
+    def test_rate_series_keyword_alone_raises_clear_error(self) -> None:
         loadgen = CLIConfig(
             search_space=["rate_series:1,100:real"],
             request_count=10,
         )
         user = _make_user(loadgen=loadgen)
-        prof = build_profiling(user)
-        assert prof["type"] == PhaseType.POISSON
+        with pytest.raises(ValueError, match="base rate"):
+            build_profiling(user)
 
-    def test_smoothness_keyword_infers_gamma_phase(self) -> None:
-        """--search-space 'smoothness:...' alone (no --request-rate, no
-        --arrival-pattern) must auto-switch to gamma, not crash."""
+    def test_smoothness_keyword_with_request_rate_infers_gamma_phase(self) -> None:
+        """--search-space 'smoothness:...' auto-switches to gamma, but still
+        needs a base rate from somewhere -- --request-rate supplies it."""
         loadgen = CLIConfig(
             search_space=["smoothness:0.5,2.0:real"],
+            request_rate=10.0,
             request_count=10,
         )
         user = _make_user(loadgen=loadgen)
         prof = build_profiling(user)
         assert prof["type"] == PhaseType.GAMMA
+        assert prof["rate"] == 10.0
+
+    def test_smoothness_keyword_alone_raises_clear_error(self) -> None:
+        """'smoothness' alone (no --request-rate, no 'rate' in search-space)
+        auto-switches the *type* to gamma but has no base rate to seed --
+        must fail with a clear error, not a raw Pydantic crash."""
+        loadgen = CLIConfig(
+            search_space=["smoothness:0.5,2.0:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="base rate"):
+            build_profiling(user)
 
     def test_users_keyword_infers_user_centric_phase(self) -> None:
+        """--user-centric-rate supplies the shared base rate; 'users' in
+        search-space self-seeds the user count from its own lower bound."""
         loadgen = CLIConfig(
             search_space=["users:1,50:int"],
+            user_centric_rate=10.0,
             conversation_turn_mean=4,
         )
         user = _make_user(loadgen=loadgen)
         prof = build_profiling(user)
         assert prof["type"] == PhaseType.USER_CENTRIC
+        assert prof["users"] == 1
+        assert prof["rate"] == 10.0
 
-    def test_users_and_rate_together_raises_clear_conflict_error(self) -> None:
-        """A benchmark has exactly one shape; searching 'users' and 'rate' at
-        once is a genuine conflict, not something to silently resolve."""
+    def test_users_keyword_alone_raises_clear_error(self) -> None:
+        """'users' alone (no --user-centric-rate, no 'rate' in search-space)
+        auto-switches the *type* to user-centric and self-seeds 'users', but
+        has no base rate to seed -- must fail with a clear error."""
         loadgen = CLIConfig(
-            search_space=["users:1,50:int", "rate:1,100:real"],
-            request_count=10,
+            search_space=["users:1,50:int"],
+            conversation_turn_mean=4,
         )
         user = _make_user(loadgen=loadgen)
-        with pytest.raises(ValueError, match="only have one shape"):
+        with pytest.raises(ValueError, match="base rate"):
             build_profiling(user)
 
+    def test_users_and_rate_together_infers_user_centric_with_both_seeded(
+        self,
+    ) -> None:
+        """'users' and 'rate' are compatible, not a conflict: UserCentricPhase
+        subclasses RatePhaseConfig, so it legitimately has both fields.
+        Searching them together fully self-seeds a user-centric shape with
+        no companion flags needed at all."""
+        loadgen = CLIConfig(
+            search_space=["users:1,50:int", "rate:1,100:real"],
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.USER_CENTRIC
+        assert prof["users"] == 1
+        assert prof["rate"] == 1.0
+
     def test_users_and_smoothness_together_raises_clear_conflict_error(self) -> None:
+        """This IS a genuine, unresolvable conflict: no phase type has both
+        a 'users' field (UserCentricPhase-only) and a 'smoothness' field
+        (GammaPhase-only)."""
         loadgen = CLIConfig(
             search_space=["users:1,50:int", "smoothness:0.5,2.0:real"],
             request_count=10,
@@ -829,3 +902,41 @@ class TestSearchSpacePhaseShapeInference:
         prof = build_profiling(user)
         assert prof["type"] == PhaseType.GAMMA
         assert prof["smoothness"] == 1.0
+
+    def test_bare_rate_keyword_produces_a_fully_valid_benchmark_config(self) -> None:
+        """End-to-end proof, not just build_profiling()'s dict: the seeded
+        phase actually passes full BenchmarkConfig/Pydantic validation."""
+        loadgen = CLIConfig(
+            search_space=["rate:1,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        cfg = BenchmarkConfig.model_validate(
+            {
+                "models": ["m"],
+                "endpoint": {"urls": ["http://x"], "type": "chat"},
+                "datasets": [{"name": "profiling", "type": "synthetic"}],
+                "phases": [{"name": "profiling", **prof}],
+            }
+        )
+        assert cfg.phases[0].type == PhaseType.POISSON
+
+    def test_users_and_rate_together_produces_a_fully_valid_benchmark_config(
+        self,
+    ) -> None:
+        loadgen = CLIConfig(
+            search_space=["users:1,50:int", "rate:1,100:real"],
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        cfg = BenchmarkConfig.model_validate(
+            {
+                "models": ["m"],
+                "endpoint": {"urls": ["http://x"], "type": "chat"},
+                "datasets": [{"name": "profiling", "type": "synthetic"}],
+                "phases": [{"name": "profiling", **prof}],
+            }
+        )
+        assert cfg.phases[0].type == PhaseType.USER_CENTRIC

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -1186,3 +1186,19 @@ class TestSearchSpacePhaseShapeInference:
         prof = build_profiling(user)
         assert prof["type"] == PhaseType.CONCURRENCY
         assert "rate" not in prof
+
+    def test_nested_cancellation_rate_path_ignored_for_shape_inference(self) -> None:
+        """'phases.profiling.cancellation.rate' is the request-cancellation
+        rate (an unrelated CancellationConfig sub-field), not the phase's
+        own 'rate'. Matching by trailing path segment alone previously
+        misclassified this as a phase-shape-selecting 'rate' dimension,
+        wrongly switching the phase to POISSON and seeding prof["rate"]
+        from the cancellation-rate range."""
+        loadgen = CLIConfig(
+            search_space=["phases.profiling.cancellation.rate:1,50:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.CONCURRENCY
+        assert "rate" not in prof

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -990,6 +990,58 @@ class TestSearchSpacePhaseShapeInference:
         with pytest.raises(ValueError, match="':int' kind"):
             build_profiling(user)
 
+    def test_users_real_kind_with_explicit_num_users_still_raises(self) -> None:
+        """An explicit --num-users must not bypass ':int'-kind validation
+        for a 'users' search-space dimension. Before this was fixed, an
+        already-set prof["users"] (from --num-users) short-circuited the
+        seed function entirely, letting 'users:1.5,50:real' silently reach
+        the search planner as a real-valued dimension for a field that
+        requires an integer."""
+        loadgen = CLIConfig(
+            search_space=["users:1.5,50:real"],
+            user_centric_rate=10.0,
+            num_users=5,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="':int' kind"):
+            build_profiling(user)
+
+    def test_users_lower_bound_zero_with_explicit_num_users_still_raises(
+        self,
+    ) -> None:
+        """Same bypass check for the bound validation: an explicit
+        --num-users must not let an out-of-bounds 'users' search-space
+        lower bound go unvalidated."""
+        loadgen = CLIConfig(
+            search_space=["users:0,50:int"],
+            user_centric_rate=10.0,
+            num_users=5,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="must be >= 1"):
+            build_profiling(user)
+
+    def test_users_explicit_num_users_wins_over_search_space_lower_bound(
+        self,
+    ) -> None:
+        """When --num-users is explicit AND 'users' is validly searched
+        (:int kind, valid bound), the explicit --num-users value is kept
+        rather than overwritten by the search-space lower bound -- the
+        search-space dimension is still validated, just not used as the
+        seed when an explicit value already exists."""
+        loadgen = CLIConfig(
+            search_space=["users:1,50:int"],
+            user_centric_rate=10.0,
+            num_users=5,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.USER_CENTRIC
+        assert prof["users"] == 5
+
     def test_warmup_path_search_space_dimension_ignored_for_shape_inference(
         self,
     ) -> None:

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -962,6 +962,32 @@ class TestSearchSpacePhaseShapeInference:
         with pytest.raises(ValueError, match="must be >= 1"):
             build_profiling(user)
 
+    def test_smoothness_negative_lower_bound_raises_clear_error(self) -> None:
+        """'smoothness' isn't seeded into prof at config-build time (it's
+        optional, only ever written by the planner once trials start), so
+        it needs its own bound check independent of the seeding logic --
+        GammaPhase.smoothness has the same gt=0 constraint 'rate' has."""
+        loadgen = CLIConfig(
+            search_space=["smoothness:-5,-1:real"],
+            request_rate=10.0,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="must be > 0"):
+            build_profiling(user)
+
+    def test_rate_ramp_negative_lower_bound_raises_clear_error(self) -> None:
+        """Same as smoothness: 'rate_ramp' isn't seeded at config-build
+        time either, but RampConfig.duration has gt=0.0."""
+        loadgen = CLIConfig(
+            search_space=["rate_ramp:-50,-10:real"],
+            request_rate=10.0,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="must be > 0"):
+            build_profiling(user)
+
     def test_explicit_request_rate_still_wins_without_search_space(self) -> None:
         """Regression guard: explicit --request-rate path (no search-space)
         is unaffected by the new inference logic."""

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -765,24 +765,55 @@ class TestSearchSpacePhaseShapeInference:
         with pytest.raises(ValueError, match="base rate"):
             build_profiling(user)
 
-    def test_rate_series_keyword_with_request_rate_stays_poisson(self) -> None:
+    def test_rate_series_keyword_alone_raises_clear_error(self) -> None:
+        """'rate_series' is a piecewise-linear schedule, not a scalar the
+        planner can sample between two bounds -- it must never be treated
+        as a searchable numeric dimension, regardless of companion flags."""
+        loadgen = CLIConfig(
+            search_space=["rate_series:1,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="not a valid adaptive-search"):
+            build_profiling(user)
+
+    def test_rate_series_keyword_with_request_rate_still_raises(self) -> None:
+        """A --request-rate companion doesn't change anything -- 'rate_series'
+        itself still can't be a scalar search dimension (it was previously
+        treated as equivalent to 'rate', which silently masked the fact
+        that a sampled float would later crash writing into a
+        RateSeriesConfig-typed field)."""
         loadgen = CLIConfig(
             search_space=["rate_series:1,100:real"],
             request_rate=10.0,
             request_count=10,
         )
         user = _make_user(loadgen=loadgen)
-        prof = build_profiling(user)
-        assert prof["type"] == PhaseType.POISSON
-        assert prof["rate"] == 10.0
+        with pytest.raises(ValueError, match="not a valid adaptive-search"):
+            build_profiling(user)
 
-    def test_rate_series_keyword_alone_raises_clear_error(self) -> None:
+    def test_rate_series_keyword_with_request_rate_series_still_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Even the documented --request-rate-series companion doesn't make
+        the schedule itself searchable as a number -- this combo was
+        already reachable before this PR (via the pre-existing
+        request_rate_series-sets-a-rate-controlled-type logic) and already
+        crashed once a sampled float reached the planner; now it's rejected
+        immediately and clearly instead."""
+        json_path = tmp_path / "rate.json"
+        json_path.write_text(
+            '{"points":[{"time_s":0,"qps":1},{"time_s":60,"qps":7}]}',
+            encoding="utf-8",
+        )
         loadgen = CLIConfig(
             search_space=["rate_series:1,100:real"],
+            request_rate_series=json_path,
+            arrival_pattern=ArrivalPattern.CONSTANT,
             request_count=10,
         )
         user = _make_user(loadgen=loadgen)
-        with pytest.raises(ValueError, match="base rate"):
+        with pytest.raises(ValueError, match="not a valid adaptive-search"):
             build_profiling(user)
 
     def test_smoothness_keyword_with_request_rate_infers_gamma_phase(self) -> None:

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -1073,6 +1073,65 @@ class TestSearchSpacePhaseShapeInference:
         assert prof["type"] == PhaseType.USER_CENTRIC
         assert prof["users"] == 5
 
+    def test_rate_negative_bound_with_explicit_request_rate_still_raises(
+        self,
+    ) -> None:
+        """An explicit --request-rate must not bypass bound validation for a
+        'rate' search-space dimension -- mirrors the analogous --num-users
+        fix. Before this was fixed, `--request-rate 10 --search-space
+        "rate:-5,100"` skipped the rate_lo <= 0 check entirely (since
+        prof["rate"] was already set from --request-rate), letting a
+        negative rate reach the planner and crash mid-search once sampled,
+        instead of failing clearly at config-build time."""
+        loadgen = CLIConfig(
+            search_space=["rate:-5,100:real"],
+            request_rate=10.0,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="must be > 0"):
+            build_profiling(user)
+
+    def test_rate_explicit_request_rate_wins_over_search_space_lower_bound(
+        self,
+    ) -> None:
+        """When --request-rate is explicit AND 'rate' is validly searched
+        (positive bound), the explicit --request-rate value is kept rather
+        than overwritten by the search-space lower bound -- the dimension
+        is still validated, just not used as the seed when an explicit
+        value already exists."""
+        loadgen = CLIConfig(
+            search_space=["rate:1,100:real"],
+            request_rate=10.0,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.POISSON
+        assert prof["rate"] == 10.0
+
+    def test_search_space_extra_kind_segment_is_skipped_not_misreported(
+        self,
+    ) -> None:
+        """'users:1,50:int:log' has an extra ':'-separated segment (a
+        malformed grammar the real parser will reject with its own error).
+        This lightweight helper must skip it rather than misparse
+        'int:log' as the kind and report the wrong complaint (e.g. telling
+        a user who wrote ':int' that they wrote ':real')."""
+        loadgen = CLIConfig(
+            search_space=["users:1,50:int:log"],
+            user_centric_rate=10.0,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        # The malformed dimension is invisible to shape inference (skipped),
+        # so with no other search-space field this falls through to
+        # whatever --user-centric-rate alone would produce: USER_CENTRIC
+        # type, but no 'users' seed and no ':int'-kind complaint about a
+        # dimension this helper never parsed.
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.USER_CENTRIC
+
     def test_warmup_path_search_space_dimension_ignored_for_shape_inference(
         self,
     ) -> None:

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -963,6 +963,33 @@ class TestSearchSpacePhaseShapeInference:
         with pytest.raises(ValueError, match="must be >= 1"):
             build_profiling(user)
 
+    def test_users_real_kind_raises_clear_error(self) -> None:
+        """'users:1.5,50:real' must not silently truncate 1.5 -> 1 (a value
+        below the user's own declared lower bound) as the seed -- the number
+        of simulated users can only ever be a whole number, so a ':real'
+        kind for 'users' must fail clearly instead."""
+        loadgen = CLIConfig(
+            search_space=["users:1.5,50:real"],
+            user_centric_rate=10.0,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="':int' kind"):
+            build_profiling(user)
+
+    def test_users_default_kind_is_real_and_still_raises(self) -> None:
+        """Omitting ':kind' defaults to 'real' (matching
+        SearchSpaceDimension's own default) -- 'users' without an explicit
+        ':int' suffix must also raise, not silently pass."""
+        loadgen = CLIConfig(
+            search_space=["users:1,50"],
+            user_centric_rate=10.0,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="':int' kind"):
+            build_profiling(user)
+
     def test_warmup_path_search_space_dimension_ignored_for_shape_inference(
         self,
     ) -> None:

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -896,6 +896,46 @@ class TestSearchSpacePhaseShapeInference:
         with pytest.raises(ValueError, match="only have one shape"):
             build_profiling(user)
 
+    def test_explicit_user_centric_rate_and_smoothness_raises_clear_conflict_error(
+        self,
+    ) -> None:
+        """The same conflict as 'users'+'smoothness', but triggered via an
+        explicit --user-centric-rate instead of a 'users' search-space
+        dimension -- either way the phase resolves to USER_CENTRIC, which
+        still has no 'smoothness' field. Previously only the 'users'-in-
+        search-space trigger was checked, so this combo built a
+        USER_CENTRIC phase that would only fail later, at the planner."""
+        loadgen = CLIConfig(
+            search_space=["smoothness:0.5,2.0:real"],
+            user_centric_rate=10.0,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="only have one shape"):
+            build_profiling(user)
+
+    def test_rate_nan_lower_bound_raises_clear_error(self) -> None:
+        """A NaN lower bound bypasses 'rate_lo <= 0' (NaN comparisons are
+        always False), so it must be explicitly rejected with
+        math.isfinite() rather than silently seeding prof["rate"] = nan."""
+        loadgen = CLIConfig(
+            search_space=["rate:nan,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="must be > 0"):
+            build_profiling(user)
+
+    def test_users_nan_lower_bound_raises_clear_error(self) -> None:
+        loadgen = CLIConfig(
+            search_space=["users:nan,50:int"],
+            user_centric_rate=10.0,
+            conversation_turn_mean=4,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="must be >= 1"):
+            build_profiling(user)
+
     def test_explicit_request_rate_still_wins_without_search_space(self) -> None:
         """Regression guard: explicit --request-rate path (no search-space)
         is unaffected by the new inference logic."""

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -988,6 +988,100 @@ class TestSearchSpacePhaseShapeInference:
         with pytest.raises(ValueError, match="must be > 0"):
             build_profiling(user)
 
+    def test_smoothness_with_explicit_non_gamma_arrival_pattern_raises_clear_error(
+        self,
+    ) -> None:
+        """'smoothness' only auto-promotes the phase to GAMMA when
+        --arrival-pattern is unset; an explicit non-gamma pattern wins
+        instead, leaving 'smoothness' with nowhere to land (only GammaPhase
+        has that field). Must fail clearly at config time, not at trial 0
+        with a raw Pydantic extra_forbidden."""
+        loadgen = CLIConfig(
+            search_space=["smoothness:0.5,2.0:real"],
+            request_rate=10.0,
+            arrival_pattern=ArrivalPattern.POISSON,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="only supported with --arrival-pattern"):
+            build_profiling(user)
+
+    def test_smoothness_with_explicit_constant_arrival_pattern_raises_clear_error(
+        self,
+    ) -> None:
+        loadgen = CLIConfig(
+            search_space=["smoothness:0.5,2.0:real"],
+            request_rate=10.0,
+            arrival_pattern=ArrivalPattern.CONSTANT,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="only supported with --arrival-pattern"):
+            build_profiling(user)
+
+    def test_search_space_path_with_leading_whitespace_ignored_for_shape_inference(
+        self,
+    ) -> None:
+        """The real parser (parse_search_space) doesn't strip whitespace --
+        ' rate' and 'rate' are different paths to it, and ' rate' is
+        accepted as a literal (broken) path rather than resolved as the
+        'rate' alias. This helper must match that exactly: stripping the
+        path here would silently reshape the benchmark for a dimension the
+        real parser treats as something else entirely."""
+        loadgen = CLIConfig(
+            search_space=[" rate:1,100:real"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.CONCURRENCY
+        assert "rate" not in prof
+
+    def test_search_space_kind_with_leading_whitespace_ignored_for_shape_inference(
+        self,
+    ) -> None:
+        """'rate:1,100: int' (space before kind) is REJECTED by the real
+        parser (kind must be exactly 'int' or 'real'). This helper must
+        not silently normalize ' int' to 'int' and proceed as if the
+        dimension were well-formed -- skip it and let the real parser
+        report the actual grammar error."""
+        loadgen = CLIConfig(
+            search_space=["rate:1,100: int"],
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        prof = build_profiling(user)
+        assert prof["type"] == PhaseType.CONCURRENCY
+        assert "rate" not in prof
+
+    def test_trace_auto_promote_conflict_message_mentions_search_space(
+        self, tmp_path: Path
+    ) -> None:
+        """When 'rate' was seeded from --search-space (not an explicit
+        --request-rate flag), the trace auto-promote conflict error must
+        not tell the user to "drop the conflicting flags" -- there is no
+        flag to drop, only a --search-space dimension."""
+        trace_path = tmp_path / "trace.jsonl"
+        trace_path.write_text(
+            '{"timestamp": 0, "input_length": 100, "output_length": 50}\n'
+            '{"timestamp": 100, "input_length": 120, "output_length": 60}\n',
+            encoding="utf-8",
+        )
+        # Built directly (not via _make_user's two-CLIConfig merge) since
+        # input_file's validator only accepts a literal str, and
+        # _make_user's model_dump()/reconstruct round-trip turns it back
+        # into a Path first.
+        user = CLIConfig(
+            url="http://localhost:8000/test",
+            model_names=["test-model"],
+            search_space=["rate:1,100:real"],
+            input_file=str(trace_path),
+            custom_dataset_type="mooncake_trace",
+            request_count=10,
+        )
+        with pytest.raises(ValueError, match="--search-space dimensions"):
+            build_profiling(user)
+
     def test_explicit_request_rate_still_wins_without_search_space(self) -> None:
         """Regression guard: explicit --request-rate path (no search-space)
         is unaffected by the new inference logic."""

--- a/tests/unit/config/test_converter_profiling_phase_routes.py
+++ b/tests/unit/config/test_converter_profiling_phase_routes.py
@@ -816,6 +816,32 @@ class TestSearchSpacePhaseShapeInference:
         with pytest.raises(ValueError, match="not a valid adaptive-search"):
             build_profiling(user)
 
+    def test_rate_keyword_with_request_rate_series_raises_mutual_exclusion_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Searching 'rate' (a valid scalar dimension on its own) while
+        --request-rate-series already supplies a fixed schedule passes
+        config conversion cleanly if left unchecked -- prof["rate_series"]
+        is already set, so the seed step's has_base_rate short-circuit
+        skips seeding prof["rate"] without complaint. But the planner
+        still samples 'rate' every trial and injects it into a phase dict
+        that already has rate_series, violating RatePhaseConfig's mutual
+        exclusion at the first trial instead of failing clearly here."""
+        json_path = tmp_path / "rate.json"
+        json_path.write_text(
+            '{"points":[{"time_s":0,"qps":1},{"time_s":60,"qps":7}]}',
+            encoding="utf-8",
+        )
+        loadgen = CLIConfig(
+            search_space=["rate:1,100:real"],
+            request_rate_series=json_path,
+            arrival_pattern=ArrivalPattern.CONSTANT,
+            request_count=10,
+        )
+        user = _make_user(loadgen=loadgen)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            build_profiling(user)
+
     def test_smoothness_keyword_with_request_rate_infers_gamma_phase(self) -> None:
         """--search-space 'smoothness:...' auto-switches to gamma, but still
         needs a base rate from somewhere -- --request-rate supplies it."""

--- a/tests/unit/orchestrator/search_planner/test_optuna_planner.py
+++ b/tests/unit/orchestrator/search_planner/test_optuna_planner.py
@@ -617,3 +617,24 @@ def test_ask_preserves_url_userinfo() -> None:
     assert cfg.endpoint.urls == [
         "http://alice:s3cret@host1.example.com/v1/chat/completions"
     ]
+
+
+def test_ask_with_shape_mismatched_search_space_raises_clear_error() -> None:
+    """Safety net: if a search-space dimension still doesn't fit the base
+    phase's shape (e.g. a hand-written dotted path our lightweight CLI-time
+    inference can't see, since this planner is constructed directly here
+    with no CLI conversion in between), ask() must raise a clear, actionable
+    ValueError -- not let a raw pydantic extra_forbidden ValidationError
+    propagate to the user."""
+    base = _base_config()  # phases[0].type == "concurrency"
+    cfg = _cfg(
+        extra_dims=[
+            SearchSpaceDimension(
+                path="phases.profiling.rate", lo=1, hi=100, kind="real"
+            )
+        ]
+    )
+    planner = OptunaSearchPlanner(base, cfg)
+
+    with pytest.raises(ValueError, match="shape"):
+        planner.ask()

--- a/tests/unit/orchestrator/search_planner/test_optuna_planner.py
+++ b/tests/unit/orchestrator/search_planner/test_optuna_planner.py
@@ -15,6 +15,8 @@ optuna = pytest.importorskip("optuna")
 
 # Imports below depend on optuna being importable. pytest.importorskip must
 # precede them so the whole module is skipped when the `optuna` extra is absent.
+from pydantic import ValidationError  # noqa: E402
+
 from aiperf.common.models.export_models import JsonMetricResult  # noqa: E402
 from aiperf.config.config import BenchmarkConfig  # noqa: E402
 from aiperf.config.sweep import (  # noqa: E402
@@ -637,4 +639,30 @@ def test_ask_with_shape_mismatched_search_space_raises_clear_error() -> None:
     planner = OptunaSearchPlanner(base, cfg)
 
     with pytest.raises(ValueError, match="shape"):
+        planner.ask()
+
+
+def test_ask_with_ordinary_bounds_violation_raises_original_error() -> None:
+    """A search-space dimension that samples an out-of-bounds value for
+    a field that DOES belong on the base phase (e.g. concurrency=0 on a
+    ConcurrencyPhase, which requires ge=1) is not a shape mismatch --
+    the original pydantic ValidationError must propagate unreframed,
+    not get relabeled as a 'shape' problem."""
+    # SearchSpaceDimension itself enforces hi > lo strictly, so lo=hi=0 isn't
+    # constructible; lo=-1, hi=0 is the smallest range where every integer
+    # in [lo, hi] still violates concurrency's ge=1, so the outcome is
+    # deterministic regardless of which value the sampler picks. This
+    # replaces (rather than extends) _cfg's default 'concurrency' dimension,
+    # since AdaptiveSearchSweep forbids duplicate-path dimensions.
+    base = _base_config()  # phases[0].type == "concurrency"
+    cfg = _cfg(
+        search_space=[
+            SearchSpaceDimension(
+                path="phases.profiling.concurrency", lo=-1, hi=0, kind="int"
+            )
+        ]
+    )
+    planner = OptunaSearchPlanner(base, cfg)
+
+    with pytest.raises(ValidationError):
         planner.ask()

--- a/tests/unit/orchestrator/search_planner/test_optuna_planner.py
+++ b/tests/unit/orchestrator/search_planner/test_optuna_planner.py
@@ -666,3 +666,60 @@ def test_ask_with_ordinary_bounds_violation_raises_original_error() -> None:
 
     with pytest.raises(ValidationError):
         planner.ask()
+
+
+def test_ask_shape_mismatch_names_profiling_phase_not_warmup() -> None:
+    """phases[0] is the warmup phase whenever one exists (warmup is
+    appended before profiling), so naming self._base.phases[0].type in
+    the shape-mismatch message would blame the wrong phase. The message
+    must name the PROFILING phase's shape, matched by kind (like
+    BenchmarkConfig.validate_profiling_phase_required does), not by
+    list position."""
+    base = BenchmarkConfig.model_validate(
+        {
+            "models": ["m"],
+            "endpoint": {"urls": ["http://x"], "type": "chat"},
+            "datasets": [{"name": "profiling", "type": "synthetic"}],
+            "phases": [
+                {
+                    "name": "warmup",
+                    "type": "concurrency",
+                    "concurrency": 1,
+                    "requests": 5,
+                },
+                {
+                    "name": "profiling",
+                    "type": "poisson",
+                    "rate": 10.0,
+                    "requests": 10,
+                },
+            ],
+        }
+    )
+    cfg = _cfg(
+        extra_dims=[
+            SearchSpaceDimension(path="phases.profiling.users", lo=1, hi=50, kind="int")
+        ]
+    )
+    planner = OptunaSearchPlanner(base, cfg)
+
+    with pytest.raises(ValueError, match=r"shape \('poisson'\)"):
+        planner.ask()
+
+
+def test_ask_with_root_level_extra_field_raises_original_error() -> None:
+    """extra_forbidden also fires for a malformed path that lands as a
+    phantom ROOT-level key (e.g. a bare, non-dotted path unrelated to any
+    phase field) -- that's not a phase-shape mismatch, and reframing it
+    as one would be actively wrong. Must propagate the original
+    ValidationError unreframed, same as an ordinary bounds violation."""
+    base = _base_config()  # phases[0].type == "concurrency"
+    cfg = _cfg(
+        search_space=[
+            SearchSpaceDimension(path="bogus_root_field", lo=1, hi=100, kind="real")
+        ]
+    )
+    planner = OptunaSearchPlanner(base, cfg)
+
+    with pytest.raises(ValidationError):
+        planner.ask()


### PR DESCRIPTION
## Summary
- Fixes NVBugs [6656707](https://nvbugspro.nvidia.com/bug/6656707) / Linear AIP-1146: `--search-space` keywords (`rate`, `rate_ramp`, `rate_series`, `smoothness`, `users`) crashed with cryptic Pydantic `extra_forbidden` errors when the CLI's default phase type (`concurrency`) didn't have the required fields.
- `_profiling_phase_type()` now infers the correct benchmark "shape" (phase type) from `--search-space` contents, and seeds the required scalar value (`rate`/`users`) from the searched dimension's own lower bound — auto-switching the benchmark shape the same way an explicit `--request-rate`/`--user-centric-rate`/`--arrival-pattern gamma` flag would. A zero/negative lower bound, or a shape-specific field with no rate source at all (e.g. `smoothness` alone), now fails with a clear, actionable error instead of a raw Pydantic crash.
- `OptunaSearchPlanner.ask()` gained a narrowly-scoped safety net: any remaining shape mismatch (`extra_forbidden`/`missing`) that reaches the planner directly surfaces as a clear error; ordinary bounds violations unrelated to shape propagate unreframed. `BayesianSearchPlanner` inherits this since it doesn't override `ask()`.
- Documented the new auto-inference/companion-rate behavior in `docs/sweeping/bayesian-optimization.md`.

Direction on the intended fix confirmed by Anthony Casagrande.

## Test plan
- [x] `uv run pytest tests/unit/ -n auto` — 18349 passed, 93 skipped, 3 xfailed, 0 failures
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Manually reproduced the exact bug-report repro command against the in-repo mock server: config validation now passes with no `ValidationError`, and the adaptive search planner samples/applies a `rate` value to a `poisson`-shaped phase
- [x] Added unit tests for all 5 affected search-space keywords, the shape-conflict case, zero/negative lower bounds, a warmup-phase path edge case, and the planner's narrowed safety net (bounds violation vs. genuine shape mismatch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically selects compatible benchmark shapes based on profiling search fields.
  * Supports user-focused, rate-controlled, Poisson, and Gamma search configurations.
  * Preserves explicit benchmark-shape selections and existing concurrency behavior.

* **Bug Fixes**
  * Provides clearer errors for conflicting shapes, missing base values, invalid bounds, unsupported rate-series searches, and invalid user settings.
  * Improves validation of sampled configurations while preserving detailed parameter errors.

* **Documentation**
  * Clarified that shape inference and validation apply to CLI search-space parsing, not YAML sweep configuration.
  * Added guidance for configuring rate-series dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->