### PR TITLE
fix(dataset): replay bailian sessions as self-contained turns

### DIFF
--- a/docs/reference/conversation-context-mode.md
+++ b/docs/reference/conversation-context-mode.md
@@ -92,7 +92,7 @@ Each turn is sent exactly as it appears in the dataset.
 
 Default for:
 - Mooncake traces with pre-built `messages` arrays
-- Bailian traces: a follow-up row's `input_length` and `hash_ids` already cover the parent's prompt, the parent's response, and the new text, so each row is sent as its own generated prompt
+- Bailian traces: a follow-up row's `input_length` and `hash_ids` already cover the history the service retained plus the new text, so each row is sent as its own generated prompt
 
 ### `message_array_without_responses`
 

--- a/docs/reference/conversation-context-mode.md
+++ b/docs/reference/conversation-context-mode.md
@@ -92,6 +92,7 @@ Each turn is sent exactly as it appears in the dataset.
 
 Default for:
 - Mooncake traces with pre-built `messages` arrays
+- Bailian traces: a follow-up row's `input_length` and `hash_ids` already cover the parent's prompt, the parent's response, and the new text, so each row is sent as its own generated prompt
 
 ### `message_array_without_responses`
 

--- a/docs/tutorials/bailian-trace.md
+++ b/docs/tutorials/bailian-trace.md
@@ -50,7 +50,7 @@ Example entries:
 {"chat_id": 160, "parent_chat_id": 159, "timestamp": 62.5, "input_length": 676, "output_length": 80, "type": "text", "turn": 2}
 ```
 
-Entries with the same root `chat_id` form a session and are replayed in `turn` order. Each entry is a complete request as the service received it: a follow-up's `input_length` counts the parent's prompt, the parent's response, and the new text, and its `hash_ids` cover that whole span. Sessions therefore run in [`message_array_with_responses`](../reference/conversation-context-mode.md) mode and every turn is sent as its own generated prompt, rather than accumulating earlier turns and live responses in front of it.
+Entries with the same root `chat_id` form a session and are replayed in `turn` order. Each entry is a complete request as the service received it: a follow-up's `input_length` counts the history the service retained plus the new text, and its `hash_ids` cover that whole span. Sessions therefore run in [`message_array_with_responses`](../reference/conversation-context-mode.md) mode and every turn is sent as its own generated prompt, rather than accumulating earlier turns and live responses in front of it.
 
 ---
 

--- a/docs/tutorials/bailian-trace.md
+++ b/docs/tutorials/bailian-trace.md
@@ -47,10 +47,10 @@ Example entries:
 
 ```json
 {"chat_id": 159, "parent_chat_id": -1, "timestamp": 61.114, "input_length": 521, "output_length": 132, "type": "text", "turn": 1}
-{"chat_id": 160, "parent_chat_id": 159, "timestamp": 62.5, "input_length": 400, "output_length": 80, "type": "text", "turn": 2}
+{"chat_id": 160, "parent_chat_id": 159, "timestamp": 62.5, "input_length": 676, "output_length": 80, "type": "text", "turn": 2}
 ```
 
-Entries with the same root `chat_id` form a session and are replayed in `turn` order.
+Entries with the same root `chat_id` form a session and are replayed in `turn` order. Each entry is a complete request as the service received it: a follow-up's `input_length` counts the parent's prompt, the parent's response, and the new text, and its `hash_ids` cover that whole span. Sessions therefore run in [`message_array_with_responses`](../reference/conversation-context-mode.md) mode and every turn is sent as its own generated prompt, rather than accumulating earlier turns and live responses in front of it.
 
 ---
 

--- a/src/aiperf/dataset/loader/bailian_trace.py
+++ b/src/aiperf/dataset/loader/bailian_trace.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from aiperf.common.enums import ConversationContextMode
 from aiperf.dataset.loader.base_trace_loader import BaseTraceDatasetLoader
 from aiperf.dataset.loader.models import BailianTrace
 
@@ -23,6 +24,11 @@ class BailianTraceDatasetLoader(BaseTraceDatasetLoader[BailianTrace]):
 
     Timestamps are **seconds since request arrival** and are converted to
     **milliseconds** internally.
+
+    Every row is a self-contained request: a follow-up's `input_length` and
+    `hash_ids` describe the whole request the service received, history
+    included, so sessions replay in `MESSAGE_ARRAY_WITH_RESPONSES` mode and
+    each turn is sent as its own generated prompt.
 
     The 16-token SipHash block size is declared in `plugins.yaml` metadata
     and applied automatically—no need to pass `--isl-block-size`.
@@ -65,6 +71,19 @@ class BailianTraceDatasetLoader(BaseTraceDatasetLoader[BailianTrace]):
 
     def _group_traces(self, items: list[BailianTrace]) -> dict[str, list[BailianTrace]]:
         return self._group_into_sessions(items)
+
+    def _infer_context_mode(
+        self, traces: list[BailianTrace]
+    ) -> ConversationContextMode | None:
+        """Bailian rows already carry their full context.
+
+        A follow-up's `input_length` is the parent's prompt plus the parent's
+        response plus the new text, and its `hash_ids` cover that whole span.
+        Accumulating prior turns and live responses in front of it (the
+        `DELTAS_WITHOUT_RESPONSES` default) would send roughly twice the
+        recorded tokens at turn 2 and more at each later turn.
+        """
+        return ConversationContextMode.MESSAGE_ARRAY_WITH_RESPONSES
 
     def _group_into_sessions(
         self, items: list[BailianTrace]

--- a/src/aiperf/dataset/loader/bailian_trace.py
+++ b/src/aiperf/dataset/loader/bailian_trace.py
@@ -77,8 +77,8 @@ class BailianTraceDatasetLoader(BaseTraceDatasetLoader[BailianTrace]):
     ) -> ConversationContextMode | None:
         """Bailian rows already carry their full context.
 
-        A follow-up's `input_length` is the parent's prompt plus the parent's
-        response plus the new text, and its `hash_ids` cover that whole span.
+        A follow-up's `input_length` is the history the service retained plus
+        the new text, and its `hash_ids` cover that whole span.
         Accumulating prior turns and live responses in front of it (the
         `DELTAS_WITHOUT_RESPONSES` default) would send roughly twice the
         recorded tokens at turn 2 and more at each later turn.

--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -377,6 +377,10 @@ class BailianTrace(AIPerfBaseModel):
     - Root request:  ``{"chat_id": 159, "parent_chat_id": -1, "timestamp": 61.114, "input_length": 521, "output_length": 132, "type": "text", "turn": 1, "hash_ids": [1089, 1090, 1091]}``
     - Follow-up:     ``{"chat_id": 160, "parent_chat_id": 159, "timestamp": 62.5, "input_length": 676, "output_length": 80, "type": "text", "turn": 2, "hash_ids": [1089, 1090, 1091, 1092]}``
 
+    The ``hash_ids`` lists above are abbreviated. A real row carries one id per
+    16-token block, so 521 and 676 input tokens give 33 and 43 ids respectively,
+    and a follow-up's list starts with all of its parent's full blocks.
+
     Note:
     The ``type`` field in Bailian JSONL is the request type (text/search/image/file),
     not the dataset type. Use ``--custom-dataset-type bailian_trace`` when loading

--- a/src/aiperf/dataset/loader/models.py
+++ b/src/aiperf/dataset/loader/models.py
@@ -375,7 +375,7 @@ class BailianTrace(AIPerfBaseModel):
 
     Examples:
     - Root request:  ``{"chat_id": 159, "parent_chat_id": -1, "timestamp": 61.114, "input_length": 521, "output_length": 132, "type": "text", "turn": 1, "hash_ids": [1089, 1090, 1091]}``
-    - Follow-up:     ``{"chat_id": 160, "parent_chat_id": 159, "timestamp": 62.5, "input_length": 400, "output_length": 80, "type": "text", "turn": 2, "hash_ids": [1089, 1090]}``
+    - Follow-up:     ``{"chat_id": 160, "parent_chat_id": 159, "timestamp": 62.5, "input_length": 676, "output_length": 80, "type": "text", "turn": 2, "hash_ids": [1089, 1090, 1091, 1092]}``
 
     Note:
     The ``type`` field in Bailian JSONL is the request type (text/search/image/file),

--- a/tests/unit/dataset/loader/test_bailian_trace.py
+++ b/tests/unit/dataset/loader/test_bailian_trace.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import ValidationError
 from pytest import param
 
+from aiperf.common.enums import ConversationContextMode
 from aiperf.config.flags.cli_config import CLIConfig
 from aiperf.dataset.loader.bailian_trace import BailianTraceDatasetLoader
 from aiperf.dataset.loader.models import BailianTrace
@@ -570,6 +571,7 @@ class TestBailianTraceDatasetLoader:
 
         assert len(conversations) == 1
         conv = conversations[0]
+        assert conv.context_mode == ConversationContextMode.MESSAGE_ARRAY_WITH_RESPONSES
         assert len(conv.turns) == 3
         assert conv.turns[0].timestamp == 1000.0
         assert conv.turns[1].timestamp == 2000.0


### PR DESCRIPTION
Fixes #1392

## Problem

Bailian trace rows record `input_length` as the whole request the service received, history included: every follow-up in traceA, coder, and thinking is longer than its parent, and its `hash_ids` start with the parent's blocks. The bailian loader set no context mode, so sessions ran under `DELTAS_WITHOUT_RESPONSES` and each follow-up went out as the prior prompts plus live responses plus a fresh prompt already sized at the row's full `input_length`. Measured on traceA against SGLang: turn index 1 replayed at 1.94x its trace `input_length`, turn index 2 at 2.66x. The trace itself predicts 1.98x and 2.62x for that accumulation.

## Fix

`BailianTraceDatasetLoader._infer_context_mode` returns `MESSAGE_ARRAY_WITH_RESPONSES`, the same treatment the mooncake loader gives rows that carry `messages`. Each turn is sent as its own generated prompt at exactly `input_length` tokens, and because the synthesizer emits identical text for identical `hash_ids`, the follow-up's prefix still matches the parent's prompt where the trace says it should.

## Changes

- `src/aiperf/dataset/loader/bailian_trace.py`: override `_infer_context_mode`, docstring explains why.
- `tests/unit/dataset/loader/test_bailian_trace.py`: `test_multi_turn_conversation_ordering` asserts the conversation's context mode. The assertion fails against main's loader.
- `docs/reference/conversation-context-mode.md`: bailian listed under "Default for" of `message_array_with_responses`.
- `docs/tutorials/bailian-trace.md`: one sentence on the mode choice; the example follow-up's `input_length` corrected from 400 to 676 so it is cumulative like every real follow-up.

Mooncake and single-turn rows are unaffected. traceB has no sessions and is unaffected.

## Verification

- `uv run pytest tests/unit/ -n auto`: 28027 passed, 211 skipped, 1 xfailed (before the test consolidation; the loader test file passes at 42).
- `uv run pre-commit run` on the staged files: all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bailian multi-turn conversations now preserve complete request history without duplicating prior turns or responses.
  - Follow-up requests correctly combine service-retained conversation history with new text.
  - Conversation context is handled consistently for message arrays that include responses.

- **Documentation**
  - Updated Bailian trace guidance with corrected follow-up values and clarified conversation replay and context handling.
  - Clarified that trace identifiers represent the complete span, including parent history in follow-up requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->