### PR TITLE
fix: detect structured SSE data errors

### DIFF
--- a/src/aiperf/cli_commands/chat.py
+++ b/src/aiperf/cli_commands/chat.py
@@ -92,8 +92,8 @@ async def _consume_stream(
     Returns ``(responses, output_parts, reasoning_parts, last_usage)``.
 
     Raises:
-        SSEResponseError: if the server signals a mid-stream ``event: error``
-            after a 200 OK (surfaced instead of reported as a truncated reply).
+        SSEResponseError: if the server sends a named or structured mid-stream
+            SSE error after a 200 OK instead of a complete reply.
     """
     responses: list[ParsedResponse] = []
     output_parts: list[str] = []

--- a/src/aiperf/transports/sse_utils.py
+++ b/src/aiperf/transports/sse_utils.py
@@ -19,21 +19,24 @@ _SSE_EVENT_FIELD_NAME = "event"
 
 
 def _raise_for_data_error(data_content: str) -> None:
-    """Raise when an SSE data payload contains a top-level structured error."""
+    """Raise when a candidate SSE data payload contains a structured error."""
     try:
         payload = orjson.loads(data_content)
     except orjson.JSONDecodeError:
         return
 
-    if not isinstance(payload, dict) or payload.get("error") is None:
+    if not isinstance(payload, dict):
         return
 
-    error = payload["error"]
+    error = payload.get("error")
+    if not error:
+        return
+
     error_code = 502
     if isinstance(error, dict):
         error_message = error.get("message")
         code = error.get("code")
-        if isinstance(code, int) and not isinstance(code, bool):
+        if isinstance(code, int) and not isinstance(code, bool) and 400 <= code <= 599:
             error_code = code
         if not isinstance(error_message, str):
             error_message = orjson.dumps(error).decode()
@@ -45,6 +48,24 @@ def _raise_for_data_error(data_content: str) -> None:
     raise SSEResponseError(
         f"Error occurred in SSE response: {error_message}", error_code=error_code
     )
+
+
+def _classify_message_fields(message: SSEMessage) -> tuple[bool, bool]:
+    """Return named-error and structured-data-candidate flags."""
+    has_error_event = False
+    has_data_error_candidate = False
+    for packet in message.packets:
+        if packet.name == _SSE_DATA_FIELD_NAME:
+            if packet.value is not None and '"error"' in packet.value:
+                has_data_error_candidate = True
+            continue
+        if (
+            packet.name.casefold() == _SSE_EVENT_FIELD_NAME
+            and packet.value is not None
+            and packet.value.casefold() == _SSE_ERROR_EVENT_VALUE
+        ):
+            has_error_event = True
+    return has_error_event, has_data_error_candidate
 
 
 class AsyncSSEStreamReader:
@@ -113,7 +134,13 @@ class AsyncSSEStreamReader:
 
     @staticmethod
     def inspect_message_for_error(message: SSEMessage) -> None:
-        """Raise for named SSE errors or structured ``data`` error payloads."""
+        """Raise for named SSE errors or structured ``data`` error payloads.
+
+        A named error uses its first comment when present. Without a comment,
+        structured data supplies the message and code before the unknown-error
+        fallback. Data is checked for the exact marker before JSON decoding to
+        keep normal streaming messages on the fast path.
+        """
         if (
             len(message.packets) == 1
             and message.packets[0].name == _SSE_DATA_FIELD_NAME
@@ -123,12 +150,7 @@ class AsyncSSEStreamReader:
                 _raise_for_data_error(data_content)
             return
 
-        has_error_event = any(
-            packet.name.casefold() == _SSE_EVENT_FIELD_NAME
-            and packet.value is not None
-            and packet.value.casefold() == _SSE_ERROR_EVENT_VALUE
-            for packet in message.packets
-        )
+        has_error_event, has_data_error_candidate = _classify_message_fields(message)
 
         if has_error_event:
             error_message = None
@@ -137,16 +159,20 @@ class AsyncSSEStreamReader:
                     error_message = packet.value
                     break
 
-            if error_message is None:
-                error_message = f"Unknown error in SSE response: {message}"
+            if error_message is not None:
+                raise SSEResponseError(
+                    f"Error occurred in SSE response: {error_message}",
+                    error_code=502,
+                )
 
+        if has_data_error_candidate:
+            _raise_for_data_error(message.extract_data_content())
+
+        if has_error_event:
             raise SSEResponseError(
-                f"Error occurred in SSE response: {error_message}", error_code=502
+                f"Error occurred in SSE response: Unknown error in SSE response: {message}",
+                error_code=502,
             )
-
-        data_content = message.extract_data_content()
-        if '"error"' in data_content:
-            _raise_for_data_error(data_content)
 
     async def __aiter__(self) -> AsyncIterator[SSEMessage]:
         """Iterate over the SSE stream in a performant manner and yield parsed SSE messages as they arrive."""

--- a/src/aiperf/transports/sse_utils.py
+++ b/src/aiperf/transports/sse_utils.py
@@ -5,6 +5,8 @@
 import time
 from collections.abc import AsyncIterator
 
+import orjson
+
 from aiperf.common.aiperf_logger import AIPerfLogger
 from aiperf.common.exceptions import SSEResponseError
 from aiperf.common.models import SSEMessage
@@ -14,6 +16,35 @@ _SSE_COMMENT_FIELD_NAME = "comment"
 _SSE_DATA_FIELD_NAME = "data"
 _SSE_ERROR_EVENT_VALUE = "error"
 _SSE_EVENT_FIELD_NAME = "event"
+
+
+def _raise_for_data_error(data_content: str) -> None:
+    """Raise when an SSE data payload contains a top-level structured error."""
+    try:
+        payload = orjson.loads(data_content)
+    except orjson.JSONDecodeError:
+        return
+
+    if not isinstance(payload, dict) or payload.get("error") is None:
+        return
+
+    error = payload["error"]
+    error_code = 502
+    if isinstance(error, dict):
+        error_message = error.get("message")
+        code = error.get("code")
+        if isinstance(code, int) and not isinstance(code, bool):
+            error_code = code
+        if not isinstance(error_message, str):
+            error_message = orjson.dumps(error).decode()
+    elif isinstance(error, str):
+        error_message = error
+    else:
+        error_message = orjson.dumps(error).decode()
+
+    raise SSEResponseError(
+        f"Error occurred in SSE response: {error_message}", error_code=error_code
+    )
 
 
 class AsyncSSEStreamReader:
@@ -81,16 +112,15 @@ class AsyncSSEStreamReader:
         return messages
 
     @staticmethod
-    def inspect_message_for_error(message: SSEMessage):
-        """Check if the message contains an error event packet and raise an SSEResponseError if so.
-
-        If so, look for any comment field and raise an SSEResponseError
-        with that comment as the error message, otherwise use the full message.
-        """
+    def inspect_message_for_error(message: SSEMessage) -> None:
+        """Raise for named SSE errors or structured ``data`` error payloads."""
         if (
             len(message.packets) == 1
             and message.packets[0].name == _SSE_DATA_FIELD_NAME
         ):
+            data_content = message.packets[0].value
+            if data_content is not None and '"error"' in data_content:
+                _raise_for_data_error(data_content)
             return
 
         has_error_event = any(
@@ -113,6 +143,10 @@ class AsyncSSEStreamReader:
             raise SSEResponseError(
                 f"Error occurred in SSE response: {error_message}", error_code=502
             )
+
+        data_content = message.extract_data_content()
+        if '"error"' in data_content:
+            _raise_for_data_error(data_content)
 
     async def __aiter__(self) -> AsyncIterator[SSEMessage]:
         """Iterate over the SSE stream in a performant manner and yield parsed SSE messages as they arrive."""

--- a/tests/unit/transports/test_aiohttp_client.py
+++ b/tests/unit/transports/test_aiohttp_client.py
@@ -202,6 +202,7 @@ class TestAioHttpClient:
             )
 
         assert record.error is not None
+        assert record.status == 200
         assert record.error.code == 500
         assert record.error.type == "SSEResponseError"
         assert "Internal server error" in record.error.message

--- a/tests/unit/transports/test_aiohttp_client.py
+++ b/tests/unit/transports/test_aiohttp_client.py
@@ -181,6 +181,34 @@ class TestAioHttpClient:
             assert isinstance(record.responses[0], SSEMessage)
 
     @pytest.mark.asyncio
+    async def test_sse_stream_data_error_handling(
+        self, aiohttp_client: AioHttpClient, mock_sse_response: Mock
+    ) -> None:
+        """Test that a structured data error in a 200 response fails the request."""
+        with patch("aiohttp.ClientSession") as mock_session_class:
+            mock_sse_response.content = MockStreamReader(
+                [
+                    b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+                    b'data: {"error":{"message":"Internal server error","type":"internal_server_error","code":500}}\n\n',
+                    b"data: [DONE]\n\n",
+                ]
+            )
+            setup_mock_session(mock_session_class, mock_sse_response, ["request"])
+
+            record = await aiohttp_client.post_request(
+                "http://test.com/stream",
+                '{"stream": true}',
+                {"Accept": "text/event-stream"},
+            )
+
+        assert record.error is not None
+        assert record.error.code == 500
+        assert record.error.type == "SSEResponseError"
+        assert "Internal server error" in record.error.message
+        assert len(record.responses) == 1
+        assert isinstance(record.responses[0], SSEMessage)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "status_code,reason,error_text",
         [

--- a/tests/unit/transports/test_sse_utils.py
+++ b/tests/unit/transports/test_sse_utils.py
@@ -620,6 +620,11 @@ class TestInspectMessageForError:
             "event: message\n: This is a comment\ndata: content",
             'data: {"metadata": {"error": "not a response error"}}',
             'data: {"error": null}',
+            'data: {"error": false}',
+            'data: {"error": ""}',
+            'data: {"error": {}}',
+            'data: {"error": []}',
+            'data: {"error": 0}',
             'data: {"error":',
             "data: [DONE]",
             ": This is just a comment",
@@ -679,6 +684,30 @@ class TestInspectMessageForError:
         assert exc_info.value.error_code == expected_error_code
 
     @pytest.mark.parametrize(
+        "code,expected_error_code",
+        [
+            param(399, 502, id="below-range"),
+            param(400, 400, id="lower-bound"),
+            param(599, 599, id="upper-bound"),
+            param(600, 502, id="above-range"),
+            param(True, 502, id="boolean"),
+        ],
+    )  # fmt: skip
+    def test_data_error_code_validation(
+        self, code: int | bool, expected_error_code: int, base_perf_ns: int
+    ) -> None:
+        """Only HTTP error status codes are preserved from data errors."""
+        raw_payload = orjson.dumps(
+            {"error": {"message": "Request failed", "code": code}}
+        ).decode()
+        message = SSEMessage.parse(f"data: {raw_payload}", base_perf_ns)
+
+        with pytest.raises(SSEResponseError) as exc_info:
+            AsyncSSEStreamReader.inspect_message_for_error(message)
+
+        assert exc_info.value.error_code == expected_error_code
+
+    @pytest.mark.parametrize(
         "raw_message,expected_error_text",
         [
             (
@@ -711,16 +740,55 @@ class TestInspectMessageForError:
         assert expected_error_text in str(exc_info.value)
         assert exc_info.value.error_code == 502
 
-    def test_error_event_without_comment(self, base_perf_ns: int) -> None:
-        """Test that error event without comment raises with full message."""
-        raw_message = 'event: error\ndata: {"error": "Something went wrong"}'
+    def test_error_event_without_comment_uses_structured_error(
+        self, base_perf_ns: int
+    ) -> None:
+        """A structured error supplies the message and code when no comment exists."""
+        raw_message = (
+            'event: error\ndata: {"error":{"message":"Overloaded","code":429}}'
+        )
         message = SSEMessage.parse(raw_message, base_perf_ns)
 
         with pytest.raises(SSEResponseError) as exc_info:
             AsyncSSEStreamReader.inspect_message_for_error(message)
 
-        assert "Unknown error in SSE response" in str(exc_info.value)
+        assert "Overloaded" in str(exc_info.value)
+        assert "Unknown error" not in str(exc_info.value)
+        assert exc_info.value.error_code == 429
+
+    def test_error_event_comment_takes_precedence_over_structured_error(
+        self, base_perf_ns: int
+    ) -> None:
+        """A named error comment remains authoritative when data also has an error."""
+        raw_message = (
+            "event: error\n: Gateway failure\n"
+            'data: {"error":{"message":"Backend failure","code":429}}'
+        )
+        message = SSEMessage.parse(raw_message, base_perf_ns)
+
+        with pytest.raises(SSEResponseError) as exc_info:
+            AsyncSSEStreamReader.inspect_message_for_error(message)
+
+        assert "Gateway failure" in str(exc_info.value)
+        assert "Backend failure" not in str(exc_info.value)
         assert exc_info.value.error_code == 502
+
+    def test_multi_packet_without_error_skips_data_assembly(
+        self, base_perf_ns: int, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Normal multi-packet messages do not allocate combined data during inspection."""
+        message = SSEMessage.parse(
+            'event: message\ndata: {"content":"Hello"}\nid: msg-1', base_perf_ns
+        )
+
+        def fail_extract_data_content(self: SSEMessage) -> str:
+            raise AssertionError("normal messages must not assemble data")
+
+        monkeypatch.setattr(
+            SSEMessage, "extract_data_content", fail_extract_data_content
+        )
+
+        AsyncSSEStreamReader.inspect_message_for_error(message)
 
     def test_error_event_with_multiple_comments_uses_first(
         self, base_perf_ns: int

--- a/tests/unit/transports/test_sse_utils.py
+++ b/tests/unit/transports/test_sse_utils.py
@@ -618,6 +618,10 @@ class TestInspectMessageForError:
         [
             'data: {"content": "Hello World"}\nevent: message\nid: msg_123',
             "event: message\n: This is a comment\ndata: content",
+            'data: {"metadata": {"error": "not a response error"}}',
+            'data: {"error": null}',
+            'data: {"error":',
+            "data: [DONE]",
             ": This is just a comment",
             "",
         ],
@@ -628,6 +632,51 @@ class TestInspectMessageForError:
         """Test that messages without error events pass through without raising."""
         message = SSEMessage.parse(raw_message, base_perf_ns)
         AsyncSSEStreamReader.inspect_message_for_error(message)
+
+    @pytest.mark.parametrize(
+        "raw_message,expected_error_text,expected_error_code",
+        [
+            param(
+                'data: {"error":{"message":"Internal server error","type":"internal_server_error","param":null,"code":500}}',
+                "Internal server error",
+                500,
+                id="object-error",
+            ),
+            param(
+                'data: {"error":"Rate limit exceeded"}',
+                "Rate limit exceeded",
+                502,
+                id="string-error",
+            ),
+            param(
+                'data: {"error":42}',
+                "42",
+                502,
+                id="other-error",
+            ),
+            param(
+                'event: message\ndata: {"error":\ndata: {"message":"Service unavailable","code":503}}',
+                "Service unavailable",
+                503,
+                id="multiline-data-error",
+            ),
+        ],
+    )  # fmt: skip
+    def test_data_error_payload_raises(
+        self,
+        raw_message: str,
+        expected_error_text: str,
+        expected_error_code: int,
+        base_perf_ns: int,
+    ) -> None:
+        """Structured data error payloads raise with their message and code."""
+        message = SSEMessage.parse(raw_message, base_perf_ns)
+
+        with pytest.raises(SSEResponseError) as exc_info:
+            AsyncSSEStreamReader.inspect_message_for_error(message)
+
+        assert expected_error_text in str(exc_info.value)
+        assert exc_info.value.error_code == expected_error_code
 
     @pytest.mark.parametrize(
         "raw_message,expected_error_text",


### PR DESCRIPTION
## Summary

- detect OpenAI-compatible nested errors carried in SSE data payloads
- preserve named SSE error events and prefer their comments when present
- use structured data as the fallback message and code for named errors without comments
- ignore falsy error sentinels and preserve only HTTP error codes from 400 through 599
- avoid assembling normal multi-packet data during error inspection

## Why

[AIPerf PR #1173](https://github.com/ai-dynamo/aiperf/pull/1173) added an early return for the common single-data SSE shape. That fast path also skipped structured error payloads such as:

    data: {"error":{"message":"Internal server error","code":500}}

[Dynamo PR #8430](https://github.com/ai-dynamo/dynamo/pull/8430) intentionally adopted this OpenAI-compatible data-error envelope because many OpenAI clients ignore named SSE error events.

This PR makes AIPerf classify that in-band error as a failed request even when the HTTP response status is 200. It does not change non-SSE HTTP response handling or add historical flat error-envelope support.

The separate server-side response-loss fix remains in [Dynamo PR #13752](https://github.com/ai-dynamo/dynamo/pull/13752).

## Behavior

- null, false, empty string, empty object, empty list, and zero error values do not fail a request
- integer codes from 400 through 599 are preserved
- missing, Boolean, and out-of-range codes use 502
- a named error comment takes precedence over structured data
- a named error without a comment uses the structured data error before the unknown-error fallback
- normal single-data events stay on the no-JSON-decode fast path
- normal multi-packet events are scanned once and do not assemble their data during inspection

## Performance

A local before/after benchmark covered 256-event parse, inspect, and JSON-decode pipelines with 2,000 iterations and seven alternating repeats:

- single-data: 0.297101 s -> 0.310502 s (+4.51%)
- multi-packet: 0.795718 s -> 0.778335 s (-2.18%)

The benchmark script is worktree-local and is not part of this PR.

## Validation

- uv run pytest tests/unit/transports/test_sse_utils.py tests/unit/transports/test_aiohttp_client.py -n auto
  - 159 passed
- uv run pytest tests/unit/transports/ -n auto
  - 429 passed
- pre-commit run --all-files
  - passed
- git diff --check
  - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of structured errors returned within SSE data, including responses delivered with HTTP 200 status.
  * Displays server-provided error messages and error codes when available.
  * Uses a default 502 status when no valid error code is provided.
  * Preserves preceding stream messages when an error is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->