### PR TITLE
ci(nightly): bound the amd64 wheel-test parallelism on the builder

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -600,6 +600,11 @@ jobs:
       # advisory; this gate sits inside the publish path.
       - name: Run unit tests against installed nightly wheel (amd64 only)
         if: matrix.arch == 'amd64'
+        # A stall here must fail the step, not take the runner down with it.
+        timeout-minutes: 45
+        env:
+          # Fewer glibc malloc arenas: the suite's threads otherwise inflate RSS.
+          MALLOC_ARENA_MAX: "2"
         run: |
           set -euo pipefail
           NIGHTLY=$(find dist/ -maxdepth 1 -name "aiperf_nightly-*.whl" -type f | head -1)
@@ -627,8 +632,10 @@ jobs:
           # package is on sys.path via the venv; src/ is NOT on sys.path,
           # so `import aiperf` resolves to the installed wheel rather than
           # the source tree.
+          # -n 8, not auto: one worker per core on the many-core builder has
+          # starved the runner agent of memory and killed the job mid-flight.
           .venv-wheel-tests/bin/pytest tests/unit \
-            -n auto \
+            -n 8 --dist=worksteal \
             -m 'not performance and not stress' \
             --tb=short
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -600,10 +600,8 @@ jobs:
       # advisory; this gate sits inside the publish path.
       - name: Run unit tests against installed nightly wheel (amd64 only)
         if: matrix.arch == 'amd64'
-        # A stall here must fail the step, not take the runner down with it.
         timeout-minutes: 45
         env:
-          # Fewer glibc malloc arenas: the suite's threads otherwise inflate RSS.
           MALLOC_ARENA_MAX: "2"
         run: |
           set -euo pipefail
@@ -632,8 +630,7 @@ jobs:
           # package is on sys.path via the venv; src/ is NOT on sys.path,
           # so `import aiperf` resolves to the installed wheel rather than
           # the source tree.
-          # -n 8, not auto: one worker per core on the many-core builder has
-          # starved the runner agent of memory and killed the job mid-flight.
+          # -n auto on the many-core builder starved the runner of memory.
           .venv-wheel-tests/bin/pytest tests/unit \
             -n 8 --dist=worksteal \
             -m 'not performance and not stress' \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Nightly wheel tests now have a 45-minute timeout.
  - Test execution is limited to eight parallel workers for more consistent resource usage.
  - Memory allocation settings were adjusted during nightly testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->