### PR TITLE
feat(search): support real-valued dimensions 1D SLA planners

### DIFF
--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -550,7 +550,7 @@ flowchart LR
     class hist,SLA output
 ```
 
-The monotonic planner mirrors Triton perf_analyzer's `--binary-search`: each point's verdict is provisional until 2 trials agree (configurable via `AdaptiveSearchSweep.monotonic_stability_trials`, default `2`).
+The monotonic planner mirrors Triton perf_analyzer's `--binary-search`: each point's verdict is provisional until 2 trials agree (configurable via `AdaptiveSearchSweep.monotonic_stability_trials`, default `2`). Both 1D planners accept an `int` or `real` search-space dimension; the exponential probe doubles from `lo`, so `lo` must be positive (`lo >= 1` for `int`, `lo > 0` for `real`). A `real` boundary is reported as the band `[feasible_max, infeasible_min]` rather than an exact point.
 
 #### `smooth_isotonic` (default)
 

--- a/docs/sweeping/bayesian-optimization.md
+++ b/docs/sweeping/bayesian-optimization.md
@@ -140,7 +140,7 @@ explicitly.
 
 - `PATH` is a dotted path resolved by `_set_nested_value` (the same primitive grid sweeps use). For named-list segments like `phases.profiling.concurrency`, the segment matches against the `name` field. Typos error loudly with the available names listed.
 - `LO` and `HI` are inclusive bounds parsed as floats. For `:int`, integer rounding happens at the planner boundary so candidates always coerce to integers before the run.
-- `:int` produces an integer-valued dimension, `:real` a real-valued dimension. Categorical dimensions are not supported by the current `SearchSpaceDimension` model.
+- `:int` produces an integer-valued dimension, `:real` a real-valued dimension. Categorical dimensions are not supported by the current `SearchSpaceDimension` model. The kind must match the field's type, e.g. `phases.profiling.concurrency` is `int`-only and requires `:int` (the bare `PATH:LO,HI` form defaults to `:real` and is rejected for `int` fields).
 
 Multi-dim:
 
@@ -550,7 +550,7 @@ flowchart LR
     class hist,SLA output
 ```
 
-The monotonic planner mirrors Triton perf_analyzer's `--binary-search`: each point's verdict is provisional until 2 trials agree (configurable via `AdaptiveSearchSweep.monotonic_stability_trials`, default `2`). Both 1D planners accept an `int` or `real` search-space dimension; the exponential probe doubles from `lo`, so `lo` must be positive (`lo >= 1` for `int`, `lo > 0` for `real`). A `real` boundary is reported as the band `[feasible_max, infeasible_min]` rather than an exact point.
+The monotonic planner mirrors Triton perf_analyzer's `--binary-search`: each point's verdict is provisional until 2 trials agree (configurable via `AdaptiveSearchSweep.monotonic_stability_trials`, default `2`). Both 1D planners accept an `int` or `real` search-space dimension; the exponential probe doubles from `lo`, so `lo` must be positive (`lo >= 1` for `int`, `lo > 0` for `real`). A dimension with `kind="real"` targeting an `int`-typed field (e.g. `concurrency`) is rejected at plan build, use `kind="int"` or a `float`-typed field such as `rate`. A `real` boundary is reported as the band `[feasible_max, infeasible_min]` rather than an exact point.
 
 #### `smooth_isotonic` (default)
 

--- a/src/aiperf/orchestrator/search_planner/_cliff_detect.py
+++ b/src/aiperf/orchestrator/search_planner/_cliff_detect.py
@@ -29,12 +29,12 @@ _MIN_LOCAL_POINTS = 3
 
 
 def detect_cliff(
-    raw_points: list[tuple[int, float]],
+    raw_points: list[tuple[int | float, float]],
     fitted_curve: Callable[[float], float],
     *,
-    feasible_max: int | None,
-    infeasible_min: int | None,
-    x_hi: int,
+    feasible_max: int | float | None,
+    infeasible_min: int | float | None,
+    x_hi: int | float,
     precision: float | None = None,
 ) -> bool:
     """Return True iff the last raw probe sits outside the smooth fit and the bracket is still wide.

--- a/src/aiperf/orchestrator/search_planner/_monotonic_boundary.py
+++ b/src/aiperf/orchestrator/search_planner/_monotonic_boundary.py
@@ -75,7 +75,7 @@ def _infeasible_min_block(
 
 
 def _latest_iteration_at(
-    planner: MonotonicSLASearchPlanner, value: int, *, feasible: bool
+    planner: MonotonicSLASearchPlanner, value: int | float, *, feasible: bool
 ) -> SearchIteration | None:
     """Return the latest iteration whose swept value matches and feasibility agrees.
 

--- a/src/aiperf/orchestrator/search_planner/_shared_warmup.py
+++ b/src/aiperf/orchestrator/search_planner/_shared_warmup.py
@@ -15,6 +15,9 @@ from aiperf.config.config import BenchmarkConfig
 from aiperf.config.sweep import AdaptiveSearchSweep, _set_nested_value
 from aiperf.config.sweep.adaptive import SearchSpaceDimension
 
+_WARMUP_LOAD_KEYS: tuple[str, ...] = ("type", "rate", "rate_series", "concurrency")
+"""Allowlist of load-defining keys copied to warmup; ramps, grace, and cancellation are dropped."""
+
 
 def find_phase_index(phases: list[dict[str, Any]], name: str) -> int | None:
     """Return the first phase matching a literal name or semantic kind.
@@ -32,16 +35,16 @@ def find_phase_index(phases: list[dict[str, Any]], name: str) -> int | None:
 
 def apply_sla_warmup(
     cfg_dict: dict[str, Any],
-    value: int,
+    value: int | float,
     *,
     cfg: AdaptiveSearchSweep,
-    first_probe_at: set[int],
+    first_probe_at: set[int | float],
 ) -> None:
     """Prepend a per-iteration ``warmup`` phase to ``cfg_dict["phases"]``.
 
     Skipped when ``cfg.sla_warmup_seconds == 0`` (explicit user opt-out)
-    or when the profiling phase cannot be located. The warmup uses the
-    same swept-dim value being probed and is excluded from results.
+    or when the profiling phase cannot be located. The warmup mirrors the
+    profiling phase's load via ``_WARMUP_LOAD_KEYS`` and is excluded from results.
 
     Mutates ``first_probe_at`` to record which values have been warmed up.
     """
@@ -51,7 +54,8 @@ def apply_sla_warmup(
     phases = cfg_dict.get("phases")
     if not phases:
         return
-    if find_phase_index(phases, "profiling") is None:
+    idx = find_phase_index(phases, "profiling")
+    if idx is None:
         return
 
     base_warmup = (
@@ -65,13 +69,16 @@ def apply_sla_warmup(
     else:
         duration = max(Environment.SEARCH_PLANNER.REPLICATE_WARMUP_FLOOR, base_warmup)
 
+    profiling_phase = phases[idx]
     warmup_phase: dict[str, Any] = {
         "name": "warmup",
-        "type": "concurrency",
-        "concurrency": value,
+        "kind": "warmup",
         "duration": duration,
         "exclude_from_results": True,
     }
+    for key in _WARMUP_LOAD_KEYS:
+        if key in profiling_phase:
+            warmup_phase[key] = profiling_phase[key]
     if phases and isinstance(phases[0], dict) and phases[0].get("name") == "warmup":
         phases[0] = warmup_phase
     else:
@@ -104,16 +111,18 @@ def apply_sla_precision(
 def mutate_base(
     base_config: BenchmarkConfig,
     dim: SearchSpaceDimension,
-    value: int,
+    value: int | float,
     *,
     cfg: AdaptiveSearchSweep,
-    first_probe_at: set[int],
+    first_probe_at: set[int | float],
 ) -> BenchmarkConfig:
     """Return a deep-copied BenchmarkConfig with ``value`` patched in at the dim path.
 
     Applies SLA precision and warmup injection.
     """
-    cfg_dict = base_config.model_dump(mode="json", exclude_none=True)
+    cfg_dict = base_config.model_dump(
+        mode="python", exclude_none=True, context={"include_secrets": True}
+    )
     _set_nested_value(cfg_dict, dim.path, value)
     apply_sla_precision(cfg_dict, cfg)
     apply_sla_warmup(cfg_dict, value, cfg=cfg, first_probe_at=first_probe_at)

--- a/src/aiperf/orchestrator/search_planner/_smooth_isotonic_boundary.py
+++ b/src/aiperf/orchestrator/search_planner/_smooth_isotonic_boundary.py
@@ -89,7 +89,7 @@ def _infeasible_min_block(
 
 
 def _latest_iteration_at(
-    planner: SmoothIsotonicSLAPlanner, value: int, *, feasible: bool
+    planner: SmoothIsotonicSLAPlanner, value: int | float, *, feasible: bool
 ) -> SearchIteration | None:
     for iteration in reversed(planner._history):
         if iteration.variation_values.get(planner._dim.path) != value:

--- a/src/aiperf/orchestrator/search_planner/_smooth_isotonic_fit.py
+++ b/src/aiperf/orchestrator/search_planner/_smooth_isotonic_fit.py
@@ -27,7 +27,7 @@ _STRICTIFY_EPS_FRAC = 1e-9
 
 
 def smooth_isotonic_fit(
-    xs: list[int], ys: list[float]
+    xs: list[int | float], ys: list[float]
 ) -> tuple[Callable[[float], float], list[float]]:
     """Fit a monotone-denoised smooth curve through ``(xs, ys)``.
 

--- a/src/aiperf/orchestrator/search_planner/_smooth_isotonic_phases.py
+++ b/src/aiperf/orchestrator/search_planner/_smooth_isotonic_phases.py
@@ -118,7 +118,7 @@ def plan_replicate_step(planner: SmoothIsotonicSLAPlanner) -> None:
 # ----------------------------------------------------------------------
 
 
-def _fit_and_solve(planner: SmoothIsotonicSLAPlanner) -> int | None:
+def _fit_and_solve(planner: SmoothIsotonicSLAPlanner) -> int | float | None:
     xs, per_filter_curves, per_filter_margins, per_filter_sigmas = _build_fit(planner)
     if not xs:
         return None
@@ -136,18 +136,23 @@ def _fit_and_solve(planner: SmoothIsotonicSLAPlanner) -> int | None:
     )
     if root is None:
         return None
-    candidate = int(round(root))
-    if candidate <= planner.feasible_max:
-        candidate = planner.feasible_max + 1
-    if candidate >= planner.infeasible_min:
-        candidate = planner.infeasible_min - 1
+    if planner._dim.kind == "int":
+        candidate = int(round(root))
+        if candidate <= planner.feasible_max:
+            candidate = planner.feasible_max + 1
+        if candidate >= planner.infeasible_min:
+            candidate = planner.infeasible_min - 1
+        return candidate
+    candidate = float(root)
+    if candidate <= planner.feasible_max or candidate >= planner.infeasible_min:
+        candidate = (planner.feasible_max + planner.infeasible_min) / 2
     return candidate
 
 
 def _build_fit(
     planner: SmoothIsotonicSLAPlanner,
 ) -> tuple[
-    list[int],
+    list[int | float],
     dict[str, Callable[[float], float] | None],
     dict[str, float],
     dict[str, float],
@@ -227,23 +232,33 @@ def _queue_more_probes_for_refit(planner: SmoothIsotonicSLAPlanner) -> None:
     if planner.feasible_max is None or planner.infeasible_min is None:
         return
     gap = planner.infeasible_min - planner.feasible_max
-    if gap <= 1:
+    if planner._dim.kind == "int" and gap <= 1:
         return
     for frac in (0.125, 0.625):
-        x = planner.feasible_max + max(1, round(gap * frac))
-        x = min(x, planner.infeasible_min - 1)
-        x = max(x, planner.feasible_max + 1)
+        if planner._dim.kind == "int":
+            x = planner.feasible_max + max(1, round(gap * frac))
+            x = min(x, planner.infeasible_min - 1)
+            x = max(x, planner.feasible_max + 1)
+        else:
+            x = planner.feasible_max + gap * frac
+            if x <= planner.feasible_max or x >= planner.infeasible_min:
+                continue
         if x not in planner._raw_probes and x not in planner._probe_queue:
-            planner._probe_queue.append(int(x))
+            planner._probe_queue.append(x)
 
 
-def _bisection_fallback(planner: SmoothIsotonicSLAPlanner) -> int | None:
+def _bisection_fallback(planner: SmoothIsotonicSLAPlanner) -> int | float | None:
     if planner.feasible_max is None or planner.infeasible_min is None:
         return None
     gap = planner.infeasible_min - planner.feasible_max
-    if gap <= 1:
+    if planner._dim.kind == "int":
+        if gap <= 1:
+            return None
+        return planner.feasible_max + gap // 2
+    midpoint = planner.feasible_max + gap / 2
+    if midpoint <= planner.feasible_max or midpoint >= planner.infeasible_min:
         return None
-    return planner.feasible_max + gap // 2
+    return midpoint
 
 
 # ----------------------------------------------------------------------
@@ -252,7 +267,7 @@ def _bisection_fallback(planner: SmoothIsotonicSLAPlanner) -> int | None:
 
 
 def _enter_replicate_or_terminate(
-    planner: SmoothIsotonicSLAPlanner, candidate: int
+    planner: SmoothIsotonicSLAPlanner, candidate: int | float
 ) -> None:
     cliff = _check_cliff(planner, candidate)
     planner.boundary_type = "cliff" if cliff else "smooth"
@@ -290,30 +305,35 @@ def _enter_replicate_or_terminate(
     planner._phase = "replicate"
 
 
-def _cliff_bisect_midpoint(planner: SmoothIsotonicSLAPlanner) -> int | None:
+def _cliff_bisect_midpoint(planner: SmoothIsotonicSLAPlanner) -> int | float | None:
     """Midpoint of [feasible_max, infeasible_min], nudged inward on collision."""
     if planner.feasible_max is None or planner.infeasible_min is None:
         return None
     gap = planner.infeasible_min - planner.feasible_max
-    if gap <= 1:
-        return None
-    mid = planner.feasible_max + gap // 2
-    if mid <= planner.feasible_max:
-        mid = planner.feasible_max + 1
-    if mid >= planner.infeasible_min:
-        mid = planner.infeasible_min - 1
+    if planner._dim.kind == "int":
+        if gap <= 1:
+            return None
+        mid = planner.feasible_max + gap // 2
+        if mid <= planner.feasible_max:
+            mid = planner.feasible_max + 1
+        if mid >= planner.infeasible_min:
+            mid = planner.infeasible_min - 1
+        if mid <= planner.feasible_max or mid >= planner.infeasible_min:
+            return None
+        return int(mid)
+    mid = planner.feasible_max + gap / 2
     if mid <= planner.feasible_max or mid >= planner.infeasible_min:
         return None
-    return int(mid)
+    return mid
 
 
-def _check_cliff(planner: SmoothIsotonicSLAPlanner, candidate: int) -> bool:
+def _check_cliff(planner: SmoothIsotonicSLAPlanner, candidate: int | float) -> bool:
     """PAVA-residual cliff guard. Returns False on degenerate fit input."""
     del candidate  # currently unused; reserved for future per-candidate residual.
     if not planner.binding_constraint:
         return False
     xs = sorted(planner._raw_probes.keys())
-    raw_pts: list[tuple[int, float]] = []
+    raw_pts: list[tuple[int | float, float]] = []
     for x in xs:
         samples = [
             m[planner.binding_constraint]
@@ -370,11 +390,11 @@ def _bracket_precision_reached(planner: SmoothIsotonicSLAPlanner) -> bool:
     if planner.feasible_max is None or planner.infeasible_min is None:
         return False
     gap = planner.infeasible_min - planner.feasible_max
-    if gap <= 1:
+    if planner._dim.kind == "int" and gap <= 1:
         return True
+    # infeasible_min >= lo > 0 (enforced at construction)
     return (
-        gap / max(planner.infeasible_min, 1)
-        < Environment.SEARCH_PLANNER.SLA_PRECISION_DEFAULT
+        gap / planner.infeasible_min < Environment.SEARCH_PLANNER.SLA_PRECISION_DEFAULT
     )
 
 

--- a/src/aiperf/orchestrator/search_planner/_smooth_isotonic_phases.py
+++ b/src/aiperf/orchestrator/search_planner/_smooth_isotonic_phases.py
@@ -146,6 +146,8 @@ def _fit_and_solve(planner: SmoothIsotonicSLAPlanner) -> int | float | None:
     candidate = float(root)
     if candidate <= planner.feasible_max or candidate >= planner.infeasible_min:
         candidate = (planner.feasible_max + planner.infeasible_min) / 2
+        if candidate <= planner.feasible_max or candidate >= planner.infeasible_min:
+            return None
     return candidate
 
 

--- a/src/aiperf/orchestrator/search_planner/factory.py
+++ b/src/aiperf/orchestrator/search_planner/factory.py
@@ -6,7 +6,9 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, get_args
+
+from aiperf.config.phases import PhaseConfig
 
 if TYPE_CHECKING:
     from aiperf.config import BenchmarkPlan
@@ -34,6 +36,29 @@ def build_search_planner(plan: BenchmarkPlan) -> SearchPlanner | None:
         return None
 
     config = plan.sweep
+    real_dims = [dim for dim in config.search_space if dim.kind == "real"]
+    if real_dims:
+        # kind="real" dimensions may only target fields that accept
+        # fractional values; int-typed phase fields would reject (or
+        # silently coerce) the fractional proposals mid-search.
+        int_fields: set[str] = set()
+        for model in get_args(get_args(PhaseConfig)[0]):
+            for name, field in model.model_fields.items():
+                ann = field.annotation
+                args = get_args(ann)
+                if ann is int or (
+                    args and all(a is int or a is type(None) for a in args)
+                ):
+                    int_fields.add(name)
+        for dim in real_dims:
+            leaf = dim.path.rsplit(".", 1)[-1]
+            if leaf in int_fields:
+                raise ValueError(
+                    f"search dimension {dim.path!r} has kind='real' but targets "
+                    f"int-typed phase field {leaf!r}; the planner would propose "
+                    f"fractional values that the phase config rejects. Use "
+                    f"kind='int', or target a float-typed field (e.g. 'rate')."
+                )
     if len(config.sla_tiers) >= 2:
         from aiperf.orchestrator.search_planner.multi_tier_planner import (
             MultiTierPlanner,

--- a/src/aiperf/orchestrator/search_planner/factory.py
+++ b/src/aiperf/orchestrator/search_planner/factory.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
@@ -44,21 +45,26 @@ def build_search_planner(plan: BenchmarkPlan) -> SearchPlanner | None:
         base = plan.configs[0] if plan.configs else None
         if base is not None:
             for dim in real_dims:
+                lo = float(dim.lo)
+                hi = float(dim.hi)
+                mid = (lo + hi) / 2
+                probe_val = math.nextafter(mid, hi)
+                if probe_val <= lo or probe_val >= hi:
+                    probe_val = math.nextafter(mid, lo)
                 probe = base.model_dump(  # type: ignore[union-attr]
                     mode="python", exclude_none=True, context={"include_secrets": True}
                 )
-                _set_nested_value(probe, dim.path, 0.5)
+                _set_nested_value(probe, dim.path, probe_val)
                 try:
                     BenchmarkConfig.model_validate(probe)
                 except ValidationError as exc:
-                    if any(err.get("type") == "int_from_float" for err in exc.errors()):
-                        leaf = dim.path.rsplit(".", 1)[-1]
-                        raise ValueError(
-                            f"search dimension {dim.path!r} has kind='real' but targets "
-                            f"int-typed field {leaf!r}; the planner would propose "
-                            f"fractional values that the config rejects. Use "
-                            f"kind='int', or target a float-typed field (e.g. 'rate')."
-                        ) from exc
+                    leaf = dim.path.rsplit(".", 1)[-1]
+                    raise ValueError(
+                        f"search dimension {dim.path!r} has kind='real' but targets "
+                        f"int-typed field {leaf!r}; the planner would propose "
+                        f"fractional values that the config rejects. Use "
+                        f"kind='int', or target a float-typed field (e.g. 'rate')."
+                    ) from exc
     if len(config.sla_tiers) >= 2:
         from aiperf.orchestrator.search_planner.multi_tier_planner import (
             MultiTierPlanner,

--- a/src/aiperf/orchestrator/search_planner/factory.py
+++ b/src/aiperf/orchestrator/search_planner/factory.py
@@ -6,9 +6,9 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, get_args
+from typing import TYPE_CHECKING
 
-from aiperf.config.phases import PhaseConfig
+from pydantic import ValidationError
 
 if TYPE_CHECKING:
     from aiperf.config import BenchmarkPlan
@@ -38,27 +38,27 @@ def build_search_planner(plan: BenchmarkPlan) -> SearchPlanner | None:
     config = plan.sweep
     real_dims = [dim for dim in config.search_space if dim.kind == "real"]
     if real_dims:
-        # kind="real" dimensions may only target fields that accept
-        # fractional values; int-typed phase fields would reject (or
-        # silently coerce) the fractional proposals mid-search.
-        int_fields: set[str] = set()
-        for model in get_args(get_args(PhaseConfig)[0]):
-            for name, field in model.model_fields.items():
-                ann = field.annotation
-                args = get_args(ann)
-                if ann is int or (
-                    args and all(a is int or a is type(None) for a in args)
-                ):
-                    int_fields.add(name)
-        for dim in real_dims:
-            leaf = dim.path.rsplit(".", 1)[-1]
-            if leaf in int_fields:
-                raise ValueError(
-                    f"search dimension {dim.path!r} has kind='real' but targets "
-                    f"int-typed phase field {leaf!r}; the planner would propose "
-                    f"fractional values that the phase config rejects. Use "
-                    f"kind='int', or target a float-typed field (e.g. 'rate')."
+        from aiperf.config.config import BenchmarkConfig
+        from aiperf.config.sweep import _set_nested_value
+
+        base = plan.configs[0] if plan.configs else None
+        if base is not None:
+            for dim in real_dims:
+                probe = base.model_dump(  # type: ignore[union-attr]
+                    mode="python", exclude_none=True, context={"include_secrets": True}
                 )
+                _set_nested_value(probe, dim.path, 0.5)
+                try:
+                    BenchmarkConfig.model_validate(probe)
+                except ValidationError as exc:
+                    if any(err.get("type") == "int_from_float" for err in exc.errors()):
+                        leaf = dim.path.rsplit(".", 1)[-1]
+                        raise ValueError(
+                            f"search dimension {dim.path!r} has kind='real' but targets "
+                            f"int-typed field {leaf!r}; the planner would propose "
+                            f"fractional values that the config rejects. Use "
+                            f"kind='int', or target a float-typed field (e.g. 'rate')."
+                        ) from exc
     if len(config.sla_tiers) >= 2:
         from aiperf.orchestrator.search_planner.multi_tier_planner import (
             MultiTierPlanner,

--- a/src/aiperf/orchestrator/search_planner/monotonic.py
+++ b/src/aiperf/orchestrator/search_planner/monotonic.py
@@ -153,11 +153,17 @@ class MonotonicSLASearchPlanner(SearchPlanner):
                 "spaces by GP-modeling the joint surface."
             )
         dim = cfg.search_space[0]
-        if dim.kind != "int":
+        if dim.kind == "int" and int(dim.lo) < 1:
             raise ValueError(
-                f"monotonic_sla planner v1 supports kind='int' dimensions only; "
-                f"got kind={dim.kind!r} on path {dim.path!r}. Use the bayesian "
-                "planner for real-valued dimensions."
+                f"monotonic_sla planner: dimension {dim.path!r} requires "
+                f"lo >= 1 (got lo={dim.lo!r}); the exponential probe doubles "
+                "from lo and would stall or diverge for lo < 1."
+            )
+        if dim.kind == "real" and dim.lo <= 0:
+            raise ValueError(
+                f"monotonic_sla planner: dimension {dim.path!r} requires "
+                f"lo > 0 (got lo={dim.lo!r}); the exponential probe doubles "
+                "from lo and would stall or diverge for lo <= 0."
             )
         if not cfg.sla_filters:
             raise ValueError(
@@ -178,25 +184,25 @@ class MonotonicSLASearchPlanner(SearchPlanner):
                 "--optuna-acquisition qlognehvi."
             )
         self._dim = dim
-        self._lo: int = int(dim.lo)
-        self._hi: int = int(dim.hi)
+        self._lo: int | float = int(dim.lo) if dim.kind == "int" else float(dim.lo)
+        self._hi: int | float = int(dim.hi) if dim.kind == "int" else float(dim.hi)
         self._stability_trials = cfg.monotonic_stability_trials
 
         # Bracket. ``feasible_max`` (lo') is the highest swept value with a
         # latched feasible verdict; ``infeasible_min`` (hi') is the lowest
         # with a latched infeasible verdict. Both None until first verdict.
-        self.feasible_max: int | None = None
-        self.infeasible_min: int | None = None
+        self.feasible_max: int | float | None = None
+        self.infeasible_min: int | float | None = None
 
         # Per-point trial logs for the stability window.
-        self._point_logs: dict[int, _PointLog] = {}
+        self._point_logs: dict[int | float, _PointLog] = {}
 
         # Algorithm phase: "probe" (exponential ramp) or "bisect".
         self._phase: Literal["probe", "bisect"] = "probe"
         # Next swept value to ask for. Starts at lo; doubled in probe phase.
-        self._next_value: int = self._lo
+        self._next_value: int | float = self._lo
         # ``ask`` returned a value but ``tell`` hasn't been called yet.
-        self._pending_value: int | None = None
+        self._pending_value: int | float | None = None
 
         self._iter = 0
         self._history: list[SearchIteration] = []
@@ -298,7 +304,7 @@ class MonotonicSLASearchPlanner(SearchPlanner):
     # Algorithm internals
     # ------------------------------------------------------------------
 
-    def _absorb_verdict(self, value: int, verdict: bool) -> bool:
+    def _absorb_verdict(self, value: int | float, verdict: bool) -> bool:
         """Update ``feasible_max`` / ``infeasible_min`` from a latched verdict.
 
         Returns True if the verdict reveals a non-monotonic transition (a
@@ -340,7 +346,7 @@ class MonotonicSLASearchPlanner(SearchPlanner):
                 self.infeasible_min = value
         return non_monotonic
 
-    def _plan_next_step(self, value: int, verdict: bool | None) -> None:
+    def _plan_next_step(self, value: int | float, verdict: bool | None) -> None:
         """Decide the next swept value to ask for, or latch a convergence reason."""
         if verdict is None:
             # Stability window: re-ask the same value until verdict latches.
@@ -352,7 +358,7 @@ class MonotonicSLASearchPlanner(SearchPlanner):
         else:
             self._plan_bisect_step()
 
-    def _plan_probe_step(self, value: int, verdict: bool) -> None:
+    def _plan_probe_step(self, value: int | float, verdict: bool) -> None:
         """Exponential ramp: double the swept value until a fail or hi reached."""
         if not verdict:
             # First failure during probing — bracket found.
@@ -378,7 +384,10 @@ class MonotonicSLASearchPlanner(SearchPlanner):
         self._next_value = next_value
 
     def _plan_bisect_step(self) -> None:
-        """Bisection: midpoint of [feasible_max, infeasible_min] until precision."""
+        """Bisection: midpoint of [feasible_max, infeasible_min] until precision.
+
+        Integer axes also stop at unit gap; real axes stop on relative precision only.
+        """
         if self.feasible_max is None or self.infeasible_min is None:
             # Cannot bisect without both bounds; defer to the failsafes.
             self._convergence_reason = (
@@ -388,28 +397,36 @@ class MonotonicSLASearchPlanner(SearchPlanner):
             )
             return
         gap = self.infeasible_min - self.feasible_max
-        if gap <= 1:
+        if self._dim.kind == "int" and gap <= 1:
             self._convergence_reason = "monotonic_precision_reached"
             return
-        relative = gap / max(self.infeasible_min, 1)
-        if relative < Environment.SEARCH_PLANNER.SLA_PRECISION_DEFAULT:
+        # infeasible_min >= lo > 0 (enforced at construction)
+        if gap / self.infeasible_min < Environment.SEARCH_PLANNER.SLA_PRECISION_DEFAULT:
             self._convergence_reason = "monotonic_precision_reached"
             return
-        # Integer midpoint biased downward — keeps the bracket tightening.
-        midpoint = self.feasible_max + gap // 2
-        # Avoid re-probing a value we already have a latched verdict on; if
-        # the midpoint coincides with one of the bounds, nudge inward.
-        if midpoint <= self.feasible_max:
-            midpoint = self.feasible_max + 1
-        if midpoint >= self.infeasible_min:
-            midpoint = self.infeasible_min - 1
+        if self._dim.kind == "int":
+            # Integer midpoint biased downward — keeps the bracket tightening.
+            midpoint = self.feasible_max + gap // 2
+            # Avoid re-probing a value we already have a latched verdict on; if
+            # the midpoint coincides with one of the bounds, nudge inward.
+            if midpoint <= self.feasible_max:
+                midpoint = self.feasible_max + 1
+            if midpoint >= self.infeasible_min:
+                midpoint = self.infeasible_min - 1
+            self._next_value = midpoint
+            return
+        midpoint = self.feasible_max + gap / 2
+        if midpoint <= self.feasible_max or midpoint >= self.infeasible_min:
+            # Midpoint absorbed by float resolution — bracket tighter than the target.
+            self._convergence_reason = "monotonic_precision_reached"
+            return
         self._next_value = midpoint
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 
-    def _mutate_base(self, value: int) -> BenchmarkConfig:
+    def _mutate_base(self, value: int | float) -> BenchmarkConfig:
         """Return a deep-copied BenchmarkConfig with ``value`` patched in at the dim path.
 
         mode="python" + context={"include_secrets": True} so neither the

--- a/src/aiperf/orchestrator/search_planner/smooth_isotonic.py
+++ b/src/aiperf/orchestrator/search_planner/smooth_isotonic.py
@@ -50,6 +50,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from aiperf.common.environment import Environment
 from aiperf.config.config import BenchmarkConfig
+from aiperf.config.phases import PhaseType
 from aiperf.config.sweep import AdaptiveSearchSweep, SweepVariation, _set_nested_value
 from aiperf.orchestrator.search_planner._sla_helpers import (
     averaged_metric_value,
@@ -115,11 +116,17 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
                 "search use the bayesian planner via `--search-planner bayesian`."
             )
         dim = cfg.search_space[0]
-        if dim.kind != "int":
+        if dim.kind == "int" and int(dim.lo) < 1:
             raise ValueError(
-                f"smooth_isotonic planner v1 supports kind='int' dimensions only; "
-                f"got kind={dim.kind!r} on path {dim.path!r}. Use the bayesian "
-                "planner for real-valued dimensions."
+                f"smooth_isotonic planner: dimension {dim.path!r} requires "
+                f"lo >= 1 (got lo={dim.lo!r}); the exponential probe doubles "
+                "from lo and would stall or diverge for lo < 1."
+            )
+        if dim.kind == "real" and dim.lo <= 0:
+            raise ValueError(
+                f"smooth_isotonic planner: dimension {dim.path!r} requires "
+                f"lo > 0 (got lo={dim.lo!r}); the exponential probe doubles "
+                "from lo and would stall or diverge for lo <= 0."
             )
         if not cfg.sla_filters:
             raise ValueError(
@@ -138,27 +145,27 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
                 "--optuna-acquisition qlognehvi."
             )
         self._dim = dim
-        self._lo: int = int(dim.lo)
-        self._hi: int = int(dim.hi)
+        self._lo: int | float = int(dim.lo) if dim.kind == "int" else float(dim.lo)
+        self._hi: int | float = int(dim.hi) if dim.kind == "int" else float(dim.hi)
         self._sla_filters: list[SLAFilter] = list(cfg.sla_filters)
         self._filter_keys: list[str] = [
             f"{i}:{f.metric_tag}.{f.stat}.{f.op}.{f.threshold}"
             for i, f in enumerate(self._sla_filters)
         ]
 
-        self.feasible_max: int | None = None
-        self.infeasible_min: int | None = None
+        self.feasible_max: int | float | None = None
+        self.infeasible_min: int | float | None = None
         # Per-x raw signed margins per filter. "Signed" means negative=feasible
         # regardless of filter ``op`` (gt filters are negated so PAVA's
         # ``increasing=True`` assumption holds for all filters).
-        self._raw_probes: dict[int, list[dict[str, float]]] = {}
+        self._raw_probes: dict[int | float, list[dict[str, float]]] = {}
 
         self._phase: _PhaseLiteral = "bracket"
-        self._next_value: int = self._lo
-        self._pending_value: int | None = None
-        self._probe_queue: list[int] = []
+        self._next_value: int | float = self._lo
+        self._pending_value: int | float | None = None
+        self._probe_queue: list[int | float] = []
 
-        self._candidate_x: int | None = None
+        self._candidate_x: int | float | None = None
         self._fit_count: int = 0
 
         self._iter = 0
@@ -180,7 +187,7 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
         # Track which swept-dim values we have already probed so the warmup
         # floor downshifts to
         # ``Environment.SEARCH_PLANNER.REPLICATE_WARMUP_FLOOR`` for replicates.
-        self._first_probe_at: set[int] = set()
+        self._first_probe_at: set[int | float] = set()
 
     # ------------------------------------------------------------------
     # SearchPlanner ABC
@@ -285,7 +292,7 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
     # Bracket step + verdict latching
     # ------------------------------------------------------------------
 
-    def _absorb_verdict(self, value: int, feasible: bool) -> None:
+    def _absorb_verdict(self, value: int | float, feasible: bool) -> None:
         """Latch ``feasible_max`` / ``infeasible_min``; flag non-monotonicity."""
         if feasible:
             if self.infeasible_min is not None and value >= self.infeasible_min:
@@ -313,7 +320,7 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
             "smooth_isotonic: %s; SLA boundary is non-monotonic in this run.", detail
         )
 
-    def _plan_bracket_step(self, value: int, feasible: bool) -> None:
+    def _plan_bracket_step(self, value: int | float, feasible: bool) -> None:
         if not feasible:
             if self.feasible_max is None:
                 self._convergence_reason = "smooth_isotonic_no_pass_in_range"
@@ -339,18 +346,23 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
         if self.feasible_max is None or self.infeasible_min is None:
             return
         gap = self.infeasible_min - self.feasible_max
-        if gap <= 1:
+        if self._dim.kind == "int" and gap <= 1:
             return
         for k in range(1, count + 1):
             frac = k / (count + 1)
-            x = self.feasible_max + max(1, round(gap * frac))
-            x = min(x, self.infeasible_min - 1)
-            x = max(x, self.feasible_max + 1)
+            if self._dim.kind == "int":
+                x = self.feasible_max + max(1, round(gap * frac))
+                x = min(x, self.infeasible_min - 1)
+                x = max(x, self.feasible_max + 1)
+            else:
+                x = self.feasible_max + gap * frac
+                if x <= self.feasible_max or x >= self.infeasible_min:
+                    continue
             if x not in self._raw_probes:
-                self._probe_queue.append(int(x))
+                self._probe_queue.append(x)
         # Dedupe while preserving order.
-        seen: set[int] = set()
-        deduped: list[int] = []
+        seen: set[int | float] = set()
+        deduped: list[int | float] = []
         for x in self._probe_queue:
             if x not in seen:
                 seen.add(x)
@@ -374,7 +386,7 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
                 out[key] = float(sla.threshold) - float(value)
         return out
 
-    def _mutate_base(self, value: int) -> BenchmarkConfig:
+    def _mutate_base(self, value: int | float) -> BenchmarkConfig:
         # mode="python" silences the when_used="json" credential redactors
         # (api_key / headers). context={"include_secrets": True} silences
         # the unconditional _redact_urls serializer that strips userinfo
@@ -418,11 +430,12 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
         if existing is None:
             phases[idx]["requests"] = target
 
-    def _apply_sla_warmup(self, cfg_dict: dict[str, Any], value: int) -> None:
+    def _apply_sla_warmup(self, cfg_dict: dict[str, Any], value: int | float) -> None:
         """Prepend a per-iteration ``warmup`` phase to ``cfg_dict["phases"]``.
 
         Skipped when ``cfg.sla_warmup_seconds == 0`` (explicit user opt-out)
-        or when the profiling phase cannot be located. The warmup uses the
+        or when the profiling phase cannot be located. Also skipped when its
+        type cannot be driven by a single swept value. The warmup uses the
         same swept-dim value being probed and is excluded from results. If
         the user already declared a warmup phase, it is replaced — the
         unique-name validator forbids two ``warmup`` entries, and the swept
@@ -434,7 +447,8 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
         phases = cfg_dict.get("phases")
         if not phases:
             return
-        if _find_phase_index(phases, "profiling") is None:
+        idx = _find_phase_index(phases, "profiling")
+        if idx is None:
             return
 
         base_warmup = (
@@ -452,13 +466,25 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
                 Environment.SEARCH_PLANNER.REPLICATE_WARMUP_FLOOR, base_warmup
             )
 
-        warmup_phase: dict[str, Any] = {
-            "name": "warmup",
-            "type": "concurrency",
-            "concurrency": value,
-            "duration": duration,
-            "exclude_from_results": True,
-        }
+        ptype = phases[idx].get("type")
+        if ptype == PhaseType.CONCURRENCY:
+            warmup_phase: dict[str, Any] = {
+                "name": "warmup",
+                "type": PhaseType.CONCURRENCY,
+                "concurrency": int(value),
+                "duration": duration,
+                "exclude_from_results": True,
+            }
+        elif ptype in (PhaseType.POISSON, PhaseType.GAMMA, PhaseType.CONSTANT):
+            warmup_phase = {
+                "name": "warmup",
+                "type": ptype,
+                "rate": float(value),
+                "duration": duration,
+                "exclude_from_results": True,
+            }
+        else:
+            return
         # Replace any user-declared warmup so the per-iteration sweep value
         # drives the warmup; the unique-name validator on BenchmarkConfig
         # forbids two phases named "warmup".

--- a/src/aiperf/orchestrator/search_planner/smooth_isotonic.py
+++ b/src/aiperf/orchestrator/search_planner/smooth_isotonic.py
@@ -50,7 +50,6 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from aiperf.common.environment import Environment
 from aiperf.config.config import BenchmarkConfig
-from aiperf.config.phases import PhaseType
 from aiperf.config.sweep import AdaptiveSearchSweep, SweepVariation, _set_nested_value
 from aiperf.orchestrator.search_planner._sla_helpers import (
     averaged_metric_value,
@@ -434,12 +433,10 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
         """Prepend a per-iteration ``warmup`` phase to ``cfg_dict["phases"]``.
 
         Skipped when ``cfg.sla_warmup_seconds == 0`` (explicit user opt-out)
-        or when the profiling phase cannot be located. Also skipped when its
-        type cannot be driven by a single swept value. The warmup uses the
-        same swept-dim value being probed and is excluded from results. If
-        the user already declared a warmup phase, it is replaced — the
-        unique-name validator forbids two ``warmup`` entries, and the swept
-        value should drive the warmup during the search.
+        or when the profiling phase cannot be located. The warmup runs at the
+        profiling phase's load and is excluded from results. If the user
+        already declared a warmup phase, it is replaced — the unique-name
+        validator forbids two ``warmup`` entries.
         """
         if self._cfg.sla_warmup_seconds == 0:
             self._first_probe_at.add(value)
@@ -466,25 +463,17 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
                 Environment.SEARCH_PLANNER.REPLICATE_WARMUP_FLOOR, base_warmup
             )
 
-        ptype = phases[idx].get("type")
-        if ptype == PhaseType.CONCURRENCY:
-            warmup_phase: dict[str, Any] = {
-                "name": "warmup",
-                "type": PhaseType.CONCURRENCY,
-                "concurrency": int(value),
-                "duration": duration,
-                "exclude_from_results": True,
-            }
-        elif ptype in (PhaseType.POISSON, PhaseType.GAMMA, PhaseType.CONSTANT):
-            warmup_phase = {
-                "name": "warmup",
-                "type": ptype,
-                "rate": float(value),
-                "duration": duration,
-                "exclude_from_results": True,
-            }
-        else:
-            return
+        warmup_phase = {
+            **phases[idx],
+            "name": "warmup",
+            "kind": "warmup",
+            "duration": duration,
+            "exclude_from_results": True,
+        }
+        # A workload stop condition would end the warmup early once its count
+        # is sent; keep it duration-bounded.
+        warmup_phase.pop("requests", None)
+        warmup_phase.pop("sessions", None)
         # Replace any user-declared warmup so the per-iteration sweep value
         # drives the warmup; the unique-name validator on BenchmarkConfig
         # forbids two phases named "warmup".

--- a/src/aiperf/orchestrator/search_planner/smooth_isotonic.py
+++ b/src/aiperf/orchestrator/search_planner/smooth_isotonic.py
@@ -48,9 +48,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Literal
 
-from aiperf.common.environment import Environment
 from aiperf.config.config import BenchmarkConfig
-from aiperf.config.sweep import AdaptiveSearchSweep, SweepVariation, _set_nested_value
+from aiperf.config.sweep import AdaptiveSearchSweep, SweepVariation
+from aiperf.orchestrator.search_planner._shared_warmup import mutate_base
 from aiperf.orchestrator.search_planner._sla_helpers import (
     averaged_metric_value,
     iteration_feasibility,
@@ -84,20 +84,6 @@ _FIT_INTERNAL_PROBES = 3
 
 
 _PhaseLiteral = Literal["bracket", "fit", "replicate", "cliff_bisect"]
-
-
-def _find_phase_index(phases: list[dict[str, Any]], name: str) -> int | None:
-    """Return the first phase matching a literal name or semantic kind.
-
-    Defensive against malformed fixtures where a phase entry is not a dict
-    (e.g. test stubs); such entries are skipped rather than raising.
-    """
-    for idx, phase in enumerate(phases):
-        if not isinstance(phase, dict):
-            continue
-        if phase.get("name") == name or phase.get("kind") == name:
-            return idx
-    return None
 
 
 class SmoothIsotonicSLAPlanner(SearchPlanner):
@@ -386,101 +372,13 @@ class SmoothIsotonicSLAPlanner(SearchPlanner):
         return out
 
     def _mutate_base(self, value: int | float) -> BenchmarkConfig:
-        # mode="python" silences the when_used="json" credential redactors
-        # (api_key / headers). context={"include_secrets": True} silences
-        # the unconditional _redact_urls serializer that strips userinfo
-        # (user:pass@host) from endpoint.urls regardless of mode. Both
-        # are needed; without the context flag, URL-credentialed sweeps
-        # like postgres / MLflow URIs would hit "<redacted>" in the
-        # iteration's config and fail to authenticate. Mirrors the
-        # pattern in config/loader/plan.py (PR #972).
-        cfg_dict = self._base.model_dump(
-            mode="python",
-            exclude_none=True,
-            context={"include_secrets": True},
+        return mutate_base(
+            self._base,
+            self._dim,
+            value,
+            cfg=self._cfg,
+            first_probe_at=self._first_probe_at,
         )
-        _set_nested_value(cfg_dict, self._dim.path, value)
-        self._apply_sla_precision(cfg_dict)
-        self._apply_sla_warmup(cfg_dict, value)
-        return BenchmarkConfig.model_validate(cfg_dict)
-
-    def _apply_sla_precision(self, cfg_dict: dict[str, Any]) -> None:
-        """Override profiling-phase ``requests`` per ``cfg.sla_precision``.
-
-        Only fills in when the user did not specify ``requests`` on the
-        profiling phase already; explicit user values always win. Defensive
-        against degenerate fixtures where ``phases`` is missing/empty or the
-        profiling phase is absent.
-        """
-        target = Environment.SEARCH_PLANNER.SLA_PRECISION_REQUESTS.get(
-            self._cfg.sla_precision
-        )
-        if target is None:
-            return
-        phases = cfg_dict.get("phases")
-        if not phases:
-            return
-        idx = _find_phase_index(phases, "profiling")
-        if idx is None:
-            return
-        # ``exclude_none=True`` on dump means an unset ``requests`` is absent
-        # from the dict; treat both ``None`` and missing key as user-unset.
-        existing = phases[idx].get("requests")
-        if existing is None:
-            phases[idx]["requests"] = target
-
-    def _apply_sla_warmup(self, cfg_dict: dict[str, Any], value: int | float) -> None:
-        """Prepend a per-iteration ``warmup`` phase to ``cfg_dict["phases"]``.
-
-        Skipped when ``cfg.sla_warmup_seconds == 0`` (explicit user opt-out)
-        or when the profiling phase cannot be located. The warmup runs at the
-        profiling phase's load and is excluded from results. If the user
-        already declared a warmup phase, it is replaced — the unique-name
-        validator forbids two ``warmup`` entries.
-        """
-        if self._cfg.sla_warmup_seconds == 0:
-            self._first_probe_at.add(value)
-            return
-        phases = cfg_dict.get("phases")
-        if not phases:
-            return
-        idx = _find_phase_index(phases, "profiling")
-        if idx is None:
-            return
-
-        base_warmup = (
-            self._cfg.sla_warmup_seconds
-            if self._cfg.sla_warmup_seconds is not None
-            else Environment.SEARCH_PLANNER.DEFAULT_WARMUP_SECONDS
-        )
-        if value not in self._first_probe_at:
-            duration = max(
-                Environment.SEARCH_PLANNER.FIRST_PROBE_WARMUP_FLOOR, base_warmup
-            )
-            self._first_probe_at.add(value)
-        else:
-            duration = max(
-                Environment.SEARCH_PLANNER.REPLICATE_WARMUP_FLOOR, base_warmup
-            )
-
-        warmup_phase = {
-            **phases[idx],
-            "name": "warmup",
-            "kind": "warmup",
-            "duration": duration,
-            "exclude_from_results": True,
-        }
-        # A workload stop condition would end the warmup early once its count
-        # is sent; keep it duration-bounded.
-        warmup_phase.pop("requests", None)
-        warmup_phase.pop("sessions", None)
-        # Replace any user-declared warmup so the per-iteration sweep value
-        # drives the warmup; the unique-name validator on BenchmarkConfig
-        # forbids two phases named "warmup".
-        if phases and phases[0].get("name") == "warmup":
-            phases[0] = warmup_phase
-        else:
-            phases.insert(0, warmup_phase)
 
     def _extract_objective(self, results: list[RunResult]) -> float | None:
         values: list[float] = []

--- a/src/aiperf/plugin/plugins.yaml
+++ b/src/aiperf/plugin/plugins.yaml
@@ -2763,12 +2763,12 @@ search_planner:
     description: |
       1D-optimized exponential-probe + bisection planner for SLA-saturation
       search. Mirrors perf_analyzer's `--binary-search`. O(log N) versus BO's
-      O(N) on 1D feasibility-only problems. Requires exactly one integer
-      search-space dimension and at least one SLA filter; rejects
-      multi-dimensional or empty-filter configs at construction. No
-      heavy dependencies.
+      O(N) on 1D feasibility-only problems. Requires exactly one search-space
+      dimension (int requires lo >= 1; real requires lo > 0) and at least one SLA
+      filter; rejects multi-dimensional or empty-filter configs at
+      construction. No heavy dependencies.
     metadata:
-      supports_continuous: false
+      supports_continuous: true
       supports_discrete: true
       supports_categorical: false
       requires_initial_samples: 0
@@ -2783,10 +2783,11 @@ search_planner:
       monotonic_sla under noise; opt-in Phase-3 replicates (via
       --sla-replicates) bound the boundary with a bootstrap CI. Cliff guard
       reports `boundary_type: cliff` for prefill-prioritizing servers where
-      the curve is genuinely discontinuous. Same dependency footprint as
-      monotonic_sla — only scipy (already required).
+      the curve is genuinely discontinuous. Accepts int or real search-space
+      dimensions (int requires lo >= 1; real requires lo > 0). Same dependency
+      footprint as monotonic_sla — only scipy (already required).
     metadata:
-      supports_continuous: false
+      supports_continuous: true
       supports_discrete: true
       supports_categorical: false
       requires_initial_samples: 0

--- a/tests/unit/orchestrator/search_planner/test_monotonic.py
+++ b/tests/unit/orchestrator/search_planner/test_monotonic.py
@@ -9,6 +9,8 @@ tests use synthetic feasibility functions (no Optuna / BoTorch dep — pure-Pyth
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 from pytest import param
 
@@ -46,15 +48,29 @@ def _base_config() -> BenchmarkConfig:
     )
 
 
+def _base_config_rate() -> BenchmarkConfig:
+    """Base config with a rate-controlled profiling phase for real-axis dims."""
+    cfg_dict = _base_config().model_dump(exclude_none=True)
+    cfg_dict["phases"][0] = {
+        "name": "profiling",
+        "type": "poisson",
+        "rate": 1.0,
+        "requests": 10,
+    }
+    return BenchmarkConfig.model_validate(cfg_dict)
+
+
 def _cfg(
     *,
-    lo: int = 1,
-    hi: int = 1000,
+    lo: int | float = 1,
+    hi: int | float = 1000,
     max_iterations: int = 30,
     sla_filters: list[SLAFilter] | None = None,
     monotonic_stability_trials: int = 1,
     objective_metric: str = "output_token_throughput",
     extra_dims: list[SearchSpaceDimension] | None = None,
+    path: str = "phases.profiling.concurrency",
+    kind: Literal["int", "real"] = "int",
 ) -> AdaptiveSearchSweep:
     if sla_filters is None:
         sla_filters = [
@@ -65,11 +81,7 @@ def _cfg(
                 threshold=200.0,
             )
         ]
-    dims = [
-        SearchSpaceDimension(
-            path="phases.profiling.concurrency", lo=lo, hi=hi, kind="int"
-        ),
-    ]
+    dims = [SearchSpaceDimension(path=path, lo=lo, hi=hi, kind=kind)]
     if extra_dims:
         dims.extend(extra_dims)
     return AdaptiveSearchSweep(
@@ -86,6 +98,22 @@ def _cfg(
         random_seed=42,
         sla_filters=sla_filters,
         monotonic_stability_trials=monotonic_stability_trials,
+    )
+
+
+def _real_cfg(
+    *,
+    lo: float = 1.0,
+    hi: float = 1000.0,
+    max_iterations: int = 30,
+) -> AdaptiveSearchSweep:
+    """Adaptive-search config sweeping a real-valued rate dimension."""
+    return _cfg(
+        lo=lo,
+        hi=hi,
+        max_iterations=max_iterations,
+        path="phases.profiling.rate",
+        kind="real",
     )
 
 
@@ -110,10 +138,11 @@ def _drive_to_convergence(
     feasibility_fn,
     *,
     max_loops: int = 60,
+    path: str = "phases.profiling.concurrency",
 ) -> int:
     """Run ask/tell pairs until is_converged() or ask() returns None.
 
-    Returns total iterations consumed. ``feasibility_fn(concurrency: int) -> bool``
+    Returns total iterations consumed. ``feasibility_fn(value) -> bool``
     drives the synthetic SLA verdict — feasible runs report TTFT below the
     200 ms threshold, infeasible runs report above.
     """
@@ -125,7 +154,7 @@ def _drive_to_convergence(
         if proposal is None:
             break
         _, variation = proposal
-        c = variation.values["phases.profiling.concurrency"]
+        c = variation.values[path]
         ttft = 100.0 if feasibility_fn(c) else 300.0
         planner.tell(variation, [_make_result(variation, ttft_p95=ttft)])
         iters += 1
@@ -158,38 +187,23 @@ def test_construction_rejects_empty_sla_filters():
     assert "sla_filter" in str(exc.value).lower()
 
 
-def test_construction_rejects_real_kind_dimension():
-    """Monotonic planner is integer-only; real-valued dim must raise."""
-    cfg = AdaptiveSearchSweep(
-        search_space=[
-            SearchSpaceDimension(
-                path="phases.profiling.rate", lo=1.0, hi=100.0, kind="real"
-            ),
-        ],
-        objectives=[
-            Objective(
-                metric="output_token_throughput",
-                stat="avg",
-                direction=OptimizationDirection.MAXIMIZE,
-            )
-        ],
-        max_iterations=20,
-        n_initial_points=2,
-        random_seed=42,
-        sla_filters=[
-            SLAFilter(
-                metric_tag="time_to_first_token",
-                stat="p95",
-                op="lt",
-                threshold=200.0,
-            )
-        ],
-    )
-    with pytest.raises(ValueError) as exc:
-        MonotonicSLASearchPlanner(_base_config(), cfg)
-    msg = str(exc.value).lower()
-    assert "int" in msg
-    assert "bayesian" in msg
+def test_construction_accepts_real_kind_dimension():
+    """Real-valued dim is accepted; lo/hi stay floats."""
+    planner = MonotonicSLASearchPlanner(_base_config(), _real_cfg(lo=1.0, hi=100.0))
+    assert isinstance(planner._lo, float)
+    assert isinstance(planner._hi, float)
+
+
+def test_construction_rejects_real_dim_with_nonpositive_lo():
+    """kind='real' lo <= 0 raises: the doubling probe would stall/diverge."""
+    with pytest.raises(ValueError, match="lo > 0"):
+        MonotonicSLASearchPlanner(_base_config(), _real_cfg(lo=0.0))
+
+
+def test_construction_rejects_int_dim_with_lo_below_one():
+    """kind='int' lo < 1 raises: the doubling probe would stall/diverge."""
+    with pytest.raises(ValueError, match="lo >= 1"):
+        MonotonicSLASearchPlanner(_base_config(), _cfg(lo=0))
 
 
 # ----------------------------------------------------------------------------
@@ -239,6 +253,46 @@ def test_all_failing_region_reports_no_pass_in_range():
     assert planner.convergence_reason() == "monotonic_no_pass_in_range"
     assert planner.feasible_max is None
     assert planner.infeasible_min == 1
+
+
+def test_real_dim_boundary_in_middle_converges_within_precision():
+    """Boundary at rate=256 in [1, 1000]: O(log N) float bisection,
+    bracket within 5% relative precision, values stay float."""
+    planner = MonotonicSLASearchPlanner(
+        _base_config_rate(),
+        _real_cfg(lo=1.0, hi=1000.0, max_iterations=30),
+    )
+    iters = _drive_to_convergence(
+        planner, lambda x: x < 256.0, path="phases.profiling.rate"
+    )
+    assert iters < 25
+    assert planner.convergence_reason() == "monotonic_precision_reached"
+    feasible_max = planner.feasible_max
+    infeasible_min = planner.infeasible_min
+    assert feasible_max is not None
+    assert infeasible_min is not None
+    assert feasible_max < 256.0 <= infeasible_min
+    # Precision: relative gap under 5%.
+    assert (infeasible_min - feasible_max) / infeasible_min < 0.05
+    assert isinstance(feasible_max, float)
+    assert isinstance(infeasible_min, float)
+
+
+def test_real_dim_small_scale_boundary_uses_relative_precision():
+    """Boundary at 0.5 in [0.1, 1.0]: sub-1.0 axes must converge on
+    relative precision, not an absolute unit-gap shortcut."""
+    planner = MonotonicSLASearchPlanner(
+        _base_config_rate(),
+        _real_cfg(lo=0.1, hi=1.0, max_iterations=30),
+    )
+    _drive_to_convergence(planner, lambda x: x < 0.5, path="phases.profiling.rate")
+    assert planner.convergence_reason() == "monotonic_precision_reached"
+    feasible_max = planner.feasible_max
+    infeasible_min = planner.infeasible_min
+    assert feasible_max is not None
+    assert infeasible_min is not None
+    assert feasible_max < 0.5 <= infeasible_min
+    assert (infeasible_min - feasible_max) / infeasible_min < 0.05
 
 
 def test_non_monotonic_sets_warning_flag_and_finds_a_boundary():

--- a/tests/unit/orchestrator/search_planner/test_monotonic.py
+++ b/tests/unit/orchestrator/search_planner/test_monotonic.py
@@ -227,7 +227,6 @@ def test_monotonic_boundary_in_middle_converges_within_15_iters():
     assert infeasible_min is not None
     # Boundary lies between feasible_max (passes) and infeasible_min (fails).
     assert feasible_max < 256 <= infeasible_min
-    # Precision: relative gap under 5%.
     assert (infeasible_min - feasible_max) / infeasible_min < 0.05
 
 
@@ -272,7 +271,6 @@ def test_real_dim_boundary_in_middle_converges_within_precision():
     assert feasible_max is not None
     assert infeasible_min is not None
     assert feasible_max < 256.0 <= infeasible_min
-    # Precision: relative gap under 5%.
     assert (infeasible_min - feasible_max) / infeasible_min < 0.05
     assert isinstance(feasible_max, float)
     assert isinstance(infeasible_min, float)

--- a/tests/unit/orchestrator/search_planner/test_smooth_isotonic_planner.py
+++ b/tests/unit/orchestrator/search_planner/test_smooth_isotonic_planner.py
@@ -9,10 +9,13 @@ cases (no-pass, no-failure), and the boundary_summary export shape.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
 from aiperf.common.models.export_models import JsonMetricResult
 from aiperf.config.config import BenchmarkConfig
+from aiperf.config.phases import PhaseType
 from aiperf.config.sweep import (
     AdaptiveSearchSweep,
     Objective,
@@ -42,6 +45,18 @@ def _base_config() -> BenchmarkConfig:
             ],
         }
     )
+
+
+def _base_config_rate() -> BenchmarkConfig:
+    """Base config with a rate-controlled profiling phase for real-axis dims."""
+    cfg_dict = _base_config().model_dump(exclude_none=True)
+    cfg_dict["phases"][0] = {
+        "name": "profiling",
+        "type": "poisson",
+        "rate": 1.0,
+        "requests": 10,
+    }
+    return BenchmarkConfig.model_validate(cfg_dict)
 
 
 def _adaptive_cfg(
@@ -98,8 +113,9 @@ def _result(variation: SweepVariation, *, ttft_p95: float) -> RunResult:
 
 def _drive(
     planner: SmoothIsotonicSLAPlanner,
-    ttft_curve: dict[int, float],
+    ttft_curve: Callable[[float], float],
     max_iters: int = 50,
+    path: str = "phases.profiling.concurrency",
 ) -> int:
     """Run the planner; return iter count when converged."""
     iters = 0
@@ -108,15 +124,8 @@ def _drive(
         if proposal is None:
             break
         _, variation = proposal
-        x = variation.values["phases.profiling.concurrency"]
-        # Fall back to the largest curve key <= x for unmapped values.
-        if x in ttft_curve:
-            ttft = ttft_curve[x]
-        else:
-            keys_le = [k for k in ttft_curve if k <= x]
-            ttft = (
-                ttft_curve[max(keys_le)] if keys_le else next(iter(ttft_curve.values()))
-            )
+        x = variation.values[path]
+        ttft = ttft_curve(float(x))
         planner.tell(variation, [_result(variation, ttft_p95=ttft)])
         iters += 1
     return iters
@@ -133,12 +142,28 @@ def test_construction_rejects_multi_dim() -> None:
         SmoothIsotonicSLAPlanner(_base_config(), cfg)
 
 
-def test_construction_rejects_real_dim() -> None:
+def test_construction_accepts_real_dim() -> None:
     cfg = _adaptive_cfg()
     cfg.search_space[0] = SearchSpaceDimension(
-        path="phases.profiling.concurrency", lo=1.0, hi=1000.0, kind="real"
+        path="phases.profiling.rate", lo=1.0, hi=1000.0, kind="real"
     )
-    with pytest.raises(ValueError, match="kind='int'"):
+    planner = SmoothIsotonicSLAPlanner(_base_config(), cfg)
+    assert isinstance(planner._lo, float)
+    assert isinstance(planner._hi, float)
+
+
+def test_construction_rejects_real_dim_with_nonpositive_lo() -> None:
+    cfg = _adaptive_cfg()
+    cfg.search_space[0] = SearchSpaceDimension(
+        path="phases.profiling.rate", lo=0.0, hi=1000.0, kind="real"
+    )
+    with pytest.raises(ValueError, match="lo > 0"):
+        SmoothIsotonicSLAPlanner(_base_config(), cfg)
+
+
+def test_construction_rejects_int_dim_with_lo_below_one() -> None:
+    cfg = _adaptive_cfg(lo=0)
+    with pytest.raises(ValueError, match="lo >= 1"):
         SmoothIsotonicSLAPlanner(_base_config(), cfg)
 
 
@@ -153,7 +178,7 @@ def test_no_pass_in_range_when_first_probe_fails() -> None:
     """First (lo) probe already infeasible -> no_pass_in_range."""
     cfg = _adaptive_cfg(lo=100, hi=1000, threshold=50.0)
     planner = SmoothIsotonicSLAPlanner(_base_config(), cfg)
-    _drive(planner, {1: 200.0, 100: 200.0, 1000: 200.0})
+    _drive(planner, lambda x: 200.0)
     assert planner.is_converged()
     assert planner.convergence_reason() == "smooth_isotonic_no_pass_in_range"
 
@@ -162,7 +187,7 @@ def test_no_failure_in_range_when_all_probes_pass() -> None:
     """Every probe up to hi passes -> no_failure_in_range."""
     cfg = _adaptive_cfg(lo=1, hi=64, threshold=200.0)
     planner = SmoothIsotonicSLAPlanner(_base_config(), cfg)
-    _drive(planner, {1: 50.0, 1000: 50.0})
+    _drive(planner, lambda x: 50.0)
     assert planner.is_converged()
     assert planner.convergence_reason() == "smooth_isotonic_no_failure_in_range"
 
@@ -172,8 +197,7 @@ def test_finds_boundary_on_smooth_curve() -> None:
     cfg = _adaptive_cfg(lo=1, hi=1024, threshold=200.0)
     planner = SmoothIsotonicSLAPlanner(_base_config(), cfg)
     # TTFT = 50 + concurrency * 2 (linear). Crosses 200 at concurrency=75.
-    curve = {x: 50.0 + x * 2.0 for x in range(1, 1025)}
-    _drive(planner, curve)
+    _drive(planner, lambda x: 50.0 + 2.0 * x)
     assert planner.is_converged()
     summary = planner.boundary_summary()
     assert summary is not None
@@ -185,11 +209,38 @@ def test_finds_boundary_on_smooth_curve() -> None:
     assert imin["value"] - fmax["value"] <= max(4, fmax["value"] // 20)
 
 
+def test_finds_boundary_on_real_axis() -> None:
+    """Real-valued dim: TTFT = 50 + rate*2 crosses 200 at rate=75.
+
+    Exercises the float bracket/fit/bisect path end-to-end; the boundary
+    band must straddle 75 and respect the relative precision target.
+    """
+    cfg = _adaptive_cfg()
+    cfg.search_space[0] = SearchSpaceDimension(
+        path="phases.profiling.rate", lo=1.0, hi=1024.0, kind="real"
+    )
+    planner = SmoothIsotonicSLAPlanner(_base_config_rate(), cfg)
+    _drive(planner, lambda x: 50.0 + 2.0 * x, path="phases.profiling.rate")
+    assert planner.is_converged()
+    assert planner.convergence_reason() in (
+        "smooth_isotonic_precision_reached",
+        "smooth_isotonic_cliff_precision_reached",
+    )
+    summary = planner.boundary_summary()
+    assert summary is not None
+    fmax = summary["feasible_max"]
+    imin = summary["infeasible_min"]
+    assert fmax is not None
+    assert imin is not None
+    assert 60 <= fmax["value"] <= 80, f"feasible_max={fmax['value']!r}"
+    assert 60 <= imin["value"] <= 90, f"infeasible_min={imin['value']!r}"
+    assert (imin["value"] - fmax["value"]) / imin["value"] < 0.10
+
+
 def test_boundary_summary_includes_smooth_isotonic_fields() -> None:
     cfg = _adaptive_cfg(lo=1, hi=512, threshold=200.0)
     planner = SmoothIsotonicSLAPlanner(_base_config(), cfg)
-    curve = {x: 50.0 + x * 2.0 for x in range(1, 513)}
-    _drive(planner, curve)
+    _drive(planner, lambda x: 50.0 + 2.0 * x)
     summary = planner.boundary_summary()
     assert summary is not None
     assert summary["swept_dim_path"] == "phases.profiling.concurrency"
@@ -202,8 +253,7 @@ def test_boundary_summary_includes_smooth_isotonic_fields() -> None:
 def test_history_grows_per_iteration() -> None:
     cfg = _adaptive_cfg(lo=1, hi=512, threshold=200.0, max_iterations=8)
     planner = SmoothIsotonicSLAPlanner(_base_config(), cfg)
-    curve = {x: 50.0 + x * 2.0 for x in range(1, 513)}
-    iters = _drive(planner, curve)
+    iters = _drive(planner, lambda x: 50.0 + 2.0 * x)
     assert iters == len(planner.history())
     assert iters >= 3
     for i, entry in enumerate(planner.history()):
@@ -214,8 +264,7 @@ def test_history_grows_per_iteration() -> None:
 def test_max_iterations_reason() -> None:
     cfg = _adaptive_cfg(lo=1, hi=4096, threshold=200.0, max_iterations=3)
     planner = SmoothIsotonicSLAPlanner(_base_config(), cfg)
-    curve = {x: 50.0 + x * 2.0 for x in range(1, 4097)}
-    _drive(planner, curve)
+    _drive(planner, lambda x: 50.0 + 2.0 * x)
     assert planner.is_converged()
     assert planner.convergence_reason() == "max_iterations"
 
@@ -228,6 +277,23 @@ def test_tell_without_ask_raises() -> None:
     )
     with pytest.raises(RuntimeError, match="without matching ask"):
         planner.tell(fake_variation, [_result(fake_variation, ttft_p95=50.0)])
+
+
+def test_sla_warmup_mirrors_rate_phase_for_real_dim() -> None:
+    """Auto warmup must run at the swept rate for a rate-controlled
+    profiling phase, not a hardcoded (non-integer) concurrency."""
+    cfg = _adaptive_cfg()
+    cfg.search_space[0] = SearchSpaceDimension(
+        path="phases.profiling.rate", lo=1.0, hi=1000.0, kind="real"
+    )
+    planner = SmoothIsotonicSLAPlanner(_base_config_rate(), cfg)
+    mutated = planner._mutate_base(50.5)
+    warmup = mutated.phases[0]
+    assert warmup.name == "warmup"
+    assert warmup.type == PhaseType.POISSON
+    assert warmup.rate == 50.5
+    assert warmup.exclude_from_results is True
+    assert mutated.phases[1].rate == 50.5
 
 
 def test_non_monotonic_warning_threaded_per_iteration() -> None:

--- a/tests/unit/orchestrator/search_planner/test_smooth_isotonic_planner.py
+++ b/tests/unit/orchestrator/search_planner/test_smooth_isotonic_planner.py
@@ -309,8 +309,6 @@ def test_sla_warmup_uses_phase_concurrency_when_sweeping_requests() -> None:
     warmup = mutated.phases[0]
     assert warmup.name == "warmup"
     assert warmup.type == PhaseType.CONCURRENCY
-    # Base config runs at concurrency=1; the swept 500 requests must not
-    # become the warmup load.
     assert warmup.concurrency == 1
     assert mutated.phases[1].requests == 500
 
@@ -327,8 +325,6 @@ def test_sla_warmup_uses_phase_rate_when_sweeping_concurrency_cap() -> None:
     warmup = mutated.phases[0]
     assert warmup.name == "warmup"
     assert warmup.type == PhaseType.POISSON
-    # Base rate phase runs at rate=1.0; the swept cap of 42 must not become
-    # the warmup rate.
     assert warmup.rate == 1.0
     assert mutated.phases[1].concurrency == 42
 

--- a/tests/unit/orchestrator/search_planner/test_smooth_isotonic_planner.py
+++ b/tests/unit/orchestrator/search_planner/test_smooth_isotonic_planner.py
@@ -296,6 +296,65 @@ def test_sla_warmup_mirrors_rate_phase_for_real_dim() -> None:
     assert mutated.phases[1].rate == 50.5
 
 
+def test_sla_warmup_uses_phase_concurrency_when_sweeping_requests() -> None:
+    """Sweeping a non-load field (requests) must not move the warmup load:
+    the warmup mirrors the profiling phase's own concurrency, not the
+    swept request count."""
+    cfg = _adaptive_cfg()
+    cfg.search_space[0] = SearchSpaceDimension(
+        path="phases.profiling.requests", lo=100, hi=1000, kind="int"
+    )
+    planner = SmoothIsotonicSLAPlanner(_base_config(), cfg)
+    mutated = planner._mutate_base(500)
+    warmup = mutated.phases[0]
+    assert warmup.name == "warmup"
+    assert warmup.type == PhaseType.CONCURRENCY
+    # Base config runs at concurrency=1; the swept 500 requests must not
+    # become the warmup load.
+    assert warmup.concurrency == 1
+    assert mutated.phases[1].requests == 500
+
+
+def test_sla_warmup_uses_phase_rate_when_sweeping_concurrency_cap() -> None:
+    """Sweeping the concurrency cap on a rate phase must not set the warmup
+    rate from the cap: the warmup mirrors the phase's own rate."""
+    cfg = _adaptive_cfg()
+    cfg.search_space[0] = SearchSpaceDimension(
+        path="phases.profiling.concurrency", lo=1, hi=64, kind="int"
+    )
+    planner = SmoothIsotonicSLAPlanner(_base_config_rate(), cfg)
+    mutated = planner._mutate_base(42)
+    warmup = mutated.phases[0]
+    assert warmup.name == "warmup"
+    assert warmup.type == PhaseType.POISSON
+    # Base rate phase runs at rate=1.0; the swept cap of 42 must not become
+    # the warmup rate.
+    assert warmup.rate == 1.0
+    assert mutated.phases[1].concurrency == 42
+
+
+def test_sla_warmup_inherits_rate_series_shape() -> None:
+    """A rate_series-driven phase yields a warmup mirroring the same rate
+    series, since the warmup copies the profiling phase shape."""
+    cfg_dict = _base_config_rate().model_dump(exclude_none=True)
+    cfg_dict["phases"][0]["rate_series"] = [
+        {"time_s": 0.0, "qps": 1.0},
+        {"time_s": 60.0, "qps": 2.0},
+    ]
+    del cfg_dict["phases"][0]["rate"]
+    base = BenchmarkConfig.model_validate(cfg_dict)
+    cfg = _adaptive_cfg()
+    cfg.search_space[0] = SearchSpaceDimension(
+        path="phases.profiling.requests", lo=100, hi=1000, kind="int"
+    )
+    planner = SmoothIsotonicSLAPlanner(base, cfg)
+    mutated = planner._mutate_base(500)
+    warmup = mutated.phases[0]
+    assert warmup.name == "warmup"
+    assert warmup.rate is None
+    assert warmup.rate_series is not None
+
+
 def test_non_monotonic_warning_threaded_per_iteration() -> None:
     """Issue #12: a non-monotonic verdict must be flagged on the iteration
     that triggered it.

--- a/tests/unit/orchestrator/test_search_planner_dispatch.py
+++ b/tests/unit/orchestrator/test_search_planner_dispatch.py
@@ -59,3 +59,26 @@ def test_build_search_planner_dispatches_via_plugin_registry(adaptive_plan):
 
     planner = build_search_planner(adaptive_plan)
     assert isinstance(planner, SearchPlanner)
+
+
+def test_build_search_planner_rejects_real_dim_on_int_typed_field(adaptive_plan):
+    """A kind='real' dimension targeting an int-typed phase field fails fast
+    instead of crashing (or silently coercing) mid-search."""
+    from aiperf.orchestrator.search_planner import build_search_planner
+
+    adaptive_plan.sweep.search_space[0] = SearchSpaceDimension(
+        path="phases.profiling.requests", lo=10, hi=1000, kind="real"
+    )
+    with pytest.raises(ValueError, match="int-typed phase field 'requests'"):
+        build_search_planner(adaptive_plan)
+
+
+def test_build_search_planner_accepts_real_dim_on_float_typed_field(adaptive_plan):
+    """A kind='real' dimension on a float-typed phase field builds normally."""
+    from aiperf.orchestrator.search_planner import build_search_planner
+    from aiperf.orchestrator.search_planner.base import SearchPlanner
+
+    adaptive_plan.sweep.search_space[0] = SearchSpaceDimension(
+        path="phases.profiling.rate", lo=1.0, hi=10.0, kind="real"
+    )
+    assert isinstance(build_search_planner(adaptive_plan), SearchPlanner)

--- a/tests/unit/orchestrator/test_search_planner_dispatch.py
+++ b/tests/unit/orchestrator/test_search_planner_dispatch.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from aiperf.config.config import BenchmarkConfig
 from aiperf.config.sweep import AdaptiveSearchSweep, Objective
 from aiperf.config.sweep.adaptive import SearchSpaceDimension, SLAFilter
 from aiperf.plugin.enums import SearchPlannerType
@@ -13,7 +14,7 @@ from aiperf.plugin.enums import SearchPlannerType
 
 @pytest.fixture
 def adaptive_plan():
-    """A MagicMock plan with the fields ``build_search_planner`` reads."""
+    """A plan with the fields ``build_search_planner`` reads."""
     plan = MagicMock()
     plan.sweep = AdaptiveSearchSweep(
         search_space=[
@@ -39,7 +40,23 @@ def adaptive_plan():
             )
         ],
     )
-    plan.configs = [MagicMock()]
+    plan.configs = [
+        BenchmarkConfig.model_validate(
+            {
+                "models": ["m"],
+                "endpoint": {"urls": ["http://x"], "type": "chat"},
+                "datasets": [{"name": "profiling", "type": "synthetic"}],
+                "phases": [
+                    {
+                        "name": "profiling",
+                        "type": "poisson",
+                        "rate": 1.0,
+                        "requests": 10,
+                    }
+                ],
+            }
+        )
+    ]
     return plan
 
 
@@ -69,7 +86,7 @@ def test_build_search_planner_rejects_real_dim_on_int_typed_field(adaptive_plan)
     adaptive_plan.sweep.search_space[0] = SearchSpaceDimension(
         path="phases.profiling.requests", lo=10, hi=1000, kind="real"
     )
-    with pytest.raises(ValueError, match="int-typed phase field 'requests'"):
+    with pytest.raises(ValueError, match="int-typed field 'requests'"):
         build_search_planner(adaptive_plan)
 
 

--- a/tests/unit/orchestrator/test_search_planner_dispatch.py
+++ b/tests/unit/orchestrator/test_search_planner_dispatch.py
@@ -86,13 +86,17 @@ def test_build_search_planner_returns_none_when_not_adaptive() -> None:
     assert build_search_planner(plan) is None
 
 
-def test_build_search_planner_dispatches_via_plugin_registry(adaptive_plan: BenchmarkPlan) -> None:
+def test_build_search_planner_dispatches_via_plugin_registry(
+    adaptive_plan: BenchmarkPlan,
+) -> None:
     """The factory returns a SearchPlanner via plugin lookup."""
     planner = build_search_planner(adaptive_plan)
     assert isinstance(planner, SearchPlanner)
 
 
-def test_build_search_planner_rejects_real_dim_on_int_typed_field(adaptive_plan: BenchmarkPlan) -> None:
+def test_build_search_planner_rejects_real_dim_on_int_typed_field(
+    adaptive_plan: BenchmarkPlan,
+) -> None:
     """A kind='real' dimension targeting an int-typed phase field fails fast
     instead of crashing (or silently coercing) mid-search."""
     assert adaptive_plan.sweep is not None
@@ -103,7 +107,9 @@ def test_build_search_planner_rejects_real_dim_on_int_typed_field(adaptive_plan:
         build_search_planner(adaptive_plan)
 
 
-def test_build_search_planner_accepts_real_dim_on_float_typed_field(adaptive_plan: BenchmarkPlan) -> None:
+def test_build_search_planner_accepts_real_dim_on_float_typed_field(
+    adaptive_plan: BenchmarkPlan,
+) -> None:
     """A kind='real' dimension on a float-typed phase field builds normally."""
     assert adaptive_plan.sweep is not None
     adaptive_plan.sweep.search_space[0] = SearchSpaceDimension(

--- a/tests/unit/orchestrator/test_search_planner_dispatch.py
+++ b/tests/unit/orchestrator/test_search_planner_dispatch.py
@@ -116,3 +116,15 @@ def test_build_search_planner_accepts_real_dim_on_float_typed_field(
         path="phases.profiling.rate", lo=1.0, hi=10.0, kind="real"
     )
     assert isinstance(build_search_planner(adaptive_plan), SearchPlanner)
+
+
+def test_build_search_planner_rejects_real_dim_on_non_numeric_field(
+    adaptive_plan: BenchmarkPlan,
+) -> None:
+    """A kind='real' dimension on a non-numeric field fails fast."""
+    assert adaptive_plan.sweep is not None
+    adaptive_plan.sweep.search_space[0] = SearchSpaceDimension(
+        path="endpoint.type", lo=1, hi=10, kind="real"
+    )
+    with pytest.raises(ValueError, match="int-typed field 'type'"):
+        build_search_planner(adaptive_plan)

--- a/tests/unit/orchestrator/test_search_planner_dispatch.py
+++ b/tests/unit/orchestrator/test_search_planner_dispatch.py
@@ -2,87 +2,100 @@
 # SPDX-License-Identifier: Apache-2.0
 """Test that the shared planner factory dispatches via the plugin registry."""
 
-from unittest.mock import MagicMock
-
 import pytest
 
+from aiperf.config import BenchmarkPlan
 from aiperf.config.config import BenchmarkConfig
 from aiperf.config.sweep import AdaptiveSearchSweep, Objective
 from aiperf.config.sweep.adaptive import SearchSpaceDimension, SLAFilter
+from aiperf.orchestrator.search_planner import build_search_planner
+from aiperf.orchestrator.search_planner.base import SearchPlanner
 from aiperf.plugin.enums import SearchPlannerType
 
 
 @pytest.fixture
-def adaptive_plan():
+def adaptive_plan() -> BenchmarkPlan:
     """A plan with the fields ``build_search_planner`` reads."""
-    plan = MagicMock()
-    plan.sweep = AdaptiveSearchSweep(
-        search_space=[
-            SearchSpaceDimension(
-                path="phases.profiling.concurrency", lo=1, hi=10, kind="int"
+    return BenchmarkPlan(
+        configs=[
+            BenchmarkConfig.model_validate(
+                {
+                    "models": ["m"],
+                    "endpoint": {"urls": ["http://x"], "type": "chat"},
+                    "datasets": [{"name": "profiling", "type": "synthetic"}],
+                    "phases": [
+                        {
+                            "name": "profiling",
+                            "type": "poisson",
+                            "rate": 1.0,
+                            "requests": 10,
+                        }
+                    ],
+                }
             )
         ],
-        objectives=[
-            Objective(
-                metric="output_token_throughput",
-                direction="maximize",
-            )
-        ],
-        planner=SearchPlannerType.MONOTONIC_SLA,
-        max_iterations=3,
-        n_initial_points=2,
-        sla_filters=[
-            SLAFilter(
-                metric_tag="time_to_first_token",
-                stat="p95",
-                op="lt",
-                threshold=200.0,
-            )
-        ],
+        sweep=AdaptiveSearchSweep(
+            search_space=[
+                SearchSpaceDimension(
+                    path="phases.profiling.concurrency", lo=1, hi=10, kind="int"
+                )
+            ],
+            objectives=[
+                Objective(
+                    metric="output_token_throughput",
+                    direction="maximize",
+                )
+            ],
+            planner=SearchPlannerType.MONOTONIC_SLA,
+            max_iterations=3,
+            n_initial_points=2,
+            sla_filters=[
+                SLAFilter(
+                    metric_tag="time_to_first_token",
+                    stat="p95",
+                    op="lt",
+                    threshold=200.0,
+                )
+            ],
+        ),
     )
-    plan.configs = [
-        BenchmarkConfig.model_validate(
-            {
-                "models": ["m"],
-                "endpoint": {"urls": ["http://x"], "type": "chat"},
-                "datasets": [{"name": "profiling", "type": "synthetic"}],
-                "phases": [
-                    {
-                        "name": "profiling",
-                        "type": "poisson",
-                        "rate": 1.0,
-                        "requests": 10,
-                    }
-                ],
-            }
-        )
-    ]
-    return plan
 
 
-def test_build_search_planner_returns_none_when_not_adaptive():
+def test_build_search_planner_returns_none_when_not_adaptive() -> None:
     """The factory returns None for non-adaptive plans."""
-    from aiperf.orchestrator.search_planner import build_search_planner
-
-    plan = MagicMock()
-    plan.sweep = None
+    plan = BenchmarkPlan(
+        configs=[
+            BenchmarkConfig.model_validate(
+                {
+                    "models": ["m"],
+                    "endpoint": {"urls": ["http://x"], "type": "chat"},
+                    "datasets": [{"name": "profiling", "type": "synthetic"}],
+                    "phases": [
+                        {
+                            "name": "profiling",
+                            "type": "poisson",
+                            "rate": 1.0,
+                            "requests": 10,
+                        }
+                    ],
+                }
+            )
+        ],
+        sweep=None,
+    )
     assert build_search_planner(plan) is None
 
 
-def test_build_search_planner_dispatches_via_plugin_registry(adaptive_plan):
+def test_build_search_planner_dispatches_via_plugin_registry(adaptive_plan: BenchmarkPlan) -> None:
     """The factory returns a SearchPlanner via plugin lookup."""
-    from aiperf.orchestrator.search_planner import build_search_planner
-    from aiperf.orchestrator.search_planner.base import SearchPlanner
-
     planner = build_search_planner(adaptive_plan)
     assert isinstance(planner, SearchPlanner)
 
 
-def test_build_search_planner_rejects_real_dim_on_int_typed_field(adaptive_plan):
+def test_build_search_planner_rejects_real_dim_on_int_typed_field(adaptive_plan: BenchmarkPlan) -> None:
     """A kind='real' dimension targeting an int-typed phase field fails fast
     instead of crashing (or silently coercing) mid-search."""
-    from aiperf.orchestrator.search_planner import build_search_planner
-
+    assert adaptive_plan.sweep is not None
     adaptive_plan.sweep.search_space[0] = SearchSpaceDimension(
         path="phases.profiling.requests", lo=10, hi=1000, kind="real"
     )
@@ -90,11 +103,9 @@ def test_build_search_planner_rejects_real_dim_on_int_typed_field(adaptive_plan)
         build_search_planner(adaptive_plan)
 
 
-def test_build_search_planner_accepts_real_dim_on_float_typed_field(adaptive_plan):
+def test_build_search_planner_accepts_real_dim_on_float_typed_field(adaptive_plan: BenchmarkPlan) -> None:
     """A kind='real' dimension on a float-typed phase field builds normally."""
-    from aiperf.orchestrator.search_planner import build_search_planner
-    from aiperf.orchestrator.search_planner.base import SearchPlanner
-
+    assert adaptive_plan.sweep is not None
     adaptive_plan.sweep.search_space[0] = SearchSpaceDimension(
         path="phases.profiling.rate", lo=1.0, hi=10.0, kind="real"
     )


### PR DESCRIPTION
The 1D SLA search planners (`monotonic_sla`, `smooth_isotonic`) now accept continuous (float) dimensions in addition to integer ones (e.g. sweeping request rate/speedup ration instead of concurrency).

On a continuous axis the search converges to a precision target and reports the boundary as a small range rather than a single exact value.

Also adds startup validation that the axis lower bound is positive (required by the exponential probe), and the auto warmup phase now runs at the swept load level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monotonic SLA and smooth-isotonic search planners now support positive real-valued dimensions alongside integer dimensions.
  * Real-valued searches use fractional probing and relative-precision convergence.
  * Warmup behavior supports real-valued sweep configurations across supported profiling modes.
  * Planner metadata now identifies both planners as supporting continuous search spaces.

* **Bug Fixes**
  * Real-valued dimensions targeting integer-typed fields are now rejected with clear validation guidance.

* **Documentation**
  * Updated guidance for supported dimension types and lower-bound requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->