### PR TITLE
fix(finite): keep numpy int and bool identities through the NaN/inf guard (cherry-pick to release/0.13.0)

### DIFF
--- a/docs/dev/patterns.md
+++ b/docs/dev/patterns.md
@@ -357,15 +357,22 @@ def export_records_json(records: list[Record], out_path: Path) -> None:
 
 `scrub_non_finite` recursively walks `dict`/`list`/`tuple` containers and
 rewrites non-finite numeric values to `None`. It leaves `str`/`bytes`/`bool`
-alone and coerces numpy scalar types to native Python numbers
-(`numpy.float32`, `numpy.float64`, `numpy.int64`, ...).
+alone and normalizes numpy scalars to the native Python type they actually
+mean — `numpy.int64(7)` becomes `7`, not `7.0`, and `numpy.bool_(True)`
+becomes `True`, not `1.0`.
 
-That coercion is load-bearing, not incidental: `orjson.dumps` **raises**
+That normalization is load-bearing, not incidental: `orjson.dumps` **raises**
 `TypeError: Type is not JSON serializable: numpy.float64` rather than
 degrading, so a numpy scalar anywhere in a payload aborts the export and
 takes the run down with it. Any code that hands values to an exporter
 (planners, scorers, analysis helpers) should still return native floats —
 `scrub_non_finite` is the backstop, not the excuse.
+
+Most exporters are shielded by accident: they call
+`scrub_non_finite(model.model_dump(mode="json"))`, and Pydantic's JSON-mode
+dump already coerces numpy. Payloads assembled as plain dicts from
+dataclasses (`search_history.json` is the live example) have no such step,
+so `scrub_non_finite` is their only guard.
 
 ### `is_finite_value` for the canonical finiteness check
 
@@ -382,6 +389,11 @@ def maybe_record_throughput(value: float) -> None:
 Use `is_finite_value` instead of `math.isfinite` or `not math.isnan`:
 `isinstance(x, float)` misses numpy scalar types on some numpy versions,
 and `math.isfinite` raises on non-numeric inputs.
+
+It rejects booleans — Python's and numpy's — because a bool is not a metric
+value. That matters for `nan_safe_mean`/`nan_safe_std`, which filter through
+it: admitting `numpy.bool_(True)` as `1.0` would make the same data average
+differently depending only on which bool type produced it.
 
 ### `nan_safe_mean` / `nan_safe_std` for aggregation
 

--- a/src/aiperf/common/finite.py
+++ b/src/aiperf/common/finite.py
@@ -52,6 +52,25 @@ __all__ = [
 ]
 
 
+def _native_scalar(x: Any) -> Any:
+    """Return the native Python counterpart of a numpy scalar, else ``x``.
+
+    Numpy's ``.item()`` maps each scalar to the Python type it actually
+    means -- ``numpy.bool_`` to ``bool``, ``numpy.int64`` to ``int``,
+    ``numpy.float32`` to ``float`` -- which ``float()`` alone would flatten.
+    Used instead of ``import numpy`` so this module stays import-light; it
+    is pulled in on per-record paths. Python scalars have no ``.item()`` and
+    cost one failed attribute lookup.
+    """
+    item = getattr(x, "item", None)
+    if not callable(item):
+        return x
+    try:
+        return item()
+    except (TypeError, ValueError):
+        return x
+
+
 def is_finite_value(x: Any) -> bool:
     """Return True if ``x`` is a finite real number.
 
@@ -61,11 +80,17 @@ def is_finite_value(x: Any) -> bool:
     ``int``/``float`` and numpy scalar types (``float32``, ``float64``,
     ``int64``, ...) because ``float(np.float64(...))`` round-trips.
 
+    ``numpy.bool_`` is rejected alongside Python ``bool``. It does not
+    subclass ``bool``, so without an explicit check it would be admitted as
+    the value ``1.0`` and skew :func:`nan_safe_mean` / :func:`nan_safe_std`
+    -- the same input would average differently depending only on which
+    bool type produced it.
+
     Strings, bytes, lists, dicts and other non-numeric types return False
     (the ``float()`` coercion either raises ``ValueError`` or
     ``TypeError``, both of which are caught).
     """
-    if x is None or isinstance(x, bool):
+    if x is None or isinstance(_native_scalar(x), bool):
         return False
     try:
         return math.isfinite(float(x))
@@ -102,16 +127,47 @@ Example::
 """
 
 
+def _scrub_scalar(obj: Any) -> Any:
+    """Normalize one non-container value for :func:`scrub_non_finite`.
+
+    Finite numerics come back as their native Python type, non-finite ones
+    as ``None``, and anything non-numeric passes through untouched.
+    """
+    if isinstance(obj, float):
+        # ``numpy.float64`` is the one numpy scalar type that subclasses
+        # ``float``, so it matches here rather than taking the ``.item()``
+        # path below. Returning it unconverted leaks it into orjson.dumps(),
+        # which rejects it outright ("Type is not JSON serializable").
+        # float() is a no-op on an exact float -- CPython returns the same
+        # object, and the call is cheaper than the isfinite() beside it.
+        return float(obj) if math.isfinite(obj) else None
+    if not hasattr(obj, "__float__") or isinstance(obj, int):
+        return obj
+    # Numpy scalar or other duck-typed number. ``numpy.int64(7)`` must stay
+    # ``7`` rather than widen to ``7.0``, and ``numpy.bool_(True)`` must stay
+    # ``True`` rather than collapse to ``1.0``.
+    native = _native_scalar(obj)
+    # bool is caught here too, since bool subclasses int; returning
+    # ``native`` keeps True a bool instead of flattening it to 1.
+    if isinstance(native, int):
+        return native
+    try:
+        f = float(native)
+    except (TypeError, ValueError):
+        return obj
+    return f if math.isfinite(f) else None
+
+
 def scrub_non_finite(obj: Any) -> Any:
     """Recursively replace non-finite numeric values with ``None``.
 
     Walks ``dict``, ``list``, and ``tuple`` containers; leaves ``str``,
     ``bytes``, and ``bytearray`` alone (a string literal ``"nan"`` is not a
-    numeric NaN and must not be rewritten). Numpy scalars are handled two
-    ways: ``numpy.float64`` subclasses ``float`` and is cast explicitly,
-    while every other numpy type (``numpy.float32``, ``numpy.int64``, ...)
-    reaches the duck-typed ``__float__``/``float()`` branch that mirrors
-    :func:`is_finite_value`'s strategy.
+    numeric NaN and must not be rewritten). Numpy scalars are normalized to
+    their native Python counterpart rather than uniformly to ``float``, so
+    ``numpy.int64(7)`` yields ``7`` (not ``7.0``) and ``numpy.bool_(True)``
+    yields ``True`` (not ``1.0``). ``numpy.float64`` needs an explicit cast
+    because it subclasses ``float``; the rest go through ``.item()``.
 
     Use before ``orjson.dumps`` on any payload that may contain metric
     values. This is the guard for two distinct orjson behaviors: it
@@ -119,10 +175,9 @@ def scrub_non_finite(obj: Any) -> Any:
     explicit-None semantics downstream), and it raises outright on numpy
     scalars ("Type is not JSON serializable: numpy.float64").
 
-    The returned structure preserves the input container types (dict
-    stays dict, tuple stays tuple); numpy scalars are coerced to Python
-    ``float``. Booleans are passed through unchanged because they are not
-    metric values.
+    The returned structure preserves the input container types (dict stays
+    dict, tuple stays tuple). Booleans are passed through unchanged because
+    they are not metric values -- a non-finite check does not apply to them.
     """
     if isinstance(obj, (str, bytes, bytearray)):
         return obj
@@ -134,25 +189,7 @@ def scrub_non_finite(obj: Any) -> Any:
         return [scrub_non_finite(v) for v in obj]
     if isinstance(obj, tuple):
         return tuple(scrub_non_finite(v) for v in obj)
-    if isinstance(obj, float):
-        if not math.isfinite(obj):
-            return None
-        # ``numpy.float64`` is the one numpy scalar type that subclasses
-        # ``float``, so it matches here instead of falling through to the
-        # duck-typed branch below that coerces every other numpy type.
-        # Returning it unconverted leaks it into orjson.dumps(), which
-        # rejects it outright ("Type is not JSON serializable"). float() is
-        # a no-op on an exact float -- CPython hands back the same object.
-        return float(obj)
-    # Numpy scalar / other numeric: duck-typed ``float()`` coercion (same
-    # strategy as is_finite_value). Non-numeric objects fall through unchanged.
-    if hasattr(obj, "__float__") and not isinstance(obj, int):
-        try:
-            f = float(obj)
-        except (TypeError, ValueError):
-            return obj
-        return f if math.isfinite(f) else None
-    return obj
+    return _scrub_scalar(obj)
 
 
 def nan_safe_mean(values: Any) -> float | None:

--- a/tests/unit/common/test_finite.py
+++ b/tests/unit/common/test_finite.py
@@ -44,6 +44,10 @@ from aiperf.common.finite import (
         param(np.float64(1.5), True, id="numpy_float64_finite"),
         param(np.int64(0), True, id="numpy_int64_zero"),
         param(np.int64(-100), True, id="numpy_int64_negative"),
+        # numpy.bool_ does not subclass Python bool, so it misses the
+        # isinstance(x, bool) rejection and would count as the value 1.0.
+        param(np.bool_(True), False, id="numpy_bool_true_rejected"),
+        param(np.bool_(False), False, id="numpy_bool_false_rejected"),
     ],
 )
 def test_is_finite_value(value: object, expected: bool) -> None:
@@ -148,15 +152,54 @@ def test_scrub_non_finite_numpy_scalars() -> None:
     assert type(out["f64_finite"]) is float
     # int passes through unchanged
     assert out["i64"] == np.int64(7)
+    assert type(out["i64"]) is int
+
+
+def test_scrub_non_finite_preserves_numpy_integer_as_int() -> None:
+    """numpy integers must stay integers, not widen to float.
+
+    ``numpy.int64`` neither subclasses ``int`` nor matches the ``float``
+    branch, so a bare ``float()`` coercion would write ``7.0`` to disk for a
+    value that is conceptually ``7``.
+    """
+    out = scrub_non_finite({"i64": np.int64(7), "i32": np.int32(-3), "u8": np.uint8(3)})
+    assert type(out["i64"]) is int
+    assert out["i64"] == 7
+    assert type(out["i32"]) is int
+    assert out["i32"] == -3
+    assert type(out["u8"]) is int
+    assert out["u8"] == 3
+
+
+def test_scrub_non_finite_preserves_numpy_bool_as_bool() -> None:
+    """numpy booleans must stay booleans.
+
+    The function documents "Booleans are passed through unchanged", but
+    ``numpy.bool_`` does not subclass Python ``bool``, so it missed that
+    branch and was coerced to ``1.0``.
+    """
+    out = scrub_non_finite({"t": np.bool_(True), "f": np.bool_(False)})
+    assert out["t"] is True
+    assert out["f"] is False
+
+
+def test_scrub_non_finite_numpy_int_and_bool_json_shape() -> None:
+    """On disk a numpy int must render as 7 and a numpy bool as true."""
+    import orjson
+
+    raw = orjson.dumps(
+        scrub_non_finite({"count": np.int64(7), "feasible": np.bool_(True)})
+    ).decode()
+
+    assert raw == '{"count":7,"feasible":true}'
 
 
 def test_scrub_non_finite_coerces_numpy_float64_to_native_float() -> None:
-    """numpy.float64 needs an explicit cast; every other numpy scalar gets one free.
+    """numpy.float64 needs its own cast; every other numpy scalar takes .item().
 
     numpy.float64 is the only numpy scalar type that subclasses Python
     ``float``, so it matches the ``isinstance(obj, float)`` branch and would
-    otherwise be returned as-is instead of falling through to the duck-typed
-    ``float()`` coercion the other numpy types take.
+    otherwise be returned as-is rather than normalized like the rest.
     """
     out = scrub_non_finite({"v": np.float64(3.14)})
     assert type(out["v"]) is float
@@ -231,6 +274,17 @@ def test_nan_safe_mean_handles_numpy_inputs() -> None:
     """numpy arrays / scalars are filtered consistently with Python floats."""
     values = [np.float64(1.0), np.float64(np.nan), np.float64(3.0)]
     assert nan_safe_mean(values) == pytest.approx(2.0)
+
+
+def test_nan_safe_mean_excludes_numpy_bool_like_python_bool() -> None:
+    """A numpy bool must not be averaged in as 1.0.
+
+    Python ``True`` is already excluded as "not a metric value"; numpy's
+    bool has to behave identically or the same data yields a different
+    mean depending only on which bool type produced it.
+    """
+    assert nan_safe_mean([np.bool_(True), 3.0]) == nan_safe_mean([True, 3.0])
+    assert nan_safe_mean([np.bool_(True), 3.0]) == pytest.approx(3.0)
 
 
 def test_nan_safe_std_empty_returns_none() -> None:


### PR DESCRIPTION
Cherry-picks #1345 to `release/0.13.0`.

## Why

#1349 backported the numpy.float64 P0 (nvbugs 6683575) to this branch, but not the follow-on hardening from #1345. The result is that 0.13.0's `scrub_non_finite` no longer crashes on `numpy.float64`, but still flattens two other numpy scalar identities:

```python
scrub_non_finite({"i": np.int64(7), "b": np.bool_(True)})
# release/0.13.0 today: {"i": 7.0, "b": 1.0}
# with this cherry-pick: {"i": 7,   "b": True}
```

The bool case is not purely cosmetic — it also reaches `is_finite_value`, so `nan_safe_mean([np.bool_(True), 3.0])` returns 2.0 while `nan_safe_mean([True, 3.0])` returns 3.0. Same data, different average, depending only on which bool type produced it.

Per #1345's own analysis these are latent contract violations rather than an observed production failure: instrumenting `scrub_non_finite` across the unit suite found no current path feeding either type into an exporter. Backporting keeps 0.13.0's serialization contract identical to `main`'s.

## Contents

Clean cherry-pick, no conflicts. Content is byte-identical to the `main` squash `0d85c8c79`; the commit message restores the full rationale that the squash dropped.

- `src/aiperf/common/finite.py` — `_native_scalar()` / `_scrub_scalar()` split (the latter to stay under the C901 guardrail)
- `tests/unit/common/test_finite.py`
- `docs/dev/patterns.md`

## Verification

Behavior on this branch:
```
{'f64': (3.14, 'float'), 'f32': (1.5, 'float'), 'i64': (7, 'int'),
 'b': (True, 'bool'), 'nan': (None, 'NoneType'), 'inf': (None, 'NoneType')}
{"f64":3.14,"f32":1.5,"i64":7,"b":true,"nan":null,"inf":null}
is_finite_value(np.bool_(True)) = False
```

- `uv run pytest tests/unit/ -n auto` → 18500 passed, 74 skipped, 3 xfailed
- `pre-commit run --from-ref origin/release/0.13.0 --to-ref HEAD` → all hooks pass
- Separately re-verified that #1349 still fixes nvbugs 6683575 end-to-end on this branch: the reported `TypeError: Type is not JSON serializable: numpy.float64` reproduces with those two commits reverted (aborts at the first GP-fit iteration) and is gone with them present, with `search_history.json` written and `variation_values` deserializing as native `float`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
