### PR TITLE
fix(synthesis): clamp prefix_len to input_len for partial blocks

### DIFF
--- a/src/aiperf/dataset/synthesis/synthesizer.py
+++ b/src/aiperf/dataset/synthesis/synthesizer.py
@@ -213,14 +213,12 @@ class Synthesizer(AIPerfLoggerMixin):
                 else:
                     break
 
-            # Compute prefix_len and prompt_len
+            # Clamp prefix_len to input_len when the shared prefix consumes a
+            # final partial block.
             prefix_len = len(prefix_ids) * block_size
+            if prefix_len > input_len:
+                prefix_len = input_len
             prompt_len = input_len - prefix_len
-            if prompt_len < 0:
-                raise ValueError(
-                    f"input_len ({input_len}) < prefix_len ({prefix_len}): "
-                    f"trace has fewer tokens than its shared prefix blocks"
-                )
 
             # Step 3: Apply prefix_len_mult - stretch or squeeze prefix
             if prefix_mult > 1.0:

--- a/src/aiperf/dataset/synthesis/synthesizer.py
+++ b/src/aiperf/dataset/synthesis/synthesizer.py
@@ -213,10 +213,16 @@ class Synthesizer(AIPerfLoggerMixin):
                 else:
                     break
 
-            # Clamp prefix_len to input_len when the shared prefix consumes a
-            # final partial block.
+            # Clamp prefix_len to input_len only when the overshoot is smaller
+            # than one block (a final partial block). Larger mismatches mean
+            # the trace claims fewer tokens than its full shared-prefix blocks.
             prefix_len = len(prefix_ids) * block_size
             if prefix_len > input_len:
+                if prefix_len - input_len >= block_size:
+                    raise ValueError(
+                        f"input_len ({input_len}) < prefix_len ({prefix_len}): "
+                        f"trace has fewer tokens than its shared prefix blocks"
+                    )
                 prefix_len = input_len
             prompt_len = input_len - prefix_len
 

--- a/tests/unit/dataset/synthesis/test_synthesizer.py
+++ b/tests/unit/dataset/synthesis/test_synthesizer.py
@@ -165,6 +165,36 @@ class TestSynthesizer:
 
         assert synthetic[0].get("timestamp") == expected_ts
 
+    def test_speedup_ratio_with_partial_final_block(self) -> None:
+        """Traces whose shared prefix ends in a partial block should not crash."""
+        # block_size=16; 756 tokens = 47 full blocks + a 4-token remainder.
+        # All hash_ids are shared, so the prefix consumes the partial final block.
+        hash_ids = list(range(1, 49))
+        traces = [
+            {
+                "input_length": 756,
+                "output_length": 10,
+                "timestamp": 1000,
+                "hash_ids": hash_ids,
+            },
+            {
+                "input_length": 756,
+                "output_length": 10,
+                "timestamp": 2000,
+                "hash_ids": hash_ids,
+            },
+        ]
+        params = SynthesisParams(speedup_ratio=2.0, block_size=16)
+        synthesizer = Synthesizer(params=params)
+        synthetic = synthesizer.synthesize_traces(traces)
+
+        assert synthetic[0].get("timestamp") == 500
+        assert synthetic[1].get("timestamp") == 1000
+        assert synthetic[0]["input_length"] == 756
+        assert synthetic[1]["input_length"] == 756
+        assert len(synthetic[0]["hash_ids"]) == 48
+        assert len(synthetic[1]["hash_ids"]) == 48
+
     # ============================================================================
     # Prefix Multiplier Tests
     # ============================================================================

--- a/tests/unit/dataset/synthesis/test_synthesizer.py
+++ b/tests/unit/dataset/synthesis/test_synthesizer.py
@@ -195,6 +195,20 @@ class TestSynthesizer:
         assert len(synthetic[0]["hash_ids"]) == 48
         assert len(synthetic[1]["hash_ids"]) == 48
 
+    def test_shared_prefix_overshoot_rejected(self) -> None:
+        """Reject traces whose shared prefix overshoots input_length by a full block."""
+        # 3 shared blocks * 16 = 48 tokens, but input_length claims only 16.
+        # The overshoot (32) is >= block_size, so this is not just a partial block.
+        traces = [
+            {"input_length": 16, "output_length": 10, "hash_ids": [1, 2, 3]},
+            {"input_length": 16, "output_length": 10, "hash_ids": [1, 2, 3]},
+        ]
+        params = SynthesisParams(speedup_ratio=2.0, block_size=16)
+        synthesizer = Synthesizer(params=params)
+
+        with pytest.raises(ValueError, match="trace has fewer tokens than"):
+            synthesizer.synthesize_traces(traces)
+
     # ============================================================================
     # Prefix Multiplier Tests
     # ============================================================================


### PR DESCRIPTION
`Synthesizer._apply_multipliers` assumed every `hash_id` maps to a full `block_size` token block. When a trace's recorded `input_length` was not block-aligned, a shared prefix could imply more tokens than `input_length`, causing:

```text
input_len (756) < prefix_len (768): trace has fewer tokens than its shared prefix blocks
```

The prompt generator already tolerates this case by treating the last hash as a partial block:
https://github.com/ai-dynamo/aiperf/blob/a84b7b3229eac17a37a7984f367ab2683ffa1a1f/src/aiperf/dataset/generator/prompt.py#L631-L638

Reproduced with traces from the Qwen Bailian usage traces (https://github.com/alibaba-edu/qwen-bailian-usagetraces-anon) (`bailian_trace` format) where the final block is partial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dataset synthesis now rejects shared-prefix and input-length mismatches of at least one full block.
  * Smaller overshoots in a partial final block are clamped to the input length, preserving valid synthesis behavior.

* **Tests**
  * Added regression coverage for invalid full-block mismatches and valid partial final blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->