### PR TITLE
feat: add stale PR/issue auto-close workflow

### DIFF
--- a/.github/workflows/stale_cleaner.yml
+++ b/.github/workflows/stale_cleaner.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# https://github.com/actions/stale
+# This workflow is used to close stale issues and PRs after 30 days of inactivity.
+# Scheduled to run every day at 1:30 AM PST.
+# Configured to close issues with the label 'bug' after 30 days of inactivity.
+# Configured to close all PRs after 30 days of inactivity.
+# Configured to close the issue and PR after 5 days of inactivity.
+# Configured to delete the branch of the PR after 5 days of inactivity.
+
+
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 9 * * *'
+
+permissions:
+  actions: write
+  contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
+        with:
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days. As a reminder, please use backlog label to avoid issues being marked as stale.'
+          close-issue-message: 'This issue has been closed due to inactivity. If you believe this issue is still relevant, please feel free to reopen it with additional context or information.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-pr-message: 'This PR has been closed due to inactivity. If you believe this PR is still relevant, please feel free to reopen it with additional context or information.'
+          delete-branch: true
+          days-before-stale: 30
+          days-before-close: 5
+          any-of-issue-labels: 'bug'
+          exempt-issue-labels: 'backlog'

--- a/.github/workflows/stale_cleaner.yml
+++ b/.github/workflows/stale_cleaner.yml
@@ -2,21 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # https://github.com/actions/stale
-# This workflow is used to close stale issues and PRs after 30 days of inactivity.
-# Scheduled to run every day at 1:30 AM PST.
-# Configured to close issues with the label 'bug' after 30 days of inactivity.
-# Configured to close all PRs after 30 days of inactivity.
-# Configured to close the issue and PR after 5 days of inactivity.
-# Configured to delete the branch of the PR after 5 days of inactivity.
-
 
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '30 9 * * *'
+    - cron: '30 9 * * *' # 09:30 UTC daily
 
 permissions:
-  actions: write
   contents: write # only for delete-branch option
   issues: write
   pull-requests: write


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/stale_cleaner.yml`, modeled on ai-dynamo/dynamo's `stale_cleaner.yml`, using [actions/stale](https://github.com/actions/stale).
- Runs daily; marks PRs (all) and `bug`-labeled issues (excluding `backlog`) stale after 30 days of inactivity, closes them 5 days later, and deletes the PR's branch on close.
- Unlike dynamo's config, explicitly sets `stale-issue-label`/`stale-pr-label` to `stale` rather than relying on the action's default label name.

Closes AIP-1184.

## Test plan
- [ ] Confirm workflow YAML is valid (`actions/stale` action pinned by SHA, same as dynamo)
- [ ] After merge, verify the first scheduled run labels expected old PRs/issues as `stale` without closing anything immediately
- [ ] Confirm closures + branch deletion begin 5 days after an item is first labeled stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated daily maintenance for inactive bug reports and pull requests.
  * Inactive items are marked after 30 days and closed after an additional 5 days.
  * Backlog items are excluded from this process.
  * Closed pull request branches are automatically cleaned up.
  * Maintenance runs daily at 09:30 UTC to keep inactive work items and related branches organized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->