### PR TITLE
fix(tokenizer): load local paths in offline workers

### DIFF
--- a/src/aiperf/common/tokenizer.py
+++ b/src/aiperf/common/tokenizer.py
@@ -674,6 +674,10 @@ class Tokenizer:
         from huggingface_hub import snapshot_download
         from huggingface_hub.errors import LocalEntryNotFoundError
 
+        local_path = Path(name).expanduser()
+        if local_path.is_dir():
+            return str(local_path.resolve())
+
         candidates = [name]
         if "/" not in name:
             cached_alias = cls._find_cached_model_for_alias(name)

--- a/tests/unit/common/test_tokenizer_cache.py
+++ b/tests/unit/common/test_tokenizer_cache.py
@@ -124,6 +124,52 @@ class TestFindCachedModelForAlias:
         assert Tokenizer._find_cached_model_for_alias("gpt2") is None
 
 
+class TestLocalTokenizerDirectory:
+    def test_offline_load_bypasses_huggingface_snapshot_resolution(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tokenizer_dir = tmp_path / "tokenizer"
+        tokenizer_dir.mkdir()
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+
+        def unexpected_snapshot_download(*args: object, **kwargs: object) -> None:
+            pytest.fail("local tokenizer path must not use snapshot_download")
+
+        monkeypatch.setattr(
+            "huggingface_hub.snapshot_download", unexpected_snapshot_download
+        )
+        seen: dict[str, object] = {}
+
+        def fake_from_pretrained(
+            name_or_path: str, **kwargs: object
+        ) -> _FakeHfTokenizer:
+            seen["name_or_path"] = name_or_path
+            seen.update(kwargs)
+            return _FakeHfTokenizer()
+
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            side_effect=fake_from_pretrained,
+        ):
+            tokenizer = Tokenizer.from_pretrained(str(tokenizer_dir))
+
+        assert seen["name_or_path"] == str(tokenizer_dir.resolve())
+        assert tokenizer.resolved_name == str(tokenizer_dir)
+
+    def test_resolve_local_snapshot_expands_user_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tokenizer_dir = tmp_path / "tokenizer"
+        tokenizer_dir.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+        resolved = Tokenizer._resolve_local_snapshot("~/tokenizer", "main")
+
+        assert resolved == str(tokenizer_dir.resolve())
+
+
 class TestTokenizerOnlyRepoCacheLoad:
     """Regression: tokenizer-only HF repos lack ``config.json``.
 


### PR DESCRIPTION
## Summary

- recognize an existing local tokenizer directory before resolving Hugging Face cache snapshots
- preserve the existing Hugging Face repository/cache path for non-directory names
- add regression coverage for offline loading and tilde expansion

## Problem

AIPerf accepts either a Hugging Face identifier or a local filesystem path as `tokenizer.name`. Dataset conversion workers intentionally enable Hugging Face offline mode after parent-process validation. In that mode, `_resolve_local_snapshot` previously sent every tokenizer name through `huggingface_hub.snapshot_download`, including existing local directories.

As a result, a valid local tokenizer path could load in the parent process but fail when an offline conversion worker treated it as a Hub repository identifier.

## Fix

Return the resolved directory immediately when `name` points to an existing local directory. Otherwise, continue through the existing cached-Hugging-Face resolution logic unchanged.

## Validation

- `uv run pre-commit run --all-files`
- tokenizer unit tests on Python 3.11, 3.12, and 3.13: 22 passed on each version
- full Python 3.13 unit suite: 18,514 passed, 97 skipped, 3 xfailed; one unrelated Rich terminal-width assertion failed with the macOS temporary path and passed in isolation with a wider terminal
- component integration suite accounted for: 270 passed and 4 skipped in the original checkout; all 36 path-sensitive cases passed when rerun from a no-space worktree

This is a draft for final review before maintainer submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Offline tokenizer loading now supports existing local directories without attempting a remote download.
  - Local paths are resolved to absolute paths, including paths using `~`.
  - Tokenizer names are preserved when loading from local directories.

- **Tests**
  - Added coverage for local directory loading and user-directory path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->