### PR TITLE
fix(controller): print the error summary when every request fails

### DIFF
--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -1109,20 +1109,28 @@ class SystemController(SignalHandlerMixin, BaseService):
         if not results.error_summary:
             return
 
-        console = Console()
-        if console.width < 100:
-            console.width = 100
+        try:
+            console = Console()
+            if console.width < 100:
+                console.width = 100
 
-        exporter = ConsoleErrorExporter(
-            ExporterConfig(
-                results=results,
-                cfg=self.run.cfg,
-                telemetry_results=self._telemetry_results,
-                server_metrics_results=self._server_metrics_results,
-                run=self.run,
+            exporter = ConsoleErrorExporter(
+                ExporterConfig(
+                    results=results,
+                    cfg=self.run.cfg,
+                    telemetry_results=self._telemetry_results,
+                    server_metrics_results=self._server_metrics_results,
+                    run=self.run,
+                )
             )
-        )
-        await exporter.export(console)
+            await exporter.export(console)
+        except Exception:
+            # A rendering failure here must never suppress the exit-error panel
+            # and log-file path that the callers print immediately after. On a
+            # run where every request failed those are the operator's remaining
+            # diagnostics, and ``ExporterManager`` gives this same exporter
+            # equivalent isolation on the normal path.
+            self.exception("Failed to render the error summary table")
 
     def _inject_accuracy_results_into_records(self) -> None:
         """Materialize the dedicated-channel accuracy summary into the profile records.

--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -1110,13 +1110,19 @@ class SystemController(SignalHandlerMixin, BaseService):
         ``error_summary`` collected during the run is discarded in exactly the
         runs that carry the least other diagnostic information.
         """
-        if not self._profile_results:
-            return
-        results = self._profile_results.results
-        if not results.error_summary:
-            return
-
         try:
+            if not self._profile_results:
+                return
+            results = self._profile_results.results
+            # ``ProcessRecordsResult.results`` is declared required, but the
+            # PROCESS_RECORDS_RESULT handler still defends against it being
+            # absent (``if not message.results.results``), so match that here
+            # rather than raising AttributeError on ``.error_summary``.
+            if results is None:
+                return
+            if not results.error_summary:
+                return
+
             console = Console()
             if console.width < 100:
                 console.width = 100
@@ -1132,11 +1138,14 @@ class SystemController(SignalHandlerMixin, BaseService):
             )
             await exporter.export(console)
         except Exception:
-            # A rendering failure here must never suppress the exit-error panel
-            # and log-file path that the callers print immediately after. On a
-            # run where every request failed those are the operator's remaining
-            # diagnostics, and ``ExporterManager`` gives this same exporter
-            # equivalent isolation on the normal path.
+            # Nothing in this method may suppress the exit-error panel and
+            # log-file path that the callers print immediately after. On a run
+            # where every request failed those are the operator's remaining
+            # diagnostics, so the guards are inside the try as well: an
+            # AttributeError while inspecting the results would otherwise
+            # escape and be swallowed by the caller's broad shutdown guard,
+            # taking the panel down with it. ``ExporterManager`` gives this
+            # same exporter equivalent isolation on the normal path.
             self.exception("Failed to render the error summary table")
 
     def _inject_accuracy_results_into_records(self) -> None:

--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -1059,6 +1059,13 @@ class SystemController(SignalHandlerMixin, BaseService):
             if not self._exit_errors:
                 await self._print_post_benchmark_info_and_metrics()
             else:
+                # A mid-run failure (a service failing a lifecycle command, or
+                # crashing) populates ``_exit_errors`` before shutdown and routes
+                # us here, skipping ``_print_post_benchmark_info_and_metrics``
+                # entirely. Export the summary here too, otherwise a run whose
+                # requests also failed loses the error table on exactly the runs
+                # carrying two kinds of failure at once.
+                await self._export_error_summary()
                 self._print_exit_errors_and_log_file()
 
             if Environment.DEV.MODE:

--- a/src/aiperf/controller/system_controller.py
+++ b/src/aiperf/controller/system_controller.py
@@ -67,6 +67,8 @@ from aiperf.controller.proxy_manager import ProxyManager
 from aiperf.controller.result_join_coordinator import ResultJoinCoordinator
 from aiperf.controller.system_mixins import SignalHandlerMixin
 from aiperf.credit.messages import CreditsCompleteMessage
+from aiperf.exporters.console_error_exporter import ConsoleErrorExporter
+from aiperf.exporters.exporter_config import ExporterConfig
 from aiperf.exporters.exporter_manager import ExporterManager
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import PluginType, ServiceRunType, ServiceType, UIType
@@ -1091,6 +1093,37 @@ class SystemController(SignalHandlerMixin, BaseService):
         console.print()
         console.file.flush()
 
+    async def _export_error_summary(self) -> None:
+        """Print the aggregated per-error breakdown, if any errors were recorded.
+
+        This renders the same Code/Type/Message/Count table that
+        ``ExporterManager`` produces on a partially successful run. The
+        early-return paths in ``_print_post_benchmark_info_and_metrics`` exit
+        before ``ExporterManager`` is constructed, so without this the
+        ``error_summary`` collected during the run is discarded in exactly the
+        runs that carry the least other diagnostic information.
+        """
+        if not self._profile_results:
+            return
+        results = self._profile_results.results
+        if not results.error_summary:
+            return
+
+        console = Console()
+        if console.width < 100:
+            console.width = 100
+
+        exporter = ConsoleErrorExporter(
+            ExporterConfig(
+                results=results,
+                cfg=self.run.cfg,
+                telemetry_results=self._telemetry_results,
+                server_metrics_results=self._server_metrics_results,
+                run=self.run,
+            )
+        )
+        await exporter.export(console)
+
     def _inject_accuracy_results_into_records(self) -> None:
         """Materialize the dedicated-channel accuracy summary into the profile records.
 
@@ -1129,6 +1162,7 @@ class SystemController(SignalHandlerMixin, BaseService):
                     service_id=self.id,
                 )
             )
+            await self._export_error_summary()
             self._print_exit_errors_and_log_file()
             return
 
@@ -1145,14 +1179,15 @@ class SystemController(SignalHandlerMixin, BaseService):
                             f"All {results.error_request_count} inference "
                             "request(s) failed. No successful responses were "
                             "collected — check the server URL, endpoint path, "
-                            "and response format. See prior log output for "
-                            "per-request error details."
+                            "and response format. See the error summary table "
+                            "above for the per-error breakdown."
                         ),
                     ),
                     operation="export_results",
                     service_id=self.id,
                 )
             )
+            await self._export_error_summary()
             self._print_exit_errors_and_log_file()
             return
 

--- a/src/aiperf/exporters/console_error_exporter.py
+++ b/src/aiperf/exporters/console_error_exporter.py
@@ -3,6 +3,7 @@
 
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from aiperf.common.models import ErrorDetailsCount
 from aiperf.exporters.exporter_config import ExporterConfig
@@ -35,14 +36,21 @@ class ConsoleErrorExporter:
         for error_details_count in errors_by_type:
             table.add_row(*self._format_row(error_details_count))
 
-    def _format_row(self, error_details_count: ErrorDetailsCount) -> list[str]:
+    def _format_row(self, error_details_count: ErrorDetailsCount) -> list[str | Text]:
         details = error_details_count.error_details
         count = error_details_count.count
 
+        # ``type`` and ``message`` carry server-controlled text verbatim (see
+        # ``ErrorDetails`` construction in ``transports/aiohttp_client``), so they
+        # are wrapped in ``Text`` to keep Rich from parsing them as console markup.
+        # Without this a response body containing a stray closing tag raises
+        # ``MarkupError``, and one containing an opening tag is silently swallowed.
+        # This matches how ``controller_utils._format_field`` renders the same
+        # fields in the exit-error panel.
         return [
             str(details.code) if details.code else "[dim]N/A[/dim]",
-            str(details.type) if details.type else "[dim]N/A[/dim]",
-            str(details.message),
+            Text(str(details.type)) if details.type else "[dim]N/A[/dim]",
+            Text(str(details.message)),
             f"{count:,}",
         ]
 

--- a/tests/unit/controller/test_error_summary_on_total_failure.py
+++ b/tests/unit/controller/test_error_summary_on_total_failure.py
@@ -15,7 +15,7 @@ operator with a single aggregate line. That is the least diagnostic output in
 precisely the runs that need it most, and it hid the HTTP status code.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from rich.console import Console
@@ -25,6 +25,7 @@ from aiperf.common.models import (
     ErrorDetailsCount,
     ExitErrorInfo,
     MetricResult,
+    ProcessRecordsResult,
     ProfileResults,
 )
 from aiperf.controller.system_controller import SystemController
@@ -350,3 +351,47 @@ class TestPreExistingExitError:
         _, mock_exit = await self._run_shutdown(controller)
 
         mock_exit.assert_called_once()
+
+
+class TestAbsentNestedResults:
+    """``ProcessRecordsResult.results`` is declared required, but the records
+    handler defends against it being absent, so the exporter must too.
+
+    Reaching ``results.error_summary`` on an unset value raises
+    ``AttributeError``. The surrounding guard catches it, but then logs a
+    misleading "failed to render the error summary" line during shutdown.
+    """
+
+    @pytest.fixture
+    def controller(self, system_controller: SystemController) -> SystemController:
+        system_controller._profile_results = ProcessRecordsResult.model_construct(
+            results=None
+        )
+        system_controller._telemetry_results = None
+        system_controller._server_metrics_results = None
+        return system_controller
+
+    async def test_returns_quietly_when_nested_results_absent(
+        self, controller: SystemController
+    ) -> None:
+        """No spurious rendering-failure log, and no exception escapes."""
+        with patch.object(controller, "exception") as mock_exception:
+            await controller._export_error_summary()
+
+        mock_exception.assert_not_called()
+
+    async def test_failure_while_inspecting_results_is_contained(
+        self, controller: SystemController
+    ) -> None:
+        """Isolation must cover the guards, not only the rendering.
+
+        The guards run inside the try for this reason: an exception raised
+        while inspecting the results would otherwise escape and be swallowed by
+        the caller's broad shutdown guard, taking the exit-error panel and the
+        log-file path down with it.
+        """
+        exploding = MagicMock()
+        type(exploding).results = PropertyMock(side_effect=RuntimeError("boom"))
+        controller._profile_results = exploding
+
+        await controller._export_error_summary()

--- a/tests/unit/controller/test_error_summary_on_total_failure.py
+++ b/tests/unit/controller/test_error_summary_on_total_failure.py
@@ -15,7 +15,7 @@ operator with a single aggregate line. That is the least diagnostic output in
 precisely the runs that need it most, and it hid the HTTP status code.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from rich.console import Console
@@ -23,9 +23,11 @@ from rich.console import Console
 from aiperf.common.models import (
     ErrorDetails,
     ErrorDetailsCount,
+    ExitErrorInfo,
     MetricResult,
     ProfileResults,
 )
+from aiperf.controller.system_controller import SystemController
 
 
 def make_record() -> MetricResult:
@@ -33,7 +35,13 @@ def make_record() -> MetricResult:
     return MetricResult(tag="request_latency", header="Request Latency", unit="ms")
 
 
-def make_profile_results(*, records, successful, errors, error_summary):
+def make_profile_results(
+    *,
+    records: list[MetricResult],
+    successful: int,
+    errors: int,
+    error_summary: list[ErrorDetailsCount],
+) -> MagicMock:
     """Wrap a ProfileResults in the message-shaped object the controller holds."""
     results = ProfileResults(
         records=records,
@@ -49,16 +57,21 @@ def make_profile_results(*, records, successful, errors, error_summary):
     return message
 
 
-def summary(code=404, type="Not Found", message="no such path", count=100):
+def summary(
+    code: int | None = 404,
+    error_type: str | None = "Not Found",
+    message: str = "no such path",
+    count: int = 100,
+) -> list[ErrorDetailsCount]:
     return [
         ErrorDetailsCount(
-            error_details=ErrorDetails(code=code, type=type, message=message),
+            error_details=ErrorDetails(code=code, type=error_type, message=message),
             count=count,
         )
     ]
 
 
-async def run_report(controller) -> str:
+async def run_report(controller: SystemController) -> tuple[str, MagicMock]:
     """Invoke the reporting path with every console redirected to a recorder."""
     recorder = Console(record=True, width=200)
 
@@ -80,7 +93,7 @@ class TestAllRequestsFailed:
     """Records exist, but every request errored."""
 
     @pytest.fixture
-    def controller(self, system_controller):
+    def controller(self, system_controller: SystemController) -> SystemController:
         system_controller._profile_results = make_profile_results(
             records=[make_record()],
             successful=0,
@@ -91,7 +104,7 @@ class TestAllRequestsFailed:
         system_controller._server_metrics_results = None
         return system_controller
 
-    async def test_error_table_is_printed(self, controller):
+    async def test_error_table_is_printed(self, controller: SystemController) -> None:
         """The regression: the Code/Type/Message/Count table must appear."""
         out, _ = await run_report(controller)
 
@@ -99,21 +112,27 @@ class TestAllRequestsFailed:
         for header in ("Code", "Type", "Message", "Count"):
             assert header in out, f"missing column header: {header}"
 
-    async def test_http_status_code_is_visible(self, controller):
+    async def test_http_status_code_is_visible(
+        self, controller: SystemController
+    ) -> None:
         """The status code is the field the operator actually needs."""
         out, _ = await run_report(controller)
 
         assert "404" in out
         assert "no such path" in out
 
-    async def test_aggregate_line_still_recorded_as_exit_error(self, controller):
+    async def test_aggregate_line_still_recorded_as_exit_error(
+        self, controller: SystemController
+    ) -> None:
         """Exit code behaviour is unchanged: _exit_errors stays non-empty."""
         await run_report(controller)
 
         assert len(controller._exit_errors) == 1
         assert "All 100 inference" in controller._exit_errors[0].error_details.message
 
-    async def test_message_no_longer_points_at_absent_log_output(self, controller):
+    async def test_message_no_longer_points_at_absent_log_output(
+        self, controller: SystemController
+    ) -> None:
         """Per-request details are not logged at INFO, so stop citing them."""
         await run_report(controller)
 
@@ -121,7 +140,9 @@ class TestAllRequestsFailed:
         assert "prior log output" not in message
         assert "error summary table" in message
 
-    async def test_full_exporter_manager_is_not_run(self, controller):
+    async def test_full_exporter_manager_is_not_run(
+        self, controller: SystemController
+    ) -> None:
         """Scope guard: we add console output without writing new artifacts.
 
         Falling through to ExporterManager would newly emit
@@ -138,18 +159,20 @@ class TestNoRecordsCollected:
     """No records at all, but errors were still tracked."""
 
     @pytest.fixture
-    def controller(self, system_controller):
+    def controller(self, system_controller: SystemController) -> SystemController:
         system_controller._profile_results = make_profile_results(
             records=[],
             successful=0,
             errors=20,
-            error_summary=summary(code=401, type="Unauthorized", message="bad token"),
+            error_summary=summary(
+                code=401, error_type="Unauthorized", message="bad token"
+            ),
         )
         system_controller._telemetry_results = None
         system_controller._server_metrics_results = None
         return system_controller
 
-    async def test_error_table_is_printed(self, controller):
+    async def test_error_table_is_printed(self, controller: SystemController) -> None:
         """This path is reached when the accumulator emits no metric records."""
         out, _ = await run_report(controller)
 
@@ -157,7 +180,9 @@ class TestNoRecordsCollected:
         assert "401" in out
         assert "bad token" in out
 
-    async def test_exit_error_still_recorded(self, controller):
+    async def test_exit_error_still_recorded(
+        self, controller: SystemController
+    ) -> None:
         await run_report(controller)
 
         assert len(controller._exit_errors) == 1
@@ -167,7 +192,7 @@ class TestNoErrorsAtAll:
     """A clean run must not grow a spurious empty table."""
 
     @pytest.fixture
-    def controller(self, system_controller):
+    def controller(self, system_controller: SystemController) -> SystemController:
         system_controller._profile_results = make_profile_results(
             records=[],
             successful=0,
@@ -178,7 +203,9 @@ class TestNoErrorsAtAll:
         system_controller._server_metrics_results = None
         return system_controller
 
-    async def test_no_table_when_summary_empty(self, controller):
+    async def test_no_table_when_summary_empty(
+        self, controller: SystemController
+    ) -> None:
         out, _ = await run_report(controller)
 
         assert "Error Summary" not in out
@@ -193,7 +220,7 @@ class TestRenderFailureIsolation:
     """
 
     @pytest.fixture
-    def controller(self, system_controller):
+    def controller(self, system_controller: SystemController) -> SystemController:
         system_controller._profile_results = make_profile_results(
             records=[make_record()],
             successful=0,
@@ -204,14 +231,18 @@ class TestRenderFailureIsolation:
         system_controller._server_metrics_results = None
         return system_controller
 
-    async def test_server_markup_renders_and_panel_survives(self, controller):
+    async def test_server_markup_renders_and_panel_survives(
+        self, controller: SystemController
+    ) -> None:
         """End to end: hostile server text renders, and the panel still prints."""
         out, _ = await run_report(controller)
 
         assert "[/INST]" in out
         assert "Log File" in out
 
-    async def test_panel_survives_arbitrary_exporter_failure(self, controller):
+    async def test_panel_survives_arbitrary_exporter_failure(
+        self, controller: SystemController
+    ) -> None:
         """Even an unrelated crash in the exporter must not eat the panel."""
         recorder = Console(record=True, width=200)
         with (
@@ -227,3 +258,95 @@ class TestRenderFailureIsolation:
         out = recorder.export_text()
         assert "Log File" in out
         assert len(controller._exit_errors) == 1
+
+
+class TestPreExistingExitError:
+    """A mid-run service failure must not also cost us the error table.
+
+    When something populates ``_exit_errors`` before shutdown (a service failing
+    a lifecycle command, or crashing mid-run), ``_stop_system_controller`` takes
+    its else branch and never calls
+    ``_print_post_benchmark_info_and_metrics``. Without an export on that branch
+    a run whose requests *also* failed loses the table on exactly the runs
+    carrying two kinds of failure at once.
+    """
+
+    @pytest.fixture
+    def controller(
+        self, system_controller: SystemController, mock_service_manager: AsyncMock
+    ) -> SystemController:
+        system_controller._profile_results = make_profile_results(
+            records=[make_record()],
+            successful=0,
+            errors=100,
+            error_summary=summary(),
+        )
+        system_controller._telemetry_results = None
+        system_controller._server_metrics_results = None
+        system_controller._exit_errors = [
+            ExitErrorInfo(
+                error_details=ErrorDetails(
+                    type="SERVICE_ERROR", message="a service died mid-run"
+                ),
+                operation="service_runtime",
+                service_id="worker_1",
+            )
+        ]
+        system_controller.publish = AsyncMock()
+        system_controller.service_manager = mock_service_manager
+        system_controller.comms = AsyncMock()
+        system_controller.proxy_manager = AsyncMock()
+        system_controller.ui = AsyncMock()
+        return system_controller
+
+    async def _run_shutdown(
+        self, controller: SystemController
+    ) -> tuple[str, MagicMock]:
+        recorder = Console(record=True, width=200)
+        with (
+            patch("aiperf.controller.system_controller.Console", return_value=recorder),
+            patch(
+                "aiperf.controller.system_controller.cleanup_global_log_queue",
+                new_callable=AsyncMock,
+            ),
+            patch("aiperf.controller.system_controller.os._exit") as mock_exit,
+        ):
+            await controller._stop_system_controller()
+        return recorder.export_text(), mock_exit
+
+    async def test_error_table_printed_on_the_exit_error_branch(
+        self, controller: SystemController
+    ) -> None:
+        """The regression: this branch printed no table at all."""
+        out, _ = await self._run_shutdown(controller)
+
+        assert "Error Summary" in out
+        assert "404" in out
+
+    async def test_exit_panel_and_log_path_still_print(
+        self, controller: SystemController
+    ) -> None:
+        out, _ = await self._run_shutdown(controller)
+
+        assert "Log File" in out
+        assert "a service died mid-run" in out
+
+    async def test_table_precedes_the_exit_panel(
+        self, controller: SystemController
+    ) -> None:
+        """The exit message says "see the table above", so ordering is load-bearing."""
+        out, _ = await self._run_shutdown(controller)
+
+        # Assert presence first: ``str.find`` returns -1 when absent, so a bare
+        # ordering comparison would pass vacuously if the table never rendered.
+        assert "Error Summary" in out
+        assert "Exit Errors" in out
+        assert out.index("Error Summary") < out.index("Exit Errors")
+
+    async def test_shutdown_still_reaches_os_exit(
+        self, controller: SystemController
+    ) -> None:
+        """The stop hook must always terminate the process."""
+        _, mock_exit = await self._run_shutdown(controller)
+
+        mock_exit.assert_called_once()

--- a/tests/unit/controller/test_error_summary_on_total_failure.py
+++ b/tests/unit/controller/test_error_summary_on_total_failure.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests: the error summary must survive a total-failure run.
+
+``_print_post_benchmark_info_and_metrics`` has two early-return paths that fire
+before ``ExporterManager`` is constructed:
+
+* no records at all
+* records exist but every request failed
+
+``ExporterManager`` is what drives ``ConsoleErrorExporter``, so before this fix
+both paths discarded the already-populated ``error_summary`` and left the
+operator with a single aggregate line. That is the least diagnostic output in
+precisely the runs that need it most, and it hid the HTTP status code.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from aiperf.common.models import (
+    ErrorDetails,
+    ErrorDetailsCount,
+    MetricResult,
+    ProfileResults,
+)
+
+
+def make_record() -> MetricResult:
+    """A single metric record, enough to get past the empty-records guard."""
+    return MetricResult(tag="request_latency", header="Request Latency", unit="ms")
+
+
+def make_profile_results(*, records, successful, errors, error_summary):
+    """Wrap a ProfileResults in the message-shaped object the controller holds."""
+    results = ProfileResults(
+        records=records,
+        completed=successful + errors,
+        start_ns=0,
+        end_ns=1,
+        successful_request_count=successful,
+        error_request_count=errors,
+        error_summary=error_summary,
+    )
+    message = MagicMock()
+    message.results = results
+    return message
+
+
+def summary(code=404, type="Not Found", message="no such path", count=100):
+    return [
+        ErrorDetailsCount(
+            error_details=ErrorDetails(code=code, type=type, message=message),
+            count=count,
+        )
+    ]
+
+
+async def run_report(controller) -> str:
+    """Invoke the reporting path with every console redirected to a recorder."""
+    recorder = Console(record=True, width=200)
+
+    with (
+        patch(
+            "aiperf.controller.system_controller.Console",
+            return_value=recorder,
+        ),
+        patch(
+            "aiperf.controller.system_controller.ExporterManager"
+        ) as mock_exporter_manager,
+    ):
+        await controller._print_post_benchmark_info_and_metrics()
+
+    return recorder.export_text(), mock_exporter_manager
+
+
+class TestAllRequestsFailed:
+    """Records exist, but every request errored."""
+
+    @pytest.fixture
+    def controller(self, system_controller):
+        system_controller._profile_results = make_profile_results(
+            records=[make_record()],
+            successful=0,
+            errors=100,
+            error_summary=summary(),
+        )
+        system_controller._telemetry_results = None
+        system_controller._server_metrics_results = None
+        return system_controller
+
+    async def test_error_table_is_printed(self, controller):
+        """The regression: the Code/Type/Message/Count table must appear."""
+        out, _ = await run_report(controller)
+
+        assert "Error Summary" in out
+        for header in ("Code", "Type", "Message", "Count"):
+            assert header in out, f"missing column header: {header}"
+
+    async def test_http_status_code_is_visible(self, controller):
+        """The status code is the field the operator actually needs."""
+        out, _ = await run_report(controller)
+
+        assert "404" in out
+        assert "no such path" in out
+
+    async def test_aggregate_line_still_recorded_as_exit_error(self, controller):
+        """Exit code behaviour is unchanged: _exit_errors stays non-empty."""
+        await run_report(controller)
+
+        assert len(controller._exit_errors) == 1
+        assert "All 100 inference" in controller._exit_errors[0].error_details.message
+
+    async def test_message_no_longer_points_at_absent_log_output(self, controller):
+        """Per-request details are not logged at INFO, so stop citing them."""
+        await run_report(controller)
+
+        message = controller._exit_errors[0].error_details.message
+        assert "prior log output" not in message
+        assert "error summary table" in message
+
+    async def test_full_exporter_manager_is_not_run(self, controller):
+        """Scope guard: we add console output without writing new artifacts.
+
+        Falling through to ExporterManager would newly emit
+        profile_export_aiperf.json/csv on runs that previously produced none,
+        which is a behaviour change for anything automating over the artifact
+        directory.
+        """
+        _, mock_exporter_manager = await run_report(controller)
+
+        mock_exporter_manager.assert_not_called()
+
+
+class TestNoRecordsCollected:
+    """No records at all, but errors were still tracked."""
+
+    @pytest.fixture
+    def controller(self, system_controller):
+        system_controller._profile_results = make_profile_results(
+            records=[],
+            successful=0,
+            errors=20,
+            error_summary=summary(code=401, type="Unauthorized", message="bad token"),
+        )
+        system_controller._telemetry_results = None
+        system_controller._server_metrics_results = None
+        return system_controller
+
+    async def test_error_table_is_printed(self, controller):
+        """This path is reached when the accumulator emits no metric records."""
+        out, _ = await run_report(controller)
+
+        assert "Error Summary" in out
+        assert "401" in out
+        assert "bad token" in out
+
+    async def test_exit_error_still_recorded(self, controller):
+        await run_report(controller)
+
+        assert len(controller._exit_errors) == 1
+
+
+class TestNoErrorsAtAll:
+    """A clean run must not grow a spurious empty table."""
+
+    @pytest.fixture
+    def controller(self, system_controller):
+        system_controller._profile_results = make_profile_results(
+            records=[],
+            successful=0,
+            errors=0,
+            error_summary=[],
+        )
+        system_controller._telemetry_results = None
+        system_controller._server_metrics_results = None
+        return system_controller
+
+    async def test_no_table_when_summary_empty(self, controller):
+        out, _ = await run_report(controller)
+
+        assert "Error Summary" not in out

--- a/tests/unit/controller/test_error_summary_on_total_failure.py
+++ b/tests/unit/controller/test_error_summary_on_total_failure.py
@@ -182,3 +182,48 @@ class TestNoErrorsAtAll:
         out, _ = await run_report(controller)
 
         assert "Error Summary" not in out
+
+
+class TestRenderFailureIsolation:
+    """A failure while rendering the table must not hide the exit-error panel.
+
+    Both callers print the exit-error panel and the log-file path immediately
+    after the table. Those are the operator's remaining diagnostics on a run
+    that already failed, so a rendering error must not take them down with it.
+    """
+
+    @pytest.fixture
+    def controller(self, system_controller):
+        system_controller._profile_results = make_profile_results(
+            records=[make_record()],
+            successful=0,
+            errors=100,
+            error_summary=summary(message="body with [/INST] in it"),
+        )
+        system_controller._telemetry_results = None
+        system_controller._server_metrics_results = None
+        return system_controller
+
+    async def test_server_markup_renders_and_panel_survives(self, controller):
+        """End to end: hostile server text renders, and the panel still prints."""
+        out, _ = await run_report(controller)
+
+        assert "[/INST]" in out
+        assert "Log File" in out
+
+    async def test_panel_survives_arbitrary_exporter_failure(self, controller):
+        """Even an unrelated crash in the exporter must not eat the panel."""
+        recorder = Console(record=True, width=200)
+        with (
+            patch("aiperf.controller.system_controller.Console", return_value=recorder),
+            patch("aiperf.controller.system_controller.ExporterManager"),
+            patch(
+                "aiperf.controller.system_controller.ConsoleErrorExporter",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            await controller._print_post_benchmark_info_and_metrics()
+
+        out = recorder.export_text()
+        assert "Log File" in out
+        assert len(controller._exit_errors) == 1

--- a/tests/unit/exporters/test_console_error_exporter.py
+++ b/tests/unit/exporters/test_console_error_exporter.py
@@ -115,3 +115,45 @@ class TestConsoleErrorExporter:
         out = render(make_results([make_error(**kwargs)]))
 
         assert "N/A" in out
+
+
+class TestMarkupSafety:
+    """Server-controlled text must never be parsed as Rich console markup.
+
+    ``ErrorDetails.type`` and ``.message`` carry the response reason and body
+    verbatim, so a server can put arbitrary bracketed text in them.
+    """
+
+    def test_stray_closing_tag_does_not_raise(self):
+        """A closing tag with no opener used to raise MarkupError."""
+        out = render(
+            make_results(
+                [make_error(message='{"error":"unexpected closing tag [/INST]"}')]
+            )
+        )
+
+        assert "[/INST]" in out
+
+    def test_opening_tag_is_not_swallowed(self):
+        """An opening tag used to render as an empty Message cell."""
+        out = render(make_results([make_error(message="[not a tag]")]))
+
+        assert "[not a tag]" in out
+
+    def test_markup_in_type_is_literal(self):
+        out = render(make_results([make_error(type="[/oops]", message="body")]))
+
+        assert "[/oops]" in out
+
+    def test_style_markup_is_not_interpreted(self):
+        """A server sending style tags must not colour our output."""
+        out = render(make_results([make_error(message="[red]not really red[/red]")]))
+
+        assert "[red]not really red[/red]" in out
+
+    def test_na_placeholders_still_render(self):
+        """The intentional [dim]N/A[/dim] placeholders must keep working."""
+        out = render(make_results([make_error(code=None, type=None)]))
+
+        assert "N/A" in out
+        assert "[dim]" not in out

--- a/tests/unit/exporters/test_console_error_exporter.py
+++ b/tests/unit/exporters/test_console_error_exporter.py
@@ -18,7 +18,9 @@ from aiperf.exporters.console_error_exporter import ConsoleErrorExporter
 from tests.unit.exporters.conftest import make_exporter_config
 
 
-def make_results(error_summary=None, **kwargs) -> ProfileResults:
+def make_results(
+    error_summary: list[ErrorDetailsCount] | None = None, **kwargs
+) -> ProfileResults:
     """Build a minimal ProfileResults carrying the given error summary."""
     defaults = dict(
         records=[],
@@ -33,14 +35,19 @@ def make_results(error_summary=None, **kwargs) -> ProfileResults:
     return ProfileResults(**defaults)
 
 
-def make_error(code=404, type="Not Found", message="Not Found", count=1):
+def make_error(
+    code: int | None = 404,
+    error_type: str | None = "Not Found",
+    message: str = "Not Found",
+    count: int = 1,
+) -> ErrorDetailsCount:
     return ErrorDetailsCount(
-        error_details=ErrorDetails(code=code, type=type, message=message),
+        error_details=ErrorDetails(code=code, type=error_type, message=message),
         count=count,
     )
 
 
-def render(results) -> str:
+def render(results: ProfileResults) -> str:
     """Run the exporter against a recording console and return the text."""
     console = Console(record=True, width=200)
     exporter = ConsoleErrorExporter(
@@ -56,23 +63,23 @@ def render(results) -> str:
 class TestConsoleErrorExporter:
     """Rendering behaviour of the error summary table."""
 
-    def test_renders_all_four_columns(self):
+    def test_renders_all_four_columns(self) -> None:
         """The table exposes Code, Type, Message and Count headers."""
         out = render(make_results([make_error()]))
 
         for header in ("Code", "Type", "Message", "Count"):
             assert header in out, f"missing column header: {header}"
 
-    def test_renders_http_status_code(self):
+    def test_renders_http_status_code(self) -> None:
         """The HTTP status is the single most useful field and must appear."""
         out = render(make_results([make_error(code=404)]))
 
         assert "404" in out
 
-    def test_renders_type_and_message(self):
+    def test_renders_type_and_message(self) -> None:
         out = render(
             make_results(
-                [make_error(code=401, type="Unauthorized", message="bad token")]
+                [make_error(code=401, error_type="Unauthorized", message="bad token")]
             )
         )
 
@@ -80,19 +87,21 @@ class TestConsoleErrorExporter:
         assert "Unauthorized" in out
         assert "bad token" in out
 
-    def test_renders_nothing_when_summary_empty(self):
+    def test_renders_nothing_when_summary_empty(self) -> None:
         """No errors means no table, not an empty table."""
         out = render(make_results([]))
 
         assert "Error Summary" not in out
         assert out.strip() == ""
 
-    def test_renders_one_row_per_distinct_error(self):
+    def test_renders_one_row_per_distinct_error(self) -> None:
         out = render(
             make_results(
                 [
-                    make_error(code=404, type="Not Found", message="no such path"),
-                    make_error(code=500, type="Server Error", message="boom"),
+                    make_error(
+                        code=404, error_type="Not Found", message="no such path"
+                    ),
+                    make_error(code=500, error_type="Server Error", message="boom"),
                 ]
             )
         )
@@ -102,15 +111,15 @@ class TestConsoleErrorExporter:
         assert "no such path" in out
         assert "boom" in out
 
-    def test_count_uses_thousands_separator(self):
+    def test_count_uses_thousands_separator(self) -> None:
         out = render(make_results([make_error(count=1234)]))
 
         assert "1,234" in out
 
-    @pytest.mark.parametrize("missing", ["code", "type"])
-    def test_missing_fields_render_as_na(self, missing):
+    @pytest.mark.parametrize("missing", ["code", "error_type"])
+    def test_missing_fields_render_as_na(self, missing: str) -> None:
         """A missing code or type degrades to N/A rather than crashing."""
-        kwargs = {"code": 404, "type": "Not Found"}
+        kwargs = {"code": 404, "error_type": "Not Found"}
         kwargs[missing] = None
         out = render(make_results([make_error(**kwargs)]))
 
@@ -124,7 +133,7 @@ class TestMarkupSafety:
     verbatim, so a server can put arbitrary bracketed text in them.
     """
 
-    def test_stray_closing_tag_does_not_raise(self):
+    def test_stray_closing_tag_does_not_raise(self) -> None:
         """A closing tag with no opener used to raise MarkupError."""
         out = render(
             make_results(
@@ -134,26 +143,26 @@ class TestMarkupSafety:
 
         assert "[/INST]" in out
 
-    def test_opening_tag_is_not_swallowed(self):
+    def test_opening_tag_is_not_swallowed(self) -> None:
         """An opening tag used to render as an empty Message cell."""
         out = render(make_results([make_error(message="[not a tag]")]))
 
         assert "[not a tag]" in out
 
-    def test_markup_in_type_is_literal(self):
-        out = render(make_results([make_error(type="[/oops]", message="body")]))
+    def test_markup_in_type_is_literal(self) -> None:
+        out = render(make_results([make_error(error_type="[/oops]", message="body")]))
 
         assert "[/oops]" in out
 
-    def test_style_markup_is_not_interpreted(self):
+    def test_style_markup_is_not_interpreted(self) -> None:
         """A server sending style tags must not colour our output."""
         out = render(make_results([make_error(message="[red]not really red[/red]")]))
 
         assert "[red]not really red[/red]" in out
 
-    def test_na_placeholders_still_render(self):
+    def test_na_placeholders_still_render(self) -> None:
         """The intentional [dim]N/A[/dim] placeholders must keep working."""
-        out = render(make_results([make_error(code=None, type=None)]))
+        out = render(make_results([make_error(code=None, error_type=None)]))
 
         assert "N/A" in out
         assert "[dim]" not in out

--- a/tests/unit/exporters/test_console_error_exporter.py
+++ b/tests/unit/exporters/test_console_error_exporter.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for :class:`ConsoleErrorExporter`.
+
+The exporter renders the aggregated Code/Type/Message/Count table that is the
+primary diagnostic for a run in which requests failed.
+"""
+
+import asyncio
+
+import pytest
+from rich.console import Console
+
+from aiperf.common.models import ErrorDetails, ErrorDetailsCount, ProfileResults
+from aiperf.config.flags.cli_config import CLIConfig
+from aiperf.exporters.console_error_exporter import ConsoleErrorExporter
+from tests.unit.exporters.conftest import make_exporter_config
+
+
+def make_results(error_summary=None, **kwargs) -> ProfileResults:
+    """Build a minimal ProfileResults carrying the given error summary."""
+    defaults = dict(
+        records=[],
+        completed=0,
+        start_ns=0,
+        end_ns=1,
+        successful_request_count=0,
+        error_request_count=sum(e.count for e in error_summary or []),
+        error_summary=error_summary or [],
+    )
+    defaults.update(kwargs)
+    return ProfileResults(**defaults)
+
+
+def make_error(code=404, type="Not Found", message="Not Found", count=1):
+    return ErrorDetailsCount(
+        error_details=ErrorDetails(code=code, type=type, message=message),
+        count=count,
+    )
+
+
+def render(results) -> str:
+    """Run the exporter against a recording console and return the text."""
+    console = Console(record=True, width=200)
+    exporter = ConsoleErrorExporter(
+        make_exporter_config(
+            results=results,
+            cli_config=CLIConfig(model_names=["test_model"]),
+        )
+    )
+    asyncio.run(exporter.export(console))
+    return console.export_text()
+
+
+class TestConsoleErrorExporter:
+    """Rendering behaviour of the error summary table."""
+
+    def test_renders_all_four_columns(self):
+        """The table exposes Code, Type, Message and Count headers."""
+        out = render(make_results([make_error()]))
+
+        for header in ("Code", "Type", "Message", "Count"):
+            assert header in out, f"missing column header: {header}"
+
+    def test_renders_http_status_code(self):
+        """The HTTP status is the single most useful field and must appear."""
+        out = render(make_results([make_error(code=404)]))
+
+        assert "404" in out
+
+    def test_renders_type_and_message(self):
+        out = render(
+            make_results(
+                [make_error(code=401, type="Unauthorized", message="bad token")]
+            )
+        )
+
+        assert "401" in out
+        assert "Unauthorized" in out
+        assert "bad token" in out
+
+    def test_renders_nothing_when_summary_empty(self):
+        """No errors means no table, not an empty table."""
+        out = render(make_results([]))
+
+        assert "Error Summary" not in out
+        assert out.strip() == ""
+
+    def test_renders_one_row_per_distinct_error(self):
+        out = render(
+            make_results(
+                [
+                    make_error(code=404, type="Not Found", message="no such path"),
+                    make_error(code=500, type="Server Error", message="boom"),
+                ]
+            )
+        )
+
+        assert "404" in out
+        assert "500" in out
+        assert "no such path" in out
+        assert "boom" in out
+
+    def test_count_uses_thousands_separator(self):
+        out = render(make_results([make_error(count=1234)]))
+
+        assert "1,234" in out
+
+    @pytest.mark.parametrize("missing", ["code", "type"])
+    def test_missing_fields_render_as_na(self, missing):
+        """A missing code or type degrades to N/A rather than crashing."""
+        kwargs = {"code": 404, "type": "Not Found"}
+        kwargs[missing] = None
+        out = render(make_results([make_error(**kwargs)]))
+
+        assert "N/A" in out


### PR DESCRIPTION
## Problem

`_print_post_benchmark_info_and_metrics` has two early-return paths that exit
before `ExporterManager` is constructed: one when no records were collected, and
one when records exist but every request failed.

`ExporterManager` drives `ConsoleErrorExporter`, the only thing that renders the
Code/Type/Message/Count error table. So a run where 100% of requests fail prints
a single aggregate line and discards the already-populated
`results.error_summary` — hiding the HTTP status code in exactly the runs that
carry the least other diagnostic information.

This is a regression. Before #912, the method fell through to `ExporterManager`
whenever records existed, so the table was printed on total-failure runs.

## Before / after

Against a server returning 413 for every request:

**Before**
```
ERROR All 10 inference request(s) failed; no successful responses were collected.
Reason: ... See prior log output for per-request error details.
```

**After**
```
┃ Code ┃                     Type ┃ Message                              ┃ Count ┃
│  413 │ Request Entity Too Large │ {"error":"request entity too large"} │    10 │
```

## Approach

Renders the error table on both early-return paths via a small
`_export_error_summary` helper.

This deliberately does **not** fall through to the full `ExporterManager`.
Doing so would newly write `profile_export_aiperf.json`/`.csv` on runs that
previously produced no artifacts, which is a behaviour change for anything
automating over the artifact directory. Verified: the artifact file sets before
and after this change are identical. Exit-code behaviour is unchanged.

Note `ajc/upstream-prep` takes the same approach (dropping the zero-success
guard so the report is emitted first); this is the minimal version of that for
`main`.

## Message correction

The exit message pointed at "prior log output for per-request error details",
but non-2xx responses are turned into `ErrorDetails` in `aiohttp_client` and
returned without any log call, so those details are absent at every log level.

## Tests

- `tests/unit/exporters/test_console_error_exporter.py` — new; this exporter had no coverage
- `tests/unit/controller/test_error_summary_on_total_failure.py` — regression tests for both paths

All 16 fail without the source change and pass with it. Full `tests/unit/controller`
and `tests/unit/exporters` suites pass (459).

## Reproducer

Point aiperf at anything that fails every request:

```bash
aiperf profile --model gpt2 --endpoint-type chat \
  --url http://127.0.0.1:8123 \
  --request-count 10 --warmup-request-count 2 --concurrency 2 --ui-type none
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added aggregated error summaries when all inference requests fail or no metrics are collected.
  - Displays error types, messages, HTTP status codes, and occurrence counts in a readable table.
  - Provides clearer guidance by referencing the displayed error breakdown.

- **Bug Fixes**
  - Preserved server-provided error text without unintended formatting.
  - Ensured exit diagnostics and log reporting continue if summary rendering fails.
  - Improved handling of missing or inaccessible result details.
  - Prevented empty error tables when no errors are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->