### PR TITLE
test(ci): run tests/ui on Windows and give its node subprocess calls more headroom

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize line endings to LF on checkout, including on Windows, where
+# git's default core.autocrlf=true otherwise converts text files to CRLF.
+# tests/ui/test_operator_*.py string/regex-strips import lines out of
+# src/aiperf/operator/ui/lib/*.js before eval'ing them as data: URL modules;
+# that stripping assumes LF and silently no-ops on CRLF, leaving the original
+# relative import in place and breaking module resolution on Windows CI.
+* text=auto eol=lf

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -117,7 +117,7 @@ jobs:
     # ``always() && runner.os == 'Windows'`` guard on the second step,
     # GitHub Actions' implicit ``success()`` short-circuits the
     # component-integration step on any unit-test failure.
-    - name: Run unit and zmq tests (Windows)
+    - name: Run unit, ui, and zmq tests (Windows)
       # Merged into one invocation to pay collection overhead once instead of
       # twice. tests/unit/conftest.py's no_sleep patch applies only to
       # tests/unit/**; tests/zmq/** uses real asyncio.sleep as before.
@@ -125,9 +125,11 @@ jobs:
       # fixture and zmq tests use neither, so they run with a real-time loop.
       # --continue-on-collection-errors preserves the previous two-step
       # behaviour where a unit collection error did not block the zmq suite.
+      # tests/ui mirrors the POSIX `make test-ci` scope (`pytest tests/unit
+      # tests/ui`).
       if: runner.os == 'Windows'
       run: |
-        uv run pytest tests/unit tests/zmq -n auto --dist=worksteal --tb=short --continue-on-collection-errors -m 'not performance and not stress and not slow'
+        uv run pytest tests/unit tests/ui tests/zmq -n auto --dist=worksteal --tb=short --continue-on-collection-errors -m 'not performance and not stress and not slow'
     - name: Run component integration tests (Windows)
       # ``!cancelled()`` overrides the implicit ``success()`` so component
       # integration still runs even if the unit-test step failed — matching

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -125,8 +125,6 @@ jobs:
       # fixture and zmq tests use neither, so they run with a real-time loop.
       # --continue-on-collection-errors preserves the previous two-step
       # behaviour where a unit collection error did not block the zmq suite.
-      # tests/ui mirrors the POSIX `make test-ci` scope (`pytest tests/unit
-      # tests/ui`).
       if: runner.os == 'Windows'
       run: |
         uv run pytest tests/unit tests/ui tests/zmq -n auto --dist=worksteal --tb=short --continue-on-collection-errors -m 'not performance and not stress and not slow'

--- a/tests/ui/node_utils.py
+++ b/tests/ui/node_utils.py
@@ -8,9 +8,12 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
+
+from aiperf.common.constants import IS_WINDOWS
 
 UI_DIR = Path(__file__).resolve().parents[2] / "src" / "aiperf" / "operator" / "ui"
 
@@ -84,20 +87,35 @@ globalThis.document = globalThis.document ?? {
 # fast (rather than hanging the whole suite) if a script never settles.
 NODE_TIMEOUT_S = 30
 
+# Outer @pytest.mark.timeout() for tests with a short, functional run_node()
+# timeout: must exceed that inner timeout by enough Windows startup headroom.
+NODE_TEST_TIMEOUT_S = 45 if IS_WINDOWS else 15
+
 
 def run_node(script: str, timeout: float = NODE_TIMEOUT_S) -> str:
-    result = subprocess.run(
-        ["node", "--input-type=module", "-e", script],
-        check=False,
-        capture_output=True,
-        text=True,
-        # lib/format.js formats with the viewer's locale (`toLocaleString`
-        # without an explicit locale), and node takes that from the ambient
-        # LC_ALL/LANG. Pin it so a developer's shell locale cannot change
-        # which separators the assertions see.
-        env={**os.environ, "LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"},
-        timeout=timeout,
-    )
+    # A script this large can exceed Windows's ~32K CreateProcess command-line
+    # limit if passed via `-e` (POSIX execve's ARG_MAX is far larger, so this
+    # never showed up there). Write it to a real .mjs file instead.
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".mjs", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        result = subprocess.run(
+            ["node", script_path],
+            check=False,
+            capture_output=True,
+            text=True,
+            # lib/format.js formats with the viewer's locale (`toLocaleString`
+            # without an explicit locale), and node takes that from the ambient
+            # LC_ALL/LANG. Pin it so a developer's shell locale cannot change
+            # which separators the assertions see.
+            env={**os.environ, "LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"},
+            timeout=timeout,
+        )
+    finally:
+        os.unlink(script_path)
     if result.returncode != 0:
         raise AssertionError(result.stderr or result.stdout)
     return result.stdout.strip()

--- a/tests/ui/test_dashboard_js.py
+++ b/tests/ui/test_dashboard_js.py
@@ -28,6 +28,7 @@ from fastapi.testclient import TestClient
 from pytest import param
 
 from aiperf.api.routers.static import static_router
+from aiperf.common.constants import IS_WINDOWS
 
 # -----------------------------------------------------------------------------
 # Paths
@@ -35,6 +36,11 @@ from aiperf.api.routers.static import static_router
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DASHBOARD_HTML = _REPO_ROOT / "src" / "aiperf" / "api" / "static" / "dashboard.html"
+
+# Windows CI runners pay a one-time AV/Defender scan on freshly-written temp
+# files before `node.EXE` can even start; under xdist contention that alone
+# can exceed a 15s budget. Give Windows more headroom than Linux/macOS.
+_NODE_TIMEOUT_SECONDS = 45 if IS_WINDOWS else 15
 
 
 # -----------------------------------------------------------------------------
@@ -83,7 +89,7 @@ class TestDashboardInlineJS:
         proc = subprocess.run(
             [_node_binary(), "--check", str(js_path)],
             capture_output=True,
-            timeout=15,
+            timeout=_NODE_TIMEOUT_SECONDS,
         )
         assert proc.returncode == 0, (
             f"inline JS failed `node --check`:\n{proc.stderr.decode(errors='replace')}"
@@ -141,7 +147,7 @@ def _run_v2_node_script(tmp_path: Path, script: str) -> dict[str, Any]:
     proc = subprocess.run(
         [node, str(script_path)],
         capture_output=True,
-        timeout=15,
+        timeout=_NODE_TIMEOUT_SECONDS,
         text=True,
         cwd=sandbox,
     )
@@ -245,7 +251,7 @@ class TestDashboardV2InlineJS:
             proc = subprocess.run(
                 [_node_binary(), "--check", str(path)],
                 capture_output=True,
-                timeout=15,
+                timeout=_NODE_TIMEOUT_SECONDS,
             )
             if proc.returncode != 0:
                 failures.append(

--- a/tests/ui/test_node_utils_timeout.py
+++ b/tests/ui/test_node_utils_timeout.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 
-from tests.ui.node_utils import requires_node, run_node
+from tests.ui.node_utils import NODE_TEST_TIMEOUT_S, requires_node, run_node
 
 # A repeating timer keeps node's event loop alive forever (unlike a dangling
 # top-level `await`, which node's own unsettled-await detector kills quickly),
@@ -15,7 +15,7 @@ _HANGING_SCRIPT = "setInterval(() => {}, 1_000_000);"
 
 
 @requires_node
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(NODE_TEST_TIMEOUT_S)
 def test_run_node_hanging_script_raises_timeout_error() -> None:
     with pytest.raises(subprocess.TimeoutExpired):
         run_node(_HANGING_SCRIPT, timeout=1)

--- a/tests/ui/test_operator_sweep_values_live_path.py
+++ b/tests/ui/test_operator_sweep_values_live_path.py
@@ -113,7 +113,7 @@ def _resolve_values(detail: dict[str, Any], archived_children: Any = None) -> An
     """
     script = f"""
       import {{ resolveSweepManifest, indexVariationValues }}
-        from '{_HELPERS.as_posix()}';
+        from {_HELPERS.as_uri()!r};
       const detail = {json.dumps(detail)};
       const archivedChildren = {json.dumps(archived_children)};
       const manifest = resolveSweepManifest({{ detail, archivedChildren }});


### PR DESCRIPTION
## Summary
Windows CI silently skipped `tests/ui/` entirely (only `tests/unit tests/zmq` ran there, unlike POSIX's `tests/unit tests/ui`), so a whole tier of dashboard/operator-UI node.js tests never actually executed on Windows. Adding `tests/ui` back exposed several previously-invisible Windows-only bugs, all fixed here.
## What's fixed
- **Missing coverage**: added `tests/ui` to the Windows CI step, matching POSIX.
- **Node startup timeouts**: Windows pays a first-touch Defender/AV scan before `node.EXE` can start, which under xdist contention can exceed a fixed 15s timeout. Bumped to 45s on Windows only (`test_dashboard_js.py`, `test_node_utils_timeout.py`).
- **CRLF breaks import-stripping**: several `tests/ui/test_operator_*.py` tests strip `import` lines out of real JS source with LF-only regexes/string matches before eval'ing it as a `data:` URL module. Windows checkouts default to CRLF (no `.gitattributes` existed), so the strip silently no-op'd, leaving the import in place and breaking module resolution. Added `.gitattributes` (`* text=auto eol=lf`).
- **Windows path as ESM specifier**: `test_operator_sweep_values_live_path.py` built its import specifier with `Path.as_posix()` (`C:/...`), which Node's ESM loader rejects on Windows (`ERR_UNSUPPORTED_ESM_URL_SCHEME`). Switched to `Path.as_uri()`, matching every other test in the directory.
- **Command-line length limit**: `node_utils.run_node()` passed scripts via `node -e <script>`. Windows's `CreateProcess` command line caps at ~32K chars (POSIX `execve`'s `ARG_MAX` is far larger), so tests splicing large page modules inline could overflow it. `run_node()` now writes the script to a temp `.mjs` file and runs that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)