### PR TITLE
fix(ci): fetch nightly job logs via REST instead of gh api

### DIFF
--- a/tools/suggest_test_docs_weights.py
+++ b/tools/suggest_test_docs_weights.py
@@ -46,6 +46,8 @@ import os
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -193,14 +195,53 @@ def fetch_test_docs_jobs(run_id: int) -> list[tuple[int, str]]:
     return out
 
 
-def fetch_job_log(job_id: int) -> str:
-    # Job logs contain ANSI escape sequences; gh refuses to print those
-    # without this flag, even when stdout is captured rather than a tty.
-    return _gh(
-        "api",
-        f"/repos/{_repo_slug()}/actions/jobs/{job_id}/logs",
-        "--allow-escape-sequences",
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Surface the 302 to the log-storage blob URL instead of following it.
+
+    ``urlopen`` forwards the Authorization header to every hop by default,
+    but the blob-storage host rejects a GitHub bearer token with 401. The
+    log content itself lives at that unauthenticated, pre-signed URL.
+    """
+
+    def redirect_request(self, *_args, **_kwargs):
+        return None
+
+
+def _gh_token() -> str:
+    return (
+        os.environ.get("GH_TOKEN")
+        or os.environ.get("GITHUB_TOKEN")
+        or _gh("auth", "token").strip()
     )
+
+
+def fetch_job_log(job_id: int) -> str:
+    """Fetch one job's raw text log via the REST API directly.
+
+    Deliberately bypasses ``gh api .../logs``: that endpoint's log bodies
+    contain ANSI escape sequences, and gh refuses to print those without
+    ``--allow-escape-sequences`` -- a flag only present from gh 2.97
+    onward, so pinning to it would break on any older gh a contributor
+    happens to have installed locally.
+    """
+    url = f"https://api.github.com/repos/{_repo_slug()}/actions/jobs/{job_id}/logs"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {_gh_token()}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        with opener.open(req) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        if e.code not in (301, 302, 303, 307, 308):
+            raise
+        with urllib.request.urlopen(e.headers["Location"]) as resp:
+            return resp.read().decode("utf-8", errors="replace")
 
 
 def _repo_slug() -> str:

--- a/tools/suggest_test_docs_weights.py
+++ b/tools/suggest_test_docs_weights.py
@@ -194,7 +194,13 @@ def fetch_test_docs_jobs(run_id: int) -> list[tuple[int, str]]:
 
 
 def fetch_job_log(job_id: int) -> str:
-    return _gh("api", f"/repos/{_repo_slug()}/actions/jobs/{job_id}/logs")
+    # Job logs contain ANSI escape sequences; gh refuses to print those
+    # without this flag, even when stdout is captured rather than a tty.
+    return _gh(
+        "api",
+        f"/repos/{_repo_slug()}/actions/jobs/{job_id}/logs",
+        "--allow-escape-sequences",
+    )
 
 
 def _repo_slug() -> str:

--- a/tools/suggest_test_docs_weights.py
+++ b/tools/suggest_test_docs_weights.py
@@ -40,6 +40,7 @@ Exits 0 even when suggestions are emitted; it's a report, not a gate.
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import logging
 import os
@@ -49,8 +50,11 @@ import sys
 import urllib.error
 import urllib.request
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
+from typing import IO
 
 # Reach the existing parser/data_types so we don't duplicate the bash-block
 # extraction logic. Both modules import each other by bare name, so we have
@@ -195,36 +199,81 @@ def fetch_test_docs_jobs(run_id: int) -> list[tuple[int, str]]:
     return out
 
 
-class _NoRedirect(urllib.request.HTTPRedirectHandler):
-    """Surface the 302 to the log-storage blob URL instead of following it.
+HTTP_TIMEOUT_SECONDS = 30
 
-    ``urlopen`` forwards the Authorization header to every hop by default,
-    but the blob-storage host rejects a GitHub bearer token with 401. The
-    log content itself lives at that unauthenticated, pre-signed URL.
+
+class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
+    """Follow the 302 to the log blob, but drop the GitHub bearer token.
+
+    ``urlopen`` replays the Authorization header on every hop, and the
+    pre-signed blob-storage URL holding the log rejects a GitHub token
+    with 401.
     """
 
-    def redirect_request(self, *_args, **_kwargs):
-        return None
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: http.client.HTTPMessage,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new is not None:
+            new.remove_header("Authorization")
+        return new
 
 
-def _gh_token() -> str:
+@lru_cache(maxsize=1)
+def _gh_host() -> str:
+    """Host owning the target repo, enterprise-aware, ``github.com`` by default."""
+    return os.environ.get("GH_HOST") or "github.com"
+
+
+@lru_cache(maxsize=1)
+def _api_base() -> str:
+    base = os.environ.get("GITHUB_API_URL")
+    if base:
+        return base.rstrip("/")
+    host = _gh_host()
     return (
-        os.environ.get("GH_TOKEN")
-        or os.environ.get("GITHUB_TOKEN")
-        or _gh("auth", "token").strip()
+        "https://api.github.com" if host == "github.com" else f"https://{host}/api/v3"
     )
 
 
-def fetch_job_log(job_id: int) -> str:
-    """Fetch one job's raw text log via the REST API directly.
+@lru_cache(maxsize=1)
+def _gh_token() -> str:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token.strip()
+    return _gh("auth", "token", "--hostname", _gh_host()).strip()
 
-    Deliberately bypasses ``gh api .../logs``: that endpoint's log bodies
-    contain ANSI escape sequences, and gh refuses to print those without
-    ``--allow-escape-sequences`` -- a flag only present from gh 2.97
-    onward, so pinning to it would break on any older gh a contributor
-    happens to have installed locally.
+
+@lru_cache(maxsize=1)
+def _log_opener() -> urllib.request.OpenerDirector:
+    return urllib.request.build_opener(_StripAuthOnRedirect)
+
+
+def _decode_log(raw: bytes, job_id: int) -> str:
+    text = raw.decode("utf-8", errors="replace")
+    if "\ufffd" in text:
+        log.warning(
+            "Job %d log contained undecodable bytes; substituted U+FFFD. "
+            "Test-run counts for this shard may be incomplete.",
+            job_id,
+        )
+    return text
+
+
+def fetch_job_log(job_id: int) -> str:
+    """Fetch one job's raw text log over REST rather than ``gh api``.
+
+    Job logs contain ANSI escape sequences, which gh refuses to emit
+    without ``--allow-escape-sequences`` (gh 2.97+); going direct keeps
+    this working on whatever gh a contributor has installed.
     """
-    url = f"https://api.github.com/repos/{_repo_slug()}/actions/jobs/{job_id}/logs"
+    url = f"{_api_base()}/repos/{_repo_slug()}/actions/jobs/{job_id}/logs"
     req = urllib.request.Request(
         url,
         headers={
@@ -233,17 +282,18 @@ def fetch_job_log(job_id: int) -> str:
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    opener = urllib.request.build_opener(_NoRedirect)
     try:
-        with opener.open(req) as resp:
-            return resp.read().decode("utf-8", errors="replace")
+        with _log_opener().open(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+            return _decode_log(resp.read(), job_id)
     except urllib.error.HTTPError as e:
-        if e.code not in (301, 302, 303, 307, 308):
-            raise
-        with urllib.request.urlopen(e.headers["Location"]) as resp:
-            return resp.read().decode("utf-8", errors="replace")
+        with e:
+            detail = e.read().decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"GET {url} failed: HTTP {e.code} {e.reason}: {detail}"
+        ) from e
 
 
+@lru_cache(maxsize=1)
 def _repo_slug() -> str:
     slug = os.environ.get("GITHUB_REPOSITORY")
     if slug:
@@ -464,9 +514,12 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     runs: list[TestRun] = []
-    for job_id, job_name in jobs:
+    log.info("Fetching logs for %d shards...", len(jobs))
+    _gh_token()  # resolve once up front so the pool never races on the fallback
+    with ThreadPoolExecutor(max_workers=min(8, len(jobs))) as pool:
+        logs = list(pool.map(lambda job: fetch_job_log(job[0]), jobs))
+    for (job_id, job_name), log_text in zip(jobs, logs, strict=True):
         log.info("Parsing log for shard %s (job %d)...", job_name, job_id)
-        log_text = fetch_job_log(job_id)
         runs.extend(parse_shard_log(log_text, job_id=job_id, job_name=job_name))
 
     log.info("Collected %d test-run records.", len(runs))

--- a/tools/suggest_test_docs_weights.py
+++ b/tools/suggest_test_docs_weights.py
@@ -225,34 +225,58 @@ class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
         return new
 
 
-@lru_cache(maxsize=1)
+def _host_from_url(url: str) -> str | None:
+    """Host portion of a git remote or server URL, without scheme, user, or port."""
+    m = re.match(r"(?:[\w+.-]+://)?(?:[^@/]+@)?([^/:]+)", url.strip())
+    return m.group(1) if m else None
+
+
 def _gh_host() -> str:
     """Host owning the target repo, enterprise-aware, ``github.com`` by default."""
-    return os.environ.get("GH_HOST") or "github.com"
+    host = os.environ.get("GH_HOST")
+    if host:
+        return host
+    for url in (os.environ.get("GITHUB_SERVER_URL"), _git_remote_url()):
+        host = _host_from_url(url) if url else None
+        if host:
+            return host
+    return "github.com"
 
 
-@lru_cache(maxsize=1)
-def _api_base() -> str:
+def _api_base(host: str) -> str:
     base = os.environ.get("GITHUB_API_URL")
     if base:
         return base.rstrip("/")
-    host = _gh_host()
     return (
         "https://api.github.com" if host == "github.com" else f"https://{host}/api/v3"
     )
 
 
-@lru_cache(maxsize=1)
-def _gh_token() -> str:
+def _gh_token(host: str) -> str:
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if token:
         return token.strip()
-    return _gh("auth", "token", "--hostname", _gh_host()).strip()
+    return _gh("auth", "token", "--hostname", host).strip()
 
 
-@lru_cache(maxsize=1)
-def _log_opener() -> urllib.request.OpenerDirector:
-    return urllib.request.build_opener(_StripAuthOnRedirect)
+@dataclass(frozen=True)
+class GhContext:
+    """Per-run constants for the REST log fetch, resolved once before any request."""
+
+    api_base: str
+    repo_slug: str
+    token: str
+    opener: urllib.request.OpenerDirector
+
+
+def resolve_gh_context() -> GhContext:
+    host = _gh_host()
+    return GhContext(
+        api_base=_api_base(host),
+        repo_slug=_repo_slug(),
+        token=_gh_token(host),
+        opener=urllib.request.build_opener(_StripAuthOnRedirect),
+    )
 
 
 def _decode_log(raw: bytes, job_id: int) -> str:
@@ -266,31 +290,49 @@ def _decode_log(raw: bytes, job_id: int) -> str:
     return text
 
 
-def fetch_job_log(job_id: int) -> str:
+def fetch_job_log(job_id: int, ctx: GhContext) -> str:
     """Fetch one job's raw text log over REST rather than ``gh api``.
 
     Job logs contain ANSI escape sequences, which gh refuses to emit
     without ``--allow-escape-sequences`` (gh 2.97+); going direct keeps
     this working on whatever gh a contributor has installed.
     """
-    url = f"{_api_base()}/repos/{_repo_slug()}/actions/jobs/{job_id}/logs"
+    url = f"{ctx.api_base}/repos/{ctx.repo_slug}/actions/jobs/{job_id}/logs"
     req = urllib.request.Request(
         url,
         headers={
-            "Authorization": f"Bearer {_gh_token()}",
+            "Authorization": f"Bearer {ctx.token}",
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
     try:
-        with _log_opener().open(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+        with ctx.opener.open(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
             return _decode_log(resp.read(), job_id)
     except urllib.error.HTTPError as e:
-        with e:
-            detail = e.read().decode("utf-8", errors="replace").strip()
+        # The log endpoint 302s to blob storage; report whichever hop failed.
+        failed_url = e.geturl() or url
+        try:
+            with e:
+                detail = e.read().decode("utf-8", errors="replace").strip()
+        except OSError as read_err:
+            detail = f"<response body unreadable: {read_err}>"
         raise RuntimeError(
-            f"GET {url} failed: HTTP {e.code} {e.reason}: {detail}"
+            f"GET {failed_url} failed for job {job_id}: "
+            f"HTTP {e.code} {e.reason}: {detail}"
         ) from e
+    except (urllib.error.URLError, TimeoutError) as e:
+        raise RuntimeError(f"GET {url} failed for job {job_id}: {e}") from e
+
+
+@lru_cache(maxsize=1)
+def _git_remote_url() -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "config", "--get", "remote.origin.url"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, OSError):
+        return None
 
 
 @lru_cache(maxsize=1)
@@ -299,15 +341,11 @@ def _repo_slug() -> str:
     if slug:
         return slug
     # Best-effort: parse from git remote
-    try:
-        url = subprocess.check_output(
-            ["git", "config", "--get", "remote.origin.url"], text=True
-        ).strip()
+    url = _git_remote_url()
+    if url:
         m = re.search(r"[:/]([\w-]+/[\w-]+?)(?:\.git)?$", url)
         if m:
             return m.group(1)
-    except subprocess.CalledProcessError:
-        pass
     raise RuntimeError(
         "Cannot determine repo slug; set $GITHUB_REPOSITORY or run inside a git checkout."
     )
@@ -515,10 +553,23 @@ def main(argv: list[str] | None = None) -> int:
 
     runs: list[TestRun] = []
     log.info("Fetching logs for %d shards...", len(jobs))
-    _gh_token()  # resolve once up front so the pool never races on the fallback
+    ctx = resolve_gh_context()
+
+    def _fetch(job: tuple[int, str]) -> str | None:
+        job_id, job_name = job
+        log.info("Fetching log for shard %s (job %d)...", job_name, job_id)
+        try:
+            return fetch_job_log(job_id, ctx)
+        except (RuntimeError, OSError) as e:
+            # Informational report: one unreachable shard must not discard the rest.
+            log.warning("Skipping shard %s (job %d): %s", job_name, job_id, e)
+            return None
+
     with ThreadPoolExecutor(max_workers=min(8, len(jobs))) as pool:
-        logs = list(pool.map(lambda job: fetch_job_log(job[0]), jobs))
+        logs = list(pool.map(_fetch, jobs))
     for (job_id, job_name), log_text in zip(jobs, logs, strict=True):
+        if log_text is None:
+            continue
         log.info("Parsing log for shard %s (job %d)...", job_name, job_id)
         runs.extend(parse_shard_log(log_text, job_id=job_id, job_name=job_name))
 


### PR DESCRIPTION
## Summary

Nightly's "Suggest Shard Weights (drift report)" job has failed every night since 2026-08-31. `tools/suggest_test_docs_weights.py`'s `fetch_job_log()` shelled out to `gh api /repos/.../actions/jobs/{id}/logs`, and `gh` refuses to print job logs containing ANSI escape sequences unless `--allow-escape-sequences` is passed — even when stdout is piped, which is how `subprocess.run(capture_output=True)` invokes it.

Reproduced directly: `gh api /repos/ai-dynamo/aiperf/actions/jobs/102002463763/logs` → `the response contains terminal escape sequences; pass --allow-escape-sequences to output it anyway`.

**The one-line flag fix was abandoned.** `--allow-escape-sequences` only exists on gh 2.97+, so it fixes the runner (which happens to ship 2.98) while still failing for any contributor on an older gh. `fetch_job_log()` now fetches the log over the GitHub REST API using only the standard library — this job runs bare `python3` via `actions/setup-python` with no dependency-install step, so stdlib-only is a hard constraint, not a preference.

What the REST path does:

- Resolves the API host from `GH_HOST` → `GITHUB_SERVER_URL` → the git remote → `github.com`, so GitHub Enterprise checkouts work without extra env vars; the token fallback (`gh auth token --hostname`) uses the same resolved host.
- Follows the log endpoint's 302 to blob storage through a `redirect_request` override that strips the `Authorization` header, since the pre-signed URL rejects a GitHub bearer token.
- Bounds both hops with an explicit 30 s timeout.
- Wraps `HTTPError`, `URLError`, and `TimeoutError` into a `RuntimeError` carrying the job id and the URL that actually failed (post-redirect where applicable) plus the response body.
- Decodes with `errors="replace"` but logs a warning when U+FFFD appears, so a mangled shard is visible rather than silently undercounting `TestRun`s.
- Fetches shard logs concurrently through a `ThreadPoolExecutor`, with per-run constants resolved once into a frozen `GhContext` before the pool starts.
- Logs each shard as its fetch begins and skips a failed shard with a warning, so one unreachable shard no longer discards every already-parsed shard's results.

## Test plan

- [x] Confirmed the original failure reproduces on gh 2.93.0 and that `--allow-escape-sequences` is rejected as an unknown flag there.
- [x] Ran the script end-to-end against real nightly run `34332709159`: all 8 shards fetched concurrently, 54 test-run records collected, drift table rendered.
- [x] Exercised the error paths against synthetic `HTTPError` (with and without a readable body), `URLError`, and `TimeoutError` — each produces the wrapped diagnostic with job id and failing URL.
- [x] Verified host resolution for `GH_HOST`, `GITHUB_SERVER_URL`, and SSH/HTTPS git remotes, including a GHES host.
- [x] `ruff format` / `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub Actions log retrieval across hosted and self-hosted environments.
  * Error messages now include relevant redirect details and job identifiers, with clearer handling of unreadable responses.
  * Network, URL, and timeout failures are reported consistently instead of causing unclear failures.
  * Failed shard log retrievals are skipped with warnings so reports can still be generated.
  * Log output containing invalid or non-standard characters is decoded without failing.
  * Authentication remains securely handled, and concurrent retrieval continues with controlled resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->