### PR TITLE
ci: increase Windows job timeout to 90 minutes

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ${{ matrix.runner }}
     # Windows x64 runners can finish the component tier just past 30 minutes.
-    timeout-minutes: 45
+    timeout-minutes: 90
     # Force CPython UTF-8 mode so file reads default to UTF-8 instead of the
     # Windows cp1252 code page (no-op on POSIX). Without it, reading a UTF-8
     # file on Windows raises UnicodeDecodeError on bytes like 0x8f.


### PR DESCRIPTION
The Windows x64 runners occasionally exceed the current 45-minute cap when
running the full unit + component integration tier. Bump to 90 minutes to
avoid spurious timeout failures.

Signed-off-by: Anthony Casagrande <acasagrande@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the build process timeout to allow longer-running builds to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->