### PR TITLE
fix: stop numpy.float64 from aborting search_history.json export (cherry-pick to release/0.13.0)

### DIFF
--- a/docs/dev/patterns.md
+++ b/docs/dev/patterns.md
@@ -357,8 +357,15 @@ def export_records_json(records: list[Record], out_path: Path) -> None:
 
 `scrub_non_finite` recursively walks `dict`/`list`/`tuple` containers and
 rewrites non-finite numeric values to `None`. It leaves `str`/`bytes`/`bool`
-alone and handles numpy scalar types correctly (`numpy.float32`,
-`numpy.float64`).
+alone and coerces numpy scalar types to native Python numbers
+(`numpy.float32`, `numpy.float64`, `numpy.int64`, ...).
+
+That coercion is load-bearing, not incidental: `orjson.dumps` **raises**
+`TypeError: Type is not JSON serializable: numpy.float64` rather than
+degrading, so a numpy scalar anywhere in a payload aborts the export and
+takes the run down with it. Any code that hands values to an exporter
+(planners, scorers, analysis helpers) should still return native floats —
+`scrub_non_finite` is the backstop, not the excuse.
 
 ### `is_finite_value` for the canonical finiteness check
 

--- a/src/aiperf/common/finite.py
+++ b/src/aiperf/common/finite.py
@@ -107,14 +107,17 @@ def scrub_non_finite(obj: Any) -> Any:
 
     Walks ``dict``, ``list``, and ``tuple`` containers; leaves ``str``,
     ``bytes``, and ``bytearray`` alone (a string literal ``"nan"`` is not a
-    numeric NaN and must not be rewritten). Coerces numpy floats correctly
-    by checking ``__float__`` and using ``float()`` directly (mirroring
-    :func:`is_finite_value`'s strategy) -- ``isinstance(x, float)`` would
-    miss ``numpy.float32``/``numpy.float64`` on some numpy versions.
+    numeric NaN and must not be rewritten). Numpy scalars are handled two
+    ways: ``numpy.float64`` subclasses ``float`` and is cast explicitly,
+    while every other numpy type (``numpy.float32``, ``numpy.int64``, ...)
+    reaches the duck-typed ``__float__``/``float()`` branch that mirrors
+    :func:`is_finite_value`'s strategy.
 
     Use before ``orjson.dumps`` on any payload that may contain metric
-    values. orjson 3.x silently coerces NaN/inf to JSON ``null`` which is
-    indistinguishable from explicit-None semantics in downstream tooling.
+    values. This is the guard for two distinct orjson behaviors: it
+    silently coerces NaN/inf to JSON ``null`` (indistinguishable from
+    explicit-None semantics downstream), and it raises outright on numpy
+    scalars ("Type is not JSON serializable: numpy.float64").
 
     The returned structure preserves the input container types (dict
     stays dict, tuple stays tuple); numpy scalars are coerced to Python
@@ -132,7 +135,15 @@ def scrub_non_finite(obj: Any) -> Any:
     if isinstance(obj, tuple):
         return tuple(scrub_non_finite(v) for v in obj)
     if isinstance(obj, float):
-        return obj if math.isfinite(obj) else None
+        if not math.isfinite(obj):
+            return None
+        # ``numpy.float64`` is the one numpy scalar type that subclasses
+        # ``float``, so it matches here instead of falling through to the
+        # duck-typed branch below that coerces every other numpy type.
+        # Returning it unconverted leaks it into orjson.dumps(), which
+        # rejects it outright ("Type is not JSON serializable"). float() is
+        # a no-op on an exact float -- CPython hands back the same object.
+        return float(obj)
     # Numpy scalar / other numeric: duck-typed ``float()`` coercion (same
     # strategy as is_finite_value). Non-numeric objects fall through unchanged.
     if hasattr(obj, "__float__") and not isinstance(obj, int):

--- a/src/aiperf/orchestrator/search_planner/optuna_planner.py
+++ b/src/aiperf/orchestrator/search_planner/optuna_planner.py
@@ -207,7 +207,13 @@ class OptunaSearchPlanner(SearchPlanner):
                     dim.path, int(dim.lo), int(dim.hi), log=log
                 )
             else:
-                v = trial.suggest_float(dim.path, dim.lo, dim.hi, log=log)
+                # BoTorch -- the default sampler -- suggests numpy.float64, and
+                # optuna only coerces to a native type for int distributions;
+                # FloatDistribution hands the sampler's scalar straight back.
+                # Unconverted it survives into the search history and blows up
+                # orjson.dumps() in write_search_history() with
+                # "Type is not JSON serializable: numpy.float64".
+                v = float(trial.suggest_float(dim.path, dim.lo, dim.hi, log=log))
             values[dim.path] = v
 
         # mode="python" + context={"include_secrets": True} so neither the

--- a/tests/unit/common/test_finite.py
+++ b/tests/unit/common/test_finite.py
@@ -145,8 +145,38 @@ def test_scrub_non_finite_numpy_scalars() -> None:
     assert out["f64_inf"] is None
     # finite numpy float coerced through the same path -> python float, finite
     assert out["f64_finite"] == pytest.approx(3.14)
+    assert type(out["f64_finite"]) is float
     # int passes through unchanged
     assert out["i64"] == np.int64(7)
+
+
+def test_scrub_non_finite_coerces_numpy_float64_to_native_float() -> None:
+    """numpy.float64 needs an explicit cast; every other numpy scalar gets one free.
+
+    numpy.float64 is the only numpy scalar type that subclasses Python
+    ``float``, so it matches the ``isinstance(obj, float)`` branch and would
+    otherwise be returned as-is instead of falling through to the duck-typed
+    ``float()`` coercion the other numpy types take.
+    """
+    out = scrub_non_finite({"v": np.float64(3.14)})
+    assert type(out["v"]) is float
+
+
+def test_scrub_non_finite_output_is_orjson_serializable_for_numpy_float64() -> None:
+    """scrub_non_finite is the pre-orjson guard, so its output must always dump.
+
+    orjson rejects numpy.float64 with "Type is not JSON serializable", which
+    aborts the exporter that called it (nvbugs 6683575).
+    """
+    import orjson
+
+    out = scrub_non_finite(
+        {"scalar": np.float64(3.14), "nested": [{"deep": np.float64(1.0)}]}
+    )
+    parsed = orjson.loads(orjson.dumps(out))
+
+    assert parsed["scalar"] == pytest.approx(3.14)
+    assert parsed["nested"][0]["deep"] == pytest.approx(1.0)
 
 
 def test_scrub_non_finite_does_not_recurse_into_str_bytes() -> None:

--- a/tests/unit/exporters/test_search_history_numpy_guard.py
+++ b/tests/unit/exporters/test_search_history_numpy_guard.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""search_history.json must survive numpy scalars reaching the exporter.
+
+``SearchIteration`` is a plain dataclass with ``variation_values:
+dict[str, Any]``, so nothing between a planner and the exporter coerces
+scalar types. Planners are expected to hand back native Python numbers,
+but the export boundary must not be the thing that fails when one
+doesn't -- ``scrub_non_finite`` is the guard that makes that true.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from aiperf.common.enums import OptimizationDirection
+from aiperf.config.sweep import (
+    AdaptiveSearchSweep,
+    Objective,
+    SearchSpaceDimension,
+)
+from aiperf.exporters.search_history import write_search_history
+from aiperf.orchestrator.search_planner.base import SearchIteration
+
+
+def _real_dim_cfg() -> AdaptiveSearchSweep:
+    return AdaptiveSearchSweep(
+        search_space=[
+            SearchSpaceDimension(path="endpoint.timeout", lo=1.0, hi=100.0, kind="real")
+        ],
+        objectives=[
+            Objective(
+                metric="output_token_throughput",
+                direction=OptimizationDirection.MAXIMIZE,
+            )
+        ],
+        max_iterations=10,
+    )
+
+
+def test_write_search_history_serializes_numpy_variation_values(tmp_path: Path) -> None:
+    """A numpy.float64 in variation_values must not abort the export.
+
+    Regression for nvbugs 6683575: orjson rejects numpy.float64 outright
+    ("Type is not JSON serializable: numpy.float64"), which failed the whole
+    run rather than just the export.
+    """
+    history = [
+        SearchIteration(
+            iteration_idx=0,
+            variation_values={"endpoint.timeout": np.float64(12.5)},
+            objective_value=np.float64(10.0),
+            objective_values=[np.float64(10.0)],
+            feasible=True,
+        )
+    ]
+
+    write_search_history(tmp_path, history, _real_dim_cfg())
+
+    payload = json.loads((tmp_path / "search_history.json").read_text())
+    assert payload["iterations"][0]["variation_values"][
+        "endpoint.timeout"
+    ] == pytest.approx(12.5)
+
+
+def test_write_search_history_maps_numpy_nan_objective_to_null(tmp_path: Path) -> None:
+    """A numpy NaN must land as JSON null, not as a coerced-but-unscrubbed value.
+
+    The guard has to preserve the module's NaN discipline: converting numpy
+    scalars without re-checking finiteness would let orjson turn a NaN into
+    ``null`` by its own silent coercion, which is right by accident here but
+    wrong for the "not scored" contract the exporter relies on.
+    """
+    history = [
+        SearchIteration(
+            iteration_idx=0,
+            variation_values={"endpoint.timeout": np.float64(12.5)},
+            objective_value=np.float64("nan"),
+            objective_values=[np.float64("nan")],
+            feasible=False,
+        )
+    ]
+
+    write_search_history(tmp_path, history, _real_dim_cfg())
+
+    payload = json.loads((tmp_path / "search_history.json").read_text())
+    assert payload["iterations"][0]["objective_values"] == [None]

--- a/tests/unit/orchestrator/search_planner/test_optuna_planner.py
+++ b/tests/unit/orchestrator/search_planner/test_optuna_planner.py
@@ -8,6 +8,8 @@ so only BoTorch-specific cases skip when that stack is unavailable.
 
 from __future__ import annotations
 
+import numpy as np
+import orjson
 import pytest
 from pytest import param
 
@@ -126,6 +128,41 @@ def _make_result(
     )
 
 
+class _NumpyScalarSampler(optuna.samplers.RandomSampler):
+    """Sampler that returns ``numpy.float64`` from float suggestions.
+
+    Stands in for BoTorchSampler without pulling in the torch/botorch stack.
+    Optuna's ``IntDistribution.to_external_repr`` coerces to native ``int``,
+    but ``FloatDistribution`` has no such coercion, so whatever scalar type
+    the sampler produces reaches the caller of ``suggest_float`` unchanged.
+    """
+
+    def sample_independent(self, study, trial, param_name, param_distribution):
+        value = super().sample_independent(study, trial, param_name, param_distribution)
+        if isinstance(param_distribution, optuna.distributions.FloatDistribution):
+            return np.float64(value)
+        return value
+
+
+@pytest.fixture
+def numpy_scalar_sampler(monkeypatch):
+    """Force the planner to build a sampler that emits numpy scalars."""
+    monkeypatch.setattr(
+        "aiperf.orchestrator.search_planner.optuna_planner.build_sampler",
+        lambda cfg: _NumpyScalarSampler(seed=42),
+    )
+
+
+def _real_dim_cfg() -> AdaptiveSearchSweep:
+    # endpoint.timeout is the float-typed path used by the other real-kind
+    # tests; phases.profiling.concurrency is int-typed in BenchmarkConfig.
+    return _cfg(
+        search_space=[
+            SearchSpaceDimension(path="endpoint.timeout", lo=1.0, hi=100.0, kind="real")
+        ]
+    )
+
+
 # ----------------------------------------------------------------------------
 # 1. Construction.
 # ----------------------------------------------------------------------------
@@ -210,6 +247,36 @@ def test_ask_float_dim_returns_float():
     proposed = variation.values["endpoint.timeout"]
     assert isinstance(proposed, float)
     assert 1.0 <= proposed <= 100.0
+
+
+def test_ask_real_dim_returns_native_float_when_sampler_emits_numpy(
+    numpy_scalar_sampler,
+) -> None:
+    """A numpy-emitting sampler must not leak numpy.float64 into variation values.
+
+    ``isinstance(np.float64(1.0), float)`` is True, so only an exact type check
+    catches this; orjson rejects the subclass even though isinstance passes.
+    """
+    planner = OptunaSearchPlanner(_base_config(), _real_dim_cfg())
+    proposal = planner.ask()
+    assert proposal is not None
+    _, variation = proposal
+    assert type(variation.values["endpoint.timeout"]) is float
+
+
+def test_history_variation_values_are_orjson_serializable_with_numpy_sampler(
+    numpy_scalar_sampler,
+) -> None:
+    """History must serialize with orjson so write_search_history() can export it."""
+    planner = OptunaSearchPlanner(_base_config(), _real_dim_cfg())
+    _, variation = planner.ask()
+    planner.tell(variation, [_make_result(variation, throughput=10.0, ttft_p95=50.0)])
+
+    encoded = orjson.dumps([h.variation_values for h in planner.history()])
+
+    assert orjson.loads(encoded)[0]["endpoint.timeout"] == pytest.approx(
+        variation.values["endpoint.timeout"]
+    )
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick of #1343 to `release/0.13.0`. Fixes nvbugs 6683575 (P0) / DYN-1022, which was filed against 0.13.0rc2.

## The bug

Adaptive search with a real-valued search space (`--search-space smoothness:0.5,2.0:real`) crashed the entire run at export time:

```
[AIPERF] TypeError: Type is not JSON serializable: numpy.float64
```

Integer-valued search spaces were unaffected, so the only workaround was to avoid real-valued dimensions entirely.

## The two commits

1. **`fix(search): cast Optuna float suggestions to native float`** — Optuna coerces int suggestions to native `int` via `IntDistribution.to_external_repr`, but `FloatDistribution` has no equivalent, so the sampler's scalar type reaches the caller of `suggest_float` unchanged. BoTorch, the default sampler, produces `numpy.float64`.

2. **`fix(finite): coerce numpy.float64 in scrub_non_finite`** — `numpy.float64` is the only numpy scalar type that subclasses Python `float`, so it matched the `isinstance(obj, float)` branch in the pre-`orjson.dumps` guard and returned early, never reaching the coercion every other numpy type takes. Commit 1 stops the planner producing the value; commit 2 closes the hole in the guard that should have caught it regardless of source.

## Backport fidelity

`git range-diff` against the original series on `main` shows the only delta is the cherry-pick trailers — **no code differences**:

```
1:  42d359b18 ! 1:  b66e2b935 fix(search): cast Optuna float suggestions to native float
    +    (cherry picked from commit 42d359b18a0b3c179f6147b6cec13a75d7e9484f)
2:  92e408660 ! 2:  9ff706eef fix(finite): coerce numpy.float64 in scrub_non_finite
    +    (cherry picked from commit 92e408660fa59a8cb218652bb8d776bd5b7dd196)
```

Both applied to `release/0.13.0` with no conflicts.

## Not included

The follow-up #1345 (`np.int64` -> `7.0`, `np.bool_` -> `1.0`) is deliberately excluded. It is a defensive fix with no known live trigger and it changes on-disk JSON representation, which does not belong in a release branch.

## Testing on this branch

- `uv run pytest tests/unit/ -n auto` -> 18399 passed, 93 skipped, 3 xfailed
- `pre-commit run --from-ref origin/release/0.13.0 --to-ref HEAD` -> all hooks pass

The regression tests drive a stand-in sampler that emits numpy scalars, so they run in CI rather than skipping like the existing BoTorch-dependent tests (the optional torch/botorch stack is not installed in unit CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)