### PR TITLE
fix(test-harness): implement num_prompt_special_tokens on FakeTokenizer (cherry-pick to release/0.13.0)

### DIFF
--- a/tests/harness/fake_tokenizer.py
+++ b/tests/harness/fake_tokenizer.py
@@ -66,3 +66,6 @@ class FakeTokenizer:
     @property
     def block_separation_token_id(self) -> int:
         return 1
+
+    def num_prompt_special_tokens(self) -> int:
+        return 0


### PR DESCRIPTION
## Summary
- Cherry-pick of `9b60a3d479` from `main` into `release/0.13.0`
- Original PR: #1322 — fix(test-harness): implement num_prompt_special_tokens on FakeTokenizer

## Conflicts
None — clean cherry-pick onto prerequisite base.

## Stack
This is PR 4 of 6. Merge after #1377, #1378, and #1371.
1. #1377 — #1245 (mmap thread-safety)
2. #1378 — #1274 (random_pool batch-size)
3. #1371 — #1280 (config flag routing)
4. **This PR** — #1322 (FakeTokenizer)
5. #1375 — #1347 (stateful responses / previous_response_id)
6. #1379 — combined #1325+#1326 (k8s-native)