### PR TITLE
fix(plot): clarify pareto frontier connectors (cherry-pick to release/0.13.0)

### DIFF
--- a/src/aiperf/plot/core/plot_generator.py
+++ b/src/aiperf/plot/core/plot_generator.py
@@ -712,6 +712,24 @@ class PlotGenerator:
 
         # Apply NVIDIA branding layout
         layout = self._get_base_layout(title, x_label, y_label)
+        layout["margin"]["b"] = max(layout["margin"].get("b", 0), 120)
+        pareto_note = {
+            "x": 0.5,
+            "y": 0,
+            "xref": "paper",
+            "yref": "paper",
+            "yshift": -65,
+            "text": "Lines connect Pareto frontier points only; other points remain markers.",
+            "showarrow": False,
+            "font": {
+                "size": 11,
+                "family": PLOT_FONT_FAMILY,
+                "color": self.colors["secondary"],
+            },
+            "xanchor": "center",
+            "yanchor": "top",
+        }
+        layout["annotations"] = list(layout.get("annotations", [])) + [pareto_note]
         fig.update_layout(layout)
 
         return fig

--- a/tests/unit/plot/test_plot_generator.py
+++ b/tests/unit/plot/test_plot_generator.py
@@ -179,6 +179,179 @@ class TestPlotGenerator:
         assert "Time to First Token" in fig.layout.xaxis.title.text
         assert "Inter Token Latency" in fig.layout.yaxis.title.text
 
+    def test_scatter_line_connects_all_points_in_concurrency_groups(
+        self, plot_generator: PlotGenerator
+    ) -> None:
+        """Test non-Pareto scatter_line plots connect every point in a group."""
+        df = pd.DataFrame(
+            {
+                "model": ["model-a", "model-b", "model-c", "model-d", "model-e"],
+                "concurrency": [50, 50, 50, 50, 50],
+                "time_to_first_token": [52000, 6000, 18000, 34000, 44000],
+                "request_throughput": [25, 123, 88, 61, 42],
+            }
+        )
+
+        fig = plot_generator.create_scatter_line_plot(
+            df=df,
+            x_metric="time_to_first_token",
+            y_metric="request_throughput",
+            label_by="model",
+            group_by="concurrency",
+        )
+
+        main_trace = fig.data[1]
+        assert main_trace.mode == "lines+markers+text"
+        assert main_trace.name == "50"
+        assert list(main_trace.x) == [6000, 18000, 34000, 44000, 52000]
+        assert list(main_trace.y) == [123, 88, 61, 42, 25]
+
+    def test_configured_concurrency_groups_use_clean_legend_names(
+        self, plot_generator: PlotGenerator
+    ) -> None:
+        """Test labels and groups stay distinct for custom multi-run plots."""
+        df = pd.DataFrame(
+            {
+                "model": ["model-a", "model-b"] * 3,
+                "concurrency": [1, 1, 10, 10, 50, 50],
+                "request_latency": [9000, 4000, 16000, 5000, 52000, 6000],
+                "output_token_throughput_per_gpu": [3, 7, 16, 56, 25, 123],
+            }
+        )
+
+        fig = plot_generator.create_pareto_plot(
+            df=df,
+            x_metric="request_latency",
+            y_metric="output_token_throughput_per_gpu",
+            label_by="model",
+            group_by="concurrency",
+        )
+
+        legend_traces = [trace for trace in fig.data if trace.showlegend]
+        assert [trace.name for trace in legend_traces] == ["1", "10", "50"]
+        assert [list(trace.text) for trace in legend_traces] == [
+            ["model-b", "model-a"],
+            ["model-b", "model-a"],
+            ["model-b", "model-a"],
+        ]
+
+    def test_pareto_plot_concurrency_groups_only_connect_frontier(
+        self, plot_generator: PlotGenerator
+    ) -> None:
+        """Test concurrency-grouped Pareto plots still connect only frontier points."""
+        df = pd.DataFrame(
+            {
+                "model": ["model-a", "model-b", "model-c", "model-d", "model-e"],
+                "concurrency": [50, 50, 50, 50, 50],
+                "request_latency": [52000, 6000, 18000, 34000, 44000],
+                "output_token_throughput_per_gpu": [25, 80, 123, 61, 42],
+            }
+        )
+
+        fig = plot_generator.create_pareto_plot(
+            df=df,
+            x_metric="request_latency",
+            y_metric="output_token_throughput_per_gpu",
+            label_by="model",
+            group_by="concurrency",
+        )
+
+        main_line_trace = fig.data[1]
+        assert main_line_trace.mode == "lines"
+        assert main_line_trace.name is None
+        assert list(main_line_trace.x) == [6000, 18000]
+        assert list(main_line_trace.y) == [80, 123]
+        assert len(fig.layout.annotations) == 1
+        pareto_note = fig.layout.annotations[0]
+        assert (
+            pareto_note.text
+            == "Lines connect Pareto frontier points only; other points remain markers."
+        )
+        assert pareto_note.y == 0
+        assert pareto_note.yshift == -65
+        assert fig.layout.margin.b >= 120
+
+    def test_pareto_plot_experiment_group_only_connects_frontier(
+        self, plot_generator: PlotGenerator
+    ) -> None:
+        """Test classification-style experiment groups stay true Pareto plots."""
+        df = pd.DataFrame(
+            {
+                "model": ["model-a", "model-b", "model-c", "model-d", "model-e"],
+                "experiment_group": ["concurrency_50"] * 5,
+                "request_latency": [52000, 6000, 18000, 34000, 44000],
+                "output_token_throughput_per_gpu": [25, 80, 123, 61, 42],
+            }
+        )
+
+        fig = plot_generator.create_pareto_plot(
+            df=df,
+            x_metric="request_latency",
+            y_metric="output_token_throughput_per_gpu",
+            label_by="model",
+            group_by="experiment_group",
+        )
+
+        main_line_trace = fig.data[1]
+        assert main_line_trace.mode == "lines"
+        assert list(main_line_trace.x) == [6000, 18000]
+        assert list(main_line_trace.y) == [80, 123]
+
+    def test_pareto_plot_swept_request_rate_only_connects_frontier(
+        self, plot_generator: PlotGenerator
+    ) -> None:
+        """Test other swept groupings also preserve Pareto-frontier connectors."""
+        df = pd.DataFrame(
+            {
+                "model": ["model-a", "model-b", "model-c", "model-d", "model-e"] * 2,
+                "request_rate": [5] * 5 + [25] * 5,
+                "request_latency": [52000, 6000, 18000, 34000, 44000] * 2,
+                "output_token_throughput_per_gpu": [25, 80, 123, 61, 42] * 2,
+            }
+        )
+
+        fig = plot_generator.create_pareto_plot(
+            df=df,
+            x_metric="request_latency",
+            y_metric="output_token_throughput_per_gpu",
+            label_by="model",
+            group_by="request_rate",
+        )
+
+        main_lines = [
+            trace
+            for trace in fig.data
+            if trace.mode == "lines" and not trace.showlegend and trace.line.width == 3
+        ]
+        assert [list(trace.x) for trace in main_lines] == [[6000, 18000], [6000, 18000]]
+        assert [list(trace.y) for trace in main_lines] == [[80, 123], [80, 123]]
+
+    def test_pareto_plot_default_model_groups_only_connect_frontier(
+        self, plot_generator: PlotGenerator
+    ) -> None:
+        """Test default Pareto grouping preserves frontier-only connector lines."""
+        df = pd.DataFrame(
+            {
+                "model": ["model-a"] * 5,
+                "concurrency": [10, 20, 30, 40, 50],
+                "request_latency": [52000, 6000, 18000, 34000, 44000],
+                "output_token_throughput_per_gpu": [25, 80, 123, 61, 42],
+            }
+        )
+
+        fig = plot_generator.create_pareto_plot(
+            df=df,
+            x_metric="request_latency",
+            y_metric="output_token_throughput_per_gpu",
+            label_by="concurrency",
+            group_by="model",
+        )
+
+        main_line_trace = fig.data[1]
+        assert main_line_trace.mode == "lines"
+        assert list(main_line_trace.x) == [6000, 18000]
+        assert list(main_line_trace.y) == [80, 123]
+
     def test_create_time_series_scatter(self, plot_generator, single_run_df):
         """Test time series scatter plot creation."""
         fig = plot_generator.create_time_series_scatter(

--- a/tests/unit/plot/test_png_exporter.py
+++ b/tests/unit/plot/test_png_exporter.py
@@ -792,6 +792,72 @@ class TestMultiRunPNGExporter:
         assert df["concurrency"].tolist() == [1, 4]
         assert df["request_latency"].tolist() == [100.0, 150.0]  # p50 values
 
+    def test_concurrency_group_legend_uses_metadata_not_run_name(
+        self, multi_run_exporter, tmp_path: Path
+    ) -> None:
+        """Regression: run-name prefixes must not leak into concurrency legends."""
+        models = ["Qwen/Qwen3-32B-FP8", "Llama-3.3-70B-Instruct-FP8-dynamic"]
+        runs = []
+        for concurrency in [1, 10, 50]:
+            for index, model in enumerate(models):
+                safe_model = model.replace("/", "_")
+                runs.append(
+                    RunData(
+                        metadata=RunMetadata(
+                            run_name=f"{safe_model}-openai-chat-concurrency{concurrency}",
+                            run_path=tmp_path
+                            / f"{safe_model}-openai-chat-concurrency{concurrency}",
+                            model=model,
+                            concurrency=concurrency,
+                        ),
+                        requests=None,
+                        aggregated={
+                            "request_latency": {
+                                "avg": 1000.0 * concurrency + index,
+                                "unit": "ms",
+                            },
+                            "output_token_throughput_per_gpu": {
+                                "avg": 100.0 / concurrency + index,
+                                "unit": "tokens/s/gpu",
+                            },
+                        },
+                        timeslices=None,
+                        slice_duration=None,
+                    )
+                )
+
+        df = multi_run_exporter._runs_to_dataframe(
+            runs, {"display_names": {}, "units": {}}
+        )
+        spec = PlotSpec(
+            name="pareto_by_concurrency",
+            plot_type=PlotType.PARETO,
+            metrics=[
+                MetricSpec(
+                    name="request_latency", source=DataSource.AGGREGATED, axis="x"
+                ),
+                MetricSpec(
+                    name="output_token_throughput_per_gpu",
+                    source=DataSource.AGGREGATED,
+                    axis="y",
+                ),
+            ],
+            title="Pareto by Concurrency",
+            filename="pareto_by_concurrency.png",
+            label_by="model",
+            group_by="concurrency",
+        )
+
+        fig = multi_run_exporter._create_plot_from_spec(
+            spec, df, {"display_names": {}, "units": {}}
+        )
+
+        legend_traces = [trace for trace in fig.data if trace.showlegend]
+        assert [trace.name for trace in legend_traces] == ["1", "10", "50"]
+        assert all(
+            "openai-chat-concurrency" not in trace.name for trace in legend_traces
+        )
+
 
 class TestSingleRunPNGExporter:
     """Tests for SingleRunPNGExporter class."""


### PR DESCRIPTION
## Summary
- Cherry-pick of `04802735f` from `main` into `release/0.13.0`
- Original PR: #1344 — fix(plot): clarify pareto frontier connectors

## Conflicts
None — clean cherry-pick.

## Validation
- Not run in the release worktree. `make first-time-setup` failed twice before cherry-pick because GitHub returned 503 while pre-commit tried to fetch `https://github.com/pre-commit/pre-commit-hooks/`.
- User will run pre-commit/checks locally.