### PR TITLE
fix(dataset): stream inputs.json to disk in bounded chunks

### DIFF
--- a/src/aiperf/dataset/dataset_manager.py
+++ b/src/aiperf/dataset/dataset_manager.py
@@ -521,13 +521,8 @@ class DatasetManager(ReplyClientMixin, BaseComponentService):
         return inputs
 
     async def _generate_inputs_json_file(self) -> None:
-        """Generate inputs.json file in the artifact directory.
-
-        The document is streamed to disk in bounded chunks (see
-        ``iter_inputs_json_chunks``) instead of being encoded in one piece, so
-        a large dataset neither holds a second copy of every payload plus the
-        whole encoded file in memory nor issues the write as one giant call.
-        """
+        """Generate inputs.json in the artifact directory, streamed in bounded chunks
+        so the fully encoded document is never held in memory."""
         file_path = self.run.cfg.artifacts.dir / OutputDefaults.INPUTS_JSON_FILE
         temp_file_path = file_path.with_suffix(".tmp")
         self.info(f"Generating inputs.json file at {file_path.resolve()}")

--- a/src/aiperf/dataset/dataset_manager.py
+++ b/src/aiperf/dataset/dataset_manager.py
@@ -56,6 +56,7 @@ from aiperf.config.artifacts import OutputDefaults
 from aiperf.config.dataset import FileDataset, PublicDataset
 from aiperf.dataset import mmap_cache
 from aiperf.dataset.memory_map_utils import turn_from_payload_turn
+from aiperf.dataset.payload_formatting import iter_inputs_json_chunks
 from aiperf.dataset.utils import encode_image
 from aiperf.plugin import plugins
 from aiperf.plugin.enums import (
@@ -520,7 +521,13 @@ class DatasetManager(ReplyClientMixin, BaseComponentService):
         return inputs
 
     async def _generate_inputs_json_file(self) -> None:
-        """Generate inputs.json file in the artifact directory."""
+        """Generate inputs.json file in the artifact directory.
+
+        The document is streamed to disk in bounded chunks (see
+        ``iter_inputs_json_chunks``) instead of being encoded in one piece, so
+        a large dataset neither holds a second copy of every payload plus the
+        whole encoded file in memory nor issues the write as one giant call.
+        """
         file_path = self.run.cfg.artifacts.dir / OutputDefaults.INPUTS_JSON_FILE
         temp_file_path = file_path.with_suffix(".tmp")
         self.info(f"Generating inputs.json file at {file_path.resolve()}")
@@ -533,13 +540,9 @@ class DatasetManager(ReplyClientMixin, BaseComponentService):
             inputs = self._generate_input_payloads(model_endpoint)
 
             async with aiofiles.open(temp_file_path, "wb") as f:
-                await f.write(
-                    orjson.dumps(
-                        inputs.model_dump(exclude_none=True, mode="json"),
-                        option=orjson.OPT_INDENT_2,
-                    )
-                )
-            temp_file_path.replace(file_path)
+                for chunk in iter_inputs_json_chunks(inputs):
+                    await f.write(chunk)
+            await asyncio.to_thread(temp_file_path.replace, file_path)
 
             duration = time.perf_counter() - start_time
             self.info(f"inputs.json file generated in {duration:.2f} seconds")

--- a/src/aiperf/dataset/payload_formatting.py
+++ b/src/aiperf/dataset/payload_formatting.py
@@ -114,12 +114,11 @@ def _iter_session_pieces(session: SessionPayloads) -> Iterator[bytes]:
 def iter_inputs_json_chunks(
     inputs: InputsFile, chunk_bytes: int = INPUTS_JSON_WRITE_CHUNK_BYTES
 ) -> Iterator[bytes]:
-    """Yield the inputs.json document in chunks flushed at payload boundaries.
+    """Yield the inputs.json document in exact ``chunk_bytes`` slices.
 
-    Every chunk but the last is at least ``chunk_bytes`` and none exceeds it by
-    more than one encoded piece: a session frame, a single payload, or a whole
-    session only when extra model fields force the single-piece fallback.
-    orjson escapes control characters inside strings, so re-indenting on raw
+    Every chunk is exactly ``chunk_bytes`` except the last, which may be
+    smaller, regardless of how large any single encoded piece is. orjson
+    escapes control characters inside strings, so re-indenting on raw
     newlines is exact and the concatenated chunks are byte-identical to
     encoding the whole ``InputsFile`` with ``OPT_INDENT_2`` in one call.
     """
@@ -134,8 +133,12 @@ def iter_inputs_json_chunks(
         buffer += _SESSION_INDENT
         for piece in _iter_session_pieces(session):
             buffer += piece
-            if len(buffer) >= chunk_bytes:
-                yield bytes(buffer)
-                buffer.clear()
+            while len(buffer) >= chunk_bytes:
+                yield bytes(buffer[:chunk_bytes])
+                del buffer[:chunk_bytes]
     buffer += _INPUTS_JSON_TAIL
-    yield bytes(buffer)
+    while len(buffer) >= chunk_bytes:
+        yield bytes(buffer[:chunk_bytes])
+        del buffer[:chunk_bytes]
+    if buffer:
+        yield bytes(buffer)

--- a/src/aiperf/dataset/payload_formatting.py
+++ b/src/aiperf/dataset/payload_formatting.py
@@ -18,7 +18,7 @@ import orjson
 
 from aiperf.common.constants import BYTES_PER_MIB
 from aiperf.common.enums import CreditPhase
-from aiperf.common.models import Conversation, InputsFile
+from aiperf.common.models import Conversation, InputsFile, SessionPayloads
 from aiperf.common.models.model_endpoint_info import ModelEndpointInfo
 from aiperf.common.models.record_models import RequestInfo
 from aiperf.plugin import plugins
@@ -70,36 +70,51 @@ def format_conversation_payloads(
 
 
 # Flush threshold for the streamed inputs.json encoder. Bounds the bytes held
-# between writes without paying an aiofiles thread hop per session.
+# between writes without paying an aiofiles thread hop per payload.
 INPUTS_JSON_WRITE_CHUNK_BYTES = BYTES_PER_MIB
 
 _INPUTS_JSON_EMPTY = b'{\n  "data": []\n}'
 _INPUTS_JSON_HEAD = b'{\n  "data": ['
 _INPUTS_JSON_TAIL = b"\n  ]\n}"
-# Sessions sit two levels deep (root object, "data" array) under OPT_INDENT_2.
+# OPT_INDENT_2 nesting: session objects sit under the "data" array, payload
+# objects under each session's "payloads" array.
 _SESSION_INDENT = b"\n    "
+_PAYLOAD_INDENT = b"\n        "
+
+
+def _iter_session_pieces(session: SessionPayloads) -> Iterator[bytes]:
+    """Yield one session exactly as OPT_INDENT_2 would print it, one payload per piece."""
+    dumped = session.model_dump(exclude_none=True, mode="json")
+    payloads = dumped.pop("payloads")
+    head = b"{"
+    if "session_id" in dumped:
+        head += b'\n      "session_id": ' + orjson.dumps(dumped["session_id"]) + b","
+    if not payloads:
+        yield head + b'\n      "payloads": []\n    }'
+        return
+    yield head + b'\n      "payloads": ['
+    for index, payload in enumerate(payloads):
+        piece = b"," if index else b""
+        yield (
+            piece
+            + _PAYLOAD_INDENT
+            + orjson.dumps(payload, option=orjson.OPT_INDENT_2).replace(
+                b"\n", _PAYLOAD_INDENT
+            )
+        )
+    yield b"\n      ]\n    }"
 
 
 def iter_inputs_json_chunks(
     inputs: InputsFile, chunk_bytes: int = INPUTS_JSON_WRITE_CHUNK_BYTES
 ) -> Iterator[bytes]:
-    """Yield the inputs.json document as byte chunks of roughly ``chunk_bytes``.
+    """Yield the inputs.json document in chunks flushed at payload boundaries.
 
-    Sessions are encoded one at a time and re-indented under ``"data"``, so the
-    peak memory cost is one chunk plus one session instead of a JSON-mode copy
-    of every payload plus the fully encoded document. orjson escapes control
-    characters inside strings, so a raw newline in a session's encoding only
-    ever separates lines and the re-indent is exact: the concatenated chunks
-    are byte-identical to encoding the whole ``InputsFile`` with
-    ``OPT_INDENT_2`` in a single call.
-
-    Args:
-        inputs: The sessions to encode.
-        chunk_bytes: Flush threshold; every chunk but the last is at least
-            this long.
-
-    Yields:
-        Byte chunks that concatenate to the inputs.json document.
+    Every chunk but the last is at least ``chunk_bytes`` and none exceeds it by
+    more than one encoded payload. orjson escapes control characters inside
+    strings, so re-indenting on raw newlines is exact and the concatenated
+    chunks are byte-identical to encoding the whole ``InputsFile`` with
+    ``OPT_INDENT_2`` in one call.
     """
     if not inputs.data:
         yield _INPUTS_JSON_EMPTY
@@ -110,12 +125,10 @@ def iter_inputs_json_chunks(
         if index:
             buffer += b","
         buffer += _SESSION_INDENT
-        buffer += orjson.dumps(
-            session.model_dump(exclude_none=True, mode="json"),
-            option=orjson.OPT_INDENT_2,
-        ).replace(b"\n", _SESSION_INDENT)
-        if len(buffer) >= chunk_bytes:
-            yield bytes(buffer)
-            buffer.clear()
+        for piece in _iter_session_pieces(session):
+            buffer += piece
+            if len(buffer) >= chunk_bytes:
+                yield bytes(buffer)
+                buffer.clear()
     buffer += _INPUTS_JSON_TAIL
     yield bytes(buffer)

--- a/src/aiperf/dataset/payload_formatting.py
+++ b/src/aiperf/dataset/payload_formatting.py
@@ -111,6 +111,11 @@ def _iter_session_pieces(session: SessionPayloads) -> Iterator[bytes]:
     yield b"\n      ]\n    }"
 
 
+def _iter_exact_slices(document: bytes, chunk_bytes: int) -> Iterator[bytes]:
+    for start in range(0, len(document), chunk_bytes):
+        yield document[start : start + chunk_bytes]
+
+
 def iter_inputs_json_chunks(
     inputs: InputsFile, chunk_bytes: int = INPUTS_JSON_WRITE_CHUNK_BYTES
 ) -> Iterator[bytes]:
@@ -122,6 +127,19 @@ def iter_inputs_json_chunks(
     newlines is exact and the concatenated chunks are byte-identical to
     encoding the whole ``InputsFile`` with ``OPT_INDENT_2`` in one call.
     """
+    if chunk_bytes <= 0:
+        raise ValueError(f"chunk_bytes must be positive, got {chunk_bytes}")
+    if inputs.model_extra:
+        # The hand-built envelope emits only the data array, so a document
+        # carrying top-level extra="allow" fields is encoded whole to keep
+        # every field and the exact byte layout of the one-shot dump, then
+        # sliced under the same write bound.
+        document = orjson.dumps(
+            inputs.model_dump(exclude_none=True, mode="json"),
+            option=orjson.OPT_INDENT_2,
+        )
+        yield from _iter_exact_slices(document, chunk_bytes)
+        return
     if not inputs.data:
         yield _INPUTS_JSON_EMPTY
         return

--- a/src/aiperf/dataset/payload_formatting.py
+++ b/src/aiperf/dataset/payload_formatting.py
@@ -5,8 +5,6 @@
 Provides a generator that creates formatted API request payloads from
 conversations using an endpoint protocol. Used by both the dataset manager
 (inputs.json generation) and the custom composer (payload pre-formatting).
-Also provides the chunked encoder the dataset manager streams inputs.json
-through.
 """
 
 from __future__ import annotations
@@ -85,6 +83,14 @@ _PAYLOAD_INDENT = b"\n        "
 def _iter_session_pieces(session: SessionPayloads) -> Iterator[bytes]:
     """Yield one session exactly as OPT_INDENT_2 would print it, one payload per piece."""
     dumped = session.model_dump(exclude_none=True, mode="json")
+    if any(key not in ("session_id", "payloads") for key in dumped):
+        # The hand-built frame emits only session_id and payloads, so a session
+        # carrying extra="allow" fields is encoded whole to keep every field
+        # and the exact byte layout of the one-shot document dump.
+        yield orjson.dumps(dumped, option=orjson.OPT_INDENT_2).replace(
+            b"\n", _SESSION_INDENT
+        )
+        return
     payloads = dumped.pop("payloads")
     head = b"{"
     if "session_id" in dumped:
@@ -111,10 +117,11 @@ def iter_inputs_json_chunks(
     """Yield the inputs.json document in chunks flushed at payload boundaries.
 
     Every chunk but the last is at least ``chunk_bytes`` and none exceeds it by
-    more than one encoded payload. orjson escapes control characters inside
-    strings, so re-indenting on raw newlines is exact and the concatenated
-    chunks are byte-identical to encoding the whole ``InputsFile`` with
-    ``OPT_INDENT_2`` in one call.
+    more than one encoded piece: a session frame, a single payload, or a whole
+    session only when extra model fields force the single-piece fallback.
+    orjson escapes control characters inside strings, so re-indenting on raw
+    newlines is exact and the concatenated chunks are byte-identical to
+    encoding the whole ``InputsFile`` with ``OPT_INDENT_2`` in one call.
     """
     if not inputs.data:
         yield _INPUTS_JSON_EMPTY

--- a/src/aiperf/dataset/payload_formatting.py
+++ b/src/aiperf/dataset/payload_formatting.py
@@ -5,6 +5,8 @@
 Provides a generator that creates formatted API request payloads from
 conversations using an endpoint protocol. Used by both the dataset manager
 (inputs.json generation) and the custom composer (payload pre-formatting).
+Also provides the chunked encoder the dataset manager streams inputs.json
+through.
 """
 
 from __future__ import annotations
@@ -12,8 +14,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from typing import Any
 
+import orjson
+
+from aiperf.common.constants import BYTES_PER_MIB
 from aiperf.common.enums import CreditPhase
-from aiperf.common.models import Conversation
+from aiperf.common.models import Conversation, InputsFile
 from aiperf.common.models.model_endpoint_info import ModelEndpointInfo
 from aiperf.common.models.record_models import RequestInfo
 from aiperf.plugin import plugins
@@ -62,3 +67,55 @@ def format_conversation_payloads(
             request_info.endpoint_headers = endpoint.get_endpoint_headers(request_info)
             request_info.endpoint_params = endpoint.get_endpoint_params(request_info)
             yield conversation.session_id, i, endpoint.format_payload(request_info)
+
+
+# Flush threshold for the streamed inputs.json encoder. Bounds the bytes held
+# between writes without paying an aiofiles thread hop per session.
+INPUTS_JSON_WRITE_CHUNK_BYTES = BYTES_PER_MIB
+
+_INPUTS_JSON_EMPTY = b'{\n  "data": []\n}'
+_INPUTS_JSON_HEAD = b'{\n  "data": ['
+_INPUTS_JSON_TAIL = b"\n  ]\n}"
+# Sessions sit two levels deep (root object, "data" array) under OPT_INDENT_2.
+_SESSION_INDENT = b"\n    "
+
+
+def iter_inputs_json_chunks(
+    inputs: InputsFile, chunk_bytes: int = INPUTS_JSON_WRITE_CHUNK_BYTES
+) -> Iterator[bytes]:
+    """Yield the inputs.json document as byte chunks of roughly ``chunk_bytes``.
+
+    Sessions are encoded one at a time and re-indented under ``"data"``, so the
+    peak memory cost is one chunk plus one session instead of a JSON-mode copy
+    of every payload plus the fully encoded document. orjson escapes control
+    characters inside strings, so a raw newline in a session's encoding only
+    ever separates lines and the re-indent is exact: the concatenated chunks
+    are byte-identical to encoding the whole ``InputsFile`` with
+    ``OPT_INDENT_2`` in a single call.
+
+    Args:
+        inputs: The sessions to encode.
+        chunk_bytes: Flush threshold; every chunk but the last is at least
+            this long.
+
+    Yields:
+        Byte chunks that concatenate to the inputs.json document.
+    """
+    if not inputs.data:
+        yield _INPUTS_JSON_EMPTY
+        return
+
+    buffer = bytearray(_INPUTS_JSON_HEAD)
+    for index, session in enumerate(inputs.data):
+        if index:
+            buffer += b","
+        buffer += _SESSION_INDENT
+        buffer += orjson.dumps(
+            session.model_dump(exclude_none=True, mode="json"),
+            option=orjson.OPT_INDENT_2,
+        ).replace(b"\n", _SESSION_INDENT)
+        if len(buffer) >= chunk_bytes:
+            yield bytes(buffer)
+            buffer.clear()
+    buffer += _INPUTS_JSON_TAIL
+    yield bytes(buffer)

--- a/src/aiperf/dataset/payload_formatting.py
+++ b/src/aiperf/dataset/payload_formatting.py
@@ -116,6 +116,17 @@ def _iter_exact_slices(document: bytes, chunk_bytes: int) -> Iterator[bytes]:
         yield document[start : start + chunk_bytes]
 
 
+def _iter_document_pieces(inputs: InputsFile) -> Iterator[bytes]:
+    """Yield the non-empty document as pieces whose concatenation is the full dump."""
+    yield _INPUTS_JSON_HEAD
+    for index, session in enumerate(inputs.data):
+        if index:
+            yield b","
+        yield _SESSION_INDENT
+        yield from _iter_session_pieces(session)
+    yield _INPUTS_JSON_TAIL
+
+
 def iter_inputs_json_chunks(
     inputs: InputsFile, chunk_bytes: int = INPUTS_JSON_WRITE_CHUNK_BYTES
 ) -> Iterator[bytes]:
@@ -141,22 +152,24 @@ def iter_inputs_json_chunks(
         yield from _iter_exact_slices(document, chunk_bytes)
         return
     if not inputs.data:
-        yield _INPUTS_JSON_EMPTY
+        yield from _iter_exact_slices(_INPUTS_JSON_EMPTY, chunk_bytes)
         return
 
-    buffer = bytearray(_INPUTS_JSON_HEAD)
-    for index, session in enumerate(inputs.data):
-        if index:
-            buffer += b","
-        buffer += _SESSION_INDENT
-        for piece in _iter_session_pieces(session):
+    # The buffer holds strictly less than chunk_bytes between pieces. A piece
+    # that reaches the threshold tops the buffer up to one exact chunk and has
+    # its remainder sliced directly, so an oversized payload never passes
+    # through the buffer and the held bytes stay under one chunk.
+    buffer = bytearray()
+    for piece in _iter_document_pieces(inputs):
+        if len(buffer) + len(piece) < chunk_bytes:
             buffer += piece
-            while len(buffer) >= chunk_bytes:
-                yield bytes(buffer[:chunk_bytes])
-                del buffer[:chunk_bytes]
-    buffer += _INPUTS_JSON_TAIL
-    while len(buffer) >= chunk_bytes:
-        yield bytes(buffer[:chunk_bytes])
-        del buffer[:chunk_bytes]
+            continue
+        offset = chunk_bytes - len(buffer)
+        buffer += piece[:offset]
+        yield bytes(buffer)
+        while len(piece) - offset >= chunk_bytes:
+            yield piece[offset : offset + chunk_bytes]
+            offset += chunk_bytes
+        buffer = bytearray(piece[offset:])
     if buffer:
         yield bytes(buffer)

--- a/tests/unit/dataset/conftest.py
+++ b/tests/unit/dataset/conftest.py
@@ -70,7 +70,7 @@ def capture_file_writes():
             self.written_content = ""
 
         def write_bytes(self, data: bytes):
-            self.written_content = data.decode("utf-8")
+            self.written_content += data.decode("utf-8")
 
     capture = FileWriteCapture()
 
@@ -79,7 +79,7 @@ def capture_file_writes():
             if isinstance(data, (bytes, bytearray)):
                 capture.write_bytes(bytes(data))
             else:
-                capture.written_content = data
+                capture.written_content += data
 
         async def __aenter__(self):
             return self

--- a/tests/unit/dataset/test_inputs_json_chunks.py
+++ b/tests/unit/dataset/test_inputs_json_chunks.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the chunked inputs.json encoder and the streamed DatasetManager writer."""
+
+from pathlib import Path
+
+import orjson
+import pytest
+from pytest import param
+
+from aiperf.common.constants import BYTES_PER_MIB
+from aiperf.common.models import Conversation, InputsFile, SessionPayloads, Turn
+from aiperf.common.models.model_endpoint_info import ModelEndpointInfo
+from aiperf.dataset.dataset_manager import DatasetManager
+from aiperf.dataset.payload_formatting import iter_inputs_json_chunks
+
+
+def _single_dump(inputs: InputsFile) -> bytes:
+    """The whole-document encoding the chunked encoder must reproduce byte for byte."""
+    return orjson.dumps(
+        inputs.model_dump(exclude_none=True, mode="json"), option=orjson.OPT_INDENT_2
+    )
+
+
+def _payload(content: str) -> dict:
+    return {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": content}],
+        "stream": False,
+    }
+
+
+def _session(
+    session_id: str | None, num_payloads: int, content: str
+) -> SessionPayloads:
+    return SessionPayloads(
+        session_id=session_id,
+        payloads=[_payload(f"{content} {i}") for i in range(num_payloads)],
+    )
+
+
+class TestIterInputsJsonChunks:
+    @pytest.mark.parametrize(
+        "inputs",
+        [
+            param(InputsFile(), id="empty"),
+            param(InputsFile(data=[_session("s1", 1, "hi")]), id="single-session"),
+            param(
+                InputsFile(
+                    data=[
+                        _session("s1", 2, 'line1\nline2\ttab "quoted" \\ slash'),
+                        _session(None, 0, ""),
+                        _session("s3", 3, "unicode é 中 \U0001f600"),
+                    ]
+                ),
+                id="escapes-unicode-no-session-id",
+            ),
+        ],
+    )  # fmt: skip
+    def test_iter_inputs_json_chunks_concatenation_matches_single_dump(
+        self, inputs: InputsFile
+    ) -> None:
+        assert b"".join(iter_inputs_json_chunks(inputs)) == _single_dump(inputs)
+
+    def test_iter_inputs_json_chunks_flushes_at_threshold(self) -> None:
+        chunk_bytes = 4096
+        inputs = InputsFile(data=[_session(f"s{i}", 2, "x" * 200) for i in range(100)])
+
+        chunks = list(iter_inputs_json_chunks(inputs, chunk_bytes=chunk_bytes))
+
+        assert len(chunks) > 1
+        assert all(len(chunk) >= chunk_bytes for chunk in chunks[:-1])
+        assert all(len(chunk) < 2 * chunk_bytes for chunk in chunks)
+        assert b"".join(chunks) == _single_dump(inputs)
+
+
+class TestGenerateInputsJsonFileStreaming:
+    @pytest.mark.asyncio
+    async def test_generate_inputs_json_file_large_dataset_matches_single_dump(
+        self, benchmark_run, tmp_path: Path
+    ) -> None:
+        """A dataset several times the flush threshold is written across multiple
+        chunks and still lands on disk byte-identical to the one-shot encoding."""
+        manager = DatasetManager(run=benchmark_run, service_id="test_dataset_manager")
+        manager.dataset = {
+            f"session_{i}": Conversation(
+                session_id=f"session_{i}",
+                turns=[
+                    Turn(role="user", raw_payload=_payload("y" * 1024))
+                    for _ in range(2)
+                ],
+            )
+            for i in range(2000)
+        }
+        expected = _single_dump(
+            manager._generate_input_payloads(ModelEndpointInfo.from_run(benchmark_run))
+        )
+        assert len(expected) > 2 * BYTES_PER_MIB
+
+        await manager._generate_inputs_json_file()
+
+        assert (tmp_path / "inputs.json").read_bytes() == expected
+        assert not (tmp_path / "inputs.tmp").exists()

--- a/tests/unit/dataset/test_inputs_json_chunks.py
+++ b/tests/unit/dataset/test_inputs_json_chunks.py
@@ -100,21 +100,43 @@ class TestIterInputsJsonChunks:
         chunks = list(iter_inputs_json_chunks(inputs, chunk_bytes=chunk_bytes))
 
         assert len(chunks) > 1
-        assert all(len(chunk) >= chunk_bytes for chunk in chunks[:-1])
-        assert all(len(chunk) < 2 * chunk_bytes for chunk in chunks)
+        assert all(len(chunk) == chunk_bytes for chunk in chunks[:-1])
+        assert 0 < len(chunks[-1]) <= chunk_bytes
         assert b"".join(chunks) == _single_dump(inputs)
 
-    def test_iter_inputs_json_chunks_splits_oversized_session_at_payload_boundaries(
-        self,
-    ) -> None:
+    def test_iter_inputs_json_chunks_bounds_chunks_for_oversized_session(self) -> None:
         chunk_bytes = 4096
         inputs = InputsFile(data=[_session("big", 64, "y" * 1024)])
 
         chunks = list(iter_inputs_json_chunks(inputs, chunk_bytes=chunk_bytes))
 
         assert len(chunks) > 1
-        assert all(len(chunk) >= chunk_bytes for chunk in chunks[:-1])
-        assert all(len(chunk) < 2 * chunk_bytes for chunk in chunks)
+        assert all(len(chunk) == chunk_bytes for chunk in chunks[:-1])
+        assert 0 < len(chunks[-1]) <= chunk_bytes
+        assert b"".join(chunks) == _single_dump(inputs)
+
+    def test_iter_inputs_json_chunks_bounds_chunks_for_oversized_extra_field(
+        self,
+    ) -> None:
+        chunk_bytes = 4096
+        inputs = InputsFile(
+            data=[
+                _session("s1", 1, "small"),
+                SessionPayloads.model_validate(
+                    {
+                        "session_id": "huge-extra",
+                        "payloads": [_payload("p")],
+                        "blob": "z" * (4 * chunk_bytes),
+                    }
+                ),
+            ]
+        )
+
+        chunks = list(iter_inputs_json_chunks(inputs, chunk_bytes=chunk_bytes))
+
+        assert len(chunks) > 4
+        assert all(len(chunk) == chunk_bytes for chunk in chunks[:-1])
+        assert 0 < len(chunks[-1]) <= chunk_bytes
         assert b"".join(chunks) == _single_dump(inputs)
 
 
@@ -158,7 +180,7 @@ class TestGenerateInputsJsonFileStreaming:
             await manager._generate_inputs_json_file()
 
         assert len(write_sizes) > 1
-        assert all(size >= BYTES_PER_MIB for size in write_sizes[:-1])
-        assert all(size < 2 * BYTES_PER_MIB for size in write_sizes)
+        assert all(size == BYTES_PER_MIB for size in write_sizes[:-1])
+        assert 0 < write_sizes[-1] <= BYTES_PER_MIB
         assert (tmp_path / "inputs.json").read_bytes() == expected
         assert not (tmp_path / "inputs.tmp").exists()

--- a/tests/unit/dataset/test_inputs_json_chunks.py
+++ b/tests/unit/dataset/test_inputs_json_chunks.py
@@ -3,6 +3,7 @@
 """Unit tests for the chunked inputs.json encoder and the streamed DatasetManager writer."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import orjson
 import pytest
@@ -16,7 +17,6 @@ from aiperf.dataset.payload_formatting import iter_inputs_json_chunks
 
 
 def _single_dump(inputs: InputsFile) -> bytes:
-    """The whole-document encoding the chunked encoder must reproduce byte for byte."""
     return orjson.dumps(
         inputs.model_dump(exclude_none=True, mode="json"), option=orjson.OPT_INDENT_2
     )
@@ -45,15 +45,28 @@ class TestIterInputsJsonChunks:
         [
             param(InputsFile(), id="empty"),
             param(InputsFile(data=[_session("s1", 1, "hi")]), id="single-session"),
+            param(InputsFile(data=[_session("s1", 0, "")]), id="session-without-payloads"),
+            param(InputsFile(data=[_session(None, 2, "hi")]), id="session-without-id"),
             param(
                 InputsFile(
                     data=[
                         _session("s1", 2, 'line1\nline2\ttab "quoted" \\ slash'),
                         _session(None, 0, ""),
                         _session("s3", 3, "unicode é 中 \U0001f600"),
+                        SessionPayloads(
+                            session_id="s4",
+                            payloads=[
+                                {},
+                                {
+                                    "top": None,
+                                    "nested": {"none": None, "list": [None, 1.5, True]},
+                                    "n": 0,
+                                },
+                            ],
+                        ),
                     ]
                 ),
-                id="escapes-unicode-no-session-id",
+                id="escapes-unicode-none-values-mixed",
             ),
         ],
     )  # fmt: skip
@@ -73,14 +86,25 @@ class TestIterInputsJsonChunks:
         assert all(len(chunk) < 2 * chunk_bytes for chunk in chunks)
         assert b"".join(chunks) == _single_dump(inputs)
 
+    def test_iter_inputs_json_chunks_splits_oversized_session_at_payload_boundaries(
+        self,
+    ) -> None:
+        chunk_bytes = 4096
+        inputs = InputsFile(data=[_session("big", 64, "y" * 1024)])
+
+        chunks = list(iter_inputs_json_chunks(inputs, chunk_bytes=chunk_bytes))
+
+        assert len(chunks) > 1
+        assert all(len(chunk) >= chunk_bytes for chunk in chunks[:-1])
+        assert all(len(chunk) < 2 * chunk_bytes for chunk in chunks)
+        assert b"".join(chunks) == _single_dump(inputs)
+
 
 class TestGenerateInputsJsonFileStreaming:
     @pytest.mark.asyncio
-    async def test_generate_inputs_json_file_large_dataset_matches_single_dump(
+    async def test_generate_inputs_json_file_writes_multiple_bounded_chunks(
         self, benchmark_run, tmp_path: Path
     ) -> None:
-        """A dataset several times the flush threshold is written across multiple
-        chunks and still lands on disk byte-identical to the one-shot encoding."""
         manager = DatasetManager(run=benchmark_run, service_id="test_dataset_manager")
         manager.dataset = {
             f"session_{i}": Conversation(
@@ -90,14 +114,32 @@ class TestGenerateInputsJsonFileStreaming:
                     for _ in range(2)
                 ],
             )
-            for i in range(2000)
+            for i in range(1200)
         }
         expected = _single_dump(
             manager._generate_input_payloads(ModelEndpointInfo.from_run(benchmark_run))
         )
         assert len(expected) > 2 * BYTES_PER_MIB
+        write_sizes: list[int] = []
 
-        await manager._generate_inputs_json_file()
+        class _RecordingFile:
+            def __init__(self, path: Path) -> None:
+                self._file = path.open("wb")
 
+            async def write(self, data: bytes) -> None:
+                write_sizes.append(len(data))
+                self._file.write(data)
+
+            async def __aenter__(self) -> "_RecordingFile":
+                return self
+
+            async def __aexit__(self, *exc: object) -> None:
+                self._file.close()
+
+        with patch("aiofiles.open", lambda path, mode: _RecordingFile(Path(path))):
+            await manager._generate_inputs_json_file()
+
+        assert len(write_sizes) > 1
+        assert all(size >= BYTES_PER_MIB for size in write_sizes[:-1])
         assert (tmp_path / "inputs.json").read_bytes() == expected
         assert not (tmp_path / "inputs.tmp").exists()

--- a/tests/unit/dataset/test_inputs_json_chunks.py
+++ b/tests/unit/dataset/test_inputs_json_chunks.py
@@ -139,6 +139,49 @@ class TestIterInputsJsonChunks:
         assert 0 < len(chunks[-1]) <= chunk_bytes
         assert b"".join(chunks) == _single_dump(inputs)
 
+    @pytest.mark.parametrize("chunk_bytes", [0, -1])
+    def test_iter_inputs_json_chunks_rejects_non_positive_chunk_bytes(
+        self, chunk_bytes: int
+    ) -> None:
+        with pytest.raises(ValueError, match="chunk_bytes must be positive"):
+            next(iter_inputs_json_chunks(InputsFile(), chunk_bytes=chunk_bytes))
+
+    @pytest.mark.parametrize(
+        "inputs",
+        [
+            param(
+                InputsFile.model_validate(
+                    {
+                        "data": [],
+                        "export_meta": {"origin": "unit", "ids": [1, 2]},
+                    }
+                ),
+                id="top-level-extras-empty-data",
+            ),
+            param(
+                InputsFile.model_validate(
+                    {
+                        "data": [
+                            {"session_id": "s1", "payloads": [_payload("hi 0")]},
+                        ],
+                        "note": "extension field",
+                        "dropped_if_none": None,
+                    }
+                ),
+                id="top-level-extras-with-data",
+            ),
+        ],
+    )  # fmt: skip
+    def test_iter_inputs_json_chunks_preserves_top_level_extra_fields(
+        self, inputs: InputsFile
+    ) -> None:
+        chunk_bytes = 64
+        chunks = list(iter_inputs_json_chunks(inputs, chunk_bytes=chunk_bytes))
+
+        assert all(len(chunk) == chunk_bytes for chunk in chunks[:-1])
+        assert 0 < len(chunks[-1]) <= chunk_bytes
+        assert b"".join(chunks) == _single_dump(inputs)
+
 
 class TestGenerateInputsJsonFileStreaming:
     @pytest.mark.asyncio

--- a/tests/unit/dataset/test_inputs_json_chunks.py
+++ b/tests/unit/dataset/test_inputs_json_chunks.py
@@ -50,6 +50,24 @@ class TestIterInputsJsonChunks:
             param(
                 InputsFile(
                     data=[
+                        _session("s1", 1, "before"),
+                        SessionPayloads.model_validate(
+                            {
+                                "session_id": "s2",
+                                "payloads": [_payload("extra 0")],
+                                "trace_meta": {"origin": "unit", "ids": [1, 2]},
+                                "note": "extension field",
+                                "dropped_if_none": None,
+                            }
+                        ),
+                        _session("s3", 1, "after"),
+                    ]
+                ),
+                id="session-with-extra-fields",
+            ),
+            param(
+                InputsFile(
+                    data=[
                         _session("s1", 2, 'line1\nline2\ttab "quoted" \\ slash'),
                         _session(None, 0, ""),
                         _session("s3", 3, "unicode é 中 \U0001f600"),
@@ -141,5 +159,6 @@ class TestGenerateInputsJsonFileStreaming:
 
         assert len(write_sizes) > 1
         assert all(size >= BYTES_PER_MIB for size in write_sizes[:-1])
+        assert all(size < 2 * BYTES_PER_MIB for size in write_sizes)
         assert (tmp_path / "inputs.json").read_bytes() == expected
         assert not (tmp_path / "inputs.tmp").exists()

--- a/tests/unit/dataset/test_inputs_json_chunks.py
+++ b/tests/unit/dataset/test_inputs_json_chunks.py
@@ -139,6 +139,27 @@ class TestIterInputsJsonChunks:
         assert 0 < len(chunks[-1]) <= chunk_bytes
         assert b"".join(chunks) == _single_dump(inputs)
 
+    def test_iter_inputs_json_chunks_bounds_chunks_for_oversized_payload(self) -> None:
+        chunk_bytes = 1024
+        inputs = InputsFile(data=[_session("big", 1, "y" * (64 * chunk_bytes))])
+
+        chunks = list(iter_inputs_json_chunks(inputs, chunk_bytes=chunk_bytes))
+
+        assert len(chunks) > 64
+        assert all(len(chunk) == chunk_bytes for chunk in chunks[:-1])
+        assert 0 < len(chunks[-1]) <= chunk_bytes
+        assert b"".join(chunks) == _single_dump(inputs)
+
+    @pytest.mark.parametrize("chunk_bytes", [1, 5, 16])
+    def test_iter_inputs_json_chunks_bounds_chunks_for_empty_document(
+        self, chunk_bytes: int
+    ) -> None:
+        chunks = list(iter_inputs_json_chunks(InputsFile(), chunk_bytes=chunk_bytes))
+
+        assert all(len(chunk) == chunk_bytes for chunk in chunks[:-1])
+        assert 0 < len(chunks[-1]) <= chunk_bytes
+        assert b"".join(chunks) == _single_dump(InputsFile())
+
     @pytest.mark.parametrize("chunk_bytes", [0, -1])
     def test_iter_inputs_json_chunks_rejects_non_positive_chunk_bytes(
         self, chunk_bytes: int


### PR DESCRIPTION
## Summary

Stream `inputs.json` to disk in bounded chunks instead of encoding the whole document in memory and pushing it through one write call. Bytes on disk are unchanged.

Fixes #894

## Root cause

`DatasetManager._generate_inputs_json_file` built `inputs.model_dump(mode="json")` (a second copy of every payload), then `orjson.dumps` of the whole document (a third copy, pretty-printed), then handed that single buffer to one `write` call. For a large dataset that is several GB of transient memory and one giant write against the artifact directory, which is what #894 hit on remote storage. The reporter asked for 1 MB chunked writes. The `.replace` of the temp file was also a blocking call on the event loop.

## Changes

- `payload_formatting.iter_inputs_json_chunks`: pydantic still dumps each `SessionPayloads` (same `exclude_none` / JSON-mode semantics), but the bytes are emitted as the session frame plus one `OPT_INDENT_2`-encoded payload per piece, re-indented under `"data"` / `"payloads"`, and the buffer is drained in exact 1 MiB (`BYTES_PER_MIB`) slices, so every write except the last is exactly the threshold no matter how large any single piece is, including a single session larger than the threshold. A session carrying extra="allow" fields beyond `session_id`/`payloads` (never produced by the current export path) is encoded whole into the buffer, so extension fields survive with the identical byte layout. orjson escapes control characters inside strings, so the re-indent is exact and the concatenation is byte-identical to the previous one-shot encoding. Peak transient memory drops from three copies of every payload to one chunk plus one session.
- `DatasetManager._generate_inputs_json_file`: writes those chunks through the existing `aiofiles` handle; `temp_file_path.replace` moved to `asyncio.to_thread`. Error handling (`OSError` non-fatal, other exceptions fatal, `.tmp` unlinked in `finally`) is unchanged.
- `tests/unit/dataset/conftest.py`: `capture_file_writes` now accumulates writes instead of keeping only the last one.
- New `tests/unit/dataset/test_inputs_json_chunks.py`: concatenation equals the single dump (empty file, single session, session without payloads, session without id, escapes/unicode, `{}` payload, `None` values inside payloads, a session with extra="allow" fields between plain sessions), exact-slice behavior for many small sessions, for one 64-payload session larger than the threshold, and for an extra field four times the threshold (every chunk but the last exactly the threshold), and a manager-level 1200-session write (> 2 MiB) that records the `aiofiles` write calls (more than one, every write but the last exactly 1 MiB) and lands byte-identical to the single dump with no `.tmp` left behind.

No CLI flag, env var, or documented behavior changes; the pretty-printed format `docs/tutorials/inputs-json-replay.md` describes is preserved, so no docs regeneration.

## Validation

- `uv run pytest tests/unit/ -n auto`: green on `main` before the change (28065 passed, 141 skipped, 1 xfailed) and on this branch (28075 passed, 141 skipped, 1 xfailed, re-run after the payload-boundary, extras-fallback, and exact-slice revisions).
- `uv run pytest tests/unit/property/ -n auto`: 61 passed.
- `pre-commit run --all-files`: 33 hooks passed, no files modified.
- Runtime, per the `aiperf-code-review` skill: the same `aiperf profile --random-seed 42` run (6 synthetic sessions, streaming chat) against the in-repo mock server with `main`'s writer and with this branch produced sha256-identical `inputs.json`, re-checked after the payload-boundary revision; after the extras-fallback and exact-slice revisions the same run's output is sha256-identical across revisions and still re-encodes byte-identically with `orjson.dumps(..., OPT_INDENT_2)`. A 1500-session run (2.18 MiB, at least three flushes) re-encodes with `orjson.dumps(..., OPT_INDENT_2)` to the identical bytes.

One caveat for the reporter's setup: the traceback in #894 shows the EIO raised from the file's `__exit__` (close, which flushes the write-back) rather than from the write call, which is the storage backend rejecting the write-back. If a backend still reports EIO at close after this change, that failure remains non-fatal to the run, as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved `inputs.json` generation for large datasets by streaming data in bounded chunks, reducing memory usage.
  - Preserved byte-identical output for mixed payloads and sessions with additional fields.
  - Improved handling of empty sessions, missing identifiers, null values, escaped content, and oversized sessions.
  - Added safer temporary-file handling to help prevent incomplete output files during generation.
  - Ensured generated files remain complete and valid when individual sessions exceed the configured chunk size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

