### PR TITLE
feat(docs-e2e): add server tags for all 12 endpoint server types

### DIFF
--- a/docs/benchmark-modes/trace-replay.md
+++ b/docs/benchmark-modes/trace-replay.md
@@ -97,6 +97,7 @@ A few formats carry timing somewhere other than a top-level `timestamp` and are 
 
 To override the auto-promotion — for example, to replay the same trace under a fresh `--concurrency` or `--request-rate` setting and ignore the captured timestamps — pass `--no-fixed-schedule`:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \

--- a/docs/tutorials/anthropic-messages-endpoint.md
+++ b/docs/tutorials/anthropic-messages-endpoint.md
@@ -31,10 +31,29 @@ It supports streaming and non-streaming responses, text content, extended thinki
 
 ---
 
+## Prerequisites
+
+<!-- setup-anthropic-messages-endpoint-server -->
+```bash
+test -n "$ANTHROPIC_API_KEY" || { echo "ANTHROPIC_API_KEY is not set"; exit 1; }
+```
+<!-- /setup-anthropic-messages-endpoint-server -->
+
+<!-- health-check-anthropic-messages-endpoint-server -->
+```bash
+curl -sf "https://api.anthropic.com/v1/models" \
+    -H "x-api-key: $ANTHROPIC_API_KEY" \
+    -H "anthropic-version: 2023-06-01" > /dev/null || { echo "Anthropic API not reachable or key invalid"; exit 1; }
+```
+<!-- /health-check-anthropic-messages-endpoint-server -->
+
+---
+
 ## Basic Usage
 
 ### Non-Streaming
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 aiperf profile \
     --model claude-sonnet-4-20250514 \
@@ -49,6 +68,7 @@ aiperf profile \
 
 Enable streaming to measure time-to-first-token (TTFT) and inter-token latency (ITL):
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 aiperf profile \
     --model claude-sonnet-4-20250514 \
@@ -64,6 +84,7 @@ aiperf profile \
 
 Control input and output token distributions:
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 aiperf profile \
     --model claude-sonnet-4-20250514 \
@@ -83,6 +104,7 @@ aiperf profile \
 
 Add a shared system prompt across all requests using `--shared-system-prompt-length`. The system message is placed in the top-level `system` field (not in the messages array), matching the Anthropic API specification:
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 aiperf profile \
     --model claude-sonnet-4-20250514 \
@@ -221,6 +243,7 @@ A typical streaming sequence:
 
 The Anthropic Messages endpoint uses `x-api-key` header authentication (not `Authorization: Bearer`):
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 aiperf profile \
     --model claude-sonnet-4-20250514 \
@@ -231,6 +254,7 @@ aiperf profile \
 
 The endpoint also sets the `anthropic-version: 2023-06-01` header by default. To override it or add beta headers (e.g., for extended thinking), use `--header`:
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 aiperf profile \
     --model claude-sonnet-4-20250514 \
@@ -248,6 +272,7 @@ Custom headers are merged with the defaults. If you provide `anthropic-version` 
 
 Pass additional API parameters with `--extra-inputs`:
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 aiperf profile \
     --model claude-sonnet-4-20250514 \
@@ -277,6 +302,7 @@ These are merged directly into the request payload, producing:
 
 ### Single-Turn with Custom Prompts
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 cat > prompts.jsonl << 'EOF'
 {"text": "Explain the theory of relativity."}
@@ -297,6 +323,7 @@ aiperf profile \
 
 ### Multi-Turn Conversations
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 cat > conversations.jsonl << 'EOF'
 {"session_id": "s1", "turns": [{"text": "What is Rust?"}, {"text": "Compare it to C++."}]}
@@ -320,6 +347,7 @@ aiperf profile \
 
 To use token counts reported by the server (from `usage` fields) instead of client-side tokenization:
 
+<!-- aiperf-run-anthropic-messages-endpoint-server -->
 ```bash
 aiperf profile \
     --model claude-sonnet-4-20250514 \

--- a/docs/tutorials/asr.md
+++ b/docs/tutorials/asr.md
@@ -54,7 +54,7 @@ curl -s localhost:8000/v1/chat/completions \
 
 LibriSpeech is the standard read-speech benchmark and requires no authentication:
 
-<!-- aiperf-run-vllm-audio-openai-endpoint-server-asr -->
+<!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-Audio-7B-Instruct \
@@ -65,7 +65,7 @@ aiperf profile \
     --request-count 10 \
     --concurrency 4
 ```
-<!-- /aiperf-run-vllm-audio-openai-endpoint-server-asr -->
+<!-- /aiperf-run-vllm-audio-openai-endpoint-server -->
 
 **Sample Output:**
 
@@ -114,6 +114,7 @@ aiperf profile \
 
 VoxPopuli contains European Parliament recordings and requires no authentication:
 
+<!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-Audio-7B-Instruct \
@@ -131,6 +132,7 @@ aiperf profile \
 
 AMI contains meeting recordings with individual headset microphone audio and requires no authentication:
 
+<!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-Audio-7B-Instruct \
@@ -149,6 +151,7 @@ aiperf profile \
 GigaSpeech is a multi-domain corpus covering audiobooks, podcasts, and YouTube. It requires a
 HuggingFace account and acceptance of the [dataset terms](https://huggingface.co/datasets/speechcolab/gigaspeech):
 
+<!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 uv run hf auth login
 
@@ -169,6 +172,7 @@ aiperf profile \
 SPGISpeech contains financial earnings call recordings. It requires a HuggingFace account and
 acceptance of the [dataset terms](https://huggingface.co/datasets/kensho/spgispeech):
 
+<!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 uv run hf auth login
 

--- a/docs/tutorials/goodput.md
+++ b/docs/tutorials/goodput.md
@@ -86,6 +86,7 @@ The fraction is in `[0.0, 1.0]`. Errors land in the denominator on purpose: a ba
 
 The same `--goodput` invocation that produces `goodput` also produces `good_request_fraction` — no extra flag is required:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     -m Qwen/Qwen3-0.6B \

--- a/docs/tutorials/gpu-telemetry.md
+++ b/docs/tutorials/gpu-telemetry.md
@@ -146,6 +146,7 @@ echo "DCGM GPU metrics are now available"
 
 ## Run AIPerf Benchmark
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -337,6 +338,7 @@ echo "DCGM GPU metrics are now available"
 
 ## Run AIPerf Benchmark
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -384,6 +386,7 @@ For simple local GPU monitoring without DCGM infrastructure, AIPerf supports dir
 
 ## Run AIPerf with pynvml
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -452,6 +455,7 @@ For inference workloads on **AMD Instinct GPUs** (MI300X, MI355X, etc.), use `--
 
 ### Run AIPerf with amdsmi
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model meta-llama/Llama-3.1-8B-Instruct \
@@ -497,6 +501,7 @@ AMD signals are emitted under their own vendor-namespaced field names (not alias
 
 For distributed setups with multiple nodes, you can collect GPU telemetry from all nodes simultaneously:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Example: Collecting telemetry from 3 nodes in a distributed setup
 # Note: The default endpoints http://localhost:9400/metrics and http://localhost:9401/metrics

--- a/docs/tutorials/huggingface-tgi.md
+++ b/docs/tutorials/huggingface-tgi.md
@@ -91,6 +91,7 @@ EOF
 ```
 Then run:
 
+<!-- aiperf-run-tgi-default-endpoint-server -->
 ```bash
 aiperf profile \
     -m TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
@@ -156,6 +157,7 @@ EOF
 
 Then run:
 
+<!-- aiperf-run-tgi-default-endpoint-server -->
 ```bash
 aiperf profile \
     -m TinyLlama/TinyLlama-1.1B-Chat-v1.0 \

--- a/docs/tutorials/huggingface-tgi.md
+++ b/docs/tutorials/huggingface-tgi.md
@@ -21,19 +21,20 @@ TGI exposes two standard HTTP endpoints for text generation:
 
 To launch a Hugging Face TGI server, use the official `ghcr.io` image:
 
+<!-- setup-tgi-default-endpoint-server -->
 ```bash
 docker run --gpus all --rm -it \
   -p 8080:80 \
   -e MODEL_ID=TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   ghcr.io/huggingface/text-generation-inference:latest
 ```
+<!-- /setup-tgi-default-endpoint-server -->
 
+<!-- health-check-tgi-default-endpoint-server -->
 ```bash
-# Verify the server is running
-curl -s http://localhost:8080/generate \
-  -H "Content-Type: application/json" \
-  -d '{"inputs":"Hello world"}' | jq
+timeout 900 bash -c 'while ! curl -sf http://localhost:8080/generate -H "Content-Type: application/json" -d "{\"inputs\":\"Hello world\"}" > /dev/null; do sleep 2; done' || { echo "TGI not ready after 15min"; exit 1; }
 ```
+<!-- /health-check-tgi-default-endpoint-server -->
 
 ## Profile with AIPerf
 
@@ -44,6 +45,7 @@ and with either synthetic inputs or a custom input file.
 
 #### Profile with synthetic inputs
 
+<!-- aiperf-run-tgi-default-endpoint-server -->
 ```bash
 aiperf profile \
     -m TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
@@ -105,6 +107,7 @@ When the `--streaming` flag is enabled, AIPerf automatically sends requests to t
 
 #### Profile with synthetic inputs
 
+<!-- aiperf-run-tgi-default-endpoint-server -->
 ```bash
 aiperf profile \
     -m TinyLlama/TinyLlama-1.1B-Chat-v1.0 \

--- a/docs/tutorials/image-generation.md
+++ b/docs/tutorials/image-generation.md
@@ -4,6 +4,31 @@
 sidebar-title: SGLang Image Generation
 ---
 
+<!-- setup-sglang-image-generation-endpoint-server -->
+```bash
+docker run --gpus all --rm \
+  --name sglang-image-generation \
+  -p 30000:30000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  --env HF_TOKEN \
+  lmsysorg/sglang:dev \
+  bash -c "pip install -q yunchang remote_pdb imageio diffusers diffusion && \
+    python -m sglang.launch_server \
+      --model-path black-forest-labs/FLUX.1-schnell \
+      --text-encoder-cpu-offload \
+      --pin-cpu-memory \
+      --num-gpus 1 \
+      --port 30000 \
+      --host 0.0.0.0"
+```
+<!-- /setup-sglang-image-generation-endpoint-server -->
+
+<!-- health-check-sglang-image-generation-endpoint-server -->
+```bash
+timeout 900 bash -c 'while ! curl -sf http://localhost:30000/v1/models 2>/dev/null | grep -q "id"; do sleep 5; done' || { echo "SGLang image server not ready after 15min"; exit 1; }
+```
+<!-- /health-check-sglang-image-generation-endpoint-server -->
+
 # Profile Image Generation Models with AIPerf
 
 ## Overview
@@ -85,6 +110,7 @@ EOF
 ```
 
 **Run the benchmark:**
+<!-- aiperf-run-sglang-image-generation-endpoint-server -->
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.1-dev \
@@ -116,6 +142,7 @@ aiperf profile \
 
 
 ### Text-to-Image Generation Using Synthetic Inputs
+<!-- aiperf-run-sglang-image-generation-endpoint-server -->
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.1-dev \
@@ -176,6 +203,7 @@ EOF
 > [!WARNING]
 > Use `--export-level raw` to get the raw input/output payloads.
 
+<!-- aiperf-run-sglang-image-generation-endpoint-server -->
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.1-dev \

--- a/docs/tutorials/multi-run-confidence.md
+++ b/docs/tutorials/multi-run-confidence.md
@@ -78,6 +78,7 @@ aiperf profile --output-artifact-dir ./run3 --ui dashboard ...
 
 Run the same benchmark 5 times:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model llama-3-8b \
@@ -93,6 +94,7 @@ aiperf profile \
 
 Use 99% confidence intervals instead of the default 95%:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model llama-3-8b \
@@ -109,6 +111,7 @@ aiperf profile \
 
 Add a 10-second cooldown between runs to reduce correlation:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model llama-3-8b \

--- a/docs/tutorials/multi-url-load-balancing.md
+++ b/docs/tutorials/multi-url-load-balancing.md
@@ -15,6 +15,7 @@ AIPerf supports distributing requests across multiple inference server instances
 
 Specify multiple `--url` options to enable load balancing:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server weight=120 -->
 ```bash
 # Round-robin across two servers
 aiperf profile --model llama \
@@ -48,6 +49,7 @@ INFO     Results saved to: artifacts/llama-chat-rate20/
 JSON Export: artifacts/llama-chat-rate20/profile_export_aiperf.json
 ```
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server weight=120 -->
 ```bash
 # Multi-GPU scaling on a single node
 aiperf profile --model llama \
@@ -92,6 +94,7 @@ Currently supported strategies:
 
 You can explicitly set the strategy with `--url-strategy`:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server weight=120 -->
 ```bash
 aiperf profile --model llama \
     --url http://server1:8000 \

--- a/docs/tutorials/nim-image-retrieval.md
+++ b/docs/tutorials/nim-image-retrieval.md
@@ -30,6 +30,7 @@ echo "$NGC_API_KEY" | docker login nvcr.io --username '$oauthtoken' --password-s
 
 Launch the NIM for Object Detection (page elements):
 
+<!-- setup-nim-image-retrieval-endpoint-server -->
 ```bash
 export NIM_MODEL_NAME=nvidia/nemoretriever-page-elements-v3
 export CONTAINER_NAME=$(basename $NIM_MODEL_NAME)
@@ -47,12 +48,15 @@ docker run -it --rm --name=$CONTAINER_NAME \
   -p 8000:8000 \
   $IMG_NAME
 ```
+<!-- /setup-nim-image-retrieval-endpoint-server -->
 
 Wait for the server to start, then verify it is ready:
 
+<!-- health-check-nim-image-retrieval-endpoint-server -->
 ```bash
-curl -s http://localhost:8000/v1/health/ready
+timeout 900 bash -c 'while ! curl -sf http://localhost:8000/v1/health/ready; do sleep 2; done' || { echo "NIM not ready after 15min"; exit 1; }
 ```
+<!-- /health-check-nim-image-retrieval-endpoint-server -->
 
 ### Verify with a Test Request
 
@@ -113,6 +117,7 @@ Each line should contain an `image` field with either:
 
 Run AIPerf against the image retrieval endpoint:
 
+<!-- aiperf-run-nim-image-retrieval-endpoint-server -->
 ```bash
 aiperf profile \
     --endpoint-type image_retrieval \
@@ -160,6 +165,7 @@ cat <<EOF > multi_image_inputs.jsonl
 EOF
 ```
 
+<!-- aiperf-run-nim-image-retrieval-endpoint-server -->
 ```bash
 aiperf profile \
     --endpoint-type image_retrieval \
@@ -179,6 +185,7 @@ When sending multiple images per request, the image throughput metric reflects t
 
 Use `--extra-inputs` to pass additional parameters to the NIM endpoint:
 
+<!-- aiperf-run-nim-image-retrieval-endpoint-server -->
 ```bash
 aiperf profile \
     --endpoint-type image_retrieval \

--- a/docs/tutorials/openai-responses.md
+++ b/docs/tutorials/openai-responses.md
@@ -56,6 +56,7 @@ curl -s http://localhost:8000/v1/responses \
 
 Run AIPerf against the Responses API endpoint using synthetic inputs:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -124,6 +125,7 @@ aiperf profile \
 
 In the Responses API, system instructions use a top-level `instructions` field rather than a system role message. AIPerf handles this mapping automatically when you use `--shared-system-prompt-length` to generate a synthetic system prompt:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -145,6 +147,7 @@ This generates a synthetic system prompt of approximately 50 tokens and places i
 
 Profile vision-capable models with synthetic images:
 
+<!-- aiperf-run-vllm-vision-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -167,6 +170,7 @@ Image inputs are formatted as `{"type": "input_image", "image_url": "<url>"}` in
 
 Profile audio-capable models with the Responses API:
 
+<!-- aiperf-run-vllm-audio-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2.5-Omni-3B \
@@ -190,6 +194,7 @@ See the [Audio](audio.md) tutorial for details on audio input configuration and 
 
 Run without streaming to get full responses:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -210,6 +215,7 @@ aiperf profile \
 
 Control load generation the same way as other endpoint types:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 # Concurrency-based
 aiperf profile \
@@ -238,6 +244,7 @@ aiperf profile \
 
 Benchmark multi-turn conversations using the Responses API:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -259,6 +266,7 @@ See the [Multi-Turn Conversations](multi-turn.md) tutorial for details on conver
 
 Use server-reported token counts instead of client-side tokenization:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \
@@ -278,6 +286,7 @@ When `--use-server-token-count` is enabled with streaming, AIPerf automatically 
 
 Pass additional API parameters using `--extra-inputs`:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \

--- a/docs/tutorials/prefill-concurrency.md
+++ b/docs/tutorials/prefill-concurrency.md
@@ -83,6 +83,7 @@ This means:
 
 Benchmark with 16K token prompts, limiting how many can prefill simultaneously:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2.5-7B-Instruct \
@@ -129,6 +130,7 @@ JSON Export: artifacts/Qwen_Qwen2.5-7B-Instruct-chat-concurrency30/profile_expor
 
 Ramp prefill concurrency gradually to observe how TTFT changes as queue depth increases:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2.5-7B-Instruct \
@@ -184,6 +186,7 @@ Prefill Concurrency
 
 Prefill concurrency works with all scheduling modes:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2.5-7B-Instruct \

--- a/docs/tutorials/rankings.md
+++ b/docs/tutorials/rankings.md
@@ -91,6 +91,7 @@ EOF
 ```
 
 Run AIPerf using the following command:
+<!-- aiperf-run-tei-rerank-endpoint-server -->
 ```bash
 aiperf profile \
     -m BAAI/bge-reranker-base \
@@ -150,6 +151,7 @@ EOF
 
 Run AIPerf:
 
+<!-- aiperf-run-cohere-rerank-endpoint-server -->
 ```bash
 aiperf profile \
     -m BAAI/bge-reranker-v2-m3 \

--- a/docs/tutorials/rankings.md
+++ b/docs/tutorials/rankings.md
@@ -18,6 +18,7 @@ These models take a query and one or more passages, returning a similarity or re
 
 Launch a Hugging Face Text Embeddings Inference (TEI) container in re-ranker mode:
 
+<!-- setup-tei-rerank-endpoint-server -->
 ```bash
 docker run --gpus all --rm -it \
   -p 8080:80 \
@@ -25,17 +26,18 @@ docker run --gpus all --rm -it \
   ghcr.io/huggingface/text-embeddings-inference:latest \
   --model-id BAAI/bge-reranker-base --port 80
 ```
+<!-- /setup-tei-rerank-endpoint-server -->
 
+<!-- health-check-tei-rerank-endpoint-server -->
 ```bash
-# Verify server is running
-curl -s http://localhost:8080/rerank \
-  -H "Content-Type: application/json" \
-  -d '{"query":"What is AI?", "texts":["AI is artificial intelligence.","Bananas are yellow."]}' | jq
+timeout 900 bash -c 'while ! curl -sf http://localhost:8080/rerank -H "Content-Type: application/json" -d "{\"query\":\"What is AI?\",\"texts\":[\"AI is artificial intelligence.\"]}" > /dev/null; do sleep 2; done' || { echo "TEI not ready after 15min"; exit 1; }
 ```
+<!-- /health-check-tei-rerank-endpoint-server -->
 
 ### Profile using Synthetic Inputs
 
 Run AIPerf using the following command:
+<!-- aiperf-run-tei-rerank-endpoint-server -->
 ```bash
 aiperf profile \
     -m BAAI/bge-reranker-base \
@@ -105,6 +107,7 @@ aiperf profile \
 
 Run vLLM with the `--runner` pooling flag to enable reranking behavior:
 
+<!-- setup-cohere-rerank-endpoint-server -->
 ```bash
 docker run --gpus all -p 8080:8000 \
   -e HF_TOKEN=<HF_TOKEN> \
@@ -112,17 +115,18 @@ docker run --gpus all -p 8080:8000 \
   --model BAAI/bge-reranker-v2-m3 \
   --runner pooling
 ```
+<!-- /setup-cohere-rerank-endpoint-server -->
 
+<!-- health-check-cohere-rerank-endpoint-server -->
 ```bash
-# Verify the server
-curl -s http://localhost:8080/v1/rerank \
-  -H "Content-Type: application/json" \
-  -d '{"query":"What is AI?","documents":["Artificial intelligence overview","Bananas are yellow"]}' | jq
+timeout 900 bash -c 'while ! curl -sf http://localhost:8080/v1/rerank -H "Content-Type: application/json" -d "{\"query\":\"What is AI?\",\"documents\":[\"AI overview\"]}" > /dev/null; do sleep 2; done' || { echo "Cohere rerank server not ready after 15min"; exit 1; }
 ```
+<!-- /health-check-cohere-rerank-endpoint-server -->
 
 ### Profile using Synthetic Inputs
 Run AIPerf using the following command:
 
+<!-- aiperf-run-cohere-rerank-endpoint-server -->
 ```bash
 aiperf profile \
     -m BAAI/bge-reranker-v2-m3 \

--- a/docs/tutorials/raw-payload-replay.md
+++ b/docs/tutorials/raw-payload-replay.md
@@ -83,6 +83,7 @@ Auto-detection rejects records that contain a `conversation_id` key or a `data` 
 
 ### Single File
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 cat > payloads.jsonl << 'EOF'
 {"messages": [{"role": "user", "content": "What is machine learning?"}], "model": "Qwen/Qwen3-0.6B", "max_tokens": 100}
@@ -112,6 +113,7 @@ aiperf profile \
 
 ### Directory for Multi-Turn Conversations
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 mkdir -p conversations/
 

--- a/docs/tutorials/sequence-distributions.md
+++ b/docs/tutorials/sequence-distributions.md
@@ -22,6 +22,7 @@ with different ISL and OSL pairings.
 
 Add variance to make workloads more realistic:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen3-0.6B \

--- a/docs/tutorials/sglang-image-edit.md
+++ b/docs/tutorials/sglang-image-edit.md
@@ -73,6 +73,7 @@ Uvicorn running on http://0.0.0.0:30000 (Press CTRL+C to quit)
 ### Image Edit Using Synthetic Reference Images
 The simplest path: AIPerf generates a synthetic reference image for every request and pairs it with a synthetic prompt. The mock image bytes are uploaded as the multipart `image` field — the server processes the request end-to-end just like a real one.
 
+<!-- aiperf-run-sglang-image-generation-endpoint-server -->
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.2-klein-4B \
@@ -120,6 +121,7 @@ EOF
 ```
 
 **Run the benchmark:**
+<!-- aiperf-run-sglang-image-generation-endpoint-server -->
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.2-klein-4B \
@@ -154,6 +156,7 @@ Image edit shares its metric set with image generation; both endpoints report im
 
 Use `--export-level raw` to capture the raw input/output payloads, which lets you extract the edited images afterwards.
 
+<!-- aiperf-run-sglang-image-generation-endpoint-server -->
 ```bash
 aiperf profile \
   --model black-forest-labs/FLUX.2-klein-4B \

--- a/docs/tutorials/sglang-video-generation.md
+++ b/docs/tutorials/sglang-video-generation.md
@@ -4,6 +4,33 @@
 sidebar-title: SGLang Video Generation
 ---
 
+<!-- setup-sglang-video-generation-endpoint-server -->
+```bash
+docker run --gpus all --rm \
+  --name sglang-video-generation \
+  --shm-size 32g \
+  -p 30010:30010 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  --env HF_TOKEN \
+  --ipc=host \
+  lmsysorg/sglang:dev \
+  bash -c "uv pip install 'sglang[diffusion]' --prerelease=allow --system && \
+    sglang serve \
+      --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+      --text-encoder-cpu-offload \
+      --pin-cpu-memory \
+      --num-gpus 1 \
+      --port 30010 \
+      --host 0.0.0.0"
+```
+<!-- /setup-sglang-video-generation-endpoint-server -->
+
+<!-- health-check-sglang-video-generation-endpoint-server -->
+```bash
+timeout 900 bash -c 'while ! curl -sf http://localhost:30010/health > /dev/null 2>&1; do sleep 5; done' || { echo "SGLang video server not ready after 15min"; exit 1; }
+```
+<!-- /health-check-sglang-video-generation-endpoint-server -->
+
 # SGLang Video Generation
 
 ## Overview
@@ -144,6 +171,7 @@ EOF
 ```
 
 **Run the benchmark:**
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
@@ -177,6 +205,7 @@ aiperf profile \
 
 Generate videos using synthetic prompts with configurable token lengths:
 
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
@@ -210,6 +239,7 @@ Control video generation through `--extra-inputs`:
 
 Use `--download-video-content` to include video content download in the benchmark timing. When enabled, request latency includes the time to download the generated video from the server. By default, only generation time is measured.
 
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
@@ -226,6 +256,7 @@ aiperf profile \
 ```
 
 **Example with advanced parameters:**
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
@@ -253,6 +284,7 @@ AIPerf automatically handles polling for video generation. Configure polling beh
 | `AIPERF_HTTP_VIDEO_POLL_INTERVAL` | Seconds between status checks (0.1-60) | `0.1` |
 
 **Example with custom timeout and polling interval:**
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 # Set slower polling (0.5s) with 20 minute timeout
 AIPERF_HTTP_VIDEO_POLL_INTERVAL=0.5 aiperf profile \
@@ -274,6 +306,7 @@ AIPERF_HTTP_VIDEO_POLL_INTERVAL=0.5 aiperf profile \
 To extract and save the generated videos, use `--export-level raw` to capture the full response payloads.
 
 **Run the benchmark with raw export:**
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
@@ -363,6 +396,7 @@ Videos saved to: /path/to/downloaded_videos
 
 Test maximum throughput with multiple concurrent requests:
 
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 aiperf profile \
     --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
@@ -380,6 +414,7 @@ aiperf profile \
 
 Test single-request latency for different video sizes:
 
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 # Short 4-second video
 aiperf profile \
@@ -410,6 +445,7 @@ aiperf profile \
 
 Compare generation quality at different inference step counts:
 
+<!-- aiperf-run-sglang-video-generation-endpoint-server weight=300 -->
 ```bash
 # Fast generation (fewer steps)
 aiperf profile \

--- a/docs/tutorials/spec-decode-metrics.md
+++ b/docs/tutorials/spec-decode-metrics.md
@@ -77,6 +77,7 @@ No spec-decode-specific flag is required -- run a normal profile. Add `--export-
 records` if you want the per-request acceptance struct in the records trace (see
 [Per-request trace](#per-request-trace) below):
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model meta-llama/Llama-3.1-8B-Instruct \

--- a/docs/tutorials/synthetic-video.md
+++ b/docs/tutorials/synthetic-video.md
@@ -50,6 +50,7 @@ The synthetic video feature provides:
 
 Generate videos at 640x480 with default temporal settings (4 fps, 5 seconds):
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -97,6 +98,7 @@ JSON Export: artifacts/your-model-name-chat-concurrency1/profile_export_aiperf.j
 
 Control the resolution of generated videos:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -111,6 +113,7 @@ aiperf profile \
 
 Adjust temporal properties:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -135,6 +138,7 @@ AIPerf supports three built-in video patterns:
 
 Generates videos with animated geometric shapes moving across the screen:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -156,6 +160,7 @@ Features:
 
 Generates videos with a grid pattern and clock-like animation:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -177,6 +182,7 @@ Features:
 
 Generates videos with random noise pixels in each frame:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -211,6 +217,7 @@ Choose encoding codec based on your hardware and requirements.
 
 #### CPU Encoding (Default)
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -233,6 +240,7 @@ aiperf profile \
 
 For faster encoding with NVIDIA GPUs, using an FFmpeg built with NVENC:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -252,6 +260,7 @@ aiperf profile \
 
 Control the number of videos per request:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -273,6 +282,7 @@ Audio embedding is disabled by default to maintain backward compatibility and mi
 
 Set `--video-audio-num-channels` to 1 (mono) or 2 (stereo) to embed an audio track:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -313,6 +323,7 @@ When `--video-audio-codec` is not specified, the codec is automatically selected
 
 You can override the auto-selection with an explicit codec:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -328,6 +339,7 @@ aiperf profile \
 
 #### Stereo Audio with Custom Sample Rate
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -366,6 +378,7 @@ For most benchmarking scenarios, the audio track adds minimal overhead compared 
 
 Benchmark with small, low-framerate videos:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -386,6 +399,7 @@ aiperf profile \
 
 Test with high-resolution, longer videos:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -406,6 +420,7 @@ aiperf profile \
 
 Combine video with text prompts for multimodal testing:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -428,6 +443,7 @@ aiperf profile \
 
 Benchmark models that process both video and audio streams:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -449,6 +465,7 @@ aiperf profile \
 
 Test with MP4 format and stereo audio for maximum compatibility:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -472,6 +489,7 @@ aiperf profile \
 
 Test with many short video clips:
 
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -495,6 +513,7 @@ aiperf profile \
 AIPerf supports both **WebM** (default) and **MP4** formats:
 
 **WebM format (default):**
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \
@@ -508,6 +527,7 @@ aiperf profile \
 ```
 
 **MP4 format:**
+<!-- aiperf-run-vllm-video-openai-endpoint-server -->
 ```bash
 aiperf profile \
     --model Qwen/Qwen2-VL-2B-Instruct \

--- a/docs/tutorials/timeslices.md
+++ b/docs/tutorials/timeslices.md
@@ -53,6 +53,7 @@ timeout 900 bash -c 'while [ "$(curl -s -o /dev/null -w "%{http_code}" localhost
 
 Run a 60-second benchmark with 10-second slices to analyze performance trends:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model Qwen/Qwen3-0.6B \

--- a/docs/tutorials/tracelab-trace.md
+++ b/docs/tutorials/tracelab-trace.md
@@ -51,6 +51,7 @@ zcat syfi_coding_trace.jsonl.gz | head -20000 | gzip > tracelab_slice.jsonl.gz
 
 ## Profile
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model Qwen/Qwen3-0.6B \

--- a/docs/tutorials/ui-types.md
+++ b/docs/tutorials/ui-types.md
@@ -47,6 +47,7 @@ The full-featured TUI provides:
 - Worker status monitoring
 - Interactive display with multiple tabs
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model Qwen/Qwen3-0.6B \
@@ -69,6 +70,7 @@ aiperf profile \
 
 Lightweight progress bars using TQDM:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model Qwen/Qwen3-0.6B \
@@ -102,6 +104,7 @@ INFO     Results saved to: artifacts/Qwen_Qwen3-0.6B-chat-concurrency10/
 
 Shows application logs only, no progress UI. This is the automatic default when output is piped or redirected:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model Qwen/Qwen3-0.6B \

--- a/docs/tutorials/yaml-config.md
+++ b/docs/tutorials/yaml-config.md
@@ -18,6 +18,7 @@ You don't need to choose between the two: CLI flags still work, and they layer o
 
 A typical concurrency sweep on the command line looks like this:
 
+<!-- aiperf-run-vllm-default-openai-endpoint-server -->
 ```bash
 aiperf profile \
   --model meta-llama/Llama-3.1-8B-Instruct \


### PR DESCRIPTION
## Summary

- Sweeps all docs for untagged `aiperf profile` commands and adds discovery tags for the docs E2E test system
- Adds `<!-- setup-{server}-endpoint-server -->`, `<!-- health-check-{server}-endpoint-server -->`, and `<!-- aiperf-run-{server}-endpoint-server -->` tags across all tutorial files
- Covers 12 endpoint server types: `vllm-default-openai`, `vllm-audio-openai`, `vllm-video-openai`, `vllm-vision-openai`, `vllm-embeddings-openai`, `tgi-default`, `tei-rerank`, `cohere-rerank`, `sglang-image-generation`, `sglang-video-generation`, `nim-image-retrieval`, `anthropic-messages`
- 150 total tagged aiperf commands discovered by the parser across all server types

## Test plan

- [ ] Parser: 12 servers, all `setup=True, health=True`
- [ ] `uv run pytest tests/ci/test_docs_end_to_end/ -m docs_e2e --collect-only --docs-e2e-local-dev` — 150 tests collected
- [ ] `uv run pytest tests/unit/ -n auto` — 18481 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)