### PR TITLE
docs: add missing PrismJS attribution

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -557,6 +557,39 @@ This document provides attribution information for public domain assets used in 
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
+### PrismJS (syntax highlighting)
+
+**Asset Information:**
+- **File(s)**: [`src/aiperf/api/static/vendor/prism-core.js`](src/aiperf/api/static/vendor/prism-core.js), [`prism-python.js`](src/aiperf/api/static/vendor/prism-python.js), [`prism-bash.js`](src/aiperf/api/static/vendor/prism-bash.js), [`prism-tomorrow.css`](src/aiperf/api/static/vendor/prism-tomorrow.css) (vendored builds, v1.30.0)
+- **Source**: [PrismJS/prism](https://github.com/PrismJS/prism) (npm: `prismjs`)
+- **Author**: Lea Verou
+- **License**: MIT License
+- **Usage**: Same-origin syntax highlighting (Python/Bash) for the local `aiperf profile` HTML dashboard.
+
+**License Text:**
+
+> MIT LICENSE
+>
+> Copyright (c) 2012 Lea Verou
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
+
 ## Usage Summary
 
 - **Public domain assets** (ShareGPT conversation data) - no legal restrictions on use


### PR DESCRIPTION
## Summary
- prismjs 1.30.0 (MIT) is vendored under `src/aiperf/api/static/vendor/` and listed in `package.json` but was missing from `ATTRIBUTIONS.md`.
- Adds the standard entry, matching the format used for js-yaml/Chart.js/etc.

## Test plan
- [x] `pre-commit run --files ATTRIBUTIONS.md` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added attribution and licensing information for the included PrismJS syntax-highlighting assets.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->