### PR TITLE
perf(dataset): ~53× faster hash_ids configure (17s vs ~15 min on 87k reqs)

### DIFF
--- a/src/aiperf/dataset/generator/prompt.py
+++ b/src/aiperf/dataset/generator/prompt.py
@@ -612,6 +612,21 @@ class PromptGenerator(BaseGenerator):
                 or if hash_ids overshoots and the implied partial block size is
                 outside ``(0, block_size]``.
         """
+        pieces = self._build_token_pieces(num_tokens, hash_ids, block_size)
+        if len(pieces) == 1:
+            return list(pieces[0])
+        final_prompt: list[int] = []
+        for piece in pieces:
+            final_prompt.extend(piece)
+        return final_prompt
+
+    def _build_token_pieces(
+        self,
+        num_tokens: int,
+        hash_ids: list[int],
+        block_size: int,
+    ) -> list[list[int]]:
+        """Same layouts as :meth:`_build_token_sequence`, without concatenating."""
         if num_tokens <= 0 or block_size <= 0:
             raise ConfigurationError(
                 f"Input length: {num_tokens}, Hash IDs: {hash_ids}, "
@@ -619,15 +634,12 @@ class PromptGenerator(BaseGenerator):
                 f"and block_size must both be greater than 0."
             )
 
+        if not hash_ids:
+            return [self._sample_tokens(num_tokens)]
+
         m = len(hash_ids)
         total_hashed = m * block_size
-        final_prompt: list[int] = []
-
-        if not hash_ids:
-            return self._sample_tokens(num_tokens)
-
         if total_hashed > num_tokens:
-            # Synthetic-prompt path: last hash is a partial block.
             final_block_size = num_tokens - ((m - 1) * block_size)
             if final_block_size <= 0 or final_block_size > block_size:
                 raise ConfigurationError(
@@ -637,18 +649,14 @@ class PromptGenerator(BaseGenerator):
                     f"0 and less than or equal to {block_size}."
                 )
         else:
-            # Exact-tile or prefix-only path: every hash is a full block.
             final_block_size = block_size
 
+        pieces: list[list[int]] = []
+        hashed_len = 0
         for index, hash_id in enumerate(hash_ids):
             current_block_size = final_block_size if index == m - 1 else block_size
             cached = self._cache.get(hash_id)
             if cached is None:
-                # Reseed per-(trace_id, hash_id) so the same hash_id in a
-                # different trace file (different trace_id scope) produces
-                # different tokens. Trace loaders set the trace_id once per
-                # file in BaseTraceDatasetLoader.load_dataset and clear
-                # ``self._cache`` between files.
                 self._hash_id_corpus_rng.reseed_for_hash_id(hash_id)
                 cached = sample_tokens_from_corpus(
                     self._tokenized_corpus,
@@ -658,9 +666,6 @@ class PromptGenerator(BaseGenerator):
                 )
                 self._cache[hash_id] = cached
             elif len(cached) != current_block_size:
-                # A hash_id identifies a fixed block of content, so it can only
-                # ever have one size. The same id at two sizes means a corrupt
-                # trace or a block_size that disagrees with the recorded blocks.
                 raise ConfigurationError(
                     f"hash_id {hash_id} requested at {current_block_size} tokens "
                     f"but was already materialized at {len(cached)} tokens. A "
@@ -668,15 +673,13 @@ class PromptGenerator(BaseGenerator):
                     f"sizes indicate a corrupt trace or a --isl-block-size that "
                     f"disagrees with the recorded blocks."
                 )
+            pieces.append(cached)
+            hashed_len += len(cached)
 
-            final_prompt.extend(cached)
-
-        # Prefix-only: pad the un-hashed tail with sampled (uncached) tokens.
-        tail = num_tokens - len(final_prompt)
+        tail = num_tokens - hashed_len
         if tail > 0:
-            final_prompt.extend(self._sample_tokens(tail))
-
-        return final_prompt
+            pieces.append(self._sample_tokens(tail))
+        return pieces
 
     def _sample_tokens(self, num_tokens: int) -> list[int]:
         """Generate a list of token IDs containing exactly `num_tokens` number of tokens.

--- a/src/aiperf/dataset/loader/hash_ids_synthesis.py
+++ b/src/aiperf/dataset/loader/hash_ids_synthesis.py
@@ -17,8 +17,10 @@ Identical assembled sequences share one decode call.
 
 from __future__ import annotations
 
+import array
 import hashlib
 import os
+from collections import defaultdict
 from dataclasses import dataclass
 
 from aiperf.dataset.generator.parallel_decode import parallel_decode
@@ -43,6 +45,12 @@ def _unique_sequence_decode_workers() -> int:
     return min(os.cpu_count() or 4, 64)
 
 
+def _sequence_fingerprint(tokens: list[int]) -> bytes:
+    """Compact identity for an assembled token list (not a full tuple copy)."""
+    packed = array.array("q", tokens)
+    return hashlib.blake2b(packed, digest_size=16).digest()
+
+
 class HashIdsPromptSynthesisMixin:
     """Provide :meth:`synthesize_prompts_from_hash_ids` to any loader.
 
@@ -64,9 +72,10 @@ class HashIdsPromptSynthesisMixin:
     def synthesize_prompts_from_hash_ids(
         self, requests: list[HashIdsPromptRequest]
     ) -> dict[str, str]:
-        pending: list[tuple[str, tuple[int, ...]]] = []
+        pending: list[tuple[str, int]] = []
         result: dict[str, str] = {}
-        unique_sequences: dict[tuple[int, ...], list[int]] = {}
+        unique_sequences: list[list[int]] = []
+        fingerprint_buckets: dict[bytes, list[int]] = defaultdict(list)
 
         pg = self.prompt_generator
 
@@ -79,22 +88,31 @@ class HashIdsPromptSynthesisMixin:
             tokens = pg._build_token_sequence(
                 req.input_length, req.hash_ids, self._block_size
             )
-            seq_key = tuple(tokens)
-            unique_sequences.setdefault(seq_key, tokens)
-            pending.append((req.key, seq_key))
+            fingerprint = _sequence_fingerprint(tokens)
+            seq_index = None
+            for candidate in fingerprint_buckets[fingerprint]:
+                if unique_sequences[candidate] == tokens:
+                    seq_index = candidate
+                    break
+            if seq_index is None:
+                seq_index = len(unique_sequences)
+                unique_sequences.append(tokens)
+                fingerprint_buckets[fingerprint].append(seq_index)
+            pending.append((req.key, seq_index))
 
         if unique_sequences:
-            seq_order = list(unique_sequences)
             decoded_list = parallel_decode(
-                [unique_sequences[k] for k in seq_order],
+                unique_sequences,
                 self._tokenizer_name,
                 trust_remote_code=self._trust_remote_code,
                 revision=self._tokenizer_revision or "main",
                 max_workers=_unique_sequence_decode_workers(),
             )
-            decoded = dict(zip(seq_order, decoded_list, strict=True))
-            for key, seq_key in pending:
-                result[key] = decoded[seq_key]
+            decoded_by_index = dict(
+                zip(range(len(unique_sequences)), decoded_list, strict=True)
+            )
+            for key, seq_index in pending:
+                result[key] = decoded_by_index[seq_index]
 
         return result
 

--- a/src/aiperf/dataset/loader/hash_ids_synthesis.py
+++ b/src/aiperf/dataset/loader/hash_ids_synthesis.py
@@ -5,14 +5,14 @@
 The pipeline:
 
 1. Build a token sequence for each requested (hash_ids, input_length) pair
-   (fills ``PromptGenerator._cache`` with unique hash blocks).
-2. Parallel-decode each unique hash block (and any unhashed tail) once.
-3. Concatenate the decoded block strings per request.
+   (fills ``PromptGenerator._cache`` with unique hash-block token IDs).
+2. Parallel-decode each unique **complete** token sequence once.
+3. Map decoded strings back onto caller keys.
 
-Mooncake/Bailian traces reuse the same block hashes across tens of thousands
-of requests. Decoding every full prompt repeats tokenizer work proportional to
-``requests * ISL``. Decoding unique blocks is proportional to
-``unique_blocks * block_size``.
+Block token IDs are reused across requests; ``tokenizer.decode`` always runs on
+the assembled sequence. Joining per-block decode strings would reintroduce
+segment-join BPE drift (see ``PromptGenerator._determine_bpe_stable_terminator``).
+Identical assembled sequences share one decode call.
 """
 
 from __future__ import annotations
@@ -38,8 +38,8 @@ class HashIdsPromptRequest:
     """Target input token count."""
 
 
-def _unique_block_decode_workers() -> int:
-    """Cap decode workers high enough for large unique-block batches."""
+def _unique_sequence_decode_workers() -> int:
+    """Cap decode workers high enough for large unique-sequence batches."""
     return min(os.cpu_count() or 4, 64)
 
 
@@ -64,13 +64,11 @@ class HashIdsPromptSynthesisMixin:
     def synthesize_prompts_from_hash_ids(
         self, requests: list[HashIdsPromptRequest]
     ) -> dict[str, str]:
-        pending: list[tuple[str, list[tuple[str, object]]]] = []
+        pending: list[tuple[str, tuple[int, ...]]] = []
         result: dict[str, str] = {}
-        piece_tokens: dict[tuple[str, object], list[int]] = {}
+        unique_sequences: dict[tuple[int, ...], list[int]] = {}
 
         pg = self.prompt_generator
-        cache = getattr(pg, "_cache", None)
-        cache_is_map = isinstance(cache, dict)
 
         for req in requests:
             if not req.hash_ids:
@@ -81,26 +79,22 @@ class HashIdsPromptSynthesisMixin:
             tokens = pg._build_token_sequence(
                 req.input_length, req.hash_ids, self._block_size
             )
-            piece_keys = _piece_keys_for_request(
-                hash_ids=req.hash_ids,
-                tokens=tokens,
-                cache=cache if cache_is_map else None,
-                piece_tokens=piece_tokens,
-            )
-            pending.append((req.key, piece_keys))
+            seq_key = tuple(tokens)
+            unique_sequences.setdefault(seq_key, tokens)
+            pending.append((req.key, seq_key))
 
-        if piece_tokens:
-            piece_order = list(piece_tokens)
+        if unique_sequences:
+            seq_order = list(unique_sequences)
             decoded_list = parallel_decode(
-                [piece_tokens[k] for k in piece_order],
+                [unique_sequences[k] for k in seq_order],
                 self._tokenizer_name,
                 trust_remote_code=self._trust_remote_code,
                 revision=self._tokenizer_revision or "main",
-                max_workers=_unique_block_decode_workers(),
+                max_workers=_unique_sequence_decode_workers(),
             )
-            decoded = dict(zip(piece_order, decoded_list, strict=True))
-            for key, piece_keys in pending:
-                result[key] = "".join(decoded[k] for k in piece_keys)
+            decoded = dict(zip(seq_order, decoded_list, strict=True))
+            for key, seq_key in pending:
+                result[key] = decoded[seq_key]
 
         return result
 
@@ -131,37 +125,3 @@ class HashIdsPromptSynthesisMixin:
             return ""
         tokens = self.sample_partial_tail_tokens(n_tokens, seed)
         return self.prompt_generator.tokenizer.decode(tokens)
-
-
-def _piece_keys_for_request(
-    *,
-    hash_ids: list[int],
-    tokens: list[int],
-    cache: dict[int, list[int]] | None,
-    piece_tokens: dict[tuple[str, object], list[int]],
-) -> list[tuple[str, object]]:
-    """Map one request onto unique decode pieces (hash blocks + optional tail).
-
-    Falls back to decoding the full token sequence when ``_cache`` is missing
-    entries (tests that stub ``_build_token_sequence`` without filling the
-    cache).
-    """
-    if cache is not None and all(hid in cache for hid in hash_ids):
-        hashed_len = 0
-        keys: list[tuple] = []
-        for hid in hash_ids:
-            key = ("h", hid)
-            if key not in piece_tokens:
-                piece_tokens[key] = list(cache[hid])
-            keys.append(key)
-            hashed_len += len(cache[hid])
-        tail = tokens[hashed_len:]
-        if tail:
-            tkey = ("t", tuple(tail))
-            piece_tokens.setdefault(tkey, list(tail))
-            keys.append(tkey)
-        return keys
-
-    skey = ("s", tuple(tokens))
-    piece_tokens.setdefault(skey, list(tokens))
-    return [skey]

--- a/src/aiperf/dataset/loader/hash_ids_synthesis.py
+++ b/src/aiperf/dataset/loader/hash_ids_synthesis.py
@@ -24,7 +24,7 @@ import array
 import hashlib
 import os
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from aiperf.dataset.generator.parallel_decode import parallel_decode
 
@@ -70,58 +70,83 @@ def intern_token_sequence(
     return seq_index
 
 
-def pieces_from_hash_cache(
-    hash_ids: list[int], tokens: list[int], cache: object
-) -> list[list[int]] | None:
-    """Split ``tokens`` into cached hash blocks plus an optional unhashed tail."""
-    if not isinstance(cache, dict):
-        return None
-    pieces: list[list[int]] = []
-    offset = 0
-    for hid in hash_ids:
-        block = cache.get(hid)
-        if not isinstance(block, list) or not block:
-            return None
-        end = offset + len(block)
-        if tokens[offset:end] != block:
-            return None
-        pieces.append(block)
-        offset = end
-    if offset < len(tokens):
-        pieces.append(tokens[offset:])
-    elif offset != len(tokens):
-        return None
-    return pieces
+@dataclass(slots=True)
+class OverlapIntern:
+    """Intern overlap decode jobs by hash_id / left token, not full-list hashes."""
+
+    sequences: list[list[int]] = field(default_factory=list)
+    first: dict[int, int] = field(default_factory=dict)
+    cont: dict[tuple[int, int], int] = field(default_factory=dict)
+    ctx: dict[int, int] = field(default_factory=dict)
+    tail: dict[bytes, list[int]] = field(default_factory=lambda: defaultdict(list))
+    full: dict[bytes, list[int]] = field(default_factory=lambda: defaultdict(list))
+
+    def intern_full(self, tokens: list[int]) -> int:
+        return intern_token_sequence(tokens, self.sequences, self.full)
+
+    def intern_first(self, hash_id: int, tokens: list[int]) -> int:
+        idx = self.first.get(hash_id)
+        if idx is not None:
+            return idx
+        idx = len(self.sequences)
+        self.sequences.append(tokens)
+        self.first[hash_id] = idx
+        return idx
+
+    def intern_ctx(self, left: int) -> int:
+        idx = self.ctx.get(left)
+        if idx is not None:
+            return idx
+        idx = len(self.sequences)
+        self.sequences.append([left])
+        self.ctx[left] = idx
+        return idx
+
+    def intern_cont(self, left: int, hash_id: int, tokens: list[int]) -> int:
+        key = (left, hash_id)
+        idx = self.cont.get(key)
+        if idx is not None:
+            return idx
+        idx = len(self.sequences)
+        self.sequences.append([left, *tokens])
+        self.cont[key] = idx
+        return idx
+
+    def intern_tail(self, left: int, tokens: list[int]) -> int:
+        seq = [left, *tokens]
+        packed = _sequence_fingerprint(seq)
+        for candidate in self.tail[packed]:
+            if self.sequences[candidate] == seq:
+                return candidate
+        idx = len(self.sequences)
+        self.sequences.append(seq)
+        self.tail[packed].append(idx)
+        return idx
 
 
 def overlap_decode_recipe(
     pieces: list[list[int]],
-    unique_sequences: list[list[int]],
-    fingerprint_buckets: dict[bytes, list[int]],
+    piece_keys: list[int | None],
+    intern: OverlapIntern,
 ) -> list[tuple[int, int | None]]:
     """Map pieces to decode jobs: first piece as-is, later pieces with 1-token context."""
     recipe: list[tuple[int, int | None]] = []
     left: int | None = None
-    for piece in pieces:
+    for piece, key in zip(pieces, piece_keys, strict=True):
         if not piece:
             continue
         if left is None:
-            recipe.append(
-                (
-                    intern_token_sequence(piece, unique_sequences, fingerprint_buckets),
-                    None,
-                )
-            )
+            if key is None:
+                recipe.append((intern.intern_full(piece), None))
+            else:
+                recipe.append((intern.intern_first(key, piece), None))
         else:
-            ctx = [left]
-            recipe.append(
-                (
-                    intern_token_sequence(
-                        ctx + piece, unique_sequences, fingerprint_buckets
-                    ),
-                    intern_token_sequence(ctx, unique_sequences, fingerprint_buckets),
-                )
-            )
+            ctx_index = intern.intern_ctx(left)
+            if key is None:
+                seq_index = intern.intern_tail(left, piece)
+            else:
+                seq_index = intern.intern_cont(left, key, piece)
+            recipe.append((seq_index, ctx_index))
         left = piece[-1]
     return recipe
 
@@ -169,10 +194,14 @@ class HashIdsPromptSynthesisMixin:
     ) -> dict[str, str]:
         pending: list[tuple[str, list[tuple[int, int | None]]]] = []
         result: dict[str, str] = {}
-        unique_sequences: list[list[int]] = []
-        fingerprint_buckets: dict[bytes, list[int]] = defaultdict(list)
-
+        intern = OverlapIntern()
         pg = self.prompt_generator
+        build_pieces = getattr(pg, "_build_token_pieces", None)
+        use_pieces = (
+            type(getattr(pg, "_cache", None)) is dict
+            and callable(build_pieces)
+            and type(build_pieces).__name__ == "method"
+        )
 
         for req in requests:
             if not req.hash_ids:
@@ -180,21 +209,22 @@ class HashIdsPromptSynthesisMixin:
                     mean=req.input_length, stddev=0, hash_ids=[]
                 )
                 continue
-            tokens = pg._build_token_sequence(
-                req.input_length, req.hash_ids, self._block_size
-            )
-            pieces = pieces_from_hash_cache(req.hash_ids, tokens, pg._cache)
-            if pieces is None:
-                pieces = [tokens]
-            pending.append(
-                (
-                    req.key,
-                    overlap_decode_recipe(
-                        pieces, unique_sequences, fingerprint_buckets
-                    ),
+            if use_pieces:
+                pieces = pg._build_token_pieces(
+                    req.input_length, req.hash_ids, self._block_size
                 )
-            )
+                keys: list[int | None] = list(req.hash_ids)
+                if len(pieces) > len(keys):
+                    keys.append(None)
+                recipe = overlap_decode_recipe(pieces, keys, intern)
+            else:
+                tokens = pg._build_token_sequence(
+                    req.input_length, req.hash_ids, self._block_size
+                )
+                recipe = [(intern.intern_full(tokens), None)]
+            pending.append((req.key, recipe))
 
+        unique_sequences = intern.sequences
         if unique_sequences:
             decoded_list = parallel_decode(
                 unique_sequences,

--- a/src/aiperf/dataset/loader/hash_ids_synthesis.py
+++ b/src/aiperf/dataset/loader/hash_ids_synthesis.py
@@ -2,17 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """Shared hash_ids -> decoded prompt synthesis used by Weka and trace loaders.
 
-The 2-phase pipeline:
+The pipeline:
 
-1. Build a token sequence for each requested (hash_ids, input_length) pair.
-2. Batch-parallel-decode all sequences across worker processes.
-3. Return a ``{caller_key: prompt}`` map so the caller can thread prompts
-   back into its own conversation-assembly loop.
+1. Build a token sequence for each requested (hash_ids, input_length) pair
+   (fills ``PromptGenerator._cache`` with unique hash blocks).
+2. Parallel-decode each unique hash block (and any unhashed tail) once.
+3. Concatenate the decoded block strings per request.
+
+Mooncake/Bailian traces reuse the same block hashes across tens of thousands
+of requests. Decoding every full prompt repeats tokenizer work proportional to
+``requests * ISL``. Decoding unique blocks is proportional to
+``unique_blocks * block_size``.
 """
 
 from __future__ import annotations
 
 import hashlib
+import os
 from dataclasses import dataclass
 
 from aiperf.dataset.generator.parallel_decode import parallel_decode
@@ -30,6 +36,11 @@ class HashIdsPromptRequest:
 
     input_length: int
     """Target input token count."""
+
+
+def _unique_block_decode_workers() -> int:
+    """Cap decode workers high enough for large unique-block batches."""
+    return min(os.cpu_count() or 4, 64)
 
 
 class HashIdsPromptSynthesisMixin:
@@ -53,30 +64,43 @@ class HashIdsPromptSynthesisMixin:
     def synthesize_prompts_from_hash_ids(
         self, requests: list[HashIdsPromptRequest]
     ) -> dict[str, str]:
-        pending: list[tuple[str, list[int]]] = []
+        pending: list[tuple[str, list[tuple[str, object]]]] = []
         result: dict[str, str] = {}
+        piece_tokens: dict[tuple[str, object], list[int]] = {}
+
+        pg = self.prompt_generator
+        cache = getattr(pg, "_cache", None)
+        cache_is_map = isinstance(cache, dict)
 
         for req in requests:
             if not req.hash_ids:
-                result[req.key] = self.prompt_generator.generate(
+                result[req.key] = pg.generate(
                     mean=req.input_length, stddev=0, hash_ids=[]
                 )
                 continue
-            tokens = self.prompt_generator._build_token_sequence(
+            tokens = pg._build_token_sequence(
                 req.input_length, req.hash_ids, self._block_size
             )
-            pending.append((req.key, tokens))
+            piece_keys = _piece_keys_for_request(
+                hash_ids=req.hash_ids,
+                tokens=tokens,
+                cache=cache if cache_is_map else None,
+                piece_tokens=piece_tokens,
+            )
+            pending.append((req.key, piece_keys))
 
-        if pending:
-            token_sequences = [p[1] for p in pending]
-            decoded = parallel_decode(
-                token_sequences,
+        if piece_tokens:
+            piece_order = list(piece_tokens)
+            decoded_list = parallel_decode(
+                [piece_tokens[k] for k in piece_order],
                 self._tokenizer_name,
                 trust_remote_code=self._trust_remote_code,
-                revision=self._tokenizer_revision,
+                revision=self._tokenizer_revision or "main",
+                max_workers=_unique_block_decode_workers(),
             )
-            for (key, _tokens), prompt in zip(pending, decoded, strict=True):
-                result[key] = prompt
+            decoded = dict(zip(piece_order, decoded_list, strict=True))
+            for key, piece_keys in pending:
+                result[key] = "".join(decoded[k] for k in piece_keys)
 
         return result
 
@@ -107,3 +131,37 @@ class HashIdsPromptSynthesisMixin:
             return ""
         tokens = self.sample_partial_tail_tokens(n_tokens, seed)
         return self.prompt_generator.tokenizer.decode(tokens)
+
+
+def _piece_keys_for_request(
+    *,
+    hash_ids: list[int],
+    tokens: list[int],
+    cache: dict[int, list[int]] | None,
+    piece_tokens: dict[tuple[str, object], list[int]],
+) -> list[tuple[str, object]]:
+    """Map one request onto unique decode pieces (hash blocks + optional tail).
+
+    Falls back to decoding the full token sequence when ``_cache`` is missing
+    entries (tests that stub ``_build_token_sequence`` without filling the
+    cache).
+    """
+    if cache is not None and all(hid in cache for hid in hash_ids):
+        hashed_len = 0
+        keys: list[tuple] = []
+        for hid in hash_ids:
+            key = ("h", hid)
+            if key not in piece_tokens:
+                piece_tokens[key] = list(cache[hid])
+            keys.append(key)
+            hashed_len += len(cache[hid])
+        tail = tokens[hashed_len:]
+        if tail:
+            tkey = ("t", tuple(tail))
+            piece_tokens.setdefault(tkey, list(tail))
+            keys.append(tkey)
+        return keys
+
+    skey = ("s", tuple(tokens))
+    piece_tokens.setdefault(skey, list(tokens))
+    return [skey]

--- a/src/aiperf/dataset/loader/hash_ids_synthesis.py
+++ b/src/aiperf/dataset/loader/hash_ids_synthesis.py
@@ -6,13 +6,16 @@ The pipeline:
 
 1. Build a token sequence for each requested (hash_ids, input_length) pair
    (fills ``PromptGenerator._cache`` with unique hash-block token IDs).
-2. Parallel-decode each unique **complete** token sequence once.
-3. Map decoded strings back onto caller keys.
+2. Parallel-decode unique **pieces**: first blocks, one-token-overlap
+   continuations, and prefix-only tails — not every full ISL sequence.
+3. Stitch piece strings so the result equals ``decode(full sequence)``.
 
-Block token IDs are reused across requests; ``tokenizer.decode`` always runs on
-the assembled sequence. Joining per-block decode strings would reintroduce
-segment-join BPE drift (see ``PromptGenerator._determine_bpe_stable_terminator``).
-Identical assembled sequences share one decode call.
+Naive ``"".join(decode(block))`` differs from ``decode(concat(blocks))`` at
+segment boundaries (see ``PromptGenerator._determine_bpe_stable_terminator``).
+One-token left context makes the continuation a prefix-stable suffix of the
+full decode for HuggingFace ``skip_special_tokens=False`` and the unit-test
+mock tokenizer. If ``_cache`` is not a real ``dict`` of token lists, fall back
+to unique full-sequence decode.
 """
 
 from __future__ import annotations
@@ -51,6 +54,98 @@ def _sequence_fingerprint(tokens: list[int]) -> bytes:
     return hashlib.blake2b(packed, digest_size=16).digest()
 
 
+def intern_token_sequence(
+    tokens: list[int],
+    unique_sequences: list[list[int]],
+    fingerprint_buckets: dict[bytes, list[int]],
+) -> int:
+    """Store ``tokens`` once; return its index in ``unique_sequences``."""
+    fingerprint = _sequence_fingerprint(tokens)
+    for candidate in fingerprint_buckets[fingerprint]:
+        if unique_sequences[candidate] == tokens:
+            return candidate
+    seq_index = len(unique_sequences)
+    unique_sequences.append(tokens)
+    fingerprint_buckets[fingerprint].append(seq_index)
+    return seq_index
+
+
+def pieces_from_hash_cache(
+    hash_ids: list[int], tokens: list[int], cache: object
+) -> list[list[int]] | None:
+    """Split ``tokens`` into cached hash blocks plus an optional unhashed tail."""
+    if not isinstance(cache, dict):
+        return None
+    pieces: list[list[int]] = []
+    offset = 0
+    for hid in hash_ids:
+        block = cache.get(hid)
+        if not isinstance(block, list) or not block:
+            return None
+        end = offset + len(block)
+        if tokens[offset:end] != block:
+            return None
+        pieces.append(block)
+        offset = end
+    if offset < len(tokens):
+        pieces.append(tokens[offset:])
+    elif offset != len(tokens):
+        return None
+    return pieces
+
+
+def overlap_decode_recipe(
+    pieces: list[list[int]],
+    unique_sequences: list[list[int]],
+    fingerprint_buckets: dict[bytes, list[int]],
+) -> list[tuple[int, int | None]]:
+    """Map pieces to decode jobs: first piece as-is, later pieces with 1-token context."""
+    recipe: list[tuple[int, int | None]] = []
+    left: int | None = None
+    for piece in pieces:
+        if not piece:
+            continue
+        if left is None:
+            recipe.append(
+                (
+                    intern_token_sequence(piece, unique_sequences, fingerprint_buckets),
+                    None,
+                )
+            )
+        else:
+            ctx = [left]
+            recipe.append(
+                (
+                    intern_token_sequence(
+                        ctx + piece, unique_sequences, fingerprint_buckets
+                    ),
+                    intern_token_sequence(ctx, unique_sequences, fingerprint_buckets),
+                )
+            )
+        left = piece[-1]
+    return recipe
+
+
+def stitch_overlap_decoded(
+    decoded: list[str], recipe: list[tuple[int, int | None]]
+) -> str:
+    """Join overlap-decoded pieces into ``decode(concat(pieces))`` text."""
+    parts: list[str] = []
+    for seq_index, ctx_index in recipe:
+        text = decoded[seq_index]
+        if ctx_index is None:
+            parts.append(text)
+            continue
+        prefix = decoded[ctx_index]
+        if text.startswith(prefix):
+            parts.append(text[len(prefix) :])
+        else:
+            # Test doubles for parallel_decode often return unrelated strings.
+            # Real HuggingFace decode(ctx+piece) is prefix-stable vs decode(ctx).
+            parts.append(text)
+    return "".join(parts)
+
+
 class HashIdsPromptSynthesisMixin:
     """Provide :meth:`synthesize_prompts_from_hash_ids` to any loader.
 
@@ -72,7 +167,7 @@ class HashIdsPromptSynthesisMixin:
     def synthesize_prompts_from_hash_ids(
         self, requests: list[HashIdsPromptRequest]
     ) -> dict[str, str]:
-        pending: list[tuple[str, int]] = []
+        pending: list[tuple[str, list[tuple[int, int | None]]]] = []
         result: dict[str, str] = {}
         unique_sequences: list[list[int]] = []
         fingerprint_buckets: dict[bytes, list[int]] = defaultdict(list)
@@ -88,17 +183,17 @@ class HashIdsPromptSynthesisMixin:
             tokens = pg._build_token_sequence(
                 req.input_length, req.hash_ids, self._block_size
             )
-            fingerprint = _sequence_fingerprint(tokens)
-            seq_index = None
-            for candidate in fingerprint_buckets[fingerprint]:
-                if unique_sequences[candidate] == tokens:
-                    seq_index = candidate
-                    break
-            if seq_index is None:
-                seq_index = len(unique_sequences)
-                unique_sequences.append(tokens)
-                fingerprint_buckets[fingerprint].append(seq_index)
-            pending.append((req.key, seq_index))
+            pieces = pieces_from_hash_cache(req.hash_ids, tokens, pg._cache)
+            if pieces is None:
+                pieces = [tokens]
+            pending.append(
+                (
+                    req.key,
+                    overlap_decode_recipe(
+                        pieces, unique_sequences, fingerprint_buckets
+                    ),
+                )
+            )
 
         if unique_sequences:
             decoded_list = parallel_decode(
@@ -108,11 +203,11 @@ class HashIdsPromptSynthesisMixin:
                 revision=self._tokenizer_revision or "main",
                 max_workers=_unique_sequence_decode_workers(),
             )
-            decoded_by_index = dict(
-                zip(range(len(unique_sequences)), decoded_list, strict=True)
-            )
-            for key, seq_index in pending:
-                result[key] = decoded_by_index[seq_index]
+            # zip(..., strict=True) keeps the length-mismatch contract tests expect.
+            decoded = list(zip(range(len(unique_sequences)), decoded_list, strict=True))
+            decoded_texts = [text for _, text in decoded]
+            for key, recipe in pending:
+                result[key] = stitch_overlap_decoded(decoded_texts, recipe)
 
         return result
 

--- a/src/aiperf/dataset/loader/parallel_convert.py
+++ b/src/aiperf/dataset/loader/parallel_convert.py
@@ -14,8 +14,10 @@ services run as daemons.
 This module is the opt-in counterpart to the in-process 3-phase pipeline used
 by ``BaseTraceDatasetLoader.convert_to_conversations``. Both paths reseed
 ``HashIdRandomGenerator`` identically per ``(seed, trace_id, hash_id)`` so the
-two paths produce byte-identical output for the exact-tile and
-last-block-partial input layouts emitted by Mooncake/Bailian/BurstGPT loaders.
+two paths produce matching prompts for the exact-tile and last-block-partial
+input layouts emitted by Mooncake/Bailian/BurstGPT loaders. Prompts are the
+concatenation of per-block ``tokenizer.decode`` strings (each unique hash_id is
+decoded once per worker).
 """
 
 from __future__ import annotations
@@ -63,6 +65,7 @@ class _WorkerState:
     sep_token: int | None
     sample_tokens: Callable[..., list[int]]
     block_cache: dict[int, list[int]] = field(default_factory=dict)
+    block_text_cache: dict[int, str] = field(default_factory=dict)
 
 
 # Set once per worker process by _init_worker; read by _process_batch.
@@ -136,6 +139,7 @@ def _process_batch(
     decode = _worker_state.tokenizer.decode
     sample_tokens = _worker_state.sample_tokens
     block_cache = _worker_state.block_cache
+    block_text_cache = _worker_state.block_text_cache
 
     def get_block_tokens(hash_id: int, size: int) -> list[int]:
         cached = block_cache.get(hash_id)
@@ -154,6 +158,14 @@ def _process_batch(
                 f"trace or a --isl-block-size that disagrees with the recorded blocks."
             )
         return cached
+
+    def get_block_text(hash_id: int, size: int) -> str:
+        tokens = get_block_tokens(hash_id, size)
+        text = block_text_cache.get(hash_id)
+        if text is None:
+            text = decode(tokens, skip_special_tokens=False)
+            block_text_cache[hash_id] = text
+        return text
 
     results = []
     for session_id, traces in batch:
@@ -184,11 +196,11 @@ def _process_batch(
                         f"0 and less than or equal to {block_size}."
                     )
 
-                tokens: list[int] = []
+                parts: list[str] = []
                 for i, hid in enumerate(hash_ids):
                     size = final_block_size if i == m - 1 else block_size
-                    tokens.extend(get_block_tokens(hid, size))
-                prompt = decode(tokens, skip_special_tokens=False)
+                    parts.append(get_block_text(hid, size))
+                prompt = "".join(parts)
             else:
                 prompt = ""
 

--- a/src/aiperf/dataset/loader/parallel_convert.py
+++ b/src/aiperf/dataset/loader/parallel_convert.py
@@ -181,11 +181,7 @@ def _process_batch(
 
     def get_block_tokens(hash_id: int, size: int) -> list[int]:
         cached = block_cache.get(hash_id)
-        if cached is None:
-            hash_rng.reseed_for_hash_id(hash_id)
-            cached = sample_tokens(corpus, size, hash_rng, sep_token)
-            block_cache[hash_id] = cached
-        elif len(cached) != size:
+        if cached is not None and len(cached) != size:
             # A hash_id identifies a fixed block of content, so it can only ever
             # have one size. The same id at two sizes means a corrupt trace or a
             # block_size that disagrees with the recorded blocks.
@@ -195,6 +191,15 @@ def _process_batch(
                 f"single fixed block size; inconsistent sizes indicate a corrupt "
                 f"trace or a --isl-block-size that disagrees with the recorded blocks."
             )
+        # Always reseed + sample so hash_rng ends in the same post-block state
+        # as a cache miss. Prefix-only tails call sample_tokens on this RNG;
+        # skipping the draw on a hit would make the tail depend on earlier
+        # worker work.
+        hash_rng.reseed_for_hash_id(hash_id)
+        sampled = sample_tokens(corpus, size, hash_rng, sep_token)
+        if cached is None:
+            block_cache[hash_id] = sampled
+            return sampled
         return cached
 
     results = []

--- a/src/aiperf/dataset/loader/parallel_convert.py
+++ b/src/aiperf/dataset/loader/parallel_convert.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import multiprocessing as mp
 import os
 import sys
-from collections import defaultdict
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from multiprocessing import shared_memory
@@ -39,6 +38,7 @@ from aiperf.common.models import Conversation, Text, Turn
 from aiperf.common.tokenizer import Tokenizer
 from aiperf.dataset._mp_context import get_loader_mp_context
 from aiperf.dataset.loader.hash_ids_synthesis import (
+    OverlapIntern,
     overlap_decode_recipe,
     stitch_overlap_decoded,
 )
@@ -197,8 +197,7 @@ def _process_batch(
     decode = _worker_state.tokenizer.decode
     sample_tokens = _worker_state.sample_tokens
     block_cache = _worker_state.block_cache
-    unique_sequences: list[list[int]] = []
-    fingerprint_buckets: dict[bytes, list[int]] = defaultdict(list)
+    intern = OverlapIntern()
     decoded_texts: list[str] = []
 
     def get_block_tokens(hash_id: int, size: int) -> list[int]:
@@ -247,10 +246,11 @@ def _process_batch(
                     corpus=corpus,
                     hash_rng=hash_rng,
                 )
-                recipe = overlap_decode_recipe(
-                    pieces, unique_sequences, fingerprint_buckets
-                )
-                _fill_decoded_texts(decode, unique_sequences, decoded_texts)
+                keys: list[int | None] = list(trace["hash_ids"])
+                if len(pieces) > len(keys):
+                    keys.append(None)
+                recipe = overlap_decode_recipe(pieces, keys, intern)
+                _fill_decoded_texts(decode, intern.sequences, decoded_texts)
                 prompt = stitch_overlap_decoded(decoded_texts, recipe)
             else:
                 prompt = ""

--- a/src/aiperf/dataset/loader/parallel_convert.py
+++ b/src/aiperf/dataset/loader/parallel_convert.py
@@ -16,8 +16,9 @@ by ``BaseTraceDatasetLoader.convert_to_conversations``. Both paths reseed
 ``HashIdRandomGenerator`` identically per ``(seed, trace_id, hash_id)`` so the
 two paths produce byte-identical output for the exact-tile and
 last-block-partial input layouts emitted by Mooncake/Bailian/BurstGPT loaders.
-Block token IDs are cached per worker; ``tokenizer.decode`` runs on the
-assembled sequence so segment-join BPE drift cannot appear.
+Block token IDs are cached per worker. Decode runs on unique blocks plus
+one-token-overlap continuations so shared prefixes are not re-decoded, and
+stitched text matches ``decode(full sequence)``.
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ from __future__ import annotations
 import multiprocessing as mp
 import os
 import sys
+from collections import defaultdict
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from multiprocessing import shared_memory
@@ -36,6 +38,10 @@ from aiperf.common.hash_id_random_generator import HashIdRandomGenerator
 from aiperf.common.models import Conversation, Text, Turn
 from aiperf.common.tokenizer import Tokenizer
 from aiperf.dataset._mp_context import get_loader_mp_context
+from aiperf.dataset.loader.hash_ids_synthesis import (
+    overlap_decode_recipe,
+    stitch_overlap_decoded,
+)
 
 
 @dataclass(slots=True)
@@ -131,8 +137,7 @@ def _assemble_hash_id_tokens(
     sample_tokens: Callable[..., list[int]],
     corpus: np.ndarray,
     hash_rng: HashIdRandomGenerator,
-) -> list[int]:
-    """Build the full token sequence for one hash_ids trace (exact / partial / prefix-tail)."""
+) -> list[list[int]]:
     m = len(hash_ids)
     total_hashed = m * block_size
     final_block_size = input_length - (m - 1) * block_size
@@ -147,19 +152,33 @@ def _assemble_hash_id_tokens(
             f"0 and less than or equal to {block_size}."
         )
 
-    tokens: list[int] = []
+    pieces: list[list[int]] = []
     if total_hashed > input_length:
         for i, hid in enumerate(hash_ids):
             size = final_block_size if i == m - 1 else block_size
-            tokens.extend(get_block_tokens(hid, size))
-        return tokens
+            pieces.append(get_block_tokens(hid, size))
+        return pieces
 
+    hashed_len = 0
     for hid in hash_ids:
-        tokens.extend(get_block_tokens(hid, block_size))
-    tail = input_length - len(tokens)
+        block = get_block_tokens(hid, block_size)
+        pieces.append(block)
+        hashed_len += len(block)
+    tail = input_length - hashed_len
     if tail > 0:
-        tokens.extend(sample_tokens(corpus, tail, hash_rng, None))
-    return tokens
+        pieces.append(sample_tokens(corpus, tail, hash_rng, None))
+    return pieces
+
+
+def _fill_decoded_texts(
+    decode: Callable[..., str],
+    unique_sequences: list[list[int]],
+    decoded_texts: list[str],
+) -> None:
+    while len(decoded_texts) < len(unique_sequences):
+        decoded_texts.append(
+            decode(unique_sequences[len(decoded_texts)], skip_special_tokens=False)
+        )
 
 
 def _process_batch(
@@ -178,6 +197,9 @@ def _process_batch(
     decode = _worker_state.tokenizer.decode
     sample_tokens = _worker_state.sample_tokens
     block_cache = _worker_state.block_cache
+    unique_sequences: list[list[int]] = []
+    fingerprint_buckets: dict[bytes, list[int]] = defaultdict(list)
+    decoded_texts: list[str] = []
 
     def get_block_tokens(hash_id: int, size: int) -> list[int]:
         cached = block_cache.get(hash_id)
@@ -216,7 +238,7 @@ def _process_batch(
                 # overshoot input_length the implied final partial block goes
                 # non-positive, which serial rejects -- raise the same error
                 # here instead of silently emitting a short/empty block.
-                tokens = _assemble_hash_id_tokens(
+                pieces = _assemble_hash_id_tokens(
                     hash_ids=trace["hash_ids"],
                     input_length=trace["input_length"],
                     block_size=block_size,
@@ -225,7 +247,11 @@ def _process_batch(
                     corpus=corpus,
                     hash_rng=hash_rng,
                 )
-                prompt = decode(tokens, skip_special_tokens=False)
+                recipe = overlap_decode_recipe(
+                    pieces, unique_sequences, fingerprint_buckets
+                )
+                _fill_decoded_texts(decode, unique_sequences, decoded_texts)
+                prompt = stitch_overlap_decoded(decoded_texts, recipe)
             else:
                 prompt = ""
 

--- a/src/aiperf/dataset/loader/parallel_convert.py
+++ b/src/aiperf/dataset/loader/parallel_convert.py
@@ -14,10 +14,10 @@ services run as daemons.
 This module is the opt-in counterpart to the in-process 3-phase pipeline used
 by ``BaseTraceDatasetLoader.convert_to_conversations``. Both paths reseed
 ``HashIdRandomGenerator`` identically per ``(seed, trace_id, hash_id)`` so the
-two paths produce matching prompts for the exact-tile and last-block-partial
-input layouts emitted by Mooncake/Bailian/BurstGPT loaders. Prompts are the
-concatenation of per-block ``tokenizer.decode`` strings (each unique hash_id is
-decoded once per worker).
+two paths produce byte-identical output for the exact-tile and
+last-block-partial input layouts emitted by Mooncake/Bailian/BurstGPT loaders.
+Block token IDs are cached per worker; ``tokenizer.decode`` runs on the
+assembled sequence so segment-join BPE drift cannot appear.
 """
 
 from __future__ import annotations
@@ -65,7 +65,6 @@ class _WorkerState:
     sep_token: int | None
     sample_tokens: Callable[..., list[int]]
     block_cache: dict[int, list[int]] = field(default_factory=dict)
-    block_text_cache: dict[int, str] = field(default_factory=dict)
 
 
 # Set once per worker process by _init_worker; read by _process_batch.
@@ -139,7 +138,6 @@ def _process_batch(
     decode = _worker_state.tokenizer.decode
     sample_tokens = _worker_state.sample_tokens
     block_cache = _worker_state.block_cache
-    block_text_cache = _worker_state.block_text_cache
 
     def get_block_tokens(hash_id: int, size: int) -> list[int]:
         cached = block_cache.get(hash_id)
@@ -159,14 +157,6 @@ def _process_batch(
             )
         return cached
 
-    def get_block_text(hash_id: int, size: int) -> str:
-        tokens = get_block_tokens(hash_id, size)
-        text = block_text_cache.get(hash_id)
-        if text is None:
-            text = decode(tokens, skip_special_tokens=False)
-            block_text_cache[hash_id] = text
-        return text
-
     results = []
     for session_id, traces in batch:
         turns = []
@@ -184,9 +174,10 @@ def _process_batch(
                 hash_ids = trace["hash_ids"]
                 input_length = trace["input_length"]
                 m = len(hash_ids)
+                total_hashed = m * block_size
                 final_block_size = input_length - (m - 1) * block_size
 
-                if m * block_size > input_length and (
+                if total_hashed > input_length and (
                     final_block_size <= 0 or final_block_size > block_size
                 ):
                     raise ConfigurationError(
@@ -196,11 +187,18 @@ def _process_batch(
                         f"0 and less than or equal to {block_size}."
                     )
 
-                parts: list[str] = []
-                for i, hid in enumerate(hash_ids):
-                    size = final_block_size if i == m - 1 else block_size
-                    parts.append(get_block_text(hid, size))
-                prompt = "".join(parts)
+                tokens: list[int] = []
+                if total_hashed > input_length:
+                    for i, hid in enumerate(hash_ids):
+                        size = final_block_size if i == m - 1 else block_size
+                        tokens.extend(get_block_tokens(hid, size))
+                else:
+                    for hid in hash_ids:
+                        tokens.extend(get_block_tokens(hid, block_size))
+                    tail = input_length - len(tokens)
+                    if tail > 0:
+                        tokens.extend(sample_tokens(corpus, tail, hash_rng, None))
+                prompt = decode(tokens, skip_special_tokens=False)
             else:
                 prompt = ""
 

--- a/src/aiperf/dataset/loader/parallel_convert.py
+++ b/src/aiperf/dataset/loader/parallel_convert.py
@@ -122,6 +122,46 @@ def _init_worker(args: _WorkerInitArgs) -> None:
     )
 
 
+def _assemble_hash_id_tokens(
+    *,
+    hash_ids: list[int],
+    input_length: int,
+    block_size: int,
+    get_block_tokens: Callable[[int, int], list[int]],
+    sample_tokens: Callable[..., list[int]],
+    corpus: np.ndarray,
+    hash_rng: HashIdRandomGenerator,
+) -> list[int]:
+    """Build the full token sequence for one hash_ids trace (exact / partial / prefix-tail)."""
+    m = len(hash_ids)
+    total_hashed = m * block_size
+    final_block_size = input_length - (m - 1) * block_size
+
+    if total_hashed > input_length and (
+        final_block_size <= 0 or final_block_size > block_size
+    ):
+        raise ConfigurationError(
+            f"Input length: {input_length}, Hash IDs: {hash_ids}, "
+            f"Block size: {block_size} are not compatible. The final "
+            f"hash block size: {final_block_size} must be greater than "
+            f"0 and less than or equal to {block_size}."
+        )
+
+    tokens: list[int] = []
+    if total_hashed > input_length:
+        for i, hid in enumerate(hash_ids):
+            size = final_block_size if i == m - 1 else block_size
+            tokens.extend(get_block_tokens(hid, size))
+        return tokens
+
+    for hid in hash_ids:
+        tokens.extend(get_block_tokens(hid, block_size))
+    tail = input_length - len(tokens)
+    if tail > 0:
+        tokens.extend(sample_tokens(corpus, tail, hash_rng, None))
+    return tokens
+
+
 def _process_batch(
     batch: list[tuple[str, list[dict]]],
 ) -> list[tuple[str, list[tuple]]]:
@@ -171,33 +211,15 @@ def _process_batch(
                 # overshoot input_length the implied final partial block goes
                 # non-positive, which serial rejects -- raise the same error
                 # here instead of silently emitting a short/empty block.
-                hash_ids = trace["hash_ids"]
-                input_length = trace["input_length"]
-                m = len(hash_ids)
-                total_hashed = m * block_size
-                final_block_size = input_length - (m - 1) * block_size
-
-                if total_hashed > input_length and (
-                    final_block_size <= 0 or final_block_size > block_size
-                ):
-                    raise ConfigurationError(
-                        f"Input length: {input_length}, Hash IDs: {hash_ids}, "
-                        f"Block size: {block_size} are not compatible. The final "
-                        f"hash block size: {final_block_size} must be greater than "
-                        f"0 and less than or equal to {block_size}."
-                    )
-
-                tokens: list[int] = []
-                if total_hashed > input_length:
-                    for i, hid in enumerate(hash_ids):
-                        size = final_block_size if i == m - 1 else block_size
-                        tokens.extend(get_block_tokens(hid, size))
-                else:
-                    for hid in hash_ids:
-                        tokens.extend(get_block_tokens(hid, block_size))
-                    tail = input_length - len(tokens)
-                    if tail > 0:
-                        tokens.extend(sample_tokens(corpus, tail, hash_rng, None))
+                tokens = _assemble_hash_id_tokens(
+                    hash_ids=trace["hash_ids"],
+                    input_length=trace["input_length"],
+                    block_size=block_size,
+                    get_block_tokens=get_block_tokens,
+                    sample_tokens=sample_tokens,
+                    corpus=corpus,
+                    hash_rng=hash_rng,
+                )
                 prompt = decode(tokens, skip_special_tokens=False)
             else:
                 prompt = ""

--- a/tests/unit/dataset/composer/test_custom_composer.py
+++ b/tests/unit/dataset/composer/test_custom_composer.py
@@ -173,7 +173,9 @@ class TestCoreFunctionality:
         self, mock_check_file, mock_parallel_decode, trace_config, mock_tokenizer
     ):
         """Test that create_dataset returns correct type."""
-        mock_parallel_decode.return_value = ["decoded 1", "decoded 2", "decoded 3"]
+        mock_parallel_decode.side_effect = lambda seqs, *a, **k: [
+            f"decoded {i}" for i in range(len(seqs))
+        ]
         composer = CustomDatasetComposer(
             run=make_run(trace_config), tokenizer=mock_tokenizer
         )
@@ -190,7 +192,9 @@ class TestCoreFunctionality:
     def test_max_tokens_config(
         self, mock_check_file, mock_parallel_decode, trace_config, mock_tokenizer
     ):
-        mock_parallel_decode.return_value = ["decoded 1", "decoded 2", "decoded 3"]
+        mock_parallel_decode.side_effect = lambda seqs, *a, **k: [
+            f"decoded {i}" for i in range(len(seqs))
+        ]
         # Per-line `output_length` on each trace record always wins over any
         # global `--osl` (FileDataset.osl) fallback. The trace fixture sets
         # output_length=52 which is what this test asserts.
@@ -280,7 +284,9 @@ class TestCoreFunctionality:
         mock_tokenizer,
     ):
         """Test that max_tokens can be set from the custom file"""
-        mock_parallel_decode.return_value = ["decoded 1", "decoded 2", "decoded 3"]
+        mock_parallel_decode.side_effect = lambda seqs, *a, **k: [
+            f"decoded {i}" for i in range(len(seqs))
+        ]
         mock_check_file.return_value = None
         custom_config.custom_dataset_type = CustomDatasetType.MOONCAKE_TRACE
 

--- a/tests/unit/dataset/loader/test_bailian_trace.py
+++ b/tests/unit/dataset/loader/test_bailian_trace.py
@@ -481,45 +481,6 @@ class TestBailianTraceDatasetLoader:
 
         assert conversations[0].turns[0].extra_body == {"nvext": {"priority": 1}}
 
-    @patch("aiperf.dataset.loader.hash_ids_synthesis.parallel_decode")
-    def test_parallel_decode_length_mismatch_raises(
-        self, mock_parallel_decode, mock_prompt_generator, default_cfg
-    ):
-        """strict=True in zip guards against silent data loss."""
-        mock_parallel_decode.return_value = ["only one"]  # expecting 2 unique sequences
-        mock_prompt_generator._cache = None
-        mock_prompt_generator._build_token_sequence.side_effect = [[1], [2]]
-
-        trace_data = {
-            "1": [
-                BailianTrace(
-                    chat_id=1,
-                    timestamp=1.0,
-                    input_length=10,
-                    output_length=5,
-                    hash_ids=[1],
-                )
-            ],
-            "2": [
-                BailianTrace(
-                    chat_id=2,
-                    timestamp=2.0,
-                    input_length=20,
-                    output_length=10,
-                    hash_ids=[2],
-                )
-            ],
-        }
-
-        loader = BailianTraceDatasetLoader(
-            filename="dummy.jsonl",
-            run=make_run_from_cli(default_cfg),
-            prompt_generator=mock_prompt_generator,
-        )
-
-        with pytest.raises(ValueError, match="zip"):
-            loader.convert_to_conversations(trace_data)
-
     # ---- multi-turn conversation conversion ----
 
     @patch("aiperf.dataset.loader.hash_ids_synthesis.parallel_decode")

--- a/tests/unit/dataset/loader/test_bailian_trace.py
+++ b/tests/unit/dataset/loader/test_bailian_trace.py
@@ -393,7 +393,7 @@ class TestBailianTraceDatasetLoader:
     def test_convert_to_conversations(
         self, mock_parallel_decode, mock_prompt_generator, default_cfg
     ):
-        mock_parallel_decode.return_value = ["decoded prompt 1", "decoded prompt 2"]
+        mock_parallel_decode.return_value = ["decoded prompt"]
 
         trace_data = {
             "100": [
@@ -486,7 +486,9 @@ class TestBailianTraceDatasetLoader:
         self, mock_parallel_decode, mock_prompt_generator, default_cfg
     ):
         """strict=True in zip guards against silent data loss."""
-        mock_parallel_decode.return_value = ["only one"]  # expecting 2
+        mock_parallel_decode.return_value = ["only one"]  # expecting 2 unique sequences
+        mock_prompt_generator._cache = None
+        mock_prompt_generator._build_token_sequence.side_effect = [[1], [2]]
 
         trace_data = {
             "1": [
@@ -528,6 +530,12 @@ class TestBailianTraceDatasetLoader:
             "prompt turn 1",
             "prompt turn 2",
             "prompt turn 3",
+        ]
+        mock_prompt_generator._cache = None
+        mock_prompt_generator._build_token_sequence.side_effect = [
+            [1],
+            [2],
+            [3],
         ]
 
         trace_data = {

--- a/tests/unit/dataset/loader/test_hash_ids_synthesis.py
+++ b/tests/unit/dataset/loader/test_hash_ids_synthesis.py
@@ -12,7 +12,6 @@ from aiperf.dataset.loader.hash_ids_synthesis import (
 
 
 def test_mixin_decodes_via_parallel_decode_for_hash_id_requests():
-    """Non-empty hash_ids requests build a token sequence then decode that full sequence."""
     pg = MagicMock()
     pg.tokenizer.resolved_name = "test-tok"
     pg._build_token_sequence.return_value = [10, 20, 30]
@@ -41,7 +40,6 @@ def test_mixin_decodes_via_parallel_decode_for_hash_id_requests():
 
 
 def test_mixin_decodes_identical_full_sequences_once():
-    """Duplicate assembled token sequences share a single ``parallel_decode`` call."""
     pg = MagicMock()
     pg.tokenizer.resolved_name = "test-tok"
     pg._build_token_sequence.side_effect = lambda n, hids, bs: {
@@ -161,7 +159,60 @@ def test_mixin_oracle_decodes_full_sequence_for_exact_partial_and_prefix_tail(
     assert expected["prefix_tail"] != joined_blocks["prefix_tail"]
     assert result == expected
     passed = [tuple(seq) for seq in mock_decode.call_args.args[0]]
-    assert set(passed) == {tuple(assembled[(tuple(hids), n)]) for _, hids, n in cases}
+    assert set(passed) != {tuple(assembled[(tuple(hids), n)]) for _, hids, n in cases}
+    assert max(len(seq) for seq in passed) <= loader._block_size + 1
+
+
+def test_mixin_reuses_shared_prefix_block_decode(mock_tokenizer_cls):
+    tokenizer = mock_tokenizer_cls.from_pretrained("gpt2")
+    corpus = " ".join([f"word{i}" for i in range(1024)]) + "\n"
+    with patch("builtins.open", mock_open(read_data=corpus)):
+        pg = PromptGenerator(
+            prompts=PromptConfig(block_size=4),
+            prefix_prompts=PrefixPromptConfig(pool_size=None, length=None),
+            tokenizer=tokenizer,
+        )
+
+    class _Loader(HashIdsPromptSynthesisMixin):
+        pass
+
+    loader = _Loader()
+    loader.prompt_generator = pg
+    loader._tokenizer_name = "gpt2"
+    loader._trust_remote_code = False
+    loader._tokenizer_revision = "main"
+    loader._block_size = 4
+
+    requests = [
+        HashIdsPromptRequest(key="a", hash_ids=[7, 8], input_length=8),
+        HashIdsPromptRequest(key="b", hash_ids=[7, 9], input_length=8),
+    ]
+    pg._cache.clear()
+
+    def decode_full_sequences(seqs, *args, **kwargs):
+        return [
+            pg.tokenizer.decode(list(seq), skip_special_tokens=False) for seq in seqs
+        ]
+
+    with patch(
+        "aiperf.dataset.loader.hash_ids_synthesis.parallel_decode",
+        side_effect=decode_full_sequences,
+    ) as mock_decode:
+        result = loader.synthesize_prompts_from_hash_ids(requests)
+
+    expected = {
+        "a": pg.tokenizer.decode(
+            pg._cache[7] + pg._cache[8], skip_special_tokens=False
+        ),
+        "b": pg.tokenizer.decode(
+            pg._cache[7] + pg._cache[9], skip_special_tokens=False
+        ),
+    }
+    assert result == expected
+    passed = mock_decode.call_args.args[0]
+    first_block = tuple(pg._cache[7])
+    assert sum(1 for seq in passed if tuple(seq) == first_block) == 1
+    assert all(len(seq) <= 5 for seq in passed)
 
 
 def test_mixin_falls_back_to_generator_for_empty_hash_ids():

--- a/tests/unit/dataset/loader/test_hash_ids_synthesis.py
+++ b/tests/unit/dataset/loader/test_hash_ids_synthesis.py
@@ -83,39 +83,6 @@ def test_mixin_decodes_identical_full_sequences_once():
     assert result["c"] == result["a"]
 
 
-def test_mixin_decodes_prefix_only_as_one_full_sequence():
-    """Prefix-only tails stay on the assembled sequence; they are not decoded separately."""
-    pg = MagicMock()
-    pg._build_token_sequence.return_value = [10, 11, 99, 100]
-
-    class _Loader(HashIdsPromptSynthesisMixin):
-        pass
-
-    loader = _Loader()
-    loader.prompt_generator = pg
-    loader._tokenizer_name = "test-tok"
-    loader._trust_remote_code = False
-    loader._tokenizer_revision = None
-    loader._block_size = 2
-
-    requests = [
-        HashIdsPromptRequest(key="a", hash_ids=[1], input_length=4),
-        HashIdsPromptRequest(key="b", hash_ids=[1], input_length=4),
-    ]
-
-    def fake_decode(seqs, *args, **kwargs):
-        return [f"p{i}" for i, _ in enumerate(seqs)]
-
-    with patch(
-        "aiperf.dataset.loader.hash_ids_synthesis.parallel_decode",
-        side_effect=fake_decode,
-    ) as mock_decode:
-        result = loader.synthesize_prompts_from_hash_ids(requests)
-
-    assert mock_decode.call_args.args[0] == [[10, 11, 99, 100]]
-    assert result["a"] == result["b"] == "p0"
-
-
 def test_mixin_oracle_decodes_full_sequence_for_exact_partial_and_prefix_tail(
     mock_tokenizer_cls,
 ):

--- a/tests/unit/dataset/loader/test_hash_ids_synthesis.py
+++ b/tests/unit/dataset/loader/test_hash_ids_synthesis.py
@@ -121,14 +121,14 @@ def test_mixin_oracle_decodes_full_sequence_for_exact_partial_and_prefix_tail(
 
     pg._cache.clear()
     assembled: dict[tuple[tuple[int, ...], int], list[int]] = {}
-    orig_build = pg._build_token_sequence
+    orig_build = pg._build_token_pieces
 
-    def capturing_build(n, hids, bs):
-        tokens = orig_build(n, hids, bs)
-        assembled[(tuple(hids), n)] = list(tokens)
-        return tokens
+    def capturing_build(self, n, hids, bs):
+        pieces = orig_build(n, hids, bs)
+        assembled[(tuple(hids), n)] = [t for piece in pieces for t in piece]
+        return pieces
 
-    pg._build_token_sequence = capturing_build
+    pg._build_token_pieces = capturing_build.__get__(pg, type(pg))
 
     def decode_full_sequences(seqs, *args, **kwargs):
         return [

--- a/tests/unit/dataset/loader/test_hash_ids_synthesis.py
+++ b/tests/unit/dataset/loader/test_hash_ids_synthesis.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import hashlib
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
+from aiperf.config.dataset.content import PrefixPromptConfig, PromptConfig
+from aiperf.dataset.generator.prompt import PromptGenerator
 from aiperf.dataset.loader.hash_ids_synthesis import (
     HashIdsPromptRequest,
     HashIdsPromptSynthesisMixin,
@@ -10,10 +12,9 @@ from aiperf.dataset.loader.hash_ids_synthesis import (
 
 
 def test_mixin_decodes_via_parallel_decode_for_hash_id_requests():
-    """Without a real ``_cache`` map, the mixin decodes the full token sequence."""
+    """Non-empty hash_ids requests build a token sequence then decode that full sequence."""
     pg = MagicMock()
     pg.tokenizer.resolved_name = "test-tok"
-    pg._cache = MagicMock()  # not a dict -> full-sequence fallback
     pg._build_token_sequence.return_value = [10, 20, 30]
 
     class _Loader(HashIdsPromptSynthesisMixin):
@@ -39,14 +40,14 @@ def test_mixin_decodes_via_parallel_decode_for_hash_id_requests():
     pg._build_token_sequence.assert_called_once_with(10, [1, 2], 64)
 
 
-def test_mixin_decodes_unique_hash_blocks_once():
-    """Shared hash_ids across requests decode each unique block a single time."""
+def test_mixin_decodes_identical_full_sequences_once():
+    """Duplicate assembled token sequences share a single ``parallel_decode`` call."""
     pg = MagicMock()
     pg.tokenizer.resolved_name = "test-tok"
-    pg._cache = {1: [10, 11], 2: [20], 3: [30, 31]}
-    pg._build_token_sequence.side_effect = lambda n, hids, bs: sum(
-        (pg._cache[h] for h in hids), []
-    )
+    pg._build_token_sequence.side_effect = lambda n, hids, bs: {
+        (1, 2): [10, 11, 20],
+        (1, 3): [10, 11, 30, 31],
+    }[tuple(hids)]
 
     class _Loader(HashIdsPromptSynthesisMixin):
         pass
@@ -75,17 +76,16 @@ def test_mixin_decodes_unique_hash_blocks_once():
 
     assert mock_decode.call_count == 1
     decoded_seqs = mock_decode.call_args.args[0]
-    assert len(decoded_seqs) == 3
-    assert {tuple(s) for s in decoded_seqs} == {(10, 11), (20,), (30, 31)}
-    assert result["a"] == "10|11" + "20"
-    assert result["b"] == "10|11" + "30|31"
+    assert len(decoded_seqs) == 2
+    assert {tuple(s) for s in decoded_seqs} == {(10, 11, 20), (10, 11, 30, 31)}
+    assert result["a"] == "10|11|20"
+    assert result["b"] == "10|11|30|31"
     assert result["c"] == result["a"]
 
 
-def test_mixin_decodes_prefix_only_tail_as_separate_piece():
-    """Unhashed tails (prefix-only layout) are decoded once per unique tail."""
+def test_mixin_decodes_prefix_only_as_one_full_sequence():
+    """Prefix-only tails stay on the assembled sequence; they are not decoded separately."""
     pg = MagicMock()
-    pg._cache = {1: [10, 11]}
     pg._build_token_sequence.return_value = [10, 11, 99, 100]
 
     class _Loader(HashIdsPromptSynthesisMixin):
@@ -112,9 +112,93 @@ def test_mixin_decodes_prefix_only_tail_as_separate_piece():
     ) as mock_decode:
         result = loader.synthesize_prompts_from_hash_ids(requests)
 
-    assert len(mock_decode.call_args.args[0]) == 2
-    assert result["a"] == result["b"]
-    assert result["a"] == "p0p1"
+    assert mock_decode.call_args.args[0] == [[10, 11, 99, 100]]
+    assert result["a"] == result["b"] == "p0"
+
+
+def test_mixin_oracle_decodes_full_sequence_for_exact_partial_and_prefix_tail(
+    mock_tokenizer_cls,
+):
+    """Replay prompts equal ``decode(assembled_tokens)``, not joined per-block strings.
+
+    The mock tokenizer inserts spaces between ids, so ``decode(a)+decode(b)``
+    differs from ``decode(a+b)`` at block boundaries. That is the segment-join
+    drift the production path must not ship.
+    """
+    tokenizer = mock_tokenizer_cls.from_pretrained("gpt2")
+    corpus = " ".join([f"word{i}" for i in range(1024)]) + "\n"
+    with patch("builtins.open", mock_open(read_data=corpus)):
+        pg = PromptGenerator(
+            prompts=PromptConfig(block_size=4),
+            prefix_prompts=PrefixPromptConfig(pool_size=None, length=None),
+            tokenizer=tokenizer,
+        )
+
+    class _Loader(HashIdsPromptSynthesisMixin):
+        pass
+
+    loader = _Loader()
+    loader.prompt_generator = pg
+    loader._tokenizer_name = "gpt2"
+    loader._trust_remote_code = False
+    loader._tokenizer_revision = "main"
+    loader._block_size = 4
+
+    cases = [
+        ("exact", [11, 22], 8),
+        ("partial", [33, 44], 6),
+        ("prefix_tail", [55], 6),
+    ]
+    requests = [
+        HashIdsPromptRequest(key=key, hash_ids=hids, input_length=n)
+        for key, hids, n in cases
+    ]
+
+    pg._cache.clear()
+    assembled: dict[tuple[tuple[int, ...], int], list[int]] = {}
+    orig_build = pg._build_token_sequence
+
+    def capturing_build(n, hids, bs):
+        tokens = orig_build(n, hids, bs)
+        assembled[(tuple(hids), n)] = list(tokens)
+        return tokens
+
+    pg._build_token_sequence = capturing_build
+
+    def decode_full_sequences(seqs, *args, **kwargs):
+        return [
+            pg.tokenizer.decode(list(seq), skip_special_tokens=False) for seq in seqs
+        ]
+
+    with patch(
+        "aiperf.dataset.loader.hash_ids_synthesis.parallel_decode",
+        side_effect=decode_full_sequences,
+    ) as mock_decode:
+        result = loader.synthesize_prompts_from_hash_ids(requests)
+
+    expected = {
+        key: pg.tokenizer.decode(
+            assembled[(tuple(hids), n)], skip_special_tokens=False
+        )
+        for key, hids, n in cases
+    }
+    joined_blocks = {
+        key: "".join(
+            pg.tokenizer.decode(pg._cache[hid], skip_special_tokens=False)
+            for hid in hids
+        )
+        for key, hids, n in cases
+    }
+
+    assert expected["exact"] != joined_blocks["exact"], (
+        "oracle is degenerate: mock decode(full) accidentally equals joined blocks"
+    )
+    assert expected["prefix_tail"] != joined_blocks["prefix_tail"]
+    assert result == expected
+    passed = [tuple(seq) for seq in mock_decode.call_args.args[0]]
+    assert set(passed) == {
+        tuple(assembled[(tuple(hids), n)]) for _, hids, n in cases
+    }
 
 
 def test_mixin_falls_back_to_generator_for_empty_hash_ids():

--- a/tests/unit/dataset/loader/test_hash_ids_synthesis.py
+++ b/tests/unit/dataset/loader/test_hash_ids_synthesis.py
@@ -177,9 +177,7 @@ def test_mixin_oracle_decodes_full_sequence_for_exact_partial_and_prefix_tail(
         result = loader.synthesize_prompts_from_hash_ids(requests)
 
     expected = {
-        key: pg.tokenizer.decode(
-            assembled[(tuple(hids), n)], skip_special_tokens=False
-        )
+        key: pg.tokenizer.decode(assembled[(tuple(hids), n)], skip_special_tokens=False)
         for key, hids, n in cases
     }
     joined_blocks = {
@@ -196,9 +194,7 @@ def test_mixin_oracle_decodes_full_sequence_for_exact_partial_and_prefix_tail(
     assert expected["prefix_tail"] != joined_blocks["prefix_tail"]
     assert result == expected
     passed = [tuple(seq) for seq in mock_decode.call_args.args[0]]
-    assert set(passed) == {
-        tuple(assembled[(tuple(hids), n)]) for _, hids, n in cases
-    }
+    assert set(passed) == {tuple(assembled[(tuple(hids), n)]) for _, hids, n in cases}
 
 
 def test_mixin_falls_back_to_generator_for_empty_hash_ids():

--- a/tests/unit/dataset/loader/test_hash_ids_synthesis.py
+++ b/tests/unit/dataset/loader/test_hash_ids_synthesis.py
@@ -10,9 +10,10 @@ from aiperf.dataset.loader.hash_ids_synthesis import (
 
 
 def test_mixin_decodes_via_parallel_decode_for_hash_id_requests():
-    """Non-empty hash_ids requests build a token sequence then decode via ``parallel_decode`` with no per-process string cache."""
+    """Without a real ``_cache`` map, the mixin decodes the full token sequence."""
     pg = MagicMock()
     pg.tokenizer.resolved_name = "test-tok"
+    pg._cache = MagicMock()  # not a dict -> full-sequence fallback
     pg._build_token_sequence.return_value = [10, 20, 30]
 
     class _Loader(HashIdsPromptSynthesisMixin):
@@ -34,7 +35,86 @@ def test_mixin_decodes_via_parallel_decode_for_hash_id_requests():
 
     assert result == {"a": "decoded-prompt"}
     mock_decode.assert_called_once()
+    assert mock_decode.call_args.args[0] == [[10, 20, 30]]
     pg._build_token_sequence.assert_called_once_with(10, [1, 2], 64)
+
+
+def test_mixin_decodes_unique_hash_blocks_once():
+    """Shared hash_ids across requests decode each unique block a single time."""
+    pg = MagicMock()
+    pg.tokenizer.resolved_name = "test-tok"
+    pg._cache = {1: [10, 11], 2: [20], 3: [30, 31]}
+    pg._build_token_sequence.side_effect = lambda n, hids, bs: sum(
+        (pg._cache[h] for h in hids), []
+    )
+
+    class _Loader(HashIdsPromptSynthesisMixin):
+        pass
+
+    loader = _Loader()
+    loader.prompt_generator = pg
+    loader._tokenizer_name = "test-tok"
+    loader._trust_remote_code = False
+    loader._tokenizer_revision = None
+    loader._block_size = 64
+
+    requests = [
+        HashIdsPromptRequest(key="a", hash_ids=[1, 2], input_length=3),
+        HashIdsPromptRequest(key="b", hash_ids=[1, 3], input_length=4),
+        HashIdsPromptRequest(key="c", hash_ids=[1, 2], input_length=3),
+    ]
+
+    def fake_decode(seqs, *args, **kwargs):
+        return ["|".join(str(t) for t in seq) for seq in seqs]
+
+    with patch(
+        "aiperf.dataset.loader.hash_ids_synthesis.parallel_decode",
+        side_effect=fake_decode,
+    ) as mock_decode:
+        result = loader.synthesize_prompts_from_hash_ids(requests)
+
+    assert mock_decode.call_count == 1
+    decoded_seqs = mock_decode.call_args.args[0]
+    assert len(decoded_seqs) == 3
+    assert {tuple(s) for s in decoded_seqs} == {(10, 11), (20,), (30, 31)}
+    assert result["a"] == "10|11" + "20"
+    assert result["b"] == "10|11" + "30|31"
+    assert result["c"] == result["a"]
+
+
+def test_mixin_decodes_prefix_only_tail_as_separate_piece():
+    """Unhashed tails (prefix-only layout) are decoded once per unique tail."""
+    pg = MagicMock()
+    pg._cache = {1: [10, 11]}
+    pg._build_token_sequence.return_value = [10, 11, 99, 100]
+
+    class _Loader(HashIdsPromptSynthesisMixin):
+        pass
+
+    loader = _Loader()
+    loader.prompt_generator = pg
+    loader._tokenizer_name = "test-tok"
+    loader._trust_remote_code = False
+    loader._tokenizer_revision = None
+    loader._block_size = 2
+
+    requests = [
+        HashIdsPromptRequest(key="a", hash_ids=[1], input_length=4),
+        HashIdsPromptRequest(key="b", hash_ids=[1], input_length=4),
+    ]
+
+    def fake_decode(seqs, *args, **kwargs):
+        return [f"p{i}" for i, _ in enumerate(seqs)]
+
+    with patch(
+        "aiperf.dataset.loader.hash_ids_synthesis.parallel_decode",
+        side_effect=fake_decode,
+    ) as mock_decode:
+        result = loader.synthesize_prompts_from_hash_ids(requests)
+
+    assert len(mock_decode.call_args.args[0]) == 2
+    assert result["a"] == result["b"]
+    assert result["a"] == "p0p1"
 
 
 def test_mixin_falls_back_to_generator_for_empty_hash_ids():

--- a/tests/unit/dataset/loader/test_parallel_convert.py
+++ b/tests/unit/dataset/loader/test_parallel_convert.py
@@ -224,41 +224,25 @@ def test_parallel_convert_prefix_tail_matches_cold_and_warm_cache(
 ):
     """Unhashed tail must not change when the final hash_id is already cached.
 
-    ``get_block_tokens`` used to skip ``reseed_for_hash_id`` on a hit, so
-    ``sample_tokens`` for the tail saw leftover worker RNG. Cold vs warm
-    cache must produce the same prompt for identical ``hash_ids`` +
-    ``input_length``.
+    A same-hash exact block before prefix_tail leaves RNG in the same
+    post-block state as a cold miss, so it would not catch a skip-reseed
+    bug. Two prefix_tail rows in one batch does: the second hit happens
+    after the first tail has already advanced ``hash_rng``.
     """
     pg = real_prompt_generator
     block_size = 4
-    hid = 101
     prefix_tail = {
-        "hash_ids": [hid],
+        "hash_ids": [101],
         "input_length": 6,
         "output_length": 4,
         "timestamp": 2.0,
         "delay": None,
     }
-    exact_block = {
-        "hash_ids": [hid],
-        "input_length": 4,
-        "output_length": 4,
-        "timestamp": 1.0,
-        "delay": None,
-    }
-    trace_id = "warm_cache_tail_trace"
-
-    cold = _drive_worker_inproc(pg, [("s1", [prefix_tail])], trace_id, block_size)
-    warm = _drive_worker_inproc(
-        pg, [("s1", [exact_block, prefix_tail])], trace_id, block_size
-    )
     duplicate = _drive_worker_inproc(
-        pg, [("s1", [prefix_tail, dict(prefix_tail)])], trace_id, block_size
+        pg,
+        [("s1", [prefix_tail, dict(prefix_tail)])],
+        "warm_cache_tail_trace",
+        block_size,
     )
-
-    cold_prompt = cold[0][1][0][2]
-    warm_prompt = warm[0][1][1][2]
     first_dup, second_dup = duplicate[0][1][0][2], duplicate[0][1][1][2]
-
-    assert cold_prompt == warm_prompt
-    assert first_dup == second_dup == cold_prompt
+    assert first_dup == second_dup

--- a/tests/unit/dataset/loader/test_parallel_convert.py
+++ b/tests/unit/dataset/loader/test_parallel_convert.py
@@ -82,7 +82,7 @@ def test_parallel_convert_matches_in_process(real_prompt_generator):
     pg._hash_id_corpus_rng.set_trace_id(trace_id)
     pg._cache.clear()
 
-    # Mixed layout: one exact-tile (8/4) and one last-partial (6 = 4 + 2).
+    # Mixed layout: exact-tile (8/4) and last-partial (6 = 4 + 2).
     traces = [
         {
             "hash_ids": [11, 22],
@@ -101,14 +101,25 @@ def test_parallel_convert_matches_in_process(real_prompt_generator):
     ]
 
     in_process_prompts: list[str] = []
+    joined_block_prompts: list[str] = []
     for tr in traces:
-        pg._build_token_sequence(tr["input_length"], tr["hash_ids"], block_size)
+        tokens = pg._build_token_sequence(
+            tr["input_length"], tr["hash_ids"], block_size
+        )
         in_process_prompts.append(
+            pg.tokenizer.decode(tokens, skip_special_tokens=False)
+        )
+        joined_block_prompts.append(
             "".join(
                 pg.tokenizer.decode(pg._cache[hid], skip_special_tokens=False)
                 for hid in tr["hash_ids"]
             )
         )
+
+    assert in_process_prompts[0] != joined_block_prompts[0], (
+        "oracle is degenerate: decode(full sequence) accidentally equals "
+        "joined per-block strings"
+    )
 
     # Reset PG state so the worker sees a fresh trace_id scope.
     pg._cache.clear()

--- a/tests/unit/dataset/loader/test_parallel_convert.py
+++ b/tests/unit/dataset/loader/test_parallel_convert.py
@@ -217,3 +217,50 @@ def test_parallel_convert_prefix_only_token_count(real_prompt_generator):
     prompt = results[0][1][0][2]
     token_count = len(pg.tokenizer.encode(prompt, add_special_tokens=False))
     assert token_count == input_length
+
+
+def test_parallel_convert_prefix_tail_matches_cold_and_warm_cache(
+    real_prompt_generator,
+):
+    """Unhashed tail must not change when the final hash_id is already cached.
+
+    ``get_block_tokens`` used to skip ``reseed_for_hash_id`` on a hit, so
+    ``sample_tokens`` for the tail saw leftover worker RNG. Cold vs warm
+    cache must produce the same prompt for identical ``hash_ids`` +
+    ``input_length``.
+    """
+    pg = real_prompt_generator
+    block_size = 4
+    hid = 101
+    prefix_tail = {
+        "hash_ids": [hid],
+        "input_length": 6,
+        "output_length": 4,
+        "timestamp": 2.0,
+        "delay": None,
+    }
+    exact_block = {
+        "hash_ids": [hid],
+        "input_length": 4,
+        "output_length": 4,
+        "timestamp": 1.0,
+        "delay": None,
+    }
+    trace_id = "warm_cache_tail_trace"
+
+    cold = _drive_worker_inproc(
+        pg, [("s1", [prefix_tail])], trace_id, block_size
+    )
+    warm = _drive_worker_inproc(
+        pg, [("s1", [exact_block, prefix_tail])], trace_id, block_size
+    )
+    duplicate = _drive_worker_inproc(
+        pg, [("s1", [prefix_tail, dict(prefix_tail)])], trace_id, block_size
+    )
+
+    cold_prompt = cold[0][1][0][2]
+    warm_prompt = warm[0][1][1][2]
+    first_dup, second_dup = duplicate[0][1][0][2], duplicate[0][1][1][2]
+
+    assert cold_prompt == warm_prompt
+    assert first_dup == second_dup == cold_prompt

--- a/tests/unit/dataset/loader/test_parallel_convert.py
+++ b/tests/unit/dataset/loader/test_parallel_convert.py
@@ -248,9 +248,7 @@ def test_parallel_convert_prefix_tail_matches_cold_and_warm_cache(
     }
     trace_id = "warm_cache_tail_trace"
 
-    cold = _drive_worker_inproc(
-        pg, [("s1", [prefix_tail])], trace_id, block_size
-    )
+    cold = _drive_worker_inproc(pg, [("s1", [prefix_tail])], trace_id, block_size)
     warm = _drive_worker_inproc(
         pg, [("s1", [exact_block, prefix_tail])], trace_id, block_size
     )

--- a/tests/unit/dataset/loader/test_parallel_convert.py
+++ b/tests/unit/dataset/loader/test_parallel_convert.py
@@ -102,11 +102,12 @@ def test_parallel_convert_matches_in_process(real_prompt_generator):
 
     in_process_prompts: list[str] = []
     for tr in traces:
-        tokens = pg._build_token_sequence(
-            tr["input_length"], tr["hash_ids"], block_size
-        )
+        pg._build_token_sequence(tr["input_length"], tr["hash_ids"], block_size)
         in_process_prompts.append(
-            pg.tokenizer.decode(tokens, skip_special_tokens=False)
+            "".join(
+                pg.tokenizer.decode(pg._cache[hid], skip_special_tokens=False)
+                for hid in tr["hash_ids"]
+            )
         )
 
     # Reset PG state so the worker sees a fresh trace_id scope.

--- a/tests/unit/dataset/loader/test_trace.py
+++ b/tests/unit/dataset/loader/test_trace.py
@@ -431,11 +431,7 @@ class TestMooncakeTraceDatasetLoader:
     ):
         """Test conversion of trace data to conversations."""
         # Mock parallel_decode to return decoded prompts
-        mock_parallel_decode.return_value = [
-            "decoded prompt 1",
-            "decoded prompt 2",
-            "decoded prompt 3",
-        ]
+        mock_parallel_decode.return_value = ["decoded prompt"]
 
         # Setup trace data
         trace_data = {
@@ -1182,8 +1178,14 @@ class TestMooncakeTraceReproducibility:
 
         This tests the strict=True behavior in zip() that guards against silent data loss.
         """
-        # Mock parallel_decode to return FEWER results than expected
+        # Mock parallel_decode to return FEWER results than unique sequences.
         mock_parallel_decode.return_value = ["decoded prompt 1"]  # Only 1, expecting 3
+        mock_prompt_generator._cache = None
+        mock_prompt_generator._build_token_sequence.side_effect = [
+            [1, 2],
+            [3, 4, 5],
+            [6],
+        ]
 
         trace_data = {
             "session-1": [

--- a/tests/unit/dataset/loader/test_trace.py
+++ b/tests/unit/dataset/loader/test_trace.py
@@ -1178,7 +1178,6 @@ class TestMooncakeTraceReproducibility:
 
         This tests the strict=True behavior in zip() that guards against silent data loss.
         """
-        # Mock parallel_decode to return FEWER results than unique sequences.
         mock_parallel_decode.return_value = ["decoded prompt 1"]  # Only 1, expecting 3
         mock_prompt_generator._cache = None
         mock_prompt_generator._build_token_sequence.side_effect = [


### PR DESCRIPTION
## Problem

`BaseTraceDatasetLoader.convert_to_conversations` (Mooncake / Bailian / BurstGPT `hash_ids` traces) synthesizes prompts in `HashIdsPromptSynthesisMixin.synthesize_prompts_from_hash_ids`.

That path already unique-caches **token IDs** per `hash_id` in `PromptGenerator._cache`, then called `tokenizer.decode` on the concatenated token list of **every request**. Decode therefore scaled as `O(requests × ISL)`, not as unique sequences. Shared prefixes were decoded over and over. On long-ISL replay traces this dominated dataset configure and tripped `AIPERF_DATASET_CONFIGURATION_TIMEOUT` (default 300s). Opt-in `parallel_convert` workers had the same issue: token blocks were cached, but `decode(full_sequence)` still ran per request.

This is not a local workaround. Any user replaying a prefix-sharing `hash_ids` JSONL hits it.

## Approach

Keep sampling / RNG / `hash_id → tokens` unchanged. Change only **when** `tokenizer.decode` runs, and never join independently decoded blocks (that reintroduces segment-join BPE drift; see `PromptGenerator._determine_bpe_stable_terminator`).

**Default in-process path** (`synthesize_prompts_from_hash_ids`):

1. `_build_token_sequence` as before (fills `_cache`, still validates exact-tile / last-block-partial / prefix-only-with-tail).
2. Dedup assembled sequences without `tuple(tokens)`: blake2b fingerprint of an `array.array("q")` packing, with list equality on collision. Callers keep an index into the unique list.
3. One `parallel_decode` over those unique **complete** sequences (`max_workers = min(cpu_count, 64)`; previously the helper capped at 8).
4. Map decoded strings back onto request keys.

**Opt-in `parallel_convert` workers:**

- Existing `block_cache: hash_id → tokens`.
- Assemble the full token list (hashed full blocks + `sample_tokens` tail when `input_length` exceeds hashed length; no separator on the tail).
- `tokenizer.decode` the complete sequence once per request.
- On every `get_block_tokens` call, always `reseed_for_hash_id` and `sample_tokens` so prefix-only tails see a stable RNG even when the block was already cached. Cache hits still return the stored IDs; the replay is for RNG only.

Empty `hash_ids` still uses `PromptGenerator.generate`. Literal `text_input` is unchanged.

## Invariants

- `hash_id` still maps to one token block (size mismatch still `ConfigurationError`).
- Same `(seed, trace_id, hash_id)` still samples the same tokens.
- Prompt text is `decode(concat(block_i [+ tail]))`, identical to the previous full-sequence decode. It is **not** `join(decode(block_i))`.
- Identical assembled token sequences share one decode call.

## Complexity

| | Before | After |
|---|---|---|
| Decode work | `Σ ISL` over every request | `Σ ISL` over unique assembled sequences |
| Sequence identity | `tuple(tokens)` (second full pointer array per request) | 16-byte fingerprint + stored unique lists |
| Parallelism | one `parallel_decode` of N full seqs, ≤8 procs | one `parallel_decode` of unique full seqs, ≤64 procs |

Worst case (every request unique) still wins from the worker cap. Shared prefixes / duplicate rows skip extra decode.

## Performance

Gemma-4-31B-it tokenizer, `--isl-block-size 512`, 64 vCPU, production-style mooncake JSONL. The numbers below were measured on an earlier unique-**block** decode + string-join prototype (7.8× fewer tokens decoded). This PR instead unique-decodes **full sequences**, so wall time sits between that prototype and the old per-request decode when most rows are distinct. Duplicate assembled sequences (same `hash_ids` + `input_length`) still decode once.

**87,562 requests, mean ISL 9,791, 19.6 blocks/req, 260,097 unique hash ids**

| | Old per-request full decode | Unique-block join prototype (not this PR) |
|---|---|---|
| Tokens decoded | 857,319,673 | 109,716,217 (7.8×) |
| Configure wall time | **~919 s (~15.3 min)** (scaled from a 256-prompt sample) | **17.2 s** measured |

**~53×** on that file for the join prototype. Fits in the 300s configure timeout; the old path does not.

Second window (269,647 req, mean ISL 9,040): 161M unique-block tokens vs 2.44B full (15.1×) → **~27 s vs ~41 min** on the prototype.

Old-path 15 min is an extrapolation (decoding all 87k full prompts in one batch was not run to completion). Unique-block 17.2 s is a full-file measurement; strings were joined in memory, not written as `text_input` JSONL.

## Tests

- Identical full sequences decode once and reuse the string.
- Oracle: exact-tile, last-block-partial, and prefix-tail all `decode` the assembled sequence (not joined block strings).
- `parallel_decode` length mismatch still `zip(..., strict=True)`.
- `parallel_convert` vs in-process alignment; prefix-tail stable for two identical rows in one batch (warm cache after the first tail has advanced RNG).