### PR TITLE
feat: Support stateful responses API with previous_response_id chaining (cherry-pick to release/0.13.0)

### DIFF
--- a/docs/tutorials/openai-responses.md
+++ b/docs/tutorials/openai-responses.md
@@ -234,7 +234,7 @@ aiperf profile \
 
 ---
 
-## Multi-Turn Conversations
+## Multi-Turn Conversations & Stateful Chaining
 
 Benchmark multi-turn conversations using the Responses API:
 
@@ -250,6 +250,61 @@ aiperf profile \
     --output-tokens-mean 200 \
     --url localhost:8000
 ```
+
+### Stateful Chaining with `previous_response_id`
+
+Stateful chaining is **opt-in and driven by requesting storage**. Enable it with:
+
+```bash
+--extra-inputs '{"store": true}'
+```
+
+`store` is a *request* parameter, not a standard field of the Responses object,
+so AIPerf keys chaining off the storage you requested rather than off an echoed
+response field — the OpenAI spec does not include `store` on the response, and
+servers such as vLLM's agentic-api accept it on the request but never serialize
+it back. (If a server *does* echo `store: true` on the response object, that is
+honored too.)
+
+Some backends also require a server-side flag (e.g. vLLM with
+`VLLM_ENABLE_RESPONSES_API_STORE=1`) to actually persist responses. If the
+server does not persist a requested response, the next chained request fails
+against the missing `previous_response_id`; use a storing backend when enabling
+this feature.
+
+> **Startup requirement:** requesting `store: true` on `--endpoint-type responses`
+> is rejected at startup unless [`--use-server-token-count`](#server-token-counts)
+> is also set. Chaining sends only the newest turn on the wire, so client-side ISL
+> would undercount the server-side prompt; server-reported token counts are the
+> only accurate source. Add `--use-server-token-count`, or drop `store: true` to
+> keep sending the full history client-side.
+
+When chaining is active with `--endpoint-type responses`:
+- On **Turn 0**, AIPerf sends the initial prompt and captures the server-generated `response.id` (e.g. `resp_<hash>`) from the response object — because `store: true` was requested for the run.
+- On **Turn 1+**, AIPerf sets `previous_response_id: <resp_id>` and sends only the single newest turn in the `input` array rather than re-sending the entire accumulated conversation history.
+
+**Scope:** chaining is applied only in the default delta context mode
+(`deltas_without_responses`), where the newest turn is a genuine delta. The
+`*_with_responses` context modes carry full per-turn history and are left
+unchained to avoid sending the conversation twice.
+
+Chaining is also limited to the session-driven request path. Pre-encoded
+datasets (`--input-file` payloads sent verbatim) bypass session tracking, so
+their requests are sent exactly as authored and are never chained — author
+`previous_response_id` into those payloads yourself if you need it.
+
+The startup requirement above inspects the endpoint-level `--extra-inputs`. If
+`store: true` is instead supplied per turn (via a dataset row's `extra`),
+it cannot be seen at startup, but chaining still triggers the one-time runtime
+warning that client-side ISL undercounts the server-side prompt — enable
+`--use-server-token-count` in that case too.
+
+> **Input Sequence Length note:** because a chained turn only puts the newest turn
+> on the wire (the prior history lives server-side), the default client-side ISL
+> reflects just that turn and undercounts the prompt the server actually prefills.
+> Use [`--use-server-token-count`](#server-token-counts) for accurate multi-turn
+> ISL when chaining is enabled. AIPerf emits a one-time warning if chaining runs
+> without it.
 
 See the [Multi-Turn Conversations](multi-turn.md) tutorial for details on conversation control parameters.
 
@@ -348,10 +403,13 @@ For reference, AIPerf processes these Responses API streaming events:
 
 | Event Type | Data Extracted |
 |---|---|
+| `response.created` | Server-generated response ID (`resp_<hash>`) for stateful session chaining |
 | `response.output_text.delta` | Text content delta |
 | `response.reasoning_text.delta` | Reasoning content delta |
+| `response.function_call_arguments.delta` | Tool call arguments delta |
 | `response.output_text.done` | Final text (fallback for providers that emit text only in done events) |
-| `response.completed` | Usage statistics |
+| `response.completed` | Usage statistics and response ID |
 | All other events | Skipped |
 
 This enables accurate measurement of TTFT, ITL, and token throughput metrics when streaming is enabled.
+

--- a/src/aiperf/common/models/record_models.py
+++ b/src/aiperf/common/models/record_models.py
@@ -1032,6 +1032,11 @@ class RequestInfo(RecordContext):
         description="Index of the URL to use when multiple --url values are configured. "
         "None means use the default (first) URL. Used for round-robin load balancing.",
     )
+    previous_response_id: str | None = Field(
+        default=None,
+        description="Response ID from the previous turn (e.g. 'resp_<hash>') "
+        "used for stateful chaining in the Responses API.",
+    )
 
 
 class RequestRecord(AIPerfBaseModel):

--- a/src/aiperf/common/utils.py
+++ b/src/aiperf/common/utils.py
@@ -25,6 +25,15 @@ def is_tty() -> bool:
     return sys.stdout is not None and getattr(sys.stdout, "isatty", lambda: False)()
 
 
+def is_truthy_flag(value: Any) -> bool:
+    """Whether a config/extra value represents a truthy boolean flag.
+
+    ``--extra-inputs`` values may arrive as a real bool or as a string
+    (e.g. ``store:true``), so accept ``True`` and case-insensitive ``"true"``.
+    """
+    return value is True or (isinstance(value, str) and value.strip().lower() == "true")
+
+
 async def call_all_functions_self(
     self_: object, funcs: list[Callable], *args, **kwargs
 ) -> None:

--- a/src/aiperf/config/endpoint.py
+++ b/src/aiperf/config/endpoint.py
@@ -26,6 +26,7 @@ from aiperf.common.enums import (
     ModelSelectionStrategy,
     RequestContentType,
 )
+from aiperf.common.utils import is_truthy_flag
 from aiperf.config.base import BaseConfig
 from aiperf.config.control_hooks import (
     ResetKvCacheConfig,
@@ -572,6 +573,32 @@ class EndpointConfig(BaseConfig):
                 "--per-chunk-usage requires --streaming "
                 "(continuous_usage_stats and inter-token latency apply only to "
                 "streaming responses)"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_responses_store_requires_server_token_count(self) -> Self:
+        """Require server token counts when Responses stateful storage is requested.
+
+        Passing ``store: true`` via ``--extra-inputs`` opts the Responses API into
+        server-side persistence, which enables ``previous_response_id`` chaining:
+        prior turns live server-side and only the newest turn is sent on the wire.
+        Client-side ISL (the default) then reflects only that newest turn and
+        undercounts the combined prompt the model actually prefills. The true count
+        is only recoverable from the server's ``usage.prompt_tokens``, so require
+        ``--use-server-token-count``.
+        """
+        if (
+            self.type == EndpointType.RESPONSES
+            and is_truthy_flag(self.extra.get("store"))
+            and not self.use_server_token_count
+        ):
+            raise ValueError(
+                "Responses endpoint with --extra-inputs store:true enables "
+                "previous_response_id chaining, which sends only the newest turn "
+                "on the wire; client-side Input Sequence Length would undercount "
+                "the server-side prompt. Add --use-server-token-count so ISL comes "
+                "from the server's usage.prompt_tokens, or remove store:true."
             )
         return self
 

--- a/src/aiperf/endpoints/_openai_responses_replay.py
+++ b/src/aiperf/endpoints/_openai_responses_replay.py
@@ -38,10 +38,26 @@ _FAILURE_EVENT_TYPES = frozenset(
     {"response.failed", "response.incomplete", "response.error", "error"}
 )
 
+# Terminal failure states on a Response object itself (non-streaming body, or
+# the nested ``response`` of a streaming lifecycle event). Streaming carries
+# these as ``type`` events (above); a non-streaming HTTP 200 body carries no
+# ``type`` and instead reports the failure via top-level ``status``.
+_FAILURE_STATUSES = frozenset({"failed", "incomplete"})
+
 
 def is_failure_event(json_obj: JsonObject) -> bool:
     """True when ``json_obj`` is a Responses-API stream-end failure event."""
     return json_obj.get("type") in _FAILURE_EVENT_TYPES
+
+
+def is_failure_status(response_obj: JsonObject) -> bool:
+    """True when a Response object reports a terminal failure via ``status``.
+
+    Non-streaming responses return HTTP 200 with a body such as
+    ``{"status": "failed", ...}`` and no ``type`` field, so ``is_failure_event``
+    does not catch them. This inspects the object's own ``status``.
+    """
+    return response_obj.get("status") in _FAILURE_STATUSES
 
 
 def collect_response_items(

--- a/src/aiperf/endpoints/base_endpoint.py
+++ b/src/aiperf/endpoints/base_endpoint.py
@@ -86,6 +86,14 @@ class BaseEndpoint(AIPerfLoggerMixin, ABC):
         record._parsed_responses_cache = parsed_responses
         return parsed_responses
 
+    def extract_response_id(self, record: RequestRecord) -> str | None:
+        """Extract server-generated response ID for stateful session chaining.
+
+        Default returns None (stateless). Subclasses implementing stateful protocols
+        (e.g. ResponsesEndpoint) override this.
+        """
+        return None
+
     def process_responses(
         self,
         record: RequestRecord,

--- a/src/aiperf/endpoints/openai_responses.py
+++ b/src/aiperf/endpoints/openai_responses.py
@@ -18,6 +18,7 @@ from aiperf.common.models import (
     Turn,
 )
 from aiperf.common.types import JsonObject
+from aiperf.common.utils import is_truthy_flag
 from aiperf.endpoints import _openai_responses_replay as _replay
 from aiperf.endpoints.base_endpoint import BaseEndpoint
 
@@ -189,15 +190,20 @@ class ResponsesEndpoint(BaseEndpoint):
         # lives in top-level ``instructions``. The per-conversation
         # ``user_context_message`` is prepended as a leading user item.
         input_items: list[dict[str, Any]] = []
-        if request_info.user_context_message:
-            input_items.append(
-                {
-                    "type": "message",
-                    "role": self.DEFAULT_TURN_ROLE,
-                    "content": request_info.user_context_message,
-                }
-            )
-        input_items.extend(self.build_messages(turns))
+        if request_info.previous_response_id:
+            # Stateful chaining: previous_response_id points to server-side history.
+            self._warn_chaining_isl_once()
+            input_items.extend(self.build_messages([turns[-1]]))
+        else:
+            if request_info.user_context_message:
+                input_items.append(
+                    {
+                        "type": "message",
+                        "role": self.DEFAULT_TURN_ROLE,
+                        "content": request_info.user_context_message,
+                    }
+                )
+            input_items.extend(self.build_messages(turns))
 
         # Conversation-level fields walk turns from the end so FORK-mode
         # children whose final turn lacks model/tools still inherit the parent's
@@ -211,6 +217,9 @@ class ResponsesEndpoint(BaseEndpoint):
             "model": model_name or model_endpoint.primary_model_name,
             "stream": model_endpoint.endpoint.streaming,
         }
+        if request_info.previous_response_id:
+            payload["previous_response_id"] = request_info.previous_response_id
+
         for key, value in (
             ("instructions", request_info.system_message or None),
             ("max_output_tokens", max_tokens),
@@ -228,6 +237,84 @@ class ResponsesEndpoint(BaseEndpoint):
 
         self.trace(lambda: f"Formatted payload: {payload}")
         return payload
+
+    _warned_chaining_isl: bool = False
+
+    def _warn_chaining_isl_once(self) -> None:
+        """Warn once that chained turns only send the newest turn on the wire.
+
+        With ``previous_response_id`` the prior history lives server-side, so
+        client-side Input Sequence Length (the default) reflects only the newest
+        turn and undercounts the prompt the server actually prefills. Server-side
+        token counts (``use_server_token_count``) report the true prompt size.
+        """
+        if (
+            self._warned_chaining_isl
+            or self.model_endpoint.endpoint.use_server_token_count
+        ):
+            return
+        self._warned_chaining_isl = True
+        self.warning(
+            "Stateful Responses chaining is active (previous_response_id): only "
+            "the newest turn is sent on the wire, so client-side Input Sequence "
+            "Length undercounts the server-side prompt for chained turns. Enable "
+            "--use-server-token-count for accurate multi-turn ISL."
+        )
+
+    def extract_response_id(self, record: RequestRecord) -> str | None:
+        """Extract the server-generated response ID (``resp_<hash>``) for stateful
+        chaining, but only when storage was requested for this run.
+
+        ``store`` is a *request* parameter, not a standard field of the Responses
+        object: the OpenAI spec does not list it on the response, and real
+        servers (e.g. vLLM's agentic-api) accept it on the request but never
+        serialize it back onto ``response.created`` / ``response.completed``.
+        Gating on the echoed response ``store`` therefore never fires against
+        those servers and silently disables chaining. We instead chain when
+        storage was requested via ``--extra-inputs store:true`` (endpoint
+        ``extra``); a server that *does* echo ``store: true`` is honored too.
+        When neither is set we return ``None`` so the caller falls back to
+        sending the full history.
+
+        The response object lives under ``response`` for streaming lifecycle
+        events (``response.created`` / ``response.completed`` / ...) and at the
+        top level for a non-streaming response body.
+
+        A request that returns HTTP 200 but fails does not set
+        ``RequestRecord.error``. Streaming signals this via a
+        ``response.failed`` / ``response.incomplete`` event; a non-streaming
+        body signals it via top-level ``status``. In either case the advertised
+        id belongs to an aborted response, so chaining onto it would corrupt the
+        next turn and we return ``None`` regardless of the advertised id.
+        """
+        store_requested = self._store_requested()
+        resp_id: str | None = None
+        for response in record.responses:
+            json_obj = response.get_json()
+            if not isinstance(json_obj, dict):
+                continue
+            if _replay.is_failure_event(json_obj):
+                return None
+            nested = json_obj.get("response")
+            source = nested if isinstance(nested, dict) else json_obj
+            if _replay.is_failure_status(source):
+                return None
+            candidate = source.get("id")
+            if not (isinstance(candidate, str) and candidate):
+                continue
+            if store_requested or source.get("store"):
+                resp_id = candidate
+        return resp_id
+
+    def _store_requested(self) -> bool:
+        """Whether the run requested server-side storage via endpoint ``extra``.
+
+        ``EndpointInfo.extra`` is a list of ``(key, value)`` pairs; ``store`` may
+        arrive as a bool or a string depending on how ``--extra-inputs`` was
+        supplied.
+        """
+        store = dict(self.model_endpoint.endpoint.extra or []).get("store")
+        return is_truthy_flag(store)
 
     @staticmethod
     def _maybe_enable_usage_stream_options(

--- a/src/aiperf/workers/session_manager.py
+++ b/src/aiperf/workers/session_manager.py
@@ -95,6 +95,11 @@ class UserSession(AIPerfBaseModel):
         "find any children to pin yet — orchestrator dispatches them on "
         "the credit-return path AFTER this terminal eviction runs).",
     )
+    previous_response_id: str | None = Field(
+        default=None,
+        description="Response ID from the previous turn (e.g. 'resp_<hash>') "
+        "used for stateful chaining in the Responses API.",
+    )
 
     def advance_turn(self, turn_index: int) -> Turn:
         """Append the next turn onto ``turn_list`` and return it.
@@ -124,6 +129,12 @@ class UserSession(AIPerfBaseModel):
             )
 
         turn = self.conversation.turns[turn_index]
+        # A context reset must always break the server-side chain: chaining onto a
+        # previous_response_id would retain history the reset is meant to discard.
+        # Clearing is the safe direction (falls back to sending full history).
+        if turn.reset_context:
+            self.previous_response_id = None
+
         if self.context_mode == ConversationContextMode.MESSAGE_ARRAY_WITH_RESPONSES:
             self.turn_list = [turn]
         else:
@@ -161,6 +172,10 @@ class UserSession(AIPerfBaseModel):
         Store the response for the turn.
         """
         self.turn_list.append(response_turn)
+
+    def store_response_id(self, response_id: str | None) -> None:
+        """Store the response ID from the server for stateful chaining."""
+        self.previous_response_id = response_id
 
 
 class UserSessionManager:
@@ -326,6 +341,12 @@ class UserSessionManager:
         assistant responses) into the child so that the request-builder
         prepends the full parent context before the child's own messages.
 
+        The parent's ``previous_response_id`` is copied too so a FORK child
+        continues the server-side Responses chain instead of replaying
+        history: replay drops filtered outputs (e.g. reasoning items) that
+        only survive server-side, so a child that lost the chain would lack
+        equivalent parent context.
+
         No-op (with a debug-friendly silent return) if either session is
         already evicted — the FORK-pin refcount usually keeps the parent
         resident, but late-arriving children may race past eviction. The
@@ -337,6 +358,7 @@ class UserSessionManager:
         if parent is None or child is None:
             return
         child.turn_list = list(parent.turn_list)
+        child.previous_response_id = parent.previous_response_id
 
     def release_fork_child(self, x_correlation_id: str) -> None:
         """Decrement the FORK-pin refcount on the session, floored at 0.

--- a/src/aiperf/workers/worker.py
+++ b/src/aiperf/workers/worker.py
@@ -1225,6 +1225,23 @@ class Worker(BaseComponentService, ProcessHealthMixin):
         )
         if assistant_turn is not None:
             session.store_response(assistant_turn)
+        # Response-ID chaining is only coherent for the mode that captures live
+        # responses and accumulates genuine deltas (DELTAS_WITHOUT_RESPONSES).
+        # In the *_WITH_RESPONSES modes ``turns[-1]`` already carries the full
+        # authored history, so chaining would double the context on the wire.
+        # A failed turn may still emit a ``response.created`` id for a partial or
+        # aborted response; chaining onto it would corrupt the server context, so
+        # keep the last good id (from a prior successful turn) instead.
+        if (
+            not record.has_error
+            and session.should_store_response()
+            and (
+                extract_response_id := getattr(
+                    self.inference_client.endpoint, "extract_response_id", None
+                )
+            )
+        ):
+            session.store_response_id(extract_response_id(record))
         self._populate_response_metrics(credit_context, record, parsed_responses)
 
     def _populate_response_metrics(
@@ -1523,6 +1540,7 @@ class Worker(BaseComponentService, ProcessHealthMixin):
             source_inner_idx=source_turn.source_inner_idx if source_turn else None,
             source_kind=source_turn.source_kind if source_turn else None,
             turns=turns,
+            previous_response_id=session.previous_response_id if session else None,
             drop_perf_ns=credit_context.drop_perf_ns,
             credit_issued_ns=credit.issued_at_ns,
             system_message=system_message,

--- a/tests/unit/config/test_endpoint.py
+++ b/tests/unit/config/test_endpoint.py
@@ -92,6 +92,53 @@ def test_per_chunk_usage_with_server_token_count_is_valid() -> None:
     assert endpoint.per_chunk_usage is True
 
 
+@pytest.mark.parametrize(
+    "store_value",
+    [
+        param(True, id="bool_true"),
+        param("True", id="str_true_capitalized"),
+    ],
+)  # fmt: skip
+def test_responses_store_true_requires_server_token_count(store_value) -> None:
+    with pytest.raises(ValueError, match="Add --use-server-token-count"):
+        EndpointConfig(
+            urls=["http://localhost:8000"],
+            type=EndpointType.RESPONSES,
+            extra={"store": store_value},
+            use_server_token_count=False,
+        )
+
+
+def test_responses_store_true_with_server_token_count_is_valid() -> None:
+    endpoint = EndpointConfig(
+        urls=["http://localhost:8000"],
+        type=EndpointType.RESPONSES,
+        extra={"store": True},
+        use_server_token_count=True,
+    )
+    assert endpoint.extra["store"] is True
+
+
+@pytest.mark.parametrize(
+    "endpoint_type,extra",
+    [
+        param(EndpointType.RESPONSES, {"store": False}, id="responses_store_false"),
+        param(EndpointType.RESPONSES, {}, id="responses_no_store"),
+        param(EndpointType.CHAT, {"store": True}, id="chat_store_true"),
+    ],
+)  # fmt: skip
+def test_store_gate_does_not_reject_when_chaining_inactive(
+    endpoint_type, extra
+) -> None:
+    endpoint = EndpointConfig(
+        urls=["http://localhost:8000"],
+        type=endpoint_type,
+        extra=extra,
+        use_server_token_count=False,
+    )
+    assert endpoint.type == endpoint_type
+
+
 def _make_model_endpoint(
     base_url: str, transport: TransportType | None = None
 ) -> ModelEndpointInfo:

--- a/tests/unit/endpoints/conftest.py
+++ b/tests/unit/endpoints/conftest.py
@@ -63,6 +63,7 @@ def create_request_info(
     system_message: str | None = None,
     user_context_message: str | None = None,
     cache_bust_target: CacheBustTarget | None = None,
+    previous_response_id: str | None = None,
     **turn_kwargs,
 ) -> RequestInfo:
     """Helper to create RequestInfo with all required fields.
@@ -95,6 +96,7 @@ def create_request_info(
         system_message=system_message,
         user_context_message=user_context_message,
         cache_bust_target=cache_bust_target,
+        previous_response_id=previous_response_id,
     )
 
 

--- a/tests/unit/endpoints/test_responses_endpoint.py
+++ b/tests/unit/endpoints/test_responses_endpoint.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import orjson
 import pytest
 from pytest import param
 
@@ -12,7 +13,12 @@ from aiperf.common.models.model_endpoint_info import (
     ModelInfo,
     ModelListInfo,
 )
-from aiperf.common.models.record_models import ReasoningResponseData, TextResponseData
+from aiperf.common.models.record_models import (
+    ReasoningResponseData,
+    RequestRecord,
+    TextResponse,
+    TextResponseData,
+)
 from aiperf.common.models.usage_models import Usage
 from aiperf.endpoints.openai_responses import ResponsesEndpoint
 from aiperf.plugin.enums import EndpointType
@@ -451,6 +457,7 @@ class TestResponsesEndpoint:
         assert payload["input"][1]["role"] == "assistant"
         assert payload["input"][2]["content"] == "Third"
         assert payload["model"] == "m3"
+        assert "previous_response_id" not in payload
 
     def test_format_payload_filters_empty_multimodal_content(
         self, endpoint, model_endpoint
@@ -960,3 +967,239 @@ class TestResponsesBuildMessagesResetContext:
         ]
         msgs = endpoint.build_messages(turns)
         assert [m["content"] for m in msgs] == ["A", "B"]
+
+
+class TestResponsesStatefulChaining:
+    """ResponsesEndpoint must extract response ID from server responses and thread
+    it as `previous_response_id` on subsequent turns while sending only the latest turn."""
+
+    @pytest.fixture
+    def endpoint(self) -> ResponsesEndpoint:
+        return create_endpoint_with_mock_transport(
+            ResponsesEndpoint, create_model_endpoint(EndpointType.RESPONSES)
+        )
+
+    @pytest.fixture
+    def store_endpoint(self) -> ResponsesEndpoint:
+        return create_endpoint_with_mock_transport(
+            ResponsesEndpoint,
+            create_model_endpoint(EndpointType.RESPONSES, extra=[("store", True)]),
+        )
+
+    def test_extract_response_id_store_requested_response_omits_store_returns_id(
+        self, store_endpoint: ResponsesEndpoint
+    ) -> None:
+        record = RequestRecord(
+            responses=[
+                TextResponse(
+                    perf_ns=1,
+                    text=orjson.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_no_echo",
+                                "object": "response",
+                                "status": "completed",
+                            },
+                        }
+                    ).decode(),
+                )
+            ]
+        )
+        assert store_endpoint.extract_response_id(record) == "resp_no_echo"
+
+    def test_extract_response_id_streaming_created_returns_id(
+        self, endpoint: ResponsesEndpoint
+    ) -> None:
+        record = RequestRecord(
+            responses=[
+                TextResponse(
+                    perf_ns=1,
+                    text=orjson.dumps(
+                        {
+                            "type": "response.created",
+                            "response": {
+                                "id": "resp_b6c65395f4fb8c7d",
+                                "object": "response",
+                                "status": "in_progress",
+                                "store": True,
+                            },
+                        }
+                    ).decode(),
+                ),
+                TextResponse(
+                    perf_ns=2,
+                    text=orjson.dumps(
+                        {
+                            "type": "response.output_text.delta",
+                            "delta": "Hello",
+                        }
+                    ).decode(),
+                ),
+            ]
+        )
+        assert endpoint.extract_response_id(record) == "resp_b6c65395f4fb8c7d"
+
+    def test_extract_response_id_stream_ends_in_failure_returns_none(
+        self, endpoint: ResponsesEndpoint
+    ) -> None:
+        record = RequestRecord(
+            responses=[
+                TextResponse(
+                    perf_ns=1,
+                    text=orjson.dumps(
+                        {
+                            "type": "response.created",
+                            "response": {
+                                "id": "resp_aborted",
+                                "object": "response",
+                                "status": "in_progress",
+                                "store": True,
+                            },
+                        }
+                    ).decode(),
+                ),
+                TextResponse(
+                    perf_ns=2,
+                    text=orjson.dumps(
+                        {
+                            "type": "response.failed",
+                            "response": {
+                                "id": "resp_aborted",
+                                "object": "response",
+                                "status": "failed",
+                                "store": True,
+                            },
+                        }
+                    ).decode(),
+                ),
+            ]
+        )
+        assert endpoint.extract_response_id(record) is None
+
+    def test_extract_response_id_non_streaming_returns_id(
+        self, endpoint: ResponsesEndpoint
+    ) -> None:
+        record = RequestRecord(
+            responses=[
+                TextResponse(
+                    perf_ns=1,
+                    text=orjson.dumps(
+                        {
+                            "id": "resp_non_stream_456",
+                            "object": "response",
+                            "status": "completed",
+                            "store": True,
+                        }
+                    ).decode(),
+                )
+            ]
+        )
+        assert endpoint.extract_response_id(record) == "resp_non_stream_456"
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            param("failed", id="failed"),
+            param("incomplete", id="incomplete"),
+        ],
+    )  # fmt: skip
+    def test_extract_response_id_non_streaming_failure_status_returns_none(
+        self, store_endpoint: ResponsesEndpoint, status: str
+    ) -> None:
+        record = RequestRecord(
+            responses=[
+                TextResponse(
+                    perf_ns=1,
+                    text=orjson.dumps(
+                        {
+                            "id": "resp_aborted_non_stream",
+                            "object": "response",
+                            "status": status,
+                        }
+                    ).decode(),
+                )
+            ]
+        )
+        assert store_endpoint.extract_response_id(record) is None
+
+    def test_extract_response_id_no_id_returns_none(
+        self, endpoint: ResponsesEndpoint
+    ) -> None:
+        record = RequestRecord(
+            responses=[
+                TextResponse(
+                    perf_ns=1,
+                    text=orjson.dumps(
+                        {
+                            "type": "response.output_text.delta",
+                            "delta": "Hello",
+                        }
+                    ).decode(),
+                )
+            ]
+        )
+        assert endpoint.extract_response_id(record) is None
+
+    def test_extract_response_id_store_false_returns_none(
+        self, endpoint: ResponsesEndpoint
+    ) -> None:
+        record = RequestRecord(
+            responses=[
+                TextResponse(
+                    perf_ns=1,
+                    text=orjson.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_not_stored",
+                                "object": "response",
+                                "status": "completed",
+                                "store": False,
+                            },
+                        }
+                    ).decode(),
+                )
+            ]
+        )
+        assert endpoint.extract_response_id(record) is None
+
+    def test_extract_response_id_store_absent_returns_none(
+        self, endpoint: ResponsesEndpoint
+    ) -> None:
+        record = RequestRecord(
+            responses=[
+                TextResponse(
+                    perf_ns=1,
+                    text=orjson.dumps(
+                        {
+                            "id": "resp_no_store_field",
+                            "object": "response",
+                            "status": "completed",
+                        }
+                    ).decode(),
+                )
+            ]
+        )
+        assert endpoint.extract_response_id(record) is None
+
+    def test_format_payload_turn1_with_previous_response_id_sends_only_latest(
+        self, endpoint: ResponsesEndpoint
+    ) -> None:
+        turn0 = Turn(
+            role="user",
+            texts=[Text(contents=["First message"])],
+        )
+        turn1 = Turn(
+            role="user",
+            texts=[Text(contents=["Second message"])],
+        )
+        request_info = create_request_info(
+            model_endpoint=endpoint.model_endpoint,
+            turns=[turn0, turn1],
+            previous_response_id="resp_b6c65395f4fb8c7d",
+        )
+        payload = endpoint.format_payload(request_info)
+        assert payload["previous_response_id"] == "resp_b6c65395f4fb8c7d"
+        assert len(payload["input"]) == 1
+        assert payload["input"][0]["content"] == "Second message"

--- a/tests/unit/workers/test_session_manager.py
+++ b/tests/unit/workers/test_session_manager.py
@@ -10,7 +10,7 @@ import pytest
 from pydantic import ValidationError
 from pytest import param
 
-from aiperf.common.enums import ConversationContextMode
+from aiperf.common.enums import ConversationBranchMode, ConversationContextMode
 from aiperf.common.models import Conversation, Turn
 from aiperf.common.models.dataset_models import DatasetMetadata
 from aiperf.plugin.enums import DatasetSamplingStrategy
@@ -421,3 +421,89 @@ class TestMessageArrayWithoutResponsesRejected:
                 sampling_strategy=DatasetSamplingStrategy.SEQUENTIAL,
                 default_context_mode=ConversationContextMode.MESSAGE_ARRAY_WITHOUT_RESPONSES,
             )
+
+
+class TestSessionPreviousResponseId:
+    """Tests for UserSession previous_response_id storage and reset_context handling."""
+
+    @pytest.mark.parametrize(
+        "reset_turn",
+        [
+            param(
+                Turn(
+                    raw_messages=[{"role": "user", "content": "Q2"}],
+                    reset_context=True,
+                ),
+                id="with_raw_messages",
+            ),
+            param(Turn(reset_context=True), id="synthetic_no_raw_messages"),
+        ],
+    )  # fmt: skip
+    def test_advance_turn_clears_previous_response_id_on_reset_context(
+        self, reset_turn: Turn
+    ) -> None:
+        conv = Conversation(
+            conversation_id="test-conv-reset",
+            turns=[
+                Turn(raw_messages=[{"role": "user", "content": "Q1"}]),
+                reset_turn,
+            ],
+        )
+        session = UserSession(
+            x_correlation_id="test-corr",
+            num_turns=2,
+            conversation=conv,
+            context_mode=ConversationContextMode.DELTAS_WITHOUT_RESPONSES,
+        )
+        session.advance_turn(0)
+        session.store_response_id("resp_turn0")
+        assert session.previous_response_id == "resp_turn0"
+
+        # A context reset always breaks the wire chain, regardless of whether the
+        # turn carries raw_messages: chaining would retain discarded history.
+        session.advance_turn(1)
+        assert session.previous_response_id is None
+
+    def test_advance_turn_preserves_previous_response_id_without_reset_context(
+        self,
+    ) -> None:
+        conv = Conversation(
+            conversation_id="test-conv-normal",
+            turns=[
+                Turn(messages=[{"role": "user", "content": "Q1"}]),
+                Turn(messages=[{"role": "user", "content": "Q2"}]),
+            ],
+        )
+        session = UserSession(
+            x_correlation_id="test-corr",
+            num_turns=2,
+            conversation=conv,
+            context_mode=ConversationContextMode.DELTAS_WITHOUT_RESPONSES,
+        )
+        session.advance_turn(0)
+        session.store_response_id("resp_turn0")
+        assert session.previous_response_id == "resp_turn0"
+
+        session.advance_turn(1)
+        assert session.previous_response_id == "resp_turn0"
+
+    def test_seed_from_parent_copies_previous_response_id(self) -> None:
+        manager = UserSessionManager()
+        conv = Conversation(
+            conversation_id="test-conv-fork",
+            turns=[Turn(messages=[{"role": "user", "content": "Q1"}])],
+        )
+        parent = manager.create_and_store("parent-corr", conv, num_turns=1)
+        parent.store_response_id("resp_parent_last")
+        child = manager.create_and_store(
+            "child-corr",
+            conv,
+            num_turns=1,
+            parent_correlation_id="parent-corr",
+            branch_mode=ConversationBranchMode.FORK,
+        )
+        assert child.previous_response_id is None
+
+        manager.seed_from_parent("child-corr", "parent-corr")
+
+        assert child.previous_response_id == "resp_parent_last"

--- a/tests/unit/workers/test_worker.py
+++ b/tests/unit/workers/test_worker.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 from pytest import param
 
-from aiperf.common.enums import CreditPhase
+from aiperf.common.enums import ConversationContextMode, CreditPhase
 from aiperf.common.models import (
     Conversation,
     ErrorDetails,
@@ -20,6 +20,7 @@ from aiperf.common.models import (
 from aiperf.config.phases import ConcurrencyPhase
 from aiperf.credit.structs import Credit, CreditContext
 from aiperf.dataset.memory_map_utils import PayloadTurnData
+from aiperf.workers.session_manager import UserSession
 from aiperf.workers.worker import (
     Worker,
     _is_terminal_context_overflow,
@@ -987,6 +988,70 @@ class TestPayloadBytesFastPath:
             "max_completion_tokens": 32,
             "messages": [],
         }
+
+
+@pytest.mark.asyncio
+class TestFinalizeSessionResponseChaining:
+    """`_finalize_session_response` must chain only onto successful responses."""
+
+    def _chaining_session(self) -> UserSession:
+        conv = Conversation(
+            conversation_id="test-conv-chain",
+            turns=[Turn(raw_messages=[{"role": "user", "content": "Q1"}])],
+        )
+        return UserSession(
+            x_correlation_id="test-corr",
+            num_turns=1,
+            conversation=conv,
+            context_mode=ConversationContextMode.DELTAS_WITHOUT_RESPONSES,
+        )
+
+    async def test_finalize_session_response_error_keeps_last_good_id(
+        self,
+        mock_worker: Worker,
+        sample_credit_context: CreditContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed turn may emit a partial ``response.created`` id; chaining onto
+        it would corrupt server context, so the last good id must be preserved."""
+        monkeypatch.setattr(
+            mock_worker, "_process_responses_for_record", Mock(return_value=([], None))
+        )
+        monkeypatch.setattr(mock_worker, "_populate_response_metrics", Mock())
+        extract = Mock(return_value="resp_partial")
+        monkeypatch.setattr(
+            mock_worker.inference_client.endpoint, "extract_response_id", extract
+        )
+        session = self._chaining_session()
+        session.store_response_id("resp_prev_good")
+        record = RequestRecord(error=ErrorDetails(message="boom", type="TestError"))
+
+        mock_worker._finalize_session_response(session, sample_credit_context, record)
+
+        assert session.previous_response_id == "resp_prev_good"
+        extract.assert_not_called()
+
+    async def test_finalize_session_response_success_stores_new_id(
+        self,
+        mock_worker: Worker,
+        sample_credit_context: CreditContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            mock_worker, "_process_responses_for_record", Mock(return_value=([], None))
+        )
+        monkeypatch.setattr(mock_worker, "_populate_response_metrics", Mock())
+        monkeypatch.setattr(
+            mock_worker.inference_client.endpoint,
+            "extract_response_id",
+            Mock(return_value="resp_new"),
+        )
+        session = self._chaining_session()
+        record = RequestRecord(timestamp_ns=1, start_perf_ns=1, end_perf_ns=2)
+
+        mock_worker._finalize_session_response(session, sample_credit_context, record)
+
+        assert session.previous_response_id == "resp_new"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Cherry-pick of `ea33cc5a57` from `main` into `release/0.13.0`
- Original PR: #1347 — feat: Support stateful responses API with previous_response_id chaining

## Conflicts
None — clean cherry-pick onto prerequisite base.

## Stack
This is PR 5 of 6. Merge after #1377, #1378, #1371, and #1372.
1. #1377 — #1245 (mmap thread-safety)
2. #1378 — #1274 (random_pool batch-size)
3. #1371 — #1280 (config flag routing)
4. #1372 — #1322 (FakeTokenizer)
5. **This PR** — #1347 (stateful responses / previous_response_id)
6. #1379 — combined #1325+#1326 (k8s-native)