### PR TITLE
fix(cli): run DatasetResolver in multi-run probe

### DIFF
--- a/src/aiperf/cli_runner/_multi_run.py
+++ b/src/aiperf/cli_runner/_multi_run.py
@@ -164,7 +164,11 @@ def _estimate_and_log_duration(
 ) -> Path:
     """Resolve artifact/timing for a probe run, log duration, return base_dir."""
     from aiperf.config import BenchmarkRun
-    from aiperf.config.resolution.resolvers import ArtifactDirResolver, TimingResolver
+    from aiperf.config.resolution.resolvers import (
+        ArtifactDirResolver,
+        DatasetResolver,
+        TimingResolver,
+    )
 
     probe_run = BenchmarkRun(
         benchmark_id="probe",
@@ -173,6 +177,7 @@ def _estimate_and_log_duration(
         variables=dict(plan.variables),
     )
     ArtifactDirResolver().resolve(probe_run, for_probe=True)
+    DatasetResolver().resolve(probe_run)
     TimingResolver().resolve(probe_run)
 
     per_run_duration = probe_run.resolved.total_expected_duration


### PR DESCRIPTION
The multi-run duration-estimate probe ran only ArtifactDir + Timing resolvers, but DatasetResolver is what populates `dataset_has_timing_data`. So any `fixed_schedule` phase under a multi-run (sweep, or numRuns > 1) crashed before launch:

```bash
Phase 'profiling' uses fixed_schedule, but could not verify timing data for dataset 'main'
```

Minimal repro

```json5
// trace.jsonl
{"chat_id": 1, "parent_chat_id": -1, "timestamp": 0.0, "input_length": 64, "output_length": 32, "type": "text", "turn": 1, "hash_ids": [1]}
{"chat_id": 2, "parent_chat_id": -1, "timestamp": 10.0, "input_length": 64, "output_length": 32, "type": "text", "turn": 1, "hash_ids": [2]}
```
```yaml
schemaVersion: "2.0"
randomSeed: 42
multiRun:
  numRuns: 2
benchmark:
  model: test-model
  endpoint:
    url: http://localhost:8000/v1/chat/completions
    type: chat
    streaming: true
  datasets:
    - name: main
      type: file
      path: ./trace.jsonl
      format: bailian_trace
  phases:
    - name: profiling
      type: fixed_schedule
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-run duration estimates by resolving dataset configuration before timing calculations.
  * Ensured probe-run setup consistently accounts for the selected dataset when estimating execution time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->