### PR TITLE
fix(ci): bust poisoned arm64 build cache in nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -652,6 +652,13 @@ jobs:
           set -euo pipefail
           REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           IMAGE_TAG="${CONTAINER_TAG}-${{ matrix.arch }}"
+          # A matrix row without cache_tag renders as empty here, which would
+          # silently build against a malformed "aiperf:" ref instead of failing.
+          CACHE_TAG="${{ matrix.cache_tag }}"
+          if [[ -z "${CACHE_TAG}" ]]; then
+            echo "::error::matrix row '${{ matrix.arch }}' is missing a cache_tag field"
+            exit 1
+          fi
 
           refresh_ecr_token() {
             while sleep 21600; do
@@ -666,8 +673,8 @@ jobs:
           docker buildx build \
             --platform "${{ matrix.platform }}" \
             --target   runtime \
-            --cache-from "type=registry,ref=${REGISTRY}/aiperf:${{ matrix.cache_tag }}" \
-            --cache-to   "type=registry,ref=${REGISTRY}/aiperf:${{ matrix.cache_tag }},mode=max" \
+            --cache-from "type=registry,ref=${REGISTRY}/aiperf:${CACHE_TAG}" \
+            --cache-to   "type=registry,ref=${REGISTRY}/aiperf:${CACHE_TAG},mode=max" \
             --push \
             --tag "${REGISTRY}/aiperf:${IMAGE_TAG}" \
             .

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -652,7 +652,10 @@ jobs:
           # arm64 build fails at `uv sync --locked` claiming uv.lock is
           # stale, even though a --no-cache build on a native arm64 builder
           # with the identical lockfile succeeds cleanly. Bust the tag so
-          # future arm64 builds stop pulling the bad cache layers.
+          # future arm64 builds stop pulling the bad cache layers. See
+          # ai-dynamo/aiperf#1403. If a future incident poisons the cache
+          # again, bump this suffix again (v3, v4, ...) rather than reusing
+          # a tag that may already be bad.
           CACHE_TAG="cache-${{ matrix.arch }}"
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             CACHE_TAG="cache-arm64-v2"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -648,14 +648,9 @@ jobs:
           REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           IMAGE_TAG="${CONTAINER_TAG}-${{ matrix.arch }}"
 
-          # cache-arm64 has been poisoned since 2026-08-31: every nightly's
-          # arm64 build fails at `uv sync --locked` claiming uv.lock is
-          # stale, even though a --no-cache build on a native arm64 builder
-          # with the identical lockfile succeeds cleanly. Bust the tag so
-          # future arm64 builds stop pulling the bad cache layers. See
-          # ai-dynamo/aiperf#1403. If a future incident poisons the cache
-          # again, bump this suffix again (v3, v4, ...) rather than reusing
-          # a tag that may already be bad.
+          # arm64 cache tag is versioned to bypass poisoned registry cache
+          # layers (ai-dynamo/aiperf#1403). Bump the suffix again (v3, v4,
+          # ...) rather than reusing a tag that may already be bad.
           CACHE_TAG="cache-${{ matrix.arch }}"
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             CACHE_TAG="cache-arm64-v2"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -409,9 +409,14 @@ jobs:
           - arch: amd64
             platform: linux/amd64
             runner: prod-aiperf-builder-amd-v1
+            cache_tag: cache-amd64
           - arch: arm64
             platform: linux/arm64
             runner: prod-aiperf-builder-arm-v1
+            # Versioned to bypass poisoned registry cache layers
+            # (ai-dynamo/aiperf#1403). Bump the suffix again (v3, v4, ...)
+            # rather than reusing a tag that may already be bad.
+            cache_tag: cache-arm64-v2
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -648,14 +653,6 @@ jobs:
           REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           IMAGE_TAG="${CONTAINER_TAG}-${{ matrix.arch }}"
 
-          # arm64 cache tag is versioned to bypass poisoned registry cache
-          # layers (ai-dynamo/aiperf#1403). Bump the suffix again (v3, v4,
-          # ...) rather than reusing a tag that may already be bad.
-          CACHE_TAG="cache-${{ matrix.arch }}"
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            CACHE_TAG="cache-arm64-v2"
-          fi
-
           refresh_ecr_token() {
             while sleep 21600; do
               aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" \
@@ -669,8 +666,8 @@ jobs:
           docker buildx build \
             --platform "${{ matrix.platform }}" \
             --target   runtime \
-            --cache-from "type=registry,ref=${REGISTRY}/aiperf:${CACHE_TAG}" \
-            --cache-to   "type=registry,ref=${REGISTRY}/aiperf:${CACHE_TAG},mode=max" \
+            --cache-from "type=registry,ref=${REGISTRY}/aiperf:${{ matrix.cache_tag }}" \
+            --cache-to   "type=registry,ref=${REGISTRY}/aiperf:${{ matrix.cache_tag }},mode=max" \
             --push \
             --tag "${REGISTRY}/aiperf:${IMAGE_TAG}" \
             .

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -648,6 +648,16 @@ jobs:
           REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           IMAGE_TAG="${CONTAINER_TAG}-${{ matrix.arch }}"
 
+          # cache-arm64 has been poisoned since 2026-08-31: every nightly's
+          # arm64 build fails at `uv sync --locked` claiming uv.lock is
+          # stale, even though a --no-cache build on a native arm64 builder
+          # with the identical lockfile succeeds cleanly. Bust the tag so
+          # future arm64 builds stop pulling the bad cache layers.
+          CACHE_TAG="cache-${{ matrix.arch }}"
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            CACHE_TAG="cache-arm64-v2"
+          fi
+
           refresh_ecr_token() {
             while sleep 21600; do
               aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" \
@@ -661,8 +671,8 @@ jobs:
           docker buildx build \
             --platform "${{ matrix.platform }}" \
             --target   runtime \
-            --cache-from "type=registry,ref=${REGISTRY}/aiperf:cache-${{ matrix.arch }}" \
-            --cache-to   "type=registry,ref=${REGISTRY}/aiperf:cache-${{ matrix.arch }},mode=max" \
+            --cache-from "type=registry,ref=${REGISTRY}/aiperf:${CACHE_TAG}" \
+            --cache-to   "type=registry,ref=${REGISTRY}/aiperf:${CACHE_TAG},mode=max" \
             --push \
             --tag "${REGISTRY}/aiperf:${IMAGE_TAG}" \
             .


### PR DESCRIPTION
## Summary
- Every nightly arm64 image build has failed since 2026-08-31 (7 consecutive nights) at `uv sync --active --locked --no-install-project --no-default-groups --extra botorch`, with `error: The lockfile at uv.lock needs to be updated, but --locked was provided`.
- No commit touched `pyproject.toml`/`uv.lock`/`Dockerfile` between the last passing nightly (2026-08-28) and the first failing one (2026-08-31) — confirmed with `git log <lastgreen>..<firstred> -- pyproject.toml uv.lock Dockerfile` (empty). The amd64 build on the exact same commit succeeds every time.
- Reproduced on a native `linux/arm64` buildx builder: `docker buildx build --platform linux/arm64 --target env-builder --no-cache .` at the current `main` HEAD completes the same `uv sync` step cleanly — the lockfile is not actually stale for arm64.
- The only build input not covered by the above is the ECR registry build cache (`--cache-from/--cache-to type=registry,ref=.../aiperf:cache-arm64`), which every nightly run since 08-31 has pulled from. That points to a poisoned/corrupted cache layer set (the same run also logged a `buildx_buildkit_builder ... context deadline exceeded` transient right before this step, a plausible trigger for a bad cache export).
- This PR rolls the arm64 cache ref to `cache-arm64-v2` so future builds stop reading the bad layers. amd64 is healthy and left untouched.

## Test plan
- [x] `docker buildx build --builder <native-arm64> --platform linux/arm64 --target env-builder --no-cache -f Dockerfile .` on current `main` — succeeds, `uv sync --locked --extra botorch` resolves and installs cleanly.
- [ ] Next scheduled/triggered nightly run's `Build Container (arm64)` job goes green with a fresh `cache-arm64-v2` populated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Updated nightly container builds to use architecture-specific cache tags.
  * ARM64 builds now use a versioned cache tag, while AMD64 builds use a dedicated cache tag.
  * Improved consistency in how build caches are selected across architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->