### PR TITLE
fix: default GpuSummary.hostname to None for exclude_none telemetry

### DIFF
--- a/src/aiperf/common/models/export_models.py
+++ b/src/aiperf/common/models/export_models.py
@@ -99,7 +99,7 @@ class GpuSummary(AIPerfBaseModel):
         default=UNKNOWN_GPU_TELEMETRY_PLATFORM,
         description="GPU telemetry platform namespace, e.g. 'nvidia', 'amd', or 'unknown'",
     )
-    hostname: str | None
+    hostname: str | None = None
     namespace: str | None = None
     pod_name: str | None = None
     metrics: dict[str, JsonMetricResult]  # metric_key -> {stat_key -> value}

--- a/tests/unit/common/models/test_export_models.py
+++ b/tests/unit/common/models/test_export_models.py
@@ -18,12 +18,6 @@ from aiperf.common.models.export_models import (
 class TestGpuSummaryHostnameDefault:
     """GpuSummary.hostname must default so exclude_none round-trips survive."""
 
-    def test_hostname_is_optional_like_siblings(self) -> None:
-        hostname = GpuSummary.model_fields["hostname"]
-        assert hostname.is_required() is False
-        for sibling in ("namespace", "pod_name"):
-            assert GpuSummary.model_fields[sibling].is_required() is False
-
     def test_exclude_none_round_trip_with_missing_hostname(self) -> None:
         """Reproduce #1417: hostname=None must validate after exclude_none dump.
 

--- a/tests/unit/common/models/test_export_models.py
+++ b/tests/unit/common/models/test_export_models.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for export model serialization edge cases."""
+
+from datetime import UTC, datetime
+
+import orjson
+
+from aiperf.common.models.export_models import (
+    EndpointData,
+    GpuSummary,
+    TelemetryExportData,
+    TelemetrySummary,
+)
+
+
+class TestGpuSummaryHostnameDefault:
+    """GpuSummary.hostname must default so exclude_none round-trips survive."""
+
+    def test_hostname_is_optional_like_siblings(self) -> None:
+        hostname = GpuSummary.model_fields["hostname"]
+        assert hostname.is_required() is False
+        for sibling in ("namespace", "pod_name"):
+            assert GpuSummary.model_fields[sibling].is_required() is False
+
+    def test_exclude_none_round_trip_with_missing_hostname(self) -> None:
+        """Reproduce #1417: hostname=None must validate after exclude_none dump.
+
+        dcgm_collector sets hostname from an optional Prometheus label. Message
+        serialization uses model_dump(exclude_none=True), so a None hostname is
+        omitted on the wire. Without a default, receive-side model_validate fails
+        with 'Field required' and profile finalization hangs.
+        """
+        gpus = {
+            "gpu_0": GpuSummary(
+                gpu_index=0,
+                gpu_name="GPU",
+                gpu_uuid="GPU-0",
+                hostname=None,
+                namespace=None,
+                pod_name=None,
+                metrics={},
+            )
+        }
+        now = datetime.now(UTC)
+        data = TelemetryExportData(
+            summary=TelemetrySummary(start_time=now, end_time=now),
+            endpoints={"localhost:9400": EndpointData(gpus=gpus)},
+        )
+
+        wire = data.model_dump(
+            exclude_none=True,
+            mode="json",
+            context={"include_internal": True},
+        )
+        gpu0 = wire["endpoints"]["localhost:9400"]["gpus"]["gpu_0"]
+        assert "hostname" not in gpu0
+
+        restored = TelemetryExportData.model_validate(orjson.loads(orjson.dumps(wire)))
+        assert restored.endpoints["localhost:9400"].gpus["gpu_0"].hostname is None


### PR DESCRIPTION
## Summary

Fixes #1417.

`GpuSummary.hostname` was declared `str | None` with no default, which under pydantic v2 is required but nullable. Sibling fields `namespace` and `pod_name` already default to `None`. The DCGM collector fills all three from optional Prometheus labels, and message serialization uses `model_dump(exclude_none=True)`, so a missing `Hostname` label dropped `hostname` from the wire payload. Receive-side `model_validate` then failed with `Field required`, the exception was swallowed as an unretrieved task exception in `ZMQSubClient._handle_message()`, and `aiperf profile` hung instead of finalizing telemetry results.

This change defaults `hostname` to `None` to match the adjacent fields, so the exclude_none round trip validates when the label is absent.

## Changes

- `src/aiperf/common/models/export_models.py`: `hostname: str | None = None`
- `tests/unit/common/models/test_export_models.py`: regression covering field optionality and the exclude_none dump/validate round trip from the issue repro

## Follow-ups (not in this PR)

The issue also notes other required-but-nullable models (`ProfileResults.records`, `RunData.requests`, `EndpointMetadata.endpoint_path` / `metrics_title`) and hardening `ZMQSubClient._handle_message()` so validation errors fail the run loudly. Left out on purpose to keep this PR surgical.

## Test plan

- [x] Issue repro (`hostname=None`, `model_dump(exclude_none=True)`, then `model_validate`): passes after the fix (`is_required=False`, round-trip OK)
- [x] `pytest tests/unit/common/models/test_export_models.py tests/unit/exporters/test_gpu_telemetry_console_exporter.py tests/unit/gpu_telemetry/test_telemetry_models.py` (72 passed)
- [x] `pytest tests/unit/exporters/test_metrics_json_exporter.py tests/unit/common/models/ -k "not adversarial"` (456 passed, 227 deselected)
- [x] `ruff check` / `ruff format --check` on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPU summary data can now be created without providing hostname information.
  * Exported telemetry remains compatible when hostname is omitted.
  * Telemetry export handling now correctly preserves round-trip behavior when optional hostname data is excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->